### PR TITLE
zfs: Fix vnode destruction on znode cache destruction

### DIFF
--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_znode.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_znode.c
@@ -145,8 +145,9 @@ zfs_znode_cache_destructor(void *buf, void *arg)
 	znode_t *zp = buf;
 
 	ASSERT(!POINTER_IS_VALID(zp->z_zfsvfs));
-	ASSERT(ZTOV(zp) == NULL);
+	ASSERT(ZTOV(zp) != NULL);
 	vn_free(ZTOV(zp));
+	zp->z_vnode = NULL;
 	ASSERT(!list_link_active(&zp->z_link_node));
 	mutex_destroy(&zp->z_lock);
 	rw_destroy(&zp->z_parent_lock);
@@ -1402,7 +1403,6 @@ zfs_znode_free(znode_t *zp)
 	zfsvfs_t *zfsvfs = zp->z_zfsvfs;
 
 	ASSERT(zp->z_sa_hdl == NULL);
-	zp->z_vnode = NULL;
 	mutex_enter(&zfsvfs->z_znodes_lock);
 	POINTER_INVALIDATE(&zp->z_zfsvfs);
 	list_remove(&zfsvfs->z_all_znodes, zp);


### PR DESCRIPTION
Looks like ZTOV(zp) couldn't be NULL at that time given that the value is passed to vn_free later on to free the underlying vnode.
For the purpose mentioned above, the statement 'zp->z_vnode = NULL' also needs to be moved around. Otherwise, ZTOV would always return NULL when zfs_znode_cache_destructor is reached.

Signed-off-by: Raphael S. Carvalho raphaelsc@cloudius-systems.com
