### PR TITLE
net/bpf: Fix writing of buffer bigger than PAGESIZE (Bug 205164)

### DIFF
--- a/sys/net/bpf.c
+++ b/sys/net/bpf.c
@@ -550,7 +550,15 @@ bpf_movein(struct uio *uio, int linktype, struct ifnet *ifp, struct mbuf **mp,
 	if (len < hlen || len - hlen > ifp->if_mtu)
 		return (EMSGSIZE);
 
-	m = m_get2(len, M_WAITOK, MT_DATA, M_PKTHDR);
+	/* Allocate a mbuf for our write, since m_get2 fails if len >= to MJUMPAGESIZE, use m_getjcl for bigger buffers */
+	if (len < MJUMPAGESIZE)
+		m = m_get2(len, M_WAITOK, MT_DATA, M_PKTHDR);
+	else if (len <= MJUM9BYTES)
+		m = m_getjcl(M_WAITOK, MT_DATA, M_PKTHDR, MJUM9BYTES);
+	else if (len <= MJUM16BYTES)
+		m = m_getjcl(M_WAITOK, MT_DATA, M_PKTHDR, MJUM16BYTES);
+	else
+		m = NULL;
 	if (m == NULL)
 		return (EIO);
 	m->m_pkthdr.len = m->m_len = len;


### PR DESCRIPTION
When allocating the mbuf we used m_get2 which fails
if len is superior to MJUMPAGESIZE, if its the case,
use m_getjcl instead.

This fixes bug 205164.