### PR TITLE
chown: link to chgrp in the same bin folder

### DIFF
--- a/usr.sbin/chown/Makefile
+++ b/usr.sbin/chown/Makefile
@@ -3,9 +3,9 @@
 
 .include <src.opts.mk>
 
-PROG=	chown
-LINKS=	${BINDIR}/chown /usr/bin/chgrp
-MAN=	chgrp.1 chown.8
+PROG=	    chown
+SYMLINKS=	${BINDIR}/chown ${BINDIR}/chgrp
+MAN=	    chgrp.1 chown.8
 
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests


### PR DESCRIPTION
chown creates a link from `/usr/sbin/chown` to `/usr/bin/chgrp`
instead of staying in the same bin-folder, e.g. `/usr/sbin/chgrp`.

it makes install world fail if one creates sepearate ZFS datasets
for` /usr/bin` and `/usr/sbin` -- cross-filesystem link fails.

BUG

```console
% find /usr/src -type f -name Makefile | \
	xargs grep --color '^LINKS' | \
	grep -v '\(\(BIN\|LIB\|FILES\|SCRIPTS\)DIR\).*\1'
./usr.sbin/chown/Makefile:LINKS=        ${BINDIR}/chown /usr/bin/chgrp
```