### PR TITLE
Fix confusing example in paste(1)

### DIFF
--- a/usr.bin/paste/paste.1
+++ b/usr.bin/paste/paste.1
@@ -120,7 +120,7 @@ Combine pairs of lines from a file into single lines:
 Number the lines in a file, similar to
 .Xr nl 1 :
 .Pp
-.Dl "sed = myfile | paste -s -d '\et\en' - -"
+.Dl "sed = myfile | paste - -"
 .Pp
 Create a colon-separated list of directories named
 .Pa bin ,


### PR DESCRIPTION
Paste's man page contains an example for a reimplementation of nl(1). This example uses the command line

    sed = myfile | paste -s -d '\t\n' - -

in order to concatenate consecutive lines with an intervening tab.

However, the way the example uses the switches `-s` and `-d` and two `-` input files is redundant. There are in fact two equivalent but simpler ways to achieve the desired result:

    sed = myfile | paste -s -d '\t\n' -

uses the same style as the previous example, while

    sed = myfile | paste - -

is arguably even simpler and illustrates the final sentence of the DESCRIPTION.

I therefore suggest to change the example to the latter style.