### PR TITLE
Repeated excessive logging about unsuccessful port reset during device enumeration

### DIFF
--- a/sys/dev/usb/usb_hub.c
+++ b/sys/dev/usb/usb_hub.c
@@ -750,7 +750,7 @@ repeat:
 		if ((sc->sc_st.port_change & UPS_C_CONNECT_STATUS) ||
 		    (!(sc->sc_st.port_status & UPS_CURRENT_CONNECT_STATUS))) {
 			if (timeout) {
-				DPRINTFN(0, "giving up port reset "
+				DPRINTFN(1, "giving up port reset "
 				    "- device vanished\n");
 				goto error;
 			}


### PR DESCRIPTION
Reduce log level for message about unsuccesful port reset which ends up flooding syslog

The following sysctl configuration also helps to get rid of excessive logging but the downside that certain USB device (Create SoundBlaster) are not even getting recognized by USB hub controller.

> hw.usb.disable_enumeration=1
