### PR TITLE
getgroup and setgroup with negative int

### DIFF
--- a/sys/kern/kern_prot.c
+++ b/sys/kern/kern_prot.c
@@ -278,7 +278,7 @@ sys_getegid(struct thread *td, struct getegid_args *uap)
 
 #ifndef _SYS_SYSPROTO_H_
 struct getgroups_args {
-	u_int	gidsetsize;
+	int	gidsetsize;
 	gid_t	*gidset;
 };
 #endif
@@ -286,7 +286,7 @@ int
 sys_getgroups(struct thread *td, struct getgroups_args *uap)
 {
 	struct ucred *cred;
-	u_int ngrp;
+	int ngrp;
 	int error;
 
 	cred = td->td_ucred;
@@ -784,7 +784,7 @@ fail:
 
 #ifndef _SYS_SYSPROTO_H_
 struct setgroups_args {
-	u_int	gidsetsize;
+	int	gidsetsize;
 	gid_t	*gidset;
 };
 #endif
@@ -794,11 +794,11 @@ sys_setgroups(struct thread *td, struct setgroups_args *uap)
 {
 	gid_t smallgroups[XU_NGROUPS];
 	gid_t *groups;
-	u_int gidsetsize;
+	int gidsetsize;
 	int error;
 
 	gidsetsize = uap->gidsetsize;
-	if (gidsetsize > ngroups_max + 1)
+	if (gidsetsize > ngroups_max + 1 || gidsetsize < 0)
 		return (EINVAL);
 
 	if (gidsetsize > XU_NGROUPS)


### PR DESCRIPTION
I was running this test on OpenBSD recently: https://github.com/NetBSD/src/blob/trunk/tests/lib/libc/sys/t_getgroups.c
getgroups/setgroups want an int and therefore casting it to u_int resulted in
`getgroups(-1, ...)` will not `return -1` and set `errno = EINVAL` but instead just work.
I haven't tested this on FreeBSD but the code already was in 4.4BSD to my knowledge.

http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/kern/kern_prot.c (8 years ago)

This change is not tested. I suggest try this:

```
#include <sys/syslimits.h>

#include <stdio.h>
#include <strings.h>
#include <unistd.h>


int
main(void)
{
        gid_t gidset[NGROUPS_MAX];
        bzero(gidset, NGROUPS_MAX * sizeof(gid_t));
        printf("%d %d %d\n", gidset[0], gidset[1], gidset[2]);
        int a = getgroups(-1, gidset);
        printf("%d\n", a);
        printf("%d %d %d\n", gidset[0], gidset[1], gidset[2]);
        return 0;
}
```