### PR TITLE
Fix an undeclared side effect in freebsd/contrib/ntp/lib/isc/backtrace.c

### DIFF
--- a/contrib/ntp/lib/isc/backtrace.c
+++ b/contrib/ntp/lib/isc/backtrace.c
@@ -131,7 +131,9 @@ isc_backtrace_gettrace(void **addrs, int maxaddrs, int *nframes) {
 #ifdef __x86_64__
 static unsigned long
 getrbp() {
-	__asm("movq %rbp, %rax\n");
+	unsigned long rbp;
+	__asm("movq %%rbp, %0\n" : "=r"(rbp));
+	return rbp;
 }
 #endif
 


### PR DESCRIPTION
In inline assembly at freebsd/contrib/ntp/lib/isc/backtrace.c:134, the
function `getrbp` directly set the rax by movq, this implementation works
in most cases but will fail with compiler optimization. When compiler
try to inline this small function, the behavior will be a little out of
expectation. I produce the bug case as below:
```
static unsigned long
getrbp() {
        __asm("movq %rbp, %rax\n");
}

int __attribute__((noinline)) set_val(int v) { return v; }

int main() {
  int a = set_val(0);
  int b = set_val(1);
  int c = set_val(2);
  a = a + b; b = b + c; c = c + a;
  unsigned long d = getrbp();
  printf("%d, %d, %d, %lx\n", a, b, c, d);
  return 0;
}
```
Assume rbp is 0x55555555 when invoke getrbp, the output of the above
code should be `1, 3, 3, 55555555`, but when the above code is compiled
with flag -O2 (gcc-8 on my PC), the output will be trash value. For
example, `1, 1108317873, 1108317873, 0`, the 2nd and 3rd number is
different when execute multiple times.