### PR TITLE
added Novatel Wireless MiFi 8800/8000 support

### DIFF
--- a/sys/dev/usb/net/if_urndis.c
+++ b/sys/dev/usb/net/if_urndis.c
@@ -179,6 +179,9 @@ static const STRUCT_USB_HOST_ID urndis_host_devs[] = {
 	/* Nokia 7 plus */
 	{USB_IFACE_CLASS(UICLASS_IAD), USB_IFACE_SUBCLASS(0x4),
 		USB_IFACE_PROTOCOL(UIPROTO_ACTIVESYNC)},
+	  /* Novatel Wireless 8800/8000/etc */
+        {USB_IFACE_CLASS(UICLASS_IAD), USB_IFACE_SUBCLASS(0xef),
+                USB_IFACE_PROTOCOL(UIPROTO_RNDIS)},
 };
 
 DRIVER_MODULE(urndis, uhub, urndis_driver, urndis_devclass, NULL, NULL);


### PR DESCRIPTION
added Novatel Wireless MiFi 8800/8000 support.  An entry was needed to recognize the "0xef" presented by the device so it would be flagged and a ueX device would be created.