### PR TITLE
Add VMware ESXi ARM Fling support

### DIFF
--- a/sys/arm64/conf/GENERIC
+++ b/sys/arm64/conf/GENERIC
@@ -177,6 +177,7 @@ device		dwc_rk		# Rockchip Designware
 device		dwc_socfpga	# Altera SOCFPGA Ethernet MAC
 device		genet		# Broadcom on RPi4
 device		ffec		# iMX FFEC
+device		vmx		# VMware vmxnet3   
 
 # Etherswitch devices
 device		etherswitch	# Enable etherswitch support
@@ -187,6 +188,7 @@ device		e6000sw		# Marvell mv88e6085 based switches
 device		ahci
 device		scbus
 device		da
+device		pvscsi		# VMware paravirtual scsi
 
 # ATA/SCSI peripherals
 device		cd		# CD
@@ -227,6 +229,7 @@ device		rk_typec_phy		# Rockchip TypeC PHY
 device		dwcotg			# DWC OTG controller
 device		musb			# Mentor Graphics USB OTG controller
 device		ohci			# OHCI USB interface
+device		uhci			# UHCI USB interface
 device		ehci			# EHCI USB interface (USB 2.0)
 device		ehci_mv			# Marvell EHCI USB interface
 device		xhci			# XHCI USB interface (USB 3.0)
@@ -235,6 +238,7 @@ device		aw_dwc3			# Allwinner DWC3 controller
 device		rk_dwc3			# Rockchip DWC3 controller
 device		usb			# USB Bus (required)
 device		ukbd			# Keyboard
+device		ums			# Mouse
 device		umass			# Disks/Mass storage - Requires scbus and da
 
 # USB ethernet support

--- a/sys/conf/files.arm64
+++ b/sys/conf/files.arm64
@@ -423,3 +423,17 @@ arm/freescale/imx/imx_i2c.c		optional fsliic
 arm/freescale/imx/imx_machdep.c		optional fdt soc_freescale_imx8
 arm64/freescale/imx/imx7gpc.c		optional fdt soc_freescale_imx8
 dev/ffec/if_ffec.c			optional ffec
+
+# VMware
+dev/vmware/vmxnet3/if_vmx.c		optional	vmx
+dev/vmware/vmci/vmci.c			optional	vmci
+dev/vmware/vmci/vmci_datagram.c		optional	vmci
+dev/vmware/vmci/vmci_doorbell.c		optional	vmci
+dev/vmware/vmci/vmci_driver.c		optional	vmci
+dev/vmware/vmci/vmci_event.c		optional	vmci
+dev/vmware/vmci/vmci_hashtable.c	optional	vmci
+dev/vmware/vmci/vmci_kernel_if.c	optional	vmci
+dev/vmware/vmci/vmci_qpair.c		optional	vmci
+dev/vmware/vmci/vmci_queue_pair.c	optional	vmci
+dev/vmware/vmci/vmci_resource.c		optional	vmci
+dev/vmware/pvscsi/pvscsi.c		optional	pvscsi


### PR DESCRIPTION
Now that there is an ARM64 version of VMware, I've added several of the drivers from AMD64 GENERIC over to ARM64 GENERIC. These drivers all work out of the box, unmodified, under VMware ESXi ARM Fling.