### PR TITLE
sbin/veriexec: fixed parameter parsing of option -x

### DIFF
--- a/sbin/veriexec/veriexec.c
+++ b/sbin/veriexec/veriexec.c
@@ -70,7 +70,7 @@ main(int argc, char *argv[])
 
 	dev_fd = open(_PATH_DEV_VERIEXEC, O_WRONLY, 0);
 
-	while ((c = getopt(argc, argv, "C:i:x:vz:")) != -1) {
+	while ((c = getopt(argc, argv, "C:i:xvz:")) != -1) {
 		switch (c) {
 		case 'C':
 			Cdir = optarg;


### PR DESCRIPTION
Parameter parsing of option -x in sbin/veriexec is broken: the parameter is simply ignored.

In my sense this is a serious issue since `veriexec -x` is used to verify files. As it is now `veriexec -x /path/to/file` does notthing and returns 0 (OK) no matter what, while `veriexec -x /path/to/file /path/to/second/file` only checks the second file and returns accordingly.

I detected the issue with these simple diff:
```
		case 'x':
			/*
			 * -x says all other args are paths to check.
			 */
+			printf("veriexec -x detected\n");
			for (x = 0; optind < argc; optind++) {
+				printf("calling veriexec_check_path on %s\n", argv[optind]);
				if (veriexec_check_path(argv[optind])) {
					warn("%s", argv[optind]);
					x = 2;
				}
			}
			exit(x);
```
and noticed that the first file was indeed skipped. This PR fixed the problem locally.