### PR TITLE
usr.sbin/uefisign: Process zero-sized sections

### DIFF
--- a/usr.sbin/uefisign/pe.c
+++ b/usr.sbin/uefisign/pe.c
@@ -232,7 +232,7 @@ parse_section_table(struct executable *x, off_t off, int number_of_sections)
 	range_check(x, off, sizeof(*psh) * number_of_sections,
 	    "section table");
 
-	if (x->x_headers_len <= off + sizeof(*psh) * number_of_sections)
+	if (x->x_headers_len < off + sizeof(*psh) * number_of_sections)
 		errx(1, "section table outside of headers");
 
 	psh = (const struct pe_section_header *)(x->x_buf + off);

--- a/usr.sbin/uefisign/pe.c
+++ b/usr.sbin/uefisign/pe.c
@@ -244,11 +244,13 @@ parse_section_table(struct executable *x, off_t off, int number_of_sections)
 	x->x_nsections = number_of_sections;
 
 	for (i = 0; i < number_of_sections; i++) {
-		if (psh->psh_pointer_to_raw_data < x->x_headers_len)
-			errx(1, "section points inside the headers");
+		if (psh->psh_size_of_raw_data) {
+			if (psh->psh_pointer_to_raw_data < x->x_headers_len)
+				errx(1, "section points inside the headers");
 
-		range_check(x, psh->psh_pointer_to_raw_data,
-		    psh->psh_size_of_raw_data, "section");
+			range_check(x, psh->psh_pointer_to_raw_data,
+			    psh->psh_size_of_raw_data, "section");
+		}
 #if 0
 		printf("section %d: start %d, size %d\n",
 		    i, psh->psh_pointer_to_raw_data, psh->psh_size_of_raw_data);


### PR DESCRIPTION
uefisign(8) tries to locate and sanity-check the sizes of all
PE sections, to compute a checksum. If a PE section contains only
uninitialized data (like .bss in ELF) then the "size of raw data"
and "pointer to raw data" section header fields are both supposed
to be zero, a condition the current code doesn't expect and which
causes it die. Most EFI binaries built these days contain one such
section, so this fixes uefisign for those binaries. Tested by signing
and booting with the FreeBSD Lua loader, which is currently broken
without this fix.