### PR TITLE
macOS Finder .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ GTAGS
 ID
 cscope.out
 ?cscope.out
+
+# macOS finder
+.DS_Store


### PR DESCRIPTION
It can be controversy, because it is for people who browse source on mac.
It thought about this pull request several times, but in Freebsd wiki, GitHub is for browsing and cloning, 
so I think .DS_Store should be added to .gitignore.