### PR TITLE
newvers.sh: add support for gitup(1)

### DIFF
--- a/sys/conf/newvers.sh
+++ b/sys/conf/newvers.sh
@@ -221,6 +221,10 @@ if findvcs .git; then
 	done
 fi
 
+if findvcs .gituprevision; then
+	gituprevision="${VCSTOP}/.gituprevision"
+fi
+
 if findvcs .hg; then
 	for dir in /usr/bin /usr/local/bin; do
 		if [ -x "${dir}/hg" ] ; then
@@ -263,6 +267,10 @@ if [ -n "$git_cmd" ] ; then
 	git=" ${git}"
 fi
 
+if [ -n "$gituprevision" ] ; then
+	gitup="$(awk -F : '{printf " %s", $2}' $gituprevision)"
+fi
+
 if [ -n "$hg_cmd" ] ; then
 	hg=$($hg_cmd id 2>/dev/null)
 	hgsvn=$($hg_cmd svn info 2>/dev/null | \
@@ -277,10 +285,10 @@ fi
 
 [ ${include_metadata} = "if-modified" -a ${modified} = "yes" ] && include_metadata=yes
 if [ ${include_metadata} != "yes" ]; then
-	VERINFO="${VERSION}${svn}${git}${hg} ${i}"
+	VERINFO="${VERSION}${svn}${git}${gitup}${hg} ${i}"
 	VERSTR="${VERINFO}\\n"
 else
-	VERINFO="${VERSION} #${v}${svn}${git}${hg}: ${t}"
+	VERINFO="${VERSION} #${v}${svn}${git}${gitup}${hg}: ${t}"
 	VERSTR="${VERINFO}\\n    ${u}@${h}:${d}\\n"
 fi
 

--- a/sys/conf/newvers.sh
+++ b/sys/conf/newvers.sh
@@ -256,10 +256,6 @@ if [ -n "$git_cmd" ] ; then
 	if [ -n "$git_cnt" ] ; then
 		git="c${git_cnt}-g${git}"
 	fi
-	git_b=$($git_cmd rev-parse --abbrev-ref HEAD)
-	if [ -n "$git_b" -a "$git_b" != "HEAD" ] ; then
-		git="${git_b}-${git}"
-	fi
 	if git_tree_modified; then
 		git="${git}-dirty"
 		modified=yes


### PR DESCRIPTION
gitup writes a .gituprevision file into the shallow clone directory. Read that
file and print commit plus branch information along with other version information.