### PR TITLE
grep: fix LINKS in Makefile

### DIFF
--- a/usr.bin/grep/Makefile
+++ b/usr.bin/grep/Makefile
@@ -23,7 +23,7 @@ LINKS=		${BINDIR}/zgrep ${BINDIR}/zfgrep \
 		${BINDIR}/zgrep ${BINDIR}/xzfgrep \
 		${BINDIR}/zgrep ${BINDIR}/zstdgrep \
 		${BINDIR}/zgrep ${BINDIR}/zstdegrep \
-		${BINDIR}/zgrep ${BINDIR}/zstdegrep
+		${BINDIR}/zgrep ${BINDIR}/zstdfgrep
 
 LINKS+=		${BINDIR}/grep ${BINDIR}/egrep \
 		${BINDIR}/grep ${BINDIR}/fgrep \


### PR DESCRIPTION
zstdegrep was listed twice, instead of zstdfgrep