### PR TITLE
User/claplace/gicv3 mbi

### DIFF
--- a/sys/arm64/arm64/gic_v3.c
+++ b/sys/arm64/arm64/gic_v3.c
@@ -882,7 +882,7 @@ gic_v3_bind_intr(device_t dev, struct intr_irqsrc *isrc)
 	if (CPU_EMPTY(&isrc->isrc_cpu)) {
 		gic_irq_cpu = intr_irq_next_cpu(gic_irq_cpu, &all_cpus);
 		CPU_SETOF(gic_irq_cpu, &isrc->isrc_cpu);
-		gic_d_write(sc, 4, GICD_IROUTER(gi->gi_irq),
+		gic_d_write(sc, 8, GICD_IROUTER(gi->gi_irq),
 		    CPU_AFFINITY(gic_irq_cpu));
 	} else {
 		/*
@@ -890,7 +890,7 @@ gic_v3_bind_intr(device_t dev, struct intr_irqsrc *isrc)
 		 * the first CPU found.
 		 */
 		cpu = CPU_FFS(&isrc->isrc_cpu) - 1;
-		gic_d_write(sc, 4, GICD_IROUTER(gi->gi_irq), CPU_AFFINITY(cpu));
+		gic_d_write(sc, 8, GICD_IROUTER(gi->gi_irq), CPU_AFFINITY(cpu));
 	}
 
 	return (0);
@@ -1152,7 +1152,7 @@ gic_v3_dist_init(struct gic_v3_softc *sc)
 	 */
 	aff = CPU_AFFINITY(0);
 	for (i = GIC_FIRST_SPI; i < sc->gic_nirqs; i++)
-		gic_d_write(sc, 4, GICD_IROUTER(i), aff);
+		gic_d_write(sc, 8, GICD_IROUTER(i), aff);
 
 	return (0);
 }

--- a/sys/arm64/arm64/gic_v3_var.h
+++ b/sys/arm64/arm64/gic_v3_var.h
@@ -68,6 +68,11 @@ struct gic_v3_softc {
 	/* Re-Distributors */
 	struct gic_redists	gic_redists;
 
+	/* Message Based Interrupts */
+	u_int			gic_mbi_start;
+	u_int			gic_mbi_end;
+	struct mtx		gic_mbi_mtx;
+
 	uint32_t		gic_pidr2;
 	u_int			gic_bus;
 


### PR DESCRIPTION
These two commits add GICv3 support for ESXi Arm Fling virtual machines:
- The first one adds MSIs using SPI interrupts, with the SPI range described in the device tree.
- The second one is updating GICD_IROUTERn writes to be 64-bit instead of 32-bit. While 32-bit accesses are allowed, the register is 64-bit. And current ESXi Arm fling ignores 32-bit writes.