### PR TITLE
Add bcm2710-rpi-cm3.dtb to the list of DTBs being added.

### DIFF
--- a/release/arm64/RPI.conf
+++ b/release/arm64/RPI.conf
@@ -4,7 +4,7 @@
 #
 
 DTB_DIR="/usr/local/share/rpi-firmware"
-DTB="bcm2710-rpi-2-b.dtb bcm2710-rpi-3-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2711-rpi-4-b.dtb"
+DTB="bcm2710-rpi-2-b.dtb bcm2710-rpi-3-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-cm3.dtb bcm2711-rpi-4-b.dtb"
 EMBEDDED_TARGET_ARCH="aarch64"
 EMBEDDED_TARGET="arm64"
 EMBEDDEDBUILD=1


### PR DESCRIPTION
This allows to boot out of the box on the RPI COmpute Module 3 with 32G
of eMMC.