### PR TITLE
Update usb_hub.c 

### DIFF
--- a/sys/dev/usb/usb_hub.c
+++ b/sys/dev/usb/usb_hub.c
@@ -2792,8 +2792,9 @@ repeat:
 			    "remote wakeup failed\n");
 		}
 	}
-
-	USB_BUS_LOCK(udev->bus);
+	if(udev->bus != NULL){	
+		USB_BUS_LOCK(udev->bus);
+	}
 	/*
 	 * Checking for suspend condition and setting suspended bit
 	 * must be atomic!


### PR DESCRIPTION
there is a path lead the udev->bus ==NULL;
1、freebsd-src/ sys / dev / usb / usb_hub.c
line 2740 :static void usb_dev_suspend_peer(struct usb_device *udev)
Start Analysis.

2、freebsd-src/ sys / dev / usb / usb_hub.c
line 2749: if (udev == NULL)
Take the false branch. 判断udev 不为空指针

3、freebsd-src/ sys / dev / usb / usb_hub.c
line 2753: if (udev->flags.self_suspended)
Take the false branch. 在udev->flags.self_suspended ！= 0的情况下

4、freebsd-src/ sys / dev / usb / usb_hub.c
line 2757: if (udev->parent_hub == NULL)
Take the false branch. 在udev->parent_hub ！= ((void *)0)的情况下

5、freebsd-src/ sys / dev / usb / usb_hub.c
line 2760: DPRINTF("udev=%p\n", udev);
Take the false branch.

6、freebsd-src/ sys / dev / usb / usb_hub.c
line 2763: if (udev->hub != NULL) {
Take the true branch. udev->hub != ((void *)0)

7、freebsd-src/ sys / dev / usb / usb_hub.c
line 2767: for (x = 0; x != nports; x++) {
Take the true branch. x != nports nports在此之前被赋值为nports = udev->hub->nports、

8、freebsd-src/ sys / dev / usb / usb_hub.c
line 2768:child = usb_bus_port_get_device(udev->bus, udev->hub->ports + x)
Call a function.

9、freebsd-src/ sys / dev / usb / usb_hub.c
line 2182:usb_bus_port_get_device(struct usb_bus *bus, struct usb_port *up)
**Enter function. ** usb_bus_port_get_device(udev->bus, udev->hub->ports + x)

10&11、freebsd-src/ sys / dev / usb / usb_hub.c
line 2184: if ((bus == NULL) || (up == NULL)) {
Take the true branch. (bus == ((void *)0)) || (up == ((void *)0))

12、freebsd-src/ sys / dev / usb / usb_hub.c
line 2186: return (NULL);
Exit function. bus在此函数内并为赋值

13、freebsd-src/ sys / dev / usb / usb_hub.c
line 2771: if (child == NULL)
Take the true branch. child == ((void *)0) 进入下一行的continue;返回循环

14、freebsd-src/ sys / dev / usb / usb_hub.c
line 2767: for (x = 0; x != nports; x++) {
Take the false branch. x == nports

15、freebsd-src/ sys / dev / usb / usb_hub.c
line 2782: if (usb_peer_can_wakeup(udev)) {
Call a function. usb_peer_can_wakeup(udev)

16、freebsd-src/ sys / dev / usb / usb_device.c
line 2842:usb_peer_can_wakeup(struct usb_device *udev)
**Enter function. ** usb_peer_can_wakeup(udev)

17&&18、freebsd-src/ sys / dev / usb / usb_device.c
line 2847:if ((cdp != NULL) && (udev->flags.usb_mode == USB_MODE_HOST)) {
Take the false branch. (cdp == ((void *)0)) && (udev->flags.usb_mode ！= USB_MODE_HOST)

19、freebsd-src/ sys / dev / usb / usb_device.c
line 2850:return (0);

20、freebsd-src/ sys / dev / usb / usb_hub.c
line 2782: if (usb_peer_can_wakeup(udev)) {
Take the false branch. return 0;

21、freebsd-src/ sys / dev / usb / usb_hub.c
line 2796:USB_BUS_LOCK(udev->bus);
The pointer is NULL. (udev->bus)