### PR TITLE
Use the default Git history depth

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,9 +7,6 @@ freebsd_instance:
   cpu: 8
   memory: 24G
 
-env:
-  CIRRUS_CLONE_DEPTH: 1
-
 task:
   only_if: $CIRRUS_BRANCH != 'svn_head'
   timeout_in: 120m


### PR DESCRIPTION
Which is `50`. I saw a few errors like `Failed to force reset to SHA: object not found!` which seems is happening because the SHA is not available because there were two commits pushed almost simultaneously and the second from the top fails with this error because the SHA is not in the history.