### PR TITLE
cron: Consume blanks in system crontabs before options.

### DIFF
--- a/usr.sbin/cron/lib/entry.c
+++ b/usr.sbin/cron/lib/entry.c
@@ -315,6 +315,9 @@ load_entry(file, error_func, pw, envp)
 			goto eof;
 		}
 
+		/* need to have consumed blanks when checking options below */
+		Skip_Blanks(ch, file)
+		unget_char(ch, file);
 #ifdef LOGIN_CAP
 		if ((s = strrchr(username, '/')) != NULL) {
 			*s = '\0';


### PR DESCRIPTION
This change makes the state consistent between user and system crontabs before processing options:  blanks have been consumed and the [next get_char()](https://github.com/freebsd/freebsd-src/blob/d765b211387c4c8a463086caeea8eb8836a50e57/usr.sbin/cron/lib/entry.c#L431) returns '-' or the start of the command.

Details
--

On system crontabs, multiple blanks are not being consumed after reading the username. This change adds blank consumption before parsing any -[qn] options. Without this change, an entry like:

 `* * * * * username<space><space>-n true`

will fail, as the shell will try to execute (' -n true'), while an entry like:

  `* * * * * username<space>-n true`

works as expected (executes 'true').

Working cases (with or without this change)
--
* For entries _without options_, this is not an issue, as the leading blanks are ignored by the shell when executing the command.
* For entries _with options_ and only one blank character between the username and the options, this is also not an issue, as the [next get_char()](https://github.com/freebsd/freebsd-src/blob/d765b211387c4c8a463086caeea8eb8836a50e57/usr.sbin/cron/lib/entry.c#L431) returns '-' and option processing occurs.
* For user crontabs, this is not an issue as the preceding ([day of week](https://github.com/freebsd/freebsd-src/blob/d765b211387c4c8a463086caeea8eb8836a50e57/usr.sbin/cron/lib/entry.c#L555) or [@shortcut](https://github.com/freebsd/freebsd-src/blob/d765b211387c4c8a463086caeea8eb8836a50e57/usr.sbin/cron/lib/entry.c#L231)) processing consumes any leading whitespace.