### PR TITLE
    Fix mediatek SoC compile errors.

### DIFF
--- a/sys/mips/mediatek/mtk_clock.c
+++ b/sys/mips/mediatek/mtk_clock.c
@@ -123,6 +123,8 @@ mtk_clock_get_info(device_t dev, int index, struct fdt_clock_info *info)
 	if (index < 0 || index > 31 || info == NULL)
 		return (EINVAL);
 
+	mask = (1u << index);
+
 	if (mtk_sysctl_get(SYSCTL_CLKCFG1) & mask)
 		info->flags = FDT_CIFLAG_RUNNING;
 	else

--- a/sys/mips/mediatek/mtk_machdep.c
+++ b/sys/mips/mediatek/mtk_machdep.c
@@ -258,11 +258,14 @@ platform_start(__register_t a0 __unused, __register_t a1 __unused,
 
 	printf("FDT DTB  at: 0x%08x\n", (uint32_t)dtbp);
 
+	printf("CPU   model: %s\n", mtk_soc_get_cpu_model());
 	printf("CPU   clock: %4dMHz\n", mtk_soc_get_cpuclk()/(1000*1000));
 	printf("Timer clock: %4dMHz\n", timer_clk/(1000*1000));
 	printf("UART  clock: %4dMHz\n\n", mtk_soc_get_uartclk()/(1000*1000));
 
 	printf("U-Boot args (from %d args):\n", argc - 1);
+
+	strcpy(cpu_model, mtk_soc_get_cpu_model());
 
 	if (argc == 1)
 		printf("\tNone\n");

--- a/sys/mips/mediatek/mtk_soc.c
+++ b/sys/mips/mediatek/mtk_soc.c
@@ -54,6 +54,7 @@ static uint32_t mtk_soc_timerclk = MTK_CPU_CLK_880MHZ / 2;
 
 static uint32_t mtk_soc_chipid0_3 = MTK_UNKNOWN_CHIPID0_3;
 static uint32_t mtk_soc_chipid4_7 = MTK_UNKNOWN_CHIPID4_7;
+static char mtk_soc_cpu_model[64];
 
 static const struct ofw_compat_data compat_data[] = {
 	{ "ralink,rt2880-soc",		MTK_SOC_RT2880 },
@@ -412,12 +413,18 @@ mtk_soc_set_cpu_model(void)
 	 * obtained for some reason.
 	 */
 	for (idx = 0; idx < offset; idx++) {
-		cpu_model[idx] = chipid0_3[idx];
-		cpu_model[idx + offset] = chipid4_7[idx];
+		mtk_soc_cpu_model[idx] = chipid0_3[idx];
+		mtk_soc_cpu_model[idx + offset] = chipid4_7[idx];
 	}
 
 	/* Null-terminate the string */
-	cpu_model[2 * offset] = 0;
+	mtk_soc_cpu_model[2 * offset] = 0;
+}
+
+const char *
+mtk_soc_get_cpu_model(void)
+{
+	return mtk_soc_cpu_model;
 }
 
 uint32_t

--- a/sys/mips/mediatek/mtk_soc.h
+++ b/sys/mips/mediatek/mtk_soc.h
@@ -123,6 +123,7 @@ enum mtk_soc_id {
 
 extern void     mtk_soc_try_early_detect(void);
 extern void	mtk_soc_set_cpu_model(void);
+extern const char *mtk_soc_get_cpu_model(void);
 extern uint32_t mtk_soc_get_uartclk(void);
 extern uint32_t mtk_soc_get_cpuclk(void);
 extern uint32_t mtk_soc_get_timerclk(void);


### PR DESCRIPTION
    sys/mips/mediatek/mtk_soc.c:415:3: error: use of undeclared identifier 'cpu_model'
                    cpu_model[idx] = chipid0_3[idx];
                    ^
    sys/mips/mediatek/mtk_soc.c:416:3: error: use of undeclared identifier 'cpu_model'
                    cpu_model[idx + offset] = chipid4_7[idx];
                    ^
    sys/mips/mediatek/mtk_soc.c:420:2: error: use of undeclared identifier 'cpu_model'
            cpu_model[2 * offset] = 0;

    sys/mips/mediatek/mtk_clock.c:126:39: error: variable 'mask' is uninitialized when used here [-Werror,-Wuninitialized]
            if (mtk_sysctl_get(SYSCTL_CLKCFG1) & mask)
                                                 ^~~~
    sys/mips/mediatek/mtk_clock.c:121:15: note: initialize the variable 'mask' to silence this warning
            uint32_t mask;
                         ^
                          = 0