### PR TITLE
contrib: Fix typos in 'host' man page

### DIFF
--- a/contrib/ldns-host/ldns-host.1
+++ b/contrib/ldns-host/ldns-host.1
@@ -36,7 +36,7 @@ When
 .Ar name
 is not provided,
 .Nm
-prints a short summary of it's usage.
+prints a short summary of its usage.
 .Pp
 .Ar server
 is an optional argument which is either a domain name or an IP
@@ -46,7 +46,7 @@ should query instead of the server or servers listed in
 .Pa /etc/resolv.conf .
 When
 .Ar server
-is a domain name, system resolver is used to obtain it's address.
+is a domain name, system resolver is used to obtain its address.
 .Pp
 Supported options:
 .Bl -tag -width indent
@@ -60,7 +60,7 @@ Query for
 .Cm SOA
 records for zone
 .Ar name
-from all of it's authoritative name servers.  The list of name
+from all of its authoritative name servers.  The list of name
 servers is obtained via
 .Cm NS
 query for


### PR DESCRIPTION
Fixes very minor typos in the docs for the host utility.