### PR TITLE
Update ibstat.c to remove implicit decleration warning

### DIFF
--- a/contrib/ofed/infiniband-diags/src/ibstat.c
+++ b/contrib/ofed/infiniband-diags/src/ibstat.c
@@ -48,6 +48,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/sysctl.h> // Removes sysctlbyname() warning, line 125
 
 #include <infiniband/umad.h>
 


### PR DESCRIPTION
Patch removes implicit decleration warning from `contrib/ofed/infiniband-diags/src/ibstat.c` via including `sys/sysctl.h`.