### PR TITLE
Optimized multiple string functions

### DIFF
--- a/lib/libc/string/memccpy.3
+++ b/lib/libc/string/memccpy.3
@@ -39,7 +39,7 @@
 .Sh SYNOPSIS
 .In string.h
 .Ft void *
-.Fn memccpy "void *dst" "const void *src" "int c" "size_t len"
+.Fn memccpy "void * __restrict dst" "const void * __restrict src" "int c" "size_t len"
 .Sh DESCRIPTION
 The
 .Fn memccpy

--- a/lib/libc/string/memccpy.c
+++ b/lib/libc/string/memccpy.c
@@ -38,13 +38,13 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 
 void *
-memccpy(void *t, const void *f, int c, size_t n)
+memccpy(void * __restrict t, const void * __restrict f, int c, size_t n)
 {
 
 	if (n) {
 		unsigned char *tp = t;
 		const unsigned char *fp = f;
-		unsigned char uc = c;
+		const unsigned char uc = (unsigned char)c;
 		do {
 			if ((*tp++ = *fp++) == uc)
 				return (tp);

--- a/lib/libc/string/memset.c
+++ b/lib/libc/string/memset.c
@@ -58,7 +58,7 @@ bzero(void *dst0, size_t length)
 #include <string.h>
 
 #define	RETURN	return (dst0)
-#define	VAL	c0
+#define	VAL	(u_char)c0
 #define	WIDEVAL	c
 
 void *

--- a/lib/libc/string/strspn.c
+++ b/lib/libc/string/strspn.c
@@ -39,14 +39,9 @@ __FBSDID("$FreeBSD$");
 size_t
 strspn(const char *s, const char *charset)
 {
-	/*
-	 * NB: idx and bit are temporaries whose use causes gcc 3.4.2 to
-	 * generate better code.  Without them, gcc gets a little confused.
-	 */
 	const char *s1;
-	u_long bit;
 	u_long tbl[(UCHAR_MAX + 1) / LONG_BIT];
-	int idx;
+	unsigned int idx;
 
 	if(*s == '\0')
 		return (0);
@@ -58,15 +53,11 @@ strspn(const char *s, const char *charset)
 		tbl[idx] = 0;
 #endif
 	for (; *charset != '\0'; charset++) {
-		idx = IDX(*charset);
-		bit = BIT(*charset);
-		tbl[idx] |= bit;
+		tbl[IDX(*charset)] |= BIT(*charset);
 	}
 
 	for(s1 = s; ; s1++) {
-		idx = IDX(*s1);
-		bit = BIT(*s1);
-		if ((tbl[idx] & bit) == 0)
+		if ((tbl[IDX(*s1)] & BIT(*charset)) == 0)
 			break;
 	}
 	return (s1 - s);

--- a/lib/libc/string/strtok.3
+++ b/lib/libc/string/strtok.3
@@ -55,9 +55,9 @@
 .Sh SYNOPSIS
 .In string.h
 .Ft char *
-.Fn strtok "char *str" "const char *sep"
+.Fn strtok "char * __restrict str" "const char * __restrict sep"
 .Ft char *
-.Fn strtok_r "char *str" "const char *sep" "char **last"
+.Fn strtok_r "char * __restrict str" "const char * __restrict sep" "char ** __restrict last"
 .Sh DESCRIPTION
 .Bf -symbolic
 This interface is obsoleted by

--- a/lib/libc/string/strtok.c
+++ b/lib/libc/string/strtok.c
@@ -46,12 +46,12 @@ __FBSDID("$FreeBSD$");
 #endif
 #include <string.h>
 
-char	*__strtok_r(char *, const char *, char **);
+char	*__strtok_r(char * __restrict, const char * __restrict, char ** __restrict);
 
 __weak_reference(__strtok_r, strtok_r);
 
 char *
-__strtok_r(char *s, const char *delim, char **last)
+__strtok_r(char * __restrict s, const char * __restrict delim, char ** __restrict last)
 {
 	char *spanp, *tok;
 	int c, sc;


### PR DESCRIPTION
Removed old lingering variables meant for GCC 3 and added restrict qualifiers to arguments for strtok and memccpy as per The Open Group Base Specifications Issue 7, 2018 edition