### PR TITLE
bsdinstall: set SCRIPT=/path/to/script env var to be able to automate…

### DIFF
--- a/usr.sbin/bsdinstall/scripts/jail
+++ b/usr.sbin/bsdinstall/scripts/jail
@@ -52,10 +52,15 @@ error() {
 	fi
 }
 
-
 rm -rf $BSDINSTALL_TMPETC
 mkdir $BSDINSTALL_TMPETC
 mkdir -p $1 || error "mkdir failed for $1"
+
+if [ -n "$SCRIPT" ]
+then
+        split -a 2 -p '^#!.*' "$SCRIPT" $TMPDIR/bsdinstall-installscript-
+        . $TMPDIR/bsdinstall-installscript-aa
+fi
 
 test ! -d $BSDINSTALL_DISTDIR && mkdir -p $BSDINSTALL_DISTDIR
 
@@ -69,20 +74,23 @@ if [ ! -f $BSDINSTALL_DISTDIR/MANIFEST -a -z "$BSDINSTALL_DISTSITE" ]; then
 	fetch -o $BSDINSTALL_DISTDIR/MANIFEST $BSDINSTALL_DISTSITE/MANIFEST || error "Could not download $BSDINSTALL_DISTSITE/MANIFEST"
 fi
 
-export DISTRIBUTIONS="base.txz"
+: ${DISTRIBUTIONS="base.txz"}; export DISTRIBUTIONS
 if [ -f $BSDINSTALL_DISTDIR/MANIFEST ]; then
 	DISTMENU=`cut -f 4,5,6 $BSDINSTALL_DISTDIR/MANIFEST | grep -v -e ^kernel -e ^base`
 
-	exec 3>&1
-	EXTRA_DISTS=$(echo $DISTMENU | xargs dialog \
-	    --backtitle "FreeBSD Installer" \
-	    --title "Distribution Select" --nocancel --separate-output \
-	    --checklist "Choose optional system components to install:" \
-	    0 0 0 \
-	2>&1 1>&3)
-	for dist in $EXTRA_DISTS; do
-		export DISTRIBUTIONS="$DISTRIBUTIONS $dist.txz"
-	done
+    if [ ! "$nonInteractive" == "YES" ]
+    then
+	    exec 3>&1
+	    EXTRA_DISTS=$(echo $DISTMENU | xargs dialog \
+	        --backtitle "FreeBSD Installer" \
+	        --title "Distribution Select" --nocancel --separate-output \
+	        --checklist "Choose optional system components to install:" \
+	        0 0 0 \
+	    2>&1 1>&3)
+	    for dist in $EXTRA_DISTS; do
+	    	export DISTRIBUTIONS="$DISTRIBUTIONS $dist.txz"
+	    done
+    fi
 fi
 
 FETCH_DISTRIBUTIONS=""
@@ -108,19 +116,37 @@ fi
 
 bsdinstall checksum || error "Distribution checksum failed"
 bsdinstall distextract || error "Distribution extract failed"
-bsdinstall rootpass || error "Could not set root password"
+
+if [ ! "$nonInteractive" == "YES" ]
+then
+    bsdinstall rootpass || error "Could not set root password"
+fi
 
 trap true SIGINT	# This section is optional
+
+if [ ! "$nonInteractive" == "YES" ]
+then
 bsdinstall services
 
-dialog --backtitle "FreeBSD Installer" --title "Add User Accounts" --yesno \
-    "Would you like to add users to the installed system now?" 0 0 && \
-    bsdinstall adduser
+    dialog --backtitle "FreeBSD Installer" --title "Add User Accounts" --yesno \
+        "Would you like to add users to the installed system now?" 0 0 && \
+        bsdinstall adduser
+fi
 
 trap error SIGINT	# SIGINT is bad again
 bsdinstall config  || error "Failed to save config"
 cp /etc/resolv.conf $1/etc
 cp /etc/localtime $1/etc
+
+# Run post-install script
+if [ -f $TMPDIR/bsdinstall-installscript-ab ]; then
+	cp $TMPDIR/bsdinstall-installscript-ab $BSDINSTALL_CHROOT/tmp/installscript
+	chmod a+x $BSDINSTALL_CHROOT/tmp/installscript
+	mount -t devfs devfs "$BSDINSTALL_CHROOT/dev"
+	chroot $BSDINSTALL_CHROOT /tmp/installscript $@ 2>&1
+	umount "$BSDINSTALL_CHROOT/dev"
+	rm $BSDINSTALL_CHROOT/tmp/installscript
+fi
 
 bsdinstall entropy
 


### PR DESCRIPTION
### automated bsdinstall to a jail

It doesn't seem to be the cleanest way, but it works with my simple example.

```bash
$ cat << EOF > /usr/local/jails/jail.template
DISTRIBUTIONS="base.txz"
export nonInteractive="YES"

#!/bin/sh
sysrc ifconfig_eb0_bind="inet 192.168.0.101 netmask 255.255.255.0"
sysrc defaultrouter="192.168.0.254"
EOF

$ zfs create -o mountpoint=/usr/local/jails zroot/jails
$ zfs create zroot/jails/jail1

$ env SCRIPT=/usr/local/jails/jail.template bsdinstall jail /usr/local/jails/jail1
```