### PR TITLE
syslogd: fix WITHOUT_INET builds

### DIFF
--- a/usr.sbin/syslogd/syslogd.c
+++ b/usr.sbin/syslogd/syslogd.c
@@ -1867,8 +1867,10 @@ fprintlog_write(struct filed *f, struct iovlist *il, int flags)
 			dprintf("\n");
 		}
 
+#if defined(INET) || defined(INET6)
 		/* Truncate messages to maximum forward length. */
 		iovlist_truncate(il, MaxForwardLen);
+#endif
 
 		lsent = 0;
 		for (r = f->fu_forw_addr; r; r = r->ai_next) {


### PR DESCRIPTION
Since 2d82b47 syslogd can't be built with `WITHOUT_INET` or
`WITHOUT_INET6` build variables set, because `iovlist_truncate` is not
defined but used.

This change wraps the problematic `iovlist_truncate` call within ifdef
directive.