### PR TITLE
Simplify fuse_device_filt_write to directly return 1

### DIFF
--- a/sys/fs/fuse/fuse_device.c
+++ b/sys/fs/fuse/fuse_device.c
@@ -242,13 +242,11 @@ fuse_device_filt_read(struct knote *kn, long hint)
 static int
 fuse_device_filt_write(struct knote *kn, long hint)
 {
-	int ready;
 
-	/* The device is always ready to write */
 	kn->kn_data = 0;
-	ready = 1;
 
-	return (ready);
+	/* The device is always ready to write, so we return 1*/
+	return (1);
 }
 
 /*


### PR DESCRIPTION
It always returns 1, so why bother having a variable?

We should directly return 1