### PR TITLE
top(1): support command name and argument grepping

### DIFF
--- a/usr.bin/top/commands.c
+++ b/usr.bin/top/commands.c
@@ -59,6 +59,7 @@ const struct command all_commands[] =
 	{'H', "toggle the displaying of threads", false, CMD_thrtog},
 	{'h', "show this help text", true, CMD_help},
 	{'?', NULL, true, CMD_help},
+	{'/', "filter on command name (+ selects all commands)", false, CMD_grep},
 	{'i', "toggle the displaying of idle processes", false, CMD_idletog},
 	{'I', NULL, false, CMD_idletog},
 	{'j', "toggle the displaying of jail ID", false, CMD_jidtog},

--- a/usr.bin/top/commands.h
+++ b/usr.bin/top/commands.h
@@ -24,6 +24,7 @@ enum cmd_id {
 	CMD_update,
 	CMD_quit,
 	CMD_help,
+	CMD_grep,
 	CMD_errors,
 	CMD_number,
 	CMD_delay,

--- a/usr.bin/top/machine.h
+++ b/usr.bin/top/machine.h
@@ -75,7 +75,7 @@ struct process_select
     bool swap;		/* show swap usage */
     bool kidle;		/* show per-CPU idle threads */
     int pid;		/* only this pid (unless pid == -1) */
-    const char *command;	/* only this command (unless == NULL) */
+    char *command;	/* only this command (unless == NULL) */
 };
 
 /* routines defined by the machine dependent module */

--- a/usr.bin/top/top.1
+++ b/usr.bin/top/top.1
@@ -243,6 +243,11 @@ Remember that the next display counts as one, so typing
 will make
 .Nm
 show one final display and then immediately exit.
+.It /
+Display only processes that contain the specified string in their
+command name.
+If displaying arguments is enabled, the arguments are searched
+too. '+' shows all processes.
 .It m
 Toggle the display between 'cpu' and 'io' modes.
 .It n or #

--- a/usr.bin/top/top.c
+++ b/usr.bin/top/top.c
@@ -53,6 +53,7 @@ typedef void sigret_t;
 static char stdoutbuf[Buffersize];
 
 static int fmt_flags = 0;
+int show_args = false;
 int pcpu_stats = false;
 
 /* signal handling routines */
@@ -907,6 +908,19 @@ restart:
 				}
 				break;
 
+			    case CMD_grep: /* grep command name */
+				new_message(MT_standout,
+				    "Grep command name: ");
+				if (readline(tempbuf1, sizeof(tempbuf1), false) > 0) {
+					free(ps.command);
+					if (tempbuf1[0] == '+' && tempbuf1[1] == '\0') {
+						ps.command = NULL;
+					} else if ((ps.command = strdup(tempbuf1)) == NULL)
+						quit(1);
+				}
+				clear_message();
+				break;
+
 			    case CMD_displays:	/* change display count */
 				new_message(MT_standout,
 					"Displays to show (currently %s): ",
@@ -1025,6 +1039,7 @@ restart:
 				break;
 			    case CMD_showargs:
 				fmt_flags ^= FMT_SHOWARGS;
+				show_args = fmt_flags & FMT_SHOWARGS;
 				new_message(MT_standout | MT_delayed,
 				    " %sisplaying process arguments.",
 				    fmt_flags & FMT_SHOWARGS ? "D" : "Not d");

--- a/usr.bin/top/top.h
+++ b/usr.bin/top/top.h
@@ -37,6 +37,8 @@ extern pid_t mypid;
 
 extern int (*compares[])(const void*, const void*);
 
+extern int show_args;
+
 const char* kill_procs(char *);
 const char* renice_procs(char *);
 


### PR DESCRIPTION
This feature is similar to the grep functionality in OpenBSD's top command.