### PR TITLE
release: Remove C-like string comparison operator

### DIFF
--- a/release/tools/arm.subr
+++ b/release/tools/arm.subr
@@ -65,13 +65,13 @@ umount_loop() {
 arm_create_disk() {
 	# Create the target raw file and temporary work directory.
 	chroot ${CHROOTDIR} gpart create -s ${PART_SCHEME} ${mddev}
-	if [ "${PART_SCHEME}" == "GPT" ]; then
+	if [ "${PART_SCHEME}" = "GPT" ]; then
 		chroot ${CHROOTDIR} gpart add -t efi -l efi -a 512k -s ${FAT_SIZE} ${mddev}
 		chroot ${CHROOTDIR} newfs_msdos -L efi -F ${FAT_TYPE} /dev/${mddev}p1
 		chroot ${CHROOTDIR} gpart add -t freebsd-ufs -l rootfs -a 64k ${mddev}
 		chroot ${CHROOTDIR} newfs -U -L rootfs /dev/${mddev}p2
 	fi
-	if [ "${PART_SCHEME}" == "MBR" ]; then
+	if [ "${PART_SCHEME}" = "MBR" ]; then
 		chroot ${CHROOTDIR} gpart add -t '!12' -a 512k -s ${FAT_SIZE} ${mddev}
 		chroot ${CHROOTDIR} gpart set -a active -i 1 ${mddev}
 		chroot ${CHROOTDIR} newfs_msdos -L msdosboot -F ${FAT_TYPE} /dev/${mddev}s1
@@ -169,10 +169,10 @@ arm_setup_minimal_loader() {
 }
 
 arm_install_base() {
-	if [ "${PART_SCHEME}" == "GPT" ]; then
+	if [ "${PART_SCHEME}" = "GPT" ]; then
 		chroot ${CHROOTDIR} mount /dev/${mddev}p2 ${DESTDIR}
 	fi
-	if [ "${PART_SCHEME}" == "MBR" ]; then
+	if [ "${PART_SCHEME}" = "MBR" ]; then
 		chroot ${CHROOTDIR} mount /dev/${mddev}s2a ${DESTDIR}
 	fi
 	_OSVERSION=$(chroot ${CHROOTDIR} /usr/bin/uname -U)
@@ -196,13 +196,13 @@ arm_install_base() {
 
 	echo '# Custom /etc/fstab for FreeBSD embedded images' \
 		> ${CHROOTDIR}/${DESTDIR}/etc/fstab
-	if [ "${PART_SCHEME}" == "GPT" ]; then
+	if [ "${PART_SCHEME}" = "GPT" ]; then
 		echo "/dev/ufs/rootfs		/		ufs	rw		1	1" \
 			>> ${CHROOTDIR}/${DESTDIR}/etc/fstab
 		echo "/dev/msdosfs/EFI		/boot/efi	msdosfs	rw,noatime	0	0" \
 			>> ${CHROOTDIR}/${DESTDIR}/etc/fstab
 	fi
-	if [ "${PART_SCHEME}" == "MBR" ]; then
+	if [ "${PART_SCHEME}" = "MBR" ]; then
 		echo "/dev/ufs/rootfs		/		ufs	rw		1	1" \
 			>> ${CHROOTDIR}/${DESTDIR}/etc/fstab
 		echo "/dev/msdosfs/MSDOSBOOT	/boot/msdos 	msdosfs	rw,noatime	0	0" \
@@ -232,11 +232,11 @@ arm_install_boot() {
 	FATMOUNT="${DESTDIR%${KERNEL}}/fat"
 	UFSMOUNT="${DESTDIR%${KERNEL}}/ufs"
 	chroot ${CHROOTDIR} mkdir -p "${FATMOUNT}" "${UFSMOUNT}"
-	if [ "${PART_SCHEME}" == "GPT" ]; then
+	if [ "${PART_SCHEME}" = "GPT" ]; then
 		dospart="/dev/${mddev}p1"
 		ufspart="/dev/${mddev}p2"
 	fi
-	if [ "${PART_SCHEME}" == "MBR" ]; then
+	if [ "${PART_SCHEME}" = "MBR" ]; then
 		dospart="/dev/${mddev}s1"
 		ufspart="/dev/${mddev}s2a"
 	fi
@@ -244,7 +244,7 @@ arm_install_boot() {
 	chroot ${CHROOTDIR} mount_msdosfs ${dospart} ${FATMOUNT}
 	chroot ${CHROOTDIR} mount ${ufspart} ${UFSMOUNT}
 
-	if [ "${EMBEDDED_TARGET}" == "arm" ]; then
+	if [ "${EMBEDDED_TARGET}" = "arm" ]; then
 	chroot ${CHROOTDIR} cp -p ${UFSMOUNT}/boot/ubldr.bin \
 		${FATMOUNT}/ubldr.bin
 	fi


### PR DESCRIPTION
Per `[(1)`, i.e. `test(1)`, the string comparison operator should be `=`, not `==` in `sh(1)` scripts.

No functional change.