### PR TITLE
Add restrict qualifiers and optimize string functions

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -136,8 +136,8 @@ typedef	__ssize_t	ssize_t;
 void	 swab(const void * __restrict, void * __restrict, ssize_t);
 #endif /* _SWAB_DECLARED */
 
-int	 timingsafe_bcmp(const void *, const void *, size_t);
-int	 timingsafe_memcmp(const void *, const void *, size_t);
+int	 timingsafe_bcmp(const void *, const void *, size_t) __pure;
+int	 timingsafe_memcmp(const void *, const void *, size_t) __pure;
 #endif /* __BSD_VISIBLE */
 
 #if __POSIX_VISIBLE >= 200112 || defined(_XLOCALE_H_)

--- a/include/string.h
+++ b/include/string.h
@@ -136,8 +136,8 @@ typedef	__ssize_t	ssize_t;
 void	 swab(const void * __restrict, void * __restrict, ssize_t);
 #endif /* _SWAB_DECLARED */
 
-int	 timingsafe_bcmp(const void *, const void *, size_t) __pure;
-int	 timingsafe_memcmp(const void *, const void *, size_t) __pure;
+int	 timingsafe_bcmp(const void *, const void *, size_t);
+int	 timingsafe_memcmp(const void *, const void *, size_t);
 #endif /* __BSD_VISIBLE */
 
 #if __POSIX_VISIBLE >= 200112 || defined(_XLOCALE_H_)

--- a/include/string.h
+++ b/include/string.h
@@ -120,7 +120,7 @@ size_t	 strspn(const char *, const char *) __pure;
 char	*strstr(const char *, const char *) __pure;
 char	*strtok(char * __restrict, const char * __restrict);
 #if __POSIX_VISIBLE >= 199506 || __XSI_VISIBLE >= 500
-char	*strtok_r(char *, const char *, char **);
+char	*strtok_r(char * __restrict, const char * __restrict, char ** __restrict);
 #endif
 size_t	 strxfrm(char * __restrict, const char * __restrict, size_t);
 #if __BSD_VISIBLE

--- a/lib/libc/string/bcopy.c
+++ b/lib/libc/string/bcopy.c
@@ -68,9 +68,9 @@ void
 bcopy(const void *src0, void *dst0, size_t length)
 #endif
 {
-	char *dst = (char *)dst0;
-	const char *src = (const char *)src0;
-	size_t t;
+	register char *dst = (char *)dst0;
+	register const char *src = (const char *)src0;
+	register size_t t;
 
 	if (length == 0 || dst == src)		/* nothing to do */
 		goto done;

--- a/lib/libc/string/bcopy.c
+++ b/lib/libc/string/bcopy.c
@@ -81,7 +81,6 @@ bcopy(const void *src0, void *dst0, size_t length)
 #define	TLOOP(s) for (; t; --t) { s; }
 #define	TLOOP1(s) do { s; } while (--t)
 
-
 #ifndef MEMCOPY
 	if ((uintptr_t)dst < (uintptr_t)src) {
 #endif

--- a/lib/libc/string/memccpy.3
+++ b/lib/libc/string/memccpy.3
@@ -39,7 +39,7 @@
 .Sh SYNOPSIS
 .In string.h
 .Ft void *
-.Fn memccpy "void *dst" "const void *src" "int c" "size_t len"
+.Fn memccpy "void * restrict dst" "const void * restrict src" "int c" "size_t len"
 .Sh DESCRIPTION
 The
 .Fn memccpy

--- a/lib/libc/string/memccpy.c
+++ b/lib/libc/string/memccpy.c
@@ -38,13 +38,12 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 
 void *
-memccpy(void * __restrict t, const void * __restrict f, int c, size_t n)
+memccpy(void * __restrict dst, const void * __restrict src, int c, size_t n)
 {
-
 	if (n) {
-		unsigned char *tp = t;
-		const unsigned char *fp = f;
-		const unsigned char uc = c;
+		unsigned char *tp = (unsigned char*)dst;
+		const unsigned char *fp = (const unsigned char*)src;
+		const unsigned char uc = (unsigned char)c;
 		do {
 			if ((*tp++ = *fp) == uc)
 				return (tp);

--- a/lib/libc/string/memccpy.c
+++ b/lib/libc/string/memccpy.c
@@ -38,16 +38,18 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 
 void *
-memccpy(void *t, const void *f, int c, size_t n)
+memccpy(void * __restrict t, const void * __restrict f, int c, size_t n)
 {
 
 	if (n) {
 		unsigned char *tp = t;
 		const unsigned char *fp = f;
-		unsigned char uc = c;
+		const unsigned char uc = c;
 		do {
-			if ((*tp++ = *fp++) == uc)
+			if ((*tp++ = *fp) == uc)
 				return (tp);
+
+			fp++;
 		} while (--n != 0);
 	}
 	return (0);

--- a/lib/libc/string/strtok.3
+++ b/lib/libc/string/strtok.3
@@ -55,9 +55,9 @@
 .Sh SYNOPSIS
 .In string.h
 .Ft char *
-.Fn strtok "char *str" "const char *sep"
+.Fn strtok "char * restrict str" "const char * restrict sep"
 .Ft char *
-.Fn strtok_r "char *str" "const char *sep" "char **last"
+.Fn strtok_r "char * restrict str" "const char * restrict sep" "char ** restrict last"
 .Sh DESCRIPTION
 .Bf -symbolic
 This interface is obsoleted by

--- a/lib/libc/string/strtok.c
+++ b/lib/libc/string/strtok.c
@@ -46,58 +46,62 @@ __FBSDID("$FreeBSD$");
 #endif
 #include <string.h>
 
-char	*__strtok_r(char *, const char *, char **);
+char	*__strtok_r(char * __restrict, const char * __restrict, char ** __restrict);
 
 __weak_reference(__strtok_r, strtok_r);
 
 char *
-__strtok_r(char *s, const char *delim, char **last)
+__strtok_r(char * __restrict s, const char * __restrict delim, char ** __restrict last)
 {
 	char *spanp, *tok;
-	int c, sc;
+	char c, sc;
 
 	if (s == NULL && (s = *last) == NULL)
-		return (NULL);
+		return NULL;
 
 	/*
 	 * Skip (span) leading delimiters (s += strspn(s, delim), sort of).
 	 */
 cont:
-	c = *s++;
-	for (spanp = (char *)delim; (sc = *spanp++) != 0;) {
-		if (c == sc)
+	c = *s;
+	for (spanp = (char *)delim; (sc = *spanp) != '\0'; spanp++) {
+		if (c == sc) {
+			s++;
 			goto cont;
+		}
 	}
 
-	if (c == 0) {		/* no non-delimiter characters */
+	if (c == '\0') {		/* no non-delimiter characters */
 		*last = NULL;
-		return (NULL);
+		return NULL;
 	}
-	tok = s - 1;
+	tok = s;
 
 	/*
 	 * Scan token (scan for delimiters: s += strcspn(s, delim), sort of).
 	 * Note that delim must have one NUL; we stop if we see that, too.
 	 */
 	for (;;) {
-		c = *s++;
+		c = *++s;
 		spanp = (char *)delim;
 		do {
-			if ((sc = *spanp++) == c) {
+			if ((sc = *spanp) == c) {
 				if (c == 0)
 					s = NULL;
 				else
-					s[-1] = '\0';
+					*s++ = '\0';
 				*last = s;
-				return (tok);
+				return tok;
 			}
-		} while (sc != 0);
+
+			spanp++;
+		} while (sc != '\0');
 	}
 	/* NOTREACHED */
 }
 
 char *
-strtok(char *s, const char *delim)
+strtok(char * __restrict s, const char * __restrict delim)
 {
 	static char *last;
 

--- a/lib/libc/string/strxfrm.3
+++ b/lib/libc/string/strxfrm.3
@@ -45,7 +45,7 @@
 .Ft size_t
 .Fn strxfrm "char * restrict dst" "const char * restrict src" "size_t n"
 .Ft size_t
-.Fn strxfrm_l "char * restrict dst" "const char *restrict src" "size_t n" "locale_t loc"
+.Fn strxfrm_l "char * restrict dst" "const char * restrict src" "size_t n" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn strxfrm


### PR DESCRIPTION
Because memcpy doesn’t require overlap, checking for backwards or forwards copying is unneeded. 

This greatly optimizes memcpy.