### PR TITLE
Fix potential overflow when comparing wide char types

### DIFF
--- a/lib/libc/string/wcscasecmp.c
+++ b/lib/libc/string/wcscasecmp.c
@@ -39,7 +39,9 @@ wcscasecmp(const wchar_t *s1, const wchar_t *s2)
 		c1 = towlower(*s1);
 		c2 = towlower(*s2);
 		if (c1 != c2)
-			return ((int)c1 - c2);
+			return ((unsigned int)c1 > (unsigned int)c2 ? 1 : -1);
+		if (c1 == L'\0')
+			return (0);
 	}
-	return (-*s2);
+	return (-1);
 }

--- a/lib/libc/string/wcscmp.c
+++ b/lib/libc/string/wcscmp.c
@@ -48,9 +48,11 @@ int
 wcscmp(const wchar_t *s1, const wchar_t *s2)
 {
 
-	while (*s1 == *s2++)
-		if (*s1++ == '\0')
+	while (*s1 == *s2) {
+		if (*s1 == L'\0')
 			return (0);
+		++s1, ++s2;
+	}
 	/* XXX assumes wchar_t = int */
-	return (*(const unsigned int *)s1 - *(const unsigned int *)--s2);
+	return (*(const unsigned int *)s1 > *(const unsigned int *)s2 ? 1 : -1);
 }

--- a/lib/libc/string/wcsncasecmp.c
+++ b/lib/libc/string/wcsncasecmp.c
@@ -41,9 +41,9 @@ wcsncasecmp(const wchar_t *s1, const wchar_t *s2, size_t n)
 		c1 = towlower(*s1);
 		c2 = towlower(*s2);
 		if (c1 != c2)
-			return ((int)c1 - c2);
-		if (--n == 0)
+			return ((unsigned int)c1 > (unsigned int)c2 ? 1 : -1);
+		if (c1 == L'\0' || --n == 0)
 			return (0);
 	}
-	return (-*s2);
+	return (-1);
 }

--- a/lib/libc/string/wcsncmp.c
+++ b/lib/libc/string/wcsncmp.c
@@ -45,13 +45,14 @@ wcsncmp(const wchar_t *s1, const wchar_t *s2, size_t n)
 	if (n == 0)
 		return (0);
 	do {
-		if (*s1 != *s2++) {
+		if (*s1 != *s2) {
 			/* XXX assumes wchar_t = int */
-			return (*(const unsigned int *)s1 -
-			    *(const unsigned int *)--s2);
+			return (*(const unsigned int *)s1 >
+			    *(const unsigned int *)s2 ? 1 : -1);
 		}
-		if (*s1++ == 0)
+		if (*s1 == L'\0')
 			break;
+		++s1, ++s2;
 	} while (--n != 0);
 	return (0);
 }


### PR DESCRIPTION
Comparing wide char types may result in an overflow when subtracting them if one value happens to be extremely large and the other isn’t, as the difference is evaluated as an unsigned int and then returned as an int.

Although this isn’t a problem for small numbers, such as 0 and 1 as the result will just be 0xFFFFFFFF, or -1, but if the subtraction is 0xFFFFFFFF and 2, the result will turn out to be -3, despite the first value being bigger when interpreted as an unsigned int.