### PR TITLE
Remove incorrect __restricted labels to avoid UB.

### DIFF
--- a/sys/libkern/strcspn.c
+++ b/sys/libkern/strcspn.c
@@ -32,7 +32,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/limits.h>
 
 #define	IDX(c)	((u_char)(c) / LONG_BIT)
-#define	BIT(c)	(1UL << ((u_char)(c) % LONG_BIT))
+#define	BIT(c)	((u_long)1 << ((u_char)(c) % LONG_BIT))
 
 size_t 
 strcspn(const char *s, const char *charset) 

--- a/sys/libkern/strcspn.c
+++ b/sys/libkern/strcspn.c
@@ -32,10 +32,10 @@ __FBSDID("$FreeBSD$");
 #include <sys/limits.h>
 
 #define	IDX(c)	((u_char)(c) / LONG_BIT)
-#define	BIT(c)	((u_long)1 << ((u_char)(c) % LONG_BIT))
+#define	BIT(c)	(1UL << ((u_char)(c) % LONG_BIT))
 
 size_t 
-strcspn(const char * __restrict s, const char * __restrict charset) 
+strcspn(const char *s, const char *charset) 
 {
 	/*
 	 * NB: idx and bit are temporaries whose use causes gcc 3.4.2 to

--- a/sys/sys/libkern.h
+++ b/sys/sys/libkern.h
@@ -144,7 +144,7 @@ char	*strcat(char * __restrict, const char * __restrict);
 char	*strchr(const char *, int);
 int	 strcmp(const char *, const char *);
 char	*strcpy(char * __restrict, const char * __restrict);
-size_t	 strcspn(const char * __restrict, const char * __restrict) __pure;
+size_t	 strcspn(const char *, const char *) __pure;
 char	*strdup(const char *__restrict, struct malloc_type *);
 char	*strncat(char *, const char *, size_t);
 char	*strndup(const char *__restrict, size_t, struct malloc_type *);


### PR DESCRIPTION
strcspn isn’t supposed to be restricted, and by making it so, it opens the door to UB, as the standard describes the function as finding a complimentary substring, which by definition may include part of the string being compared to.