### PR TITLE
Switch to unsigned char

### DIFF
--- a/lib/libc/string/memmem.c
+++ b/lib/libc/string/memmem.c
@@ -38,9 +38,9 @@ __FBSDID("$FreeBSD$");
 void *
 memmem(const void *l, size_t l_len, const void *s, size_t s_len)
 {
-	register char *cur, *last;
-	const char *cl = (const char *)l;
-	const char *cs = (const char *)s;
+	register const unsigned char *cur, *last;
+	const unsigned char *cl = (const unsigned char *)l;
+	const unsigned char *cs = (const unsigned char *)s;
 
 	/* empty "s" matches the beginning of "l" */
 	if (s_len == 0)
@@ -55,11 +55,11 @@ memmem(const void *l, size_t l_len, const void *s, size_t s_len)
 		return memchr(l, (int)*cs, l_len);
 
 	/* the last position where its possible to find "s" in "l" */
-	last = (char *)cl + l_len - s_len;
+	last = cl + (l_len - s_len);
 
-	for (cur = (char *)cl; cur <= last; cur++)
-		if (cur[0] == cs[0] && memcmp(cur, cs, s_len) == 0)
-			return cur;
+	for (cur = cl; cur <= last; cur++)
+		if (*cur == *cs && memcmp(cur, cs, s_len) == 0)
+			return (void *)cur;
 
 	return NULL;
 }


### PR DESCRIPTION
memchr and memcmp both work by comparing the values as unsigned chars. This is mostly an issue when memchr is called, as the (int) cast causes a sign extension instead of a zero extension, which is problematic