### PR TITLE
passwd: remove the hardcoded local / NIS user check

### DIFF
--- a/usr.bin/passwd/passwd.c
+++ b/usr.bin/passwd/passwd.c
@@ -122,9 +122,9 @@ main(int argc, char *argv[])
 		    pwd->pw_name);
 		break;
 	default:
-		/* XXX: Green men ought to be supported via PAM. */
-		errx(1, 
-	  "Sorry, `passwd' can only change passwords for local or NIS users.");
+		fprintf(stderr, "Changing password for %s\n",
+		    pwd->pw_name);
+		break;
 	}
 
 #define pam_check(func) do { \


### PR DESCRIPTION
This check was first introduced as the process of PAMify passwd back in 2002 (see 5f0ae68a1890ba5b50257f7195ebdeaa789c9079). However, passwd already used pam for password modification and thus the password change process should be handled by specific pam modules. Therefore, the check to make passwd only available to local or NIS users is nonsense.

On my systems, passwd works perfectly to change users' LDAP passwords using nss-pam-ldapd or their Kerberos passwords using pam-krb5 in the ports after removing this check, so I believe it has nothing to do with passwd.