### PR TITLE
Remove hacks made to please the compiler

### DIFF
--- a/sys/libkern/fnmatch.c
+++ b/sys/libkern/fnmatch.c
@@ -50,21 +50,21 @@ __FBSDID("$FreeBSD$");
 #define RANGE_NOMATCH   0
 #define RANGE_ERROR     (-1)
 
-static int rangematch(const char *, char, int, char **);
+static int rangematch(const char *, char, const int, const char **);
 
 int
 fnmatch(const char *pattern, const char *string, int flags)
 {
 	const char *stringstart;
-	char *newp;
+	const char *newp;
 	char c, test;
 
 	for (stringstart = string;;)
 		switch (c = *pattern++) {
 		case EOS:
-			if ((flags & FNM_LEADING_DIR) && *string == '/')
+			if ((*string == EOS) || (*string == '/' && (flags & FNM_LEADING_DIR)))
 				return (0);
-			return (*string == EOS ? 0 : FNM_NOMATCH);
+			return (FNM_NOMATCH);
 		case '?':
 			if (*string == EOS)
 				return (FNM_NOMATCH);
@@ -88,26 +88,27 @@ fnmatch(const char *pattern, const char *string, int flags)
 				return (FNM_NOMATCH);
 
 			/* Optimize for pattern with * at end or before /. */
-			if (c == EOS)
+			if (c == EOS) {
 				if (flags & FNM_PATHNAME)
 					return ((flags & FNM_LEADING_DIR) ||
 					    strchr(string, '/') == NULL ?
 					    0 : FNM_NOMATCH);
-				else
-					return (0);
-			else if (c == '/' && flags & FNM_PATHNAME) {
+		
+				return (0);
+			}
+
+			if (c == '/' && flags & FNM_PATHNAME) {
 				if ((string = strchr(string, '/')) == NULL)
 					return (FNM_NOMATCH);
 				break;
 			}
 
 			/* General case, use recursion. */
-			while ((test = *string) != EOS) {
+			for (; (test = *string) != EOS; ++string) {
 				if (!fnmatch(pattern, string, flags & ~FNM_PERIOD))
 					return (0);
-				if (test == '/' && flags & FNM_PATHNAME)
+				if (test == '/' && (flags & FNM_PATHNAME))
 					break;
-				++string;
 			}
 			return (FNM_NOMATCH);
 		case '[':
@@ -133,9 +134,10 @@ fnmatch(const char *pattern, const char *string, int flags)
 			break;
 		case '\\':
 			if (!(flags & FNM_NOESCAPE)) {
-				if ((c = *pattern++) == EOS) {
+				if ((c = *pattern) == EOS) {
 					c = '\\';
-					--pattern;
+				} else {
+					++pattern;
 				}
 			}
 			/* FALLTHROUGH */
@@ -149,14 +151,14 @@ fnmatch(const char *pattern, const char *string, int flags)
 				;
 			else
 				return (FNM_NOMATCH);
-			string++;
+			++string;
 			break;
 		}
 	/* NOTREACHED */
 }
 
 static int
-rangematch(const char *pattern, char test, int flags, char **newp)
+rangematch(const char *pattern, char test, const int flags, const char **newp)
 {
 	int negate, ok;
 	char c, c2;
@@ -210,6 +212,6 @@ rangematch(const char *pattern, char test, int flags, char **newp)
 			ok = 1;
 	} while ((c = *pattern++) != ']');
 
-	*newp = (char *)(uintptr_t)pattern;
+	*newp = pattern;
 	return (ok == negate ? RANGE_NOMATCH : RANGE_MATCH);
 }

--- a/sys/libkern/fnmatch.c
+++ b/sys/libkern/fnmatch.c
@@ -50,7 +50,7 @@ __FBSDID("$FreeBSD$");
 #define RANGE_NOMATCH   0
 #define RANGE_ERROR     (-1)
 
-static int rangematch(const char *, char, int, const char **);
+static int rangematch(const char *, char, const int, const char **);
 
 int
 fnmatch(const char *pattern, const char *string, int flags)
@@ -159,7 +159,7 @@ fnmatch(const char *pattern, const char *string, int flags)
 }
 
 static int
-rangematch(const char *pattern, char test, const flags, const char **newp)
+rangematch(const char *pattern, char test, const int flags, const char **newp)
 {
 	int negate, ok;
 	char c, c2;

--- a/sys/libkern/fnmatch.c
+++ b/sys/libkern/fnmatch.c
@@ -50,7 +50,7 @@ __FBSDID("$FreeBSD$");
 #define RANGE_NOMATCH   0
 #define RANGE_ERROR     (-1)
 
-static int rangematch(const char *, char, const int, const char **);
+static int rangematch(const char *, char, int, const char **);
 
 int
 fnmatch(const char *pattern, const char *string, int flags)
@@ -62,7 +62,8 @@ fnmatch(const char *pattern, const char *string, int flags)
 	for (stringstart = string;;)
 		switch (c = *pattern++) {
 		case EOS:
-			if ((*string == EOS) || (*string == '/' && (flags & FNM_LEADING_DIR)))
+			if (*string == EOS || (*string == '/' && 
+			    (flags & FNM_LEADING_DIR)))
 				return (0);
 			return (FNM_NOMATCH);
 		case '?':
@@ -158,7 +159,7 @@ fnmatch(const char *pattern, const char *string, int flags)
 }
 
 static int
-rangematch(const char *pattern, char test, const int flags, const char **newp)
+rangematch(const char *pattern, char test, const flags, const char **newp)
 {
 	int negate, ok;
 	char c, c2;


### PR DESCRIPTION
Some code, such as strange else statement placements and the (uintptr_t) cast, were made to avoid warning errors.

This patch makes the proper fixes as well as putting parenthesis around flag bitwise AND statements