### PR TITLE
fgetstr: Handle case if len is negative

### DIFF
--- a/stand/libsa/gets.c
+++ b/stand/libsa/gets.c
@@ -92,25 +92,22 @@ fgetstr(char *buf, int size, int fd)
     char	c;
     int		err, len;
     
-    size--;	/* leave space for terminator */
     len = 0;
-    while (size != 0) {
+    while (--size > 0) { 	/* leave space for terminator */
 	err = read(fd, &c, sizeof(c));
 	if (err < 0)		/* read error */
-	    return(-1);
+	    return (-1);
 	if (err == 0) {		/* EOF */
 	    if (len == 0)
-		return(-1);	/* nothing to read */
+		return (-1);	/* nothing to read */
 	    break;
 	}
 	if ((c == '\r') ||	/* line terminators */
 	    (c == '\n'))
 	    break;
 	*buf++ = c;		/* keep char */
-	size--;
 	len++;
     }
-    *buf = 0;
-    return(len);
+    *buf = '\0';
+    return (len);
 }
-


### PR DESCRIPTION
This shouldn’t happen, but if it does, it’s good to have a fallback, lest the loop be stuck until an underflow happens.

It’s not as if it won’t be obvious anymore if a bug happens due to a bad input, but the impact should be lessened.

MFC