### PR TITLE
Use unsigned char * to represent caddr_t [DO NOT MERGE]

### DIFF
--- a/sys/sys/types.h
+++ b/sys/sys/types.h
@@ -73,8 +73,8 @@ typedef	__uint64_t	u_quad_t;	/* quads (deprecated) */
 typedef	__int64_t	quad_t;
 typedef	quad_t *	qaddr_t;
 
-typedef	char *		caddr_t;	/* core address */
-typedef	const char *	c_caddr_t;	/* core address, pointer to const */
+typedef	void *		caddr_t;	/* core address */
+typedef	const caddr_t	c_caddr_t;	/* core address, pointer to const */
 
 #ifndef _BLKSIZE_T_DECLARED
 typedef	__blksize_t	blksize_t;

--- a/sys/sys/types.h
+++ b/sys/sys/types.h
@@ -73,8 +73,8 @@ typedef	__uint64_t	u_quad_t;	/* quads (deprecated) */
 typedef	__int64_t	quad_t;
 typedef	quad_t *	qaddr_t;
 
-typedef	void *		caddr_t;	/* core address */
-typedef	const caddr_t	c_caddr_t;	/* core address, pointer to const */
+typedef	unsigned char *		caddr_t;	/* core address */
+typedef	const unsigned char *	c_caddr_t;	/* core address, pointer to const */
 
 #ifndef _BLKSIZE_T_DECLARED
 typedef	__blksize_t	blksize_t;


### PR DESCRIPTION
40 years ago, when Unix was first being developed, way before the C language was even standardized, a type needed to exist for a general core pointer. 

This pointer needed to represent the smallest unit of RAM. The caddr_t type was thus created.

However, it’s intended purpose was a core pointer, not explicitly a char pointer, and multiple standard c functions such as mmap use void * instead of caddr_t. For this reason, mostly because void* supersedes caddr_t, it would be a better typedef than char*, especially considering caddr_t isn’t used in modern code anymore in favor of void*.

This isn’t a change to be made lightly, so I’m labeling it as Do Not Merge for the time being, as this seems to be something that should have the opinion and scrutiny of all maintainers