### PR TITLE
ANSI libsa functions

### DIFF
--- a/stand/libsa/dev.c
+++ b/stand/libsa/dev.c
@@ -40,22 +40,19 @@ __FBSDID("$FreeBSD$");
 #include "stand.h"
 
 int
-nodev()
+nodev(void)
 {
 	return (ENXIO);
 }
 
 void
-nullsys()
+nullsys(void)
 {
 }
 
 /* ARGSUSED */
 int
-noioctl(f, cmd, data)
-	struct open_file *f;
-	u_long cmd;
-	void *data;
+noioctl(struct open_file *f __unused, u_long cmd __unused, void *data __unused)
 {
 	return (EINVAL);
 }

--- a/stand/libsa/in_cksum.c
+++ b/stand/libsa/in_cksum.c
@@ -50,9 +50,7 @@ __FBSDID("$FreeBSD$");
  * In particular, it should not be this one.
  */
 int
-in_cksum(p, len)
-	void *p;
-	int len;
+in_cksum(void *p, int len)
 {
 	int sum = 0, oddbyte = 0, v = 0;
 	u_char *cp = p;

--- a/stand/libsa/inet_ntoa.c
+++ b/stand/libsa/inet_ntoa.c
@@ -45,8 +45,7 @@ static char sccsid[] = "@(#)inet_ntoa.c	8.1 (Berkeley) 6/4/93";
  * to base 256 d.d.d.d representation.
  */
 char *
-inet_ntoa(in)
-	struct in_addr in;
+inet_ntoa(struct in_addr in)
 {
 	static const char fmt[] = "%u.%u.%u.%u";
 	static char ret[sizeof "255.255.255.255"];

--- a/stand/libsa/stat.c
+++ b/stand/libsa/stat.c
@@ -37,9 +37,7 @@ __FBSDID("$FreeBSD$");
 #include "stand.h"
 
 int
-stat(str, sb)
-	const char *str;
-	struct stat *sb;
+stat(const char *str, struct stat *sb)
 {
 	int fd, rv;
 

--- a/stand/libsa/strcasecmp.c
+++ b/stand/libsa/strcasecmp.c
@@ -39,8 +39,7 @@ static char sccsid[] = "@(#)strcasecmp.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
 
 int
-strcasecmp(s1, s2)
-	const char *s1, *s2;
+strcasecmp(const char *s1, const char *s2, size_t n)
 {
 	const u_char
 			*us1 = (const u_char *)s1,
@@ -53,9 +52,7 @@ strcasecmp(s1, s2)
 }
 
 int
-strncasecmp(s1, s2, n)
-	const char *s1, *s2;
-	size_t n;
+strncasecmp(const char *s1, const char *s2, size_t n)
 {
 	if (n != 0) {
 		const u_char

--- a/stand/libsa/strdup.c
+++ b/stand/libsa/strdup.c
@@ -39,8 +39,7 @@ static char sccsid[] = "@(#)strdup.c	8.1 (Berkeley) 6/4/93";
 #include <string.h>
 
 char *
-strdup(str)
-	const char *str;
+strdup(const char *str)
 {
 	size_t len;
 	char *copy = NULL;


### PR DESCRIPTION
A lot of the libsa functions were written back when ANSI C wasn’t a thing. So, I replaced their old, nonstandard parts with their modern-day equivalents.

No functional change intended.