### PR TITLE
Remove compiler hacks

### DIFF
--- a/crypto/heimdal/lib/gssapi/mech/gss_import_name.c
+++ b/crypto/heimdal/lib/gssapi/mech/gss_import_name.c
@@ -71,7 +71,7 @@ _gss_import_export_name(OM_uint32 *minor_status,
 	 */
 	if (len < 2)
 		return (GSS_S_BAD_NAME);
-	t = (p[0] << 8) + p[1];
+	t = (p[0] << 8) | p[1];
 	p += 2;
 	len -= 2;
 

--- a/crypto/heimdal/lib/krb5/store-int.c
+++ b/crypto/heimdal/lib/krb5/store-int.c
@@ -52,7 +52,7 @@ _krb5_get_int(void *buffer, unsigned long *value, size_t size)
     unsigned long v = 0;
     size_t i;
     for (i = 0; i < size; i++)
-	v = (v << 8) + p[i];
+	v = (v << 8) | p[i];
     *value = v;
     return size;
 }

--- a/crypto/heimdal/lib/wind/utf8.c
+++ b/crypto/heimdal/lib/wind/utf8.c
@@ -281,7 +281,7 @@ wind_ucs2read(const void *ptr, size_t len, unsigned int *flags,
      * the LE/BE flag and set the resulting LE/BE flag.
      */
     if ((*flags) & WIND_RW_BOM) {
-	uint16_t bom = (p[0] << 8) + p[1];
+	uint16_t bom = (p[0] << 8) | p[1];
 	if (bom == 0xfffe || bom == 0xfeff) {
 	    little = (bom == 0xfffe);
 	    p += 2;
@@ -298,9 +298,9 @@ wind_ucs2read(const void *ptr, size_t len, unsigned int *flags,
 	if (olen < 1)
 	    return WIND_ERR_OVERRUN;
 	if (little)
-	    *out = (p[1] << 8) + p[0];
+	    *out = (p[1] << 8) | p[0];
 	else
-	    *out = (p[0] << 8) + p[1];
+	    *out = (p[0] << 8) | p[1];
 	out++; p += 2; len -= 2; olen--;
     }
     *out_len -= olen;

--- a/crypto/openssh/openbsd-compat/base64.c
+++ b/crypto/openssh/openbsd-compat/base64.c
@@ -144,8 +144,8 @@ b64_ntop(u_char const *src, size_t srclength, char *target, size_t targsize)
 		srclength -= 3;
 
 		output[0] = input[0] >> 2;
-		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
-		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+		output[1] = ((input[0] & 0x03) << 4) | (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) | (input[2] >> 6);
 		output[3] = input[2] & 0x3f;
 
 		if (datalength + 4 > targsize)
@@ -164,8 +164,8 @@ b64_ntop(u_char const *src, size_t srclength, char *target, size_t targsize)
 			input[i] = *src++;
 	
 		output[0] = input[0] >> 2;
-		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
-		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+		output[1] = ((input[0] & 0x03) << 4) | (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) | (input[2] >> 6);
 
 		if (datalength + 4 > targsize)
 			return (-1);

--- a/lib/libc/net/base64.c
+++ b/lib/libc/net/base64.c
@@ -139,8 +139,8 @@ b64_ntop(u_char const *src, size_t srclength, char *target, size_t targsize) {
 		srclength -= 3;
 
 		output[0] = input[0] >> 2;
-		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
-		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+		output[1] = ((input[0] & 0x03) << 4) | (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) | (input[2] >> 6);
 		output[3] = input[2] & 0x3f;
 		Assert(output[0] < 64);
 		Assert(output[1] < 64);
@@ -163,8 +163,8 @@ b64_ntop(u_char const *src, size_t srclength, char *target, size_t targsize) {
 			input[i] = *src++;
 	
 		output[0] = input[0] >> 2;
-		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
-		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+		output[1] = ((input[0] & 0x03) << 4) | (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) | (input[2] >> 6);
 		Assert(output[0] < 64);
 		Assert(output[1] < 64);
 		Assert(output[2] < 64);

--- a/lib/libc/string/strcspn.c
+++ b/lib/libc/string/strcspn.c
@@ -34,40 +34,24 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 
 #define	IDX(c)	((u_char)(c) / LONG_BIT)
-#define	BIT(c)	((u_long)1 << ((u_char)(c) % LONG_BIT))
+#define	BIT(c)	(1UL << ((u_char)(c) % LONG_BIT))
 
 size_t
 strcspn(const char *s, const char *charset)
 {
-	/*
-	 * NB: idx and bit are temporaries whose use causes gcc 3.4.2 to
-	 * generate better code.  Without them, gcc gets a little confused.
-	 */
 	const char *s1;
-	u_long bit;
-	u_long tbl[(UCHAR_MAX + 1) / LONG_BIT];
-	int idx;
 
-	if(*s == '\0')
+	if (*s == '\0')
 		return (0);
 
-#if LONG_BIT == 64	/* always better to unroll on 64-bit architectures */
-	tbl[0] = 1;
-	tbl[3] = tbl[2] = tbl[1] = 0;
-#else
-	for (tbl[0] = idx = 1; idx < sizeof(tbl) / sizeof(tbl[0]); idx++)
-		tbl[idx] = 0;
-#endif
+	u_long tbl[(UCHAR_MAX + 1) / LONG_BIT] = {1}; // Rest of array is 0s
+
 	for (; *charset != '\0'; charset++) {
-		idx = IDX(*charset);
-		bit = BIT(*charset);
-		tbl[idx] |= bit;
+		tbl[IDX(*charset)] |= BIT(*charset);
 	}
 
-	for(s1 = s; ; s1++) {
-		idx = IDX(*s1);
-		bit = BIT(*s1);
-		if ((tbl[idx] & bit) != 0)
+	for (s1 = s; ; s1++) {
+		if ((tbl[IDX(*s1)] & BIT(*s1)) != 0)
 			break;
 	}
 	return (s1 - s);

--- a/lib/libc/string/strspn.c
+++ b/lib/libc/string/strspn.c
@@ -34,39 +34,24 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 
 #define	IDX(c)	((u_char)(c) / LONG_BIT)
-#define	BIT(c)	((u_long)1 << ((u_char)(c) % LONG_BIT))
+#define	BIT(c)	(1UL << ((u_char)(c) % LONG_BIT))
 
 size_t
 strspn(const char *s, const char *charset)
 {
-	/*
-	 * NB: idx and bit are temporaries whose use causes gcc 3.4.2 to
-	 * generate better code.  Without them, gcc gets a little confused.
-	 */
 	const char *s1;
-	u_long bit;
-	u_long tbl[(UCHAR_MAX + 1) / LONG_BIT];
-	int idx;
 
 	if(*s == '\0')
 		return (0);
 
-#if LONG_BIT == 64	/* always better to unroll on 64-bit architectures */
-	tbl[3] = tbl[2] = tbl[1] = tbl[0] = 0;
-#else
-	for (idx = 0; idx < sizeof(tbl) / sizeof(tbl[0]); idx++)
-		tbl[idx] = 0;
-#endif
+	u_long tbl[(UCHAR_MAX + 1) / LONG_BIT] = {0};
+
 	for (; *charset != '\0'; charset++) {
-		idx = IDX(*charset);
-		bit = BIT(*charset);
-		tbl[idx] |= bit;
+		tbl[IDX(*charset)] |= BIT(*charset);
 	}
 
-	for(s1 = s; ; s1++) {
-		idx = IDX(*s1);
-		bit = BIT(*s1);
-		if ((tbl[idx] & bit) == 0)
+	for (s1 = s; ; s1++) {
+		if ((tbl[IDX(*s1)] & BIT(*s1)) == 0)
 			break;
 	}
 	return (s1 - s);

--- a/sbin/dhclient/options.c
+++ b/sbin/dhclient/options.c
@@ -354,7 +354,7 @@ expand_search_domain_name(struct option_data *option, size_t *offset,
 			return;
 		} else if (label_len & 0xC0) {
 			/* This is a pointer to another list of labels. */
-			pointer = ((label_len & ~(0xC0)) << 8) +
+			pointer = ((label_len & ~(0xC0)) << 8) |
 			    option->data[i + 1];
 
 			expand_search_domain_name(option, &pointer, &cursor);

--- a/sbin/fsck_msdosfs/boot.c
+++ b/sbin/fsck_msdosfs/boot.c
@@ -129,12 +129,12 @@ readboot(int dosfs, struct bootblock *boot)
 	boot->bpbHeads = block[26] + (block[27] << 8);
 
 	/* Hidden sectors: ignored */
-	boot->bpbHiddenSecs = block[28] + (block[29] << 8) +
-	    (block[30] << 16) + (block[31] << 24);
+	boot->bpbHiddenSecs = block[28] | (block[29] << 8) |
+	    (block[30] << 16) | (block[31] << 24);
 
 	/* Total sectors (32 bits) */
-	boot->bpbHugeSectors = block[32] + (block[33] << 8) +
-	    (block[34] << 16) + (block[35] << 24);
+	boot->bpbHugeSectors = block[32] | (block[33] << 8) |
+	    (block[34] << 16) | (block[35] << 24);
 	if (boot->bpbHugeSectors == 0) {
 		if (boot->flags & FAT32) {
 			pfatal("FAT32 with sector count of zero");
@@ -160,8 +160,8 @@ readboot(int dosfs, struct bootblock *boot)
 		}
 
 		/* 32-bit count of sectors per FAT */
-		boot->FATsecs = block[36] + (block[37] << 8)
-				+ (block[38] << 16) + (block[39] << 24);
+		boot->FATsecs = block[36] | (block[37] << 8)
+				| (block[38] << 16) | (block[39] << 24);
 
 		if (block[40] & 0x80)
 			boot->ValidFat = block[40] & 0x0f;
@@ -178,14 +178,14 @@ readboot(int dosfs, struct bootblock *boot)
 		 *
 		 * Should be 2 but do not require it.
 		 */
-		boot->bpbRootClust = block[44] + (block[45] << 8)
-			       + (block[46] << 16) + (block[47] << 24);
+		boot->bpbRootClust = block[44] | (block[45] << 8)
+			       | (block[46] << 16) | (block[47] << 24);
 
 		/* Sector number of the FSInfo structure, usually 1 */
-		boot->bpbFSInfo = block[48] + (block[49] << 8);
+		boot->bpbFSInfo = block[48] | (block[49] << 8);
 
 		/* Sector number of the backup boot block, ignored */
-		boot->bpbBackup = block[50] + (block[51] << 8);
+		boot->bpbBackup = block[50] | (block[51] << 8);
 
 		/* Check basic parameters */
 		if (boot->bpbFSInfo == 0) {
@@ -238,12 +238,12 @@ readboot(int dosfs, struct bootblock *boot)
 				boot->bpbFSInfo = 0;
 		} else {
 			/* We appear to have a valid FSInfo block, decode */
-			boot->FSFree = fsinfo[0x1e8] + (fsinfo[0x1e9] << 8)
-				       + (fsinfo[0x1ea] << 16)
-				       + (fsinfo[0x1eb] << 24);
-			boot->FSNext = fsinfo[0x1ec] + (fsinfo[0x1ed] << 8)
-				       + (fsinfo[0x1ee] << 16)
-				       + (fsinfo[0x1ef] << 24);
+			boot->FSFree = fsinfo[0x1e8] | (fsinfo[0x1e9] << 8)
+				       | (fsinfo[0x1ea] << 16)
+				       | (fsinfo[0x1eb] << 24);
+			boot->FSNext = fsinfo[0x1ec] | (fsinfo[0x1ed] << 8)
+				       | (fsinfo[0x1ee] << 16)
+				       | (fsinfo[0x1ef] << 24);
 		}
 	} else {
 		/* !FAT32: FAT12/FAT16 */

--- a/stand/common/isapnp.c
+++ b/stand/common/isapnp.c
@@ -191,8 +191,7 @@ isapnp_scan_resdata(struct pnpinfo *pi)
 	    if (isapnp_get_resource_info(resinfo, 2))
 		return(1);
 
-	    large_len = resinfo[1];
-	    large_len = (large_len << 8) + resinfo[0];
+	    large_len = (resinfo[1] << 8) | resinfo[0];
 
 	    switch(PNP_LRES_NUM(tag)) {
 

--- a/stand/i386/libi386/biospci.c
+++ b/stand/i386/libi386/biospci.c
@@ -277,7 +277,7 @@ biospci_enumerate(void)
 		for (device_index = 0; ; device_index++) {
 		    /* Look for a match */
 		    err = biospci_find_devclass((pc->pc_class << 16)
-			+ (psc->ps_subclass << 8) + ppi->pi_code,
+			| (psc->ps_subclass << 8) | ppi->pi_code,
 			device_index, &locator);
 		    if (err != 0)
 			break;

--- a/stand/libsa/dosfs.c
+++ b/stand/libsa/dosfs.c
@@ -571,7 +571,7 @@ dos_readdir(struct open_file *fd, struct dirent *d)
 		}
 	}
 
-	d->d_fileno = (dd.de.clus[1] << 8) + dd.de.clus[0];
+	d->d_fileno = (dd.de.clus[1] << 8) | dd.de.clus[0];
 	d->d_reclen = sizeof(*d);
 	d->d_type = (dd.de.attr & FA_DIR) ? DT_DIR : DT_REG;
 	memcpy(d->d_name, fn, sizeof(d->d_name));

--- a/sys/arm/nvidia/drm2/hdmi.c
+++ b/sys/arm/nvidia/drm2/hdmi.c
@@ -1012,12 +1012,12 @@ static int hdmi_avi_infoframe_unpack(struct hdmi_avi_infoframe *frame,
 	if (ptr[0] & 0x10)
 		frame->active_aspect = ptr[1] & 0xf;
 	if (ptr[0] & 0x8) {
-		frame->top_bar = (ptr[5] << 8) + ptr[6];
-		frame->bottom_bar = (ptr[7] << 8) + ptr[8];
+		frame->top_bar = (ptr[5] << 8) | ptr[6];
+		frame->bottom_bar = (ptr[7] << 8) | ptr[8];
 	}
 	if (ptr[0] & 0x4) {
-		frame->left_bar = (ptr[9] << 8) + ptr[10];
-		frame->right_bar = (ptr[11] << 8) + ptr[12];
+		frame->left_bar = (ptr[9] << 8) | ptr[10];
+		frame->right_bar = (ptr[11] << 8) | ptr[12];
 	}
 	frame->scan_mode = ptr[0] & 0x3;
 

--- a/sys/ddb/db_access.c
+++ b/sys/ddb/db_access.c
@@ -72,7 +72,7 @@ db_get_value(db_addr_t addr, int size, bool is_signed)
 	for (i = size - 1; i >= 0; i--)
 #endif
 	{
-	    value = (value << 8) + (data[i] & 0xFF);
+	    value = (value << 8) | (data[i] & 0xFF);
 	}
 
 	if (size < 4) {

--- a/sys/dev/ath/if_ath_btcoex_mci.c
+++ b/sys/dev/ath/if_ath_btcoex_mci.c
@@ -393,7 +393,7 @@ ath_btcoex_mci_coex_msg(struct ath_softc *sc, uint8_t opcode,
 		minor = *(rx_payload + MCI_GPM_COEX_B_MINOR_VERSION);
 		DPRINTF(sc, ATH_DEBUG_BTCOEX,
 		    "(MCI) BT Coex version: %d.%d\n", major, minor);
-		version = (major << 8) + minor;
+		version = (major << 8) | minor;
 		version = ath_hal_btcoex_mci_state(sc->sc_ah,
 		    HAL_MCI_STATE_SET_BT_COEX_VERSION, &version);
 		break;

--- a/sys/dev/cxgbe/common/t4_hw.c
+++ b/sys/dev/cxgbe/common/t4_hw.c
@@ -3253,7 +3253,7 @@ int t4_write_flash(struct adapter *adapter, unsigned int addr,
 	for (left = n; left; left -= c) {
 		c = min(left, 4U);
 		for (val = 0, i = 0; i < c; ++i)
-			val = (val << 8) + *data++;
+			val = (val << 8) | *data++;
 
 		if (!byte_oriented)
 			val = cpu_to_be32(val);

--- a/sys/dev/drm2/drm_edid.c
+++ b/sys/dev/drm2/drm_edid.c
@@ -683,7 +683,7 @@ drm_gtf2_m(struct edid *edid)
 {
 	u8 *r = NULL;
 	drm_for_each_detailed_block((u8 *)edid, find_gtf2, &r);
-	return r ? (r[15] << 8) + r[14] : 0;
+	return r ? (r[15] << 8) | r[14] : 0;
 }
 
 static int

--- a/sys/dev/isci/scil/sati_mode_select.c
+++ b/sys/dev/isci/scil/sati_mode_select.c
@@ -859,7 +859,7 @@ SATI_STATUS sati_mode_select_translate_command(
       else
       {
          //CDB byte 7 and 8 for Mode Select 10
-         data_transfer_length = (sati_get_cdb_byte(cdb, 7) << 8) + sati_get_cdb_byte(cdb, 8);
+         data_transfer_length = (sati_get_cdb_byte(cdb, 7) << 8) | sati_get_cdb_byte(cdb, 8);
       }
 
       sequence->allocation_length = data_transfer_length;

--- a/sys/dev/iwm/if_iwmreg.h
+++ b/sys/dev/iwm/if_iwmreg.h
@@ -6847,7 +6847,7 @@ iwm_cmd_version(uint32_t cmdid)
 static inline uint32_t
 iwm_cmd_id(uint8_t opcode, uint8_t groupid, uint8_t version)
 {
-	return opcode + (groupid << 8) + (version << 16);
+	return opcode | (groupid << 8) | (version << 16);
 }
 
 /* make uint16_t wide id out of uint8_t group and opcode */

--- a/sys/libkern/strcspn.c
+++ b/sys/libkern/strcspn.c
@@ -34,40 +34,23 @@ __FBSDID("$FreeBSD$");
 #include <sys/limits.h>
 
 #define	IDX(c)	((u_char)(c) / LONG_BIT)
-#define	BIT(c)	((u_long)1 << ((u_char)(c) % LONG_BIT))
+#define	BIT(c)	(1UL << ((u_char)(c) % LONG_BIT))
 
 size_t 
 strcspn(const char *s, const char *charset)
 {
-	/*
-	 * NB: idx and bit are temporaries whose use causes gcc 3.4.2 to
-	 * generate better code.  Without them, gcc gets a little confused.
-	 */
 	const char *s1;
-	u_long bit;
-	u_long tbl[(UCHAR_MAX + 1) / LONG_BIT];
-	int idx;
 
 	if(*s == '\0')
 		return (0);
 
-#if LONG_BIT == 64	/* always better to unroll on 64-bit architectures */
-	tbl[0] = 1;
-	tbl[3] = tbl[2] = tbl[1] = 0;
-#else
-	for (tbl[0] = idx = 1; idx < sizeof(tbl) / sizeof(tbl[0]); idx++)
-		tbl[idx] = 0;
-#endif
+	u_long tbl[(UCHAR_MAX + 1) / LONG_BIT] = {1}; // Rest of array is zeroes
 	for (; *charset != '\0'; charset++) {
-		idx = IDX(*charset);
-		bit = BIT(*charset);
-		tbl[idx] |= bit;
+		tbl[IDX(*charset)] |= BIT(*charset);
 	}
 
 	for(s1 = s; ; s1++) {
-		idx = IDX(*s1);
-		bit = BIT(*s1);
-		if ((tbl[idx] & bit) != 0)
+		if ((tbl[IDX(*s1)] & BIT(*s1)) != 0)
 			break;
 	}
 	return (s1 - s);

--- a/sys/libkern/strspn.c
+++ b/sys/libkern/strspn.c
@@ -34,39 +34,24 @@ __FBSDID("$FreeBSD$");
 #include <sys/types.h>
 
 #define	IDX(c)	((u_char)(c) / LONG_BIT)
-#define	BIT(c)	((u_long)1 << ((u_char)(c) % LONG_BIT))
+#define	BIT(c)	(1UL << ((u_char)(c) % LONG_BIT))
 
 size_t
 strspn(const char *s, const char *charset)
 {
-	/*
-	 * NB: idx and bit are temporaries whose use causes gcc 3.4.2 to
-	 * generate better code.  Without them, gcc gets a little confused.
-	 */
 	const char *s1;
-	u_long bit;
-	u_long tbl[(UCHAR_MAX + 1) / LONG_BIT];
-	int idx;
 
-	if(*s == '\0')
+	if (*s == '\0')
 		return (0);
 
-#if LONG_BIT == 64	/* always better to unroll on 64-bit architectures */
-	tbl[3] = tbl[2] = tbl[1] = tbl[0] = 0;
-#else
-	for (idx = 0; idx < sizeof(tbl) / sizeof(tbl[0]); idx++)
-		tbl[idx] = 0;
-#endif
+	u_long tbl[(UCHAR_MAX + 1) / LONG_BIT] = {0};
+
 	for (; *charset != '\0'; charset++) {
-		idx = IDX(*charset);
-		bit = BIT(*charset);
-		tbl[idx] |= bit;
+		tbl[IDX(*charset)] |= BIT(*charset);
 	}
 
-	for(s1 = s; ; s1++) {
-		idx = IDX(*s1);
-		bit = BIT(*s1);
-		if ((tbl[idx] & bit) == 0)
+	for (s1 = s; ; s1++) {
+		if ((tbl[IDX(*s1)] & BIT(*s1)) == 0)
 			break;
 	}
 	return (s1 - s);

--- a/sys/netgraph/ng_socket.c
+++ b/sys/netgraph/ng_socket.c
@@ -428,7 +428,7 @@ ngd_send(struct socket *so, int flags, struct mbuf *m, struct sockaddr *addr,
 	}
 
 	if (sap == NULL) {
-		len = 0;		/* Make compiler happy. */
+		goto noaddress;
 	} else {
 		if (sap->sg_len > NG_NODESIZ +
 		    offsetof(struct sockaddr_ng, sg_data)) {
@@ -442,7 +442,8 @@ ngd_send(struct socket *so, int flags, struct mbuf *m, struct sockaddr *addr,
 	 * If the user used any of these ways to not specify an address
 	 * then handle specially.
 	 */
-	if ((sap == NULL) || (len <= 0) || (*sap->sg_data == '\0')) {
+	if ((len <= 0) || (*sap->sg_data == '\0')) {
+noaddress:
 		if (NG_NODE_NUMHOOKS(pcbp->sockdata->node) != 1) {
 			error = EDESTADDRREQ;
 			goto release;

--- a/usr.sbin/bsnmpd/tools/libbsnmptools/bsnmpmap.c
+++ b/usr.sbin/bsnmpd/tools/libbsnmptools/bsnmpmap.c
@@ -503,14 +503,15 @@ snmp_table_insert(struct snmp_toolinfo *snmptoolctx,
 
 	if (snmptoolctx == NULL || snmptoolctx->mappings == NULL ||
 	    entry == NULL)
-		return(-1);
+		return (-1);
 
 	if ((prev = SLIST_FIRST(&snmptoolctx->snmp_tablelist)) == NULL ||
 	    asn_compare_oid(&(entry->var), &(prev->var)) < 0) {
 		SLIST_INSERT_HEAD(&snmptoolctx->snmp_tablelist, entry, link);
 		return (1);
-	} else
-		rc = -1;	/* Make the compiler happy. */
+	}
+
+	rc = -1;
 
 	SLIST_FOREACH(temp, &snmptoolctx->snmp_tablelist, link) {
 		if ((rc = asn_compare_oid(&(entry->var), &(temp->var))) <= 0)

--- a/usr.sbin/ppp/deflate.c
+++ b/usr.sbin/ppp/deflate.c
@@ -477,10 +477,10 @@ DeflateSetOptsInput(struct bundle *bundle __unused, struct fsm_opt *o,
   want = (o->data[0] >> 4) + 8;
   if (cfg->deflate.in.winsize == 0) {
     if (want < 8 || want > 15) {
-      o->data[0] = ((15 - 8) << 4) + 8;
+      o->data[0] = ((15 - 8) << 4) | 8;
     }
   } else if (want != cfg->deflate.in.winsize) {
-    o->data[0] = ((cfg->deflate.in.winsize - 8) << 4) + 8;
+    o->data[0] = ((cfg->deflate.in.winsize - 8) << 4) | 8;
     return MODE_NAK;
   }
 


### PR DESCRIPTION
Some code clearly was written to please the compiler and avoid a warning, as Werror is enabled, or trick older compilers into producing better code generation. However, the way this was achieved came at the cost of readability.

These hacks aren’t needed anymore and I have proposed much better solutions.