### PR TITLE
NanoBSD: Fix the pattern for changing PermitRootLogin

### DIFF
--- a/tools/tools/nanobsd/defaults.sh
+++ b/tools/tools/nanobsd/defaults.sh
@@ -728,7 +728,7 @@ cust_comconsole ( ) (
 # Allow root login via ssh
 
 cust_allow_ssh_root ( ) (
-	sed -i "" -e '/PermitRootLogin/s/.*/PermitRootLogin yes/' \
+	sed -i "" -E 's/^#?PermitRootLogin.*/PermitRootLogin yes/' \
 	    ${NANO_WORLDDIR}/etc/ssh/sshd_config
 )
 


### PR DESCRIPTION
The previous pattern had the (harmless) side-effect of duplicating the entry in the config file.

No functional change intended.