### PR TITLE
Convert isipv6 to bool since it is used as one

### DIFF
--- a/sys/netinet/tcp_output.c
+++ b/sys/netinet/tcp_output.c
@@ -229,9 +229,7 @@ tcp_default_output(struct tcpcb *tp)
 #endif
 #ifdef INET6
 	struct ip6_hdr *ip6 = NULL;
-	int isipv6;
-
-	isipv6 = (inp->inp_vflag & INP_IPV6) != 0;
+	const bool isipv6 = (inp->inp_vflag & INP_IPV6) != 0;
 #endif
 #ifdef KERN_TLS
 	const bool hw_tls = (so->so_snd.sb_flags & SB_TLS_IFNET) != 0;

--- a/sys/netinet/tcp_var.h
+++ b/sys/netinet/tcp_var.h
@@ -1271,7 +1271,7 @@ tcp_set_flags(struct tcphdr *th, uint16_t flags)
 
 static inline void
 tcp_account_for_send(struct tcpcb *tp, uint32_t len, uint8_t is_rxt,
-    uint8_t is_tlp, int hw_tls)
+    uint8_t is_tlp, bool hw_tls)
 {
 	if (is_tlp) {
 		tp->t_sndtlppack++;


### PR DESCRIPTION
I also removed an unused hw_tls struct member that I found was completely unused.