### PR TITLE
Optimize swab so that it can take any ssize_t value

### DIFF
--- a/lib/libc/string/swab.c
+++ b/lib/libc/string/swab.c
@@ -43,15 +43,16 @@ __FBSDID("$FreeBSD$");
 void
 swab(const void * __restrict from, void * __restrict to, ssize_t len)
 {
-	unsigned long temp;
-	int n;
-	char *fp, *tp;
+	unsigned char temp;
+	size_t n;
+	const unsigned char *fp;
+	unsigned char *tp;
 
 	if (len <= 0)
 		return;
-	n = len >> 1;
-	fp = (char *)from;
-	tp = (char *)to;
+	n  = (size_t)len >> 1;
+	fp = (const unsigned char *)from;
+	tp = (unsigned char *)to;
 #define	STEP	temp = *fp++,*tp++ = *fp++,*tp++ = temp
 	/* round to multiple of 8 */
 	for (; n & 0x7; --n)


### PR DESCRIPTION
Casting to int cuts off data on some platforms, resulting in the incorrect results for swab.