### PR TITLE
Update ftpd.c to use va_end()

### DIFF
--- a/libexec/ftpd/ftpd.c
+++ b/libexec/ftpd/ftpd.c
@@ -3345,6 +3345,7 @@ setproctitle(const char *fmt, ...)
 
 	va_start(ap, fmt);
 	(void)vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
 
 	/* make ps print our process name */
 	p = Argv[0];


### PR DESCRIPTION
va_start opened but not closed by va_end()

pointed out by cppcheck