### PR TITLE
Use C++ features and headers in C++ code instead of C

### DIFF
--- a/lib/csu/tests/cxx_constructors.cc
+++ b/lib/csu/tests/cxx_constructors.cc
@@ -35,25 +35,25 @@ __FBSDID("$FreeBSD$");
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#include <errno.h>
-#include <stdlib.h>
+#include <cerrno>
+#include <cstdlib>
 #include <unistd.h>
 
 #ifndef DSO_LIB
 #include <atf-c++.hpp>
 #endif
 
-extern volatile int constructor_run;
+extern volatile bool constructor_run;
 extern bool run_destructor_test;
 
 #ifndef DSO_BASE
-volatile int constructor_run;
+volatile bool constructor_run;
 bool run_destructor_test = false;
 #endif
 
 struct Foo {
 	Foo() {
-		constructor_run = 1;
+		constructor_run = false;
 	}
 	~Foo() {
 		if (run_destructor_test)
@@ -71,7 +71,7 @@ ATF_TEST_CASE_WITHOUT_HEAD(cxx_constructor);
 ATF_TEST_CASE_BODY(cxx_constructor)
 {
 
-	ATF_REQUIRE(constructor_run == 1);
+	ATF_REQUIRE(constructor_run);
 }
 
 ATF_TEST_CASE_WITHOUT_HEAD(cxx_destructor);

--- a/lib/libdevdctl/consumer.cc
+++ b/lib/libdevdctl/consumer.cc
@@ -40,11 +40,11 @@
 #include <sys/un.h>
 
 #include <err.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <syslog.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstdarg>
 #include <cstring>
 #include <list>
@@ -90,7 +90,7 @@ Consumer::~Consumer()
 }
 
 bool
-Consumer::ConnectToDevd()
+Consumer::ConnectToDevd() noexcept
 {
 	struct sockaddr_un devdAddr;
 	int		   sLen;
@@ -103,7 +103,7 @@ Consumer::ConnectToDevd()
 	}
 	syslog(LOG_INFO, "%s: Connecting to devd.", __func__);
 
-	memset(&devdAddr, 0, sizeof(devdAddr));
+	std::memset(&devdAddr, 0, sizeof(devdAddr));
 	devdAddr.sun_family= AF_UNIX;
 	strlcpy(devdAddr.sun_path, s_devdSockPath, sizeof(devdAddr.sun_path));
 	sLen = SUN_LEN(&devdAddr);
@@ -125,7 +125,7 @@ Consumer::ConnectToDevd()
 }
 
 void
-Consumer::DisconnectFromDevd()
+Consumer::DisconnectFromDevd() noexcept
 {
 	if (m_devdSockFD != -1) {
 		syslog(LOG_INFO, "Disconnecting from devd.");
@@ -135,7 +135,7 @@ Consumer::DisconnectFromDevd()
 }
 
 std::string
-Consumer::ReadEvent()
+Consumer::ReadEvent() noexcept
 {
 	char buf[MAX_EVENT_SIZE + 1];
 	ssize_t len;
@@ -151,7 +151,7 @@ Consumer::ReadEvent()
 }
 
 void
-Consumer::ReplayUnconsumedEvents(bool discardUnconsumed)
+Consumer::ReplayUnconsumedEvents(bool discardUnconsumed) noexcept
 {
 	EventList::iterator event(m_unconsumedEvents.begin());
 	bool replayed_any = (event != m_unconsumedEvents.end());
@@ -174,7 +174,7 @@ Consumer::ReplayUnconsumedEvents(bool discardUnconsumed)
 }
 
 bool
-Consumer::SaveEvent(const Event &event)
+Consumer::SaveEvent(const Event &event) noexcept
 {
         if (m_replayingEvents)
                 return (false);
@@ -183,7 +183,7 @@ Consumer::SaveEvent(const Event &event)
 }
 
 Event *
-Consumer::NextEvent()
+Consumer::NextEvent() noexcept
 {
 	if (!Connected())
 		return(NULL);
@@ -206,7 +206,7 @@ Consumer::NextEvent()
 
 /* Capture and process buffered events. */
 void
-Consumer::ProcessEvents()
+Consumer::ProcessEvents() noexcept
 {
 	Event *event;
 	while ((event = NextEvent()) != NULL) {
@@ -217,7 +217,7 @@ Consumer::ProcessEvents()
 }
 
 void
-Consumer::FlushEvents()
+Consumer::FlushEvents() noexcept
 {
 	std::string s;
 

--- a/lib/libdevdctl/consumer.h
+++ b/lib/libdevdctl/consumer.h
@@ -69,7 +69,7 @@ public:
 	/**                                                          
          * Queue an event for deferred processing or replay.
          */ 
-	bool SaveEvent(const Event &event);
+	bool SaveEvent(const Event &event) noexcept;
 
 	/**                                  
 	 * Reprocess any events saved via the SaveEvent() facility.   
@@ -77,18 +77,18 @@ public:
 	 * \param discardUnconsumed  If true, events that are not consumed
 	 *                           during replay are discarded.
 	 */                                                              
-	void ReplayUnconsumedEvents(bool discardUnconsumed);
+	void ReplayUnconsumedEvents(bool discardUnconsumed) noexcept;
 
 	/** Return an event, if one is available.  */
-	Event *NextEvent();
+	Event *NextEvent() noexcept;
 
 	/**
 	 * Extract events and invoke each event's Process method.
 	 */
-	void ProcessEvents();
+	void ProcessEvents() noexcept;
 
 	/** Discard all data pending in m_devdSockFD. */
-	void FlushEvents();
+	void FlushEvents() noexcept;
 
 	/**
 	 * Test for data pending in m_devdSockFD
@@ -103,12 +103,12 @@ public:
 	 * \return  True if the connection attempt is successsful.  Otherwise
 	 *          false.
 	 */
-	bool ConnectToDevd();
+	bool ConnectToDevd() noexcept;
 
 	/**
 	 * Close a connection (if any) to devd's unix domain socket.
 	 */
-	void DisconnectFromDevd();
+	void DisconnectFromDevd() noexcept;
 
 	EventFactory GetFactory();
 
@@ -120,7 +120,7 @@ protected:
 	 *
 	 * \returns      A string containing the record
 	 */
-	std::string ReadEvent();
+	std::string ReadEvent() noexcept;
 
 	enum {
 		/*

--- a/lib/libdevdctl/event.cc
+++ b/lib/libdevdctl/event.cc
@@ -44,13 +44,13 @@
 
 #include <err.h>
 #include <fcntl.h>
-#include <inttypes.h>
 #include <paths.h>
-#include <stdlib.h>
 #include <syslog.h>
 #include <unistd.h>
 
+#include <cinttypes>
 #include <cstdarg>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <list>
@@ -440,8 +440,8 @@ Event::TimestampEventString(std::string &eventString)
 			size_t eventEnd(eventString.find_last_not_of('\n') + 1);
 			if (gettimeofday(&now, NULL) != 0)
 				err(1, "gettimeofday");
-			snprintf(timebuf, bufsize, " timestamp=%" PRId64,
-				(int64_t) now.tv_sec);
+			std::snprintf(timebuf, bufsize, " timestamp=%" PRId64,
+				static_cast<int64_t>(now.tv_sec));
 			eventString.insert(eventEnd, timebuf);
 		}
 	}

--- a/lib/libdevdctl/guid.cc
+++ b/lib/libdevdctl/guid.cc
@@ -39,9 +39,9 @@
  */
 #include <sys/cdefs.h>
 
-#include <stdlib.h>
-#include <limits.h>
-#include <inttypes.h>
+#include <cstdlib>
+#include <climits>
+#include <cinttypes>
 
 #include <iostream>
 #include <string>
@@ -56,7 +56,7 @@ namespace DevdCtl
 
 /*=========================== Class Implementations ==========================*/
 /*----------------------------------- Guid -----------------------------------*/
-Guid::Guid(const string &guidString)
+Guid::Guid(const string &guidString) noexcept
 {
 	if (guidString.empty()) {
 		m_GUID = INVALID_GUID;
@@ -65,15 +65,15 @@ Guid::Guid(const string &guidString)
 		 * strtoumax() returns zero on conversion failure
 		 * which nicely matches our choice for INVALID_GUID.
 		 */
-		m_GUID = (uint64_t)strtoumax(guidString.c_str(), NULL, 0);
+		m_GUID = static_cast<uint64_t>(std::strtoumax(guidString.c_str(), NULL, 0));
 	}
 }
 
 std::ostream&
-operator<< (std::ostream& out, Guid g)
+operator<< (std::ostream& out, Guid g) noexcept
 {
 	if (g.IsValid())
-		out << (uint64_t)g;
+		out << static_cast<uint64_t>(g);
 	else
 		out << "None";
 	return (out);

--- a/lib/libdevdctl/guid.h
+++ b/lib/libdevdctl/guid.h
@@ -67,7 +67,7 @@ public:
 	/* Construct a guid from a provided integer */
 	Guid(uint64_t guid);
 	/* Construct a guid from a string in base 8, 10, or 16 */
-	Guid(const std::string &guid);
+	Guid(const std::string &guid) noexcept;
 	static Guid InvalidGuid();
 
 	/* Test the validity of this guid. */
@@ -138,7 +138,7 @@ Guid::operator bool() const
 }
 
 /** Convert the GUID into its string representation */
-std::ostream& operator<< (std::ostream& out, Guid g);
+std::ostream& operator<< (std::ostream& out, Guid g) noexcept;
 
 } // namespace DevdCtl
 #endif /* _DEVDCTL_GUID_H_ */

--- a/lib/libpmc/libpmc_json.cc
+++ b/lib/libpmc/libpmc_json.cc
@@ -30,20 +30,21 @@
 
 #include <sys/types.h>
 #include <sys/sysctl.h>
-#include <assert.h>
-#include <err.h>
-#include <errno.h>
-#include <limits.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <string>
-#include <sysexits.h>
 
+#include <err.h>
 #include <pmc.h>
 #include <pmcformat.h>
 #include <pmclog.h>
+#include <sysexits.h>
+
+#include <cassert>
+#include <cerrno>
+#include <climits>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
 
 using std::string;
 
@@ -72,54 +73,54 @@ static const char *typenames[] = {
 };
 
 static string
-startentry(struct pmclog_ev *ev)
+startentry(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[128];
 
-	snprintf(eventbuf, sizeof(eventbuf), "%s, \"tsc\": \"%jd\"",
-	    typenames[ev->pl_type], (uintmax_t)ev->pl_ts.tv_sec);
+	std::snprintf(eventbuf, sizeof(eventbuf), "%s, \"tsc\": \"%jd\"",
+	    typenames[ev->pl_type], static_cast<uintmax_t>(ev->pl_ts.tv_sec));
 	return (string(eventbuf));
 }
 
 static string
-initialize_to_json(struct pmclog_ev *ev)
+initialize_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[256];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 	    "%s, \"version\": \"0x%08x\", \"arch\": \"0x%08x\", \"cpuid\": \"%s\", "
 		"\"tsc_freq\": \"%jd\", \"sec\": \"%jd\", \"nsec\": \"%jd\"}\n",
 		startent.c_str(), ev->pl_u.pl_i.pl_version, ev->pl_u.pl_i.pl_arch,
-		ev->pl_u.pl_i.pl_cpuid, (uintmax_t)ev->pl_u.pl_i.pl_tsc_freq,
-		(uintmax_t)ev->pl_u.pl_i.pl_ts.tv_sec, (uintmax_t)ev->pl_u.pl_i.pl_ts.tv_nsec);
+		ev->pl_u.pl_i.pl_cpuid, static_cast<uintmax_t>(ev->pl_u.pl_i.pl_tsc_freq),
+		static_cast<uintmax_t>(ev->pl_u.pl_i.pl_ts.tv_sec), static_cast<uintmax_t>(ev->pl_u.pl_i.pl_ts.tv_nsec));
 	return string(eventbuf);
 }
 
 static string
-pmcallocate_to_json(struct pmclog_ev *ev)
+pmcallocate_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[256];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 	    "%s, \"pmcid\": \"0x%08x\", \"event\": \"0x%08x\", \"flags\": \"0x%08x\", "
 	    "\"rate\": \"%jd\"}\n",
 		startent.c_str(), ev->pl_u.pl_a.pl_pmcid, ev->pl_u.pl_a.pl_event,
-	    ev->pl_u.pl_a.pl_flags, (intmax_t)ev->pl_u.pl_a.pl_rate);
+	    ev->pl_u.pl_a.pl_flags, static_cast<intmax_t>(ev->pl_u.pl_a.pl_rate));
 	return string(eventbuf);
 }
 
 static string
-pmcattach_to_json(struct pmclog_ev *ev)
+pmcattach_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[2048];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 	    "%s, \"pmcid\": \"0x%08x\", \"pid\": \"%d\", \"pathname\": \"%s\"}\n",
 		startent.c_str(), ev->pl_u.pl_t.pl_pmcid, ev->pl_u.pl_t.pl_pid,
 	    ev->pl_u.pl_t.pl_pathname);
@@ -127,13 +128,13 @@ pmcattach_to_json(struct pmclog_ev *ev)
 }
 
 static string
-pmcdetach_to_json(struct pmclog_ev *ev)
+pmcdetach_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[128];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 		"%s, \"pmcid\": \"0x%08x\", \"pid\": \"%d\"}\n",
 			 startent.c_str(), ev->pl_u.pl_d.pl_pmcid, ev->pl_u.pl_d.pl_pid);
 	return string(eventbuf);
@@ -141,117 +142,117 @@ pmcdetach_to_json(struct pmclog_ev *ev)
 
 
 static string
-proccsw_to_json(struct pmclog_ev *ev)
+proccsw_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[128];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf), "%s, \"pmcid\": \"0x%08x\", \"pid\": \"%d\" "
+	std::snprintf(eventbuf, sizeof(eventbuf), "%s, \"pmcid\": \"0x%08x\", \"pid\": \"%d\" "
 	    "\"tid\": \"%d\", \"value\": \"0x%016jx\"}\n",
 		startent.c_str(), ev->pl_u.pl_c.pl_pmcid, ev->pl_u.pl_c.pl_pid,
-	    ev->pl_u.pl_c.pl_tid, (uintmax_t)ev->pl_u.pl_c.pl_value);
+	    ev->pl_u.pl_c.pl_tid, static_cast<uintmax_t>(ev->pl_u.pl_c.pl_value));
 	return string(eventbuf);
 }
 
 static string
-procexec_to_json(struct pmclog_ev *ev)
+procexec_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[2048];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 		"%s, \"pmcid\": \"0x%08x\", \"pid\": \"%d\", "
 	    "\"start\": \"0x%016jx\", \"pathname\": \"%s\"}\n",
 		startent.c_str(), ev->pl_u.pl_x.pl_pmcid, ev->pl_u.pl_x.pl_pid,
-		(uintmax_t)ev->pl_u.pl_x.pl_entryaddr, ev->pl_u.pl_x.pl_pathname);
+		static_cast<uintmax_t>(ev->pl_u.pl_x.pl_entryaddr), ev->pl_u.pl_x.pl_pathname);
 	return string(eventbuf);
 }
 
 static string
-procexit_to_json(struct pmclog_ev *ev)
+procexit_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[128];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 		"%s, \"pmcid\": \"0x%08x\", \"pid\": \"%d\", "
 	    "\"value\": \"0x%016jx\"}\n",
 		startent.c_str(), ev->pl_u.pl_e.pl_pmcid, ev->pl_u.pl_e.pl_pid,
-	    (uintmax_t)ev->pl_u.pl_e.pl_value);
+	    static_cast<uintmax_t>(ev->pl_u.pl_e.pl_value));
 	return string(eventbuf);
 }
 
 static string
-procfork_to_json(struct pmclog_ev *ev)
+procfork_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[128];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 		"%s, \"oldpid\": \"%d\", \"newpid\": \"%d\"}\n",
 		startent.c_str(), ev->pl_u.pl_f.pl_oldpid, ev->pl_u.pl_f.pl_newpid);
 	return string(eventbuf);
 }
 
 static string
-sysexit_to_json(struct pmclog_ev *ev)
+sysexit_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[128];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf), "%s, \"pid\": \"%d\"}\n",
+	std::snprintf(eventbuf, sizeof(eventbuf), "%s, \"pid\": \"%d\"}\n",
 		startent.c_str(), ev->pl_u.pl_se.pl_pid);
 	return string(eventbuf);
 }
 
 static string
-userdata_to_json(struct pmclog_ev *ev)
+userdata_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[128];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf), "%s, \"userdata\": \"0x%08x\"}\n",
+	std::snprintf(eventbuf, sizeof(eventbuf), "%s, \"userdata\": \"0x%08x\"}\n",
 	    startent.c_str(), ev->pl_u.pl_u.pl_userdata);
 	return string(eventbuf);
 }
 
 static string
-map_in_to_json(struct pmclog_ev *ev)
+map_in_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[2048];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf), "%s, \"pid\": \"%d\", "
+	std::snprintf(eventbuf, sizeof(eventbuf), "%s, \"pid\": \"%d\", "
 	    "\"start\": \"0x%016jx\", \"pathname\": \"%s\"}\n",
 	    startent.c_str(), ev->pl_u.pl_mi.pl_pid,
-	    (uintmax_t)ev->pl_u.pl_mi.pl_start, ev->pl_u.pl_mi.pl_pathname);
+	    static_cast<uintmax_t>(ev->pl_u.pl_mi.pl_start), ev->pl_u.pl_mi.pl_pathname);
 	return string(eventbuf);
 }
 
 static string
-map_out_to_json(struct pmclog_ev *ev)
+map_out_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[256];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf), "%s, \"pid\": \"%d\", "
+	std::snprintf(eventbuf, sizeof(eventbuf), "%s, \"pid\": \"%d\", "
 	    "\"start\": \"0x%016jx\", \"end\": \"0x%016jx\"}\n",
 	    startent.c_str(), ev->pl_u.pl_mi.pl_pid,
-	    (uintmax_t)ev->pl_u.pl_mi.pl_start,
-	    (uintmax_t)ev->pl_u.pl_mo.pl_end);
+	    static_cast<uintmax_t>(ev->pl_u.pl_mi.pl_start),
+	    static_cast<uintmax_t>(ev->pl_u.pl_mo.pl_end));
 	return string(eventbuf);
 }
 
 static string
-callchain_to_json(struct pmclog_ev *ev)
+callchain_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[1024];
 	string result;
@@ -259,29 +260,29 @@ callchain_to_json(struct pmclog_ev *ev)
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 	    "%s, \"pmcid\": \"0x%08x\", \"pid\": \"%d\", \"tid\": \"%d\", "
 	    "\"cpuflags\": \"0x%08x\", \"cpuflags2\": \"0x%08x\", \"pc\": [ ",
 		startent.c_str(), ev->pl_u.pl_cc.pl_pmcid, ev->pl_u.pl_cc.pl_pid,
 	    ev->pl_u.pl_cc.pl_tid, ev->pl_u.pl_cc.pl_cpuflags, ev->pl_u.pl_cc.pl_cpuflags2);
 	result = string(eventbuf);
 	for (i = 0; i < ev->pl_u.pl_cc.pl_npc - 1; i++) {
-		snprintf(eventbuf, sizeof(eventbuf), "\"0x%016jx\", ", (uintmax_t)ev->pl_u.pl_cc.pl_pc[i]);
+		std::snprintf(eventbuf, sizeof(eventbuf), "\"0x%016jx\", ", (uintmax_t)ev->pl_u.pl_cc.pl_pc[i]);
 		result += string(eventbuf);
 	}
-	snprintf(eventbuf, sizeof(eventbuf), "\"0x%016jx\"]}\n", (uintmax_t)ev->pl_u.pl_cc.pl_pc[i]);
+	std::snprintf(eventbuf, sizeof(eventbuf), "\"0x%016jx\"]}\n", (uintmax_t)ev->pl_u.pl_cc.pl_pc[i]);
 	result += string(eventbuf);
 	return (result);
 }
 
 static string
-pmcallocatedyn_to_json(struct pmclog_ev *ev)
+pmcallocatedyn_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[2048];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 	    "%s, \"pmcid\": \"0x%08x\", \"event\": \"%d\", \"flags\": \"0x%08x\", \"evname\": \"%s\"}\n",
 	    startent.c_str(), ev->pl_u.pl_ad.pl_pmcid, ev->pl_u.pl_ad.pl_event,
 	    ev->pl_u.pl_ad.pl_flags, ev->pl_u.pl_ad.pl_evname);
@@ -289,13 +290,13 @@ pmcallocatedyn_to_json(struct pmclog_ev *ev)
 }
 
 static string
-proccreate_to_json(struct pmclog_ev *ev)
+proccreate_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[2048];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 	    "%s, \"pid\": \"%d\", \"flags\": \"0x%08x\", \"pcomm\": \"%s\"}\n",
 	    startent.c_str(), ev->pl_u.pl_pc.pl_pid,
 	    ev->pl_u.pl_pc.pl_flags, ev->pl_u.pl_pc.pl_pcomm);
@@ -303,13 +304,13 @@ proccreate_to_json(struct pmclog_ev *ev)
 }
 
 static string
-threadcreate_to_json(struct pmclog_ev *ev)
+threadcreate_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[2048];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf),
+	std::snprintf(eventbuf, sizeof(eventbuf),
 	    "%s, \"tid\": \"%d\", \"pid\": \"%d\", \"flags\": \"0x%08x\", \"tdname\": \"%s\"}\n",
 	    startent.c_str(), ev->pl_u.pl_tc.pl_tid, ev->pl_u.pl_tc.pl_pid,
 	    ev->pl_u.pl_tc.pl_flags, ev->pl_u.pl_tc.pl_tdname);
@@ -317,19 +318,19 @@ threadcreate_to_json(struct pmclog_ev *ev)
 }
 
 static string
-threadexit_to_json(struct pmclog_ev *ev)
+threadexit_to_json(struct pmclog_ev *ev) noexcept
 {
 	char eventbuf[256];
 	string startent;
 
 	startent = startentry(ev);
-	snprintf(eventbuf, sizeof(eventbuf), "%s, \"tid\": \"%d\"}\n",
+	std::snprintf(eventbuf, sizeof(eventbuf), "%s, \"tid\": \"%d\"}\n",
 	    startent.c_str(), ev->pl_u.pl_te.pl_tid);
 	return string(eventbuf);
 }
 
 static string
-stub_to_json(struct pmclog_ev *ev)
+stub_to_json(struct pmclog_ev *ev) noexcept
 {
 	string startent;
 
@@ -365,7 +366,7 @@ static jconv jsonconvert[] = {
 };
 
 string
-event_to_json(struct pmclog_ev *ev){
+event_to_json(struct pmclog_ev *ev) noexcept {
 
 	switch (ev->pl_type) {
 	case PMCLOG_TYPE_DROPNOTIFY:

--- a/lib/libpmc/pmcformat.h
+++ b/lib/libpmc/pmcformat.h
@@ -29,5 +29,6 @@
  */
 #ifndef __PMCFORMAT_H_
 #define __PMCFORMAT_H_
-std::string event_to_json(struct pmclog_ev *ev);
+#include <string>
+std::string event_to_json(struct pmclog_ev *ev) noexcept;
 #endif

--- a/tests/sys/fs/fusefs/io.cc
+++ b/tests/sys/fs/fusefs/io.cc
@@ -30,15 +30,14 @@
  * $FreeBSD$
  */
 
-extern "C" {
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
 
 #include <fcntl.h>
-#include <stdlib.h>
 #include <unistd.h>
-}
+
+#include <cstdlib>
 
 #include "mockfs.hh"
 #include "utils.hh"
@@ -49,6 +48,7 @@ extern "C" {
  */
 
 using namespace testing;
+using namespace std;
 
 const char FULLPATH[] = "mountpoint/some_file.txt";
 const char RELPATH[] = "some_file.txt";
@@ -57,7 +57,7 @@ const uint64_t ino = 42;
 static void compare(const void *tbuf, const void *controlbuf, off_t baseofs,
 	ssize_t size)
 {
-	int i;
+	ssize_t i;
 
 	for (i = 0; i < size; i++) {
 		if (((const char*)tbuf)[i] != ((const char*)controlbuf)[i]) {

--- a/tests/sys/fs/fusefs/rename.cc
+++ b/tests/sys/fs/fusefs/rename.cc
@@ -29,16 +29,15 @@
  *
  * $FreeBSD$
  */
-
-extern "C" {
-#include <stdlib.h>
 #include <unistd.h>
-}
+
+#include <cstdlib>
 
 #include "mockfs.hh"
 #include "utils.hh"
 
 using namespace testing;
+using namespace std;
 
 class Rename: public FuseTest {
 	public:

--- a/tools/regression/pthread/unwind/Test.cpp
+++ b/tools/regression/pthread/unwind/Test.cpp
@@ -1,37 +1,37 @@
 /* $FreeBSD$ */
 
-static int destructed;
-static int destructed2;
+static bool destructed;
+static bool destructed2;
 
 class Test {
 public:
-	Test() { printf("Test::Test()\n"); }
-	~Test() { printf("Test::~Test()\n"); destructed = 1; }
+	Test() { std::printf("Test::Test()\n"); }
+	~Test() { std::printf("Test::~Test()\n"); destructed = true; }
 };
 
 void
-cleanup_handler(void *arg __unused)
+cleanup_handler(void *arg __unused) noexcept
 {
-	destructed2 = 1;
-	printf("%s()\n", __func__);
+	destructed2 = true;
+	std::printf("%s()\n", __func__);
 }
 
 void
-check_destruct(void)
+check_destruct(void) noexcept
 {
-	if (!destructed)
-		printf("Bug, object destructor is not called\n");
+	if (destructed)
+		std::printf("OK\n");
 	else
-		printf("OK\n");
+		std::printf("Bug, object destructor is not called\n");
 }
 
 void
-check_destruct2(void)
+check_destruct2(void) noexcept
 {
 	if (!destructed)
-		printf("Bug, object destructor is not called\n");
+		std::printf("Bug, object destructor is not called\n");
 	else if (!destructed2)
-		printf("Bug, cleanup handler is not called\n");
+		std::printf("Bug, cleanup handler is not called\n");
 	else
-		printf("OK\n");
+		std::printf("OK\n");
 }

--- a/tools/regression/pthread/unwind/catch_pthread_exit.cpp
+++ b/tools/regression/pthread/unwind/catch_pthread_exit.cpp
@@ -2,10 +2,8 @@
 /* try to catch thread exiting, and rethrow the exception */
 
 #include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
 
-static int caught;
+static bool caught;
 
 static void *
 thr_routine(void *arg __unused)
@@ -13,8 +11,8 @@ thr_routine(void *arg __unused)
 	try {
 		pthread_exit(NULL);
 	} catch (...) {
-		caught = 1;
-		printf("thread exiting exception caught\n");
+		caught = true;
+		std::printf("thread exiting exception caught\n");
 		/* rethrow */
 		throw;
 	}
@@ -28,8 +26,8 @@ main()
 	pthread_create(&td, NULL, thr_routine, NULL);
 	pthread_join(td, NULL);
 	if (caught)
-		printf("OK\n");
+		std::printf("OK\n");
 	else
-		printf("failure\n");
+		std::printf("failure\n");
 	return (0);
 }

--- a/tools/regression/pthread/unwind/cond_wait_cancel.cpp
+++ b/tools/regression/pthread/unwind/cond_wait_cancel.cpp
@@ -1,8 +1,8 @@
 /* $FreeBSD$ */
 /* Test stack unwinding for pthread_cond_wait function */
 
+#include <cstdio>
 #include <pthread.h>
-#include <stdio.h>
 #include <semaphore.h>
 #include <unistd.h>
 
@@ -12,19 +12,19 @@ static pthread_mutex_t mtx;
 static pthread_cond_t cv;
 
 static void *
-thr(void *arg __unused)
+thr(void *arg __unused) noexcept
 {
 	Test t;
 
 	pthread_mutex_lock(&mtx);
 	pthread_cond_wait(&cv, &mtx);
 	pthread_mutex_unlock(&mtx);
-	printf("Bug, thread shouldn't be here.\n");
+	std::printf("Bug, thread shouldn't be here.\n");
 	return (0);
 }
 
 int
-main()
+main() noexcept
 {
 	pthread_t td;
 

--- a/tools/regression/pthread/unwind/cond_wait_cancel2.cpp
+++ b/tools/regression/pthread/unwind/cond_wait_cancel2.cpp
@@ -6,8 +6,8 @@
  *
  */
 
+#include <cstdio>
 #include <pthread.h>
-#include <stdio.h>
 #include <semaphore.h>
 #include <unistd.h>
 

--- a/tools/regression/pthread/unwind/main_thread_exit.cpp
+++ b/tools/regression/pthread/unwind/main_thread_exit.cpp
@@ -1,9 +1,9 @@
 /* $FreeBSD$ */
 /* check unwinding for main thread */
 
+#include <cstdio>
+#include <cstdlib>
 #include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 #include "Test.cpp"
 

--- a/tools/regression/pthread/unwind/thread_normal_exit.cpp
+++ b/tools/regression/pthread/unwind/thread_normal_exit.cpp
@@ -1,9 +1,9 @@
 /* $FreeBSD$ */
 /* test stack unwinding for a new thread */
 
+#include <cstdio>
+#include <cstdlib>
 #include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 #include "Test.cpp"
 

--- a/tools/tools/mcgrab/mcgrab.cc
+++ b/tools/tools/mcgrab/mcgrab.cc
@@ -33,15 +33,15 @@
 __FBSDID("$FreeBSD$");
 
 // C++ STL and other related includes
-#include <stdlib.h>
-#include <limits.h>
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
-#include <string.h>
 #include <string>
 
 // Operating System and other C based includes
 #include <unistd.h>
-#include <errno.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/socket.h>

--- a/usr.bin/dtc/dtb.cc
+++ b/usr.bin/dtc/dtb.cc
@@ -34,11 +34,12 @@
 
 #include "dtb.hh"
 #include <sys/types.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
-#include <errno.h>
+
+#include <cerrno>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
 
 using std::string;
 
@@ -58,7 +59,7 @@ void write(dtc::byte_buffer &buffer, int fd)
 		}
 		else if (errno != EAGAIN)
 		{
-			fprintf(stderr, "Writing to file failed\n");
+			std::fprintf(stderr, "Writing to file failed\n");
 			exit(-1);
 		}
 	}
@@ -72,7 +73,7 @@ namespace dtb
 
 void output_writer::write_data(byte_buffer b)
 {
-	for (auto i : b)
+	for (const auto i : b)
 	{
 		write_data(i);
 	}
@@ -144,7 +145,7 @@ asm_writer::write_byte(uint8_t b)
 		buffer.push_back('\t');
 	}
 	write_string(".byte 0x");
-	snprintf(out, 3, "%.2hhx", b);
+	std::snprintf(out, 3, "%.2hhx", b);
 	buffer.push_back(out[0]);
 	buffer.push_back(out[1]);
 	if (byte_count == 4)
@@ -188,7 +189,7 @@ asm_writer::write_string(const char *c)
 {
 	while (*c)
 	{
-		buffer.push_back((uint8_t)*(c++));
+		buffer.push_back(static_cast<uint8_t>(*(c++)));
 	}
 }
 
@@ -287,12 +288,12 @@ header::read_dtb(input_buffer &input)
 {
 	if (!input.consume_binary(magic))
 	{
-		fprintf(stderr, "Missing magic token in header.");
+		std::fprintf(stderr, "Missing magic token in header.");
 		return false;
 	}
 	if (magic != 0xd00dfeed)
 	{
-		fprintf(stderr, "Bad magic token in header.  Got %" PRIx32
+		std::fprintf(stderr, "Bad magic token in header.  Got %" PRIx32
 		                " expected 0xd00dfeed\n", magic);
 		return false;
 	}
@@ -330,7 +331,7 @@ string_table::write(dtb::output_writer &writer)
 {
 	writer.write_comment("Strings table.");
 	writer.write_label("dt_strings_start");
-	for (auto &i : strings)
+	for (const auto &i : strings)
 	{
 		writer.write_string(i);
 	}

--- a/usr.bin/dtc/dtc.cc
+++ b/usr.bin/dtc/dtc.cc
@@ -35,13 +35,13 @@
 #include <sys/resource.h>
 #include <fcntl.h>
 #include <libgen.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
 #include <unistd.h>
 
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 #include "fdt.hh"
 #include "checking.hh"
@@ -55,22 +55,22 @@ namespace {
 /**
  * The current major version of the tool.
  */
-int version_major = 0;
-int version_major_compatible = 1;
+constexpr int version_major = 0;
+constexpr int version_major_compatible = 1;
 /**
  * The current minor version of the tool.
  */
-int version_minor = 5;
-int version_minor_compatible = 4;
+constexpr int version_minor = 5;
+constexpr int version_minor_compatible = 4;
 /**
  * The current patch level of the tool.
  */
-int version_patch = 0;
-int version_patch_compatible = 7;
+constexpr int version_patch = 0;
+constexpr int version_patch_compatible = 7;
 
-void usage(const string &argv0)
+void usage(const string &argv0) noexcept
 {
-	fprintf(stderr, "Usage:\n"
+	std::fprintf(stderr, "Usage:\n"
 		"\t%s\t[-fhsv@] [-b boot_cpu_id] [-d dependency_file]"
 			"[-E [no-]checker_name]\n"
 		"\t\t[-H phandle_format] [-I input_format]"
@@ -83,9 +83,9 @@ void usage(const string &argv0)
 /**
  * Prints the current version of this program..
  */
-void version(const char* progname)
+void version(const char* progname) noexcept
 {
-	fprintf(stdout, "Version: %s %d.%d.%d compatible with gpl dtc %d.%d.%d\n", progname,
+	std::fprintf(stdout, "Version: %s %d.%d.%d compatible with gpl dtc %d.%d.%d\n", progname,
 		version_major, version_minor, version_patch,
 		version_major_compatible, version_minor_compatible,
 		version_patch_compatible);
@@ -148,7 +148,7 @@ main(int argc, char **argv)
 			}
 			else
 			{
-				fprintf(stderr, "Unknown input format: %s\n", optarg);
+				std::fprintf(stderr, "Unknown input format: %s\n", optarg);
 				return EXIT_FAILURE;
 			}
 			break;
@@ -174,7 +174,7 @@ main(int argc, char **argv)
 			}
 			else
 			{
-				fprintf(stderr, "Unknown output format: %s\n", optarg);
+				std::fprintf(stderr, "Unknown output format: %s\n", optarg);
 				return EXIT_FAILURE;
 			}
 			break;
@@ -182,7 +182,7 @@ main(int argc, char **argv)
 		case 'o':
 		{
 			outfile_name = optarg;
-			if (strcmp(outfile_name, "-") != 0)
+			if (std::strcmp(outfile_name, "-") != 0)
 			{
 				outfile = open(optarg, O_CREAT | O_TRUNC | O_WRONLY, 0666);
 				if (outfile == -1)
@@ -199,7 +199,7 @@ main(int argc, char **argv)
 		case 'V':
 			if (string(optarg) != "17")
 			{
-				fprintf(stderr, "Unknown output format version: %s\n", optarg);
+				std::fprintf(stderr, "Unknown output format version: %s\n", optarg);
 				return EXIT_FAILURE;
 			}
 			break;
@@ -207,7 +207,7 @@ main(int argc, char **argv)
 		{
 			if (depfile != 0)
 			{
-				fclose(depfile);
+				std::fclose(depfile);
 			}
 			if (string(optarg) == "-")
 			{
@@ -241,7 +241,7 @@ main(int argc, char **argv)
 			}
 			else
 			{
-				fprintf(stderr, "Unknown phandle format: %s\n", optarg);
+				std::fprintf(stderr, "Unknown phandle format: %s\n", optarg);
 				return EXIT_FAILURE;
 			}
 			break;
@@ -249,7 +249,7 @@ main(int argc, char **argv)
 		case 'b':
 			// Don't bother to check if strtoll fails, just
 			// use the 0 it returns.
-			boot_cpu = (uint32_t)strtoll(optarg, 0, 10);
+			boot_cpu = static_cast<uint32_t>(strtoll(optarg, 0, 10));
 			boot_cpu_specified = true;
 			break;
 		case 'f':
@@ -259,18 +259,18 @@ main(int argc, char **argv)
 		case 'E':
 		{
 			string arg(optarg);
-			if ((arg.size() > 3) && (strncmp(optarg, "no-", 3) == 0))
+			if ((arg.size() > 3) && (std::strncmp(optarg, "no-", 3) == 0))
 			{
 				arg = string(optarg+3);
 				if (!checks.disable_checker(arg))
 				{
-					fprintf(stderr, "Checker %s either does not exist or is already disabled\n", optarg+3);
+					std::fprintf(stderr, "Checker %s either does not exist or is already disabled\n", optarg+3);
 				}
 				break;
 			}
 			if (!checks.enable_checker(arg))
 			{
-				fprintf(stderr, "Checker %s either does not exist or is already enabled\n", optarg);
+				std::fprintf(stderr, "Checker %s either does not exist or is already enabled\n", optarg);
 			}
 			break;
 		}
@@ -299,7 +299,7 @@ main(int argc, char **argv)
 		case 'P':
 			if (!tree.parse_define(optarg))
 			{
-				fprintf(stderr, "Invalid predefine value %s\n",
+				std::fprintf(stderr, "Invalid predefine value %s\n",
 				        optarg);
 			}
 			break;
@@ -325,9 +325,9 @@ main(int argc, char **argv)
 	}
 	if (depfile != 0)
 	{
-		fputs(outfile_name, depfile);
-		fputs(": ", depfile);
-		fputs(in_file, depfile);
+		std::fputs(outfile_name, depfile);
+		std::fputs(": ", depfile);
+		std::fputs(in_file, depfile);
 	}
 	clock_t c1 = clock();
 	(tree.*read_fn)(in_file, depfile);
@@ -342,12 +342,12 @@ main(int argc, char **argv)
 	}
 	if (depfile != 0)
 	{
-		putc('\n', depfile);
-		fclose(depfile);
+		std::putc('\n', depfile);
+		std::fclose(depfile);
 	}
 	if (!(tree.is_valid() || keep_going))
 	{
-		fprintf(stderr, "Failed to parse tree.\n");
+		std::fprintf(stderr, "Failed to parse tree.\n");
 		return EXIT_FAILURE;
 	}
 	clock_t c2 = clock();
@@ -365,19 +365,17 @@ main(int argc, char **argv)
 		struct rusage r;
 
 		getrusage(RUSAGE_SELF, &r);
-		fprintf(stderr, "Peak memory usage: %ld bytes\n", r.ru_maxrss);
-		fprintf(stderr, "Setup and option parsing took %f seconds\n",
+		std::fprintf(stderr, "Peak memory usage: %ld bytes\n", r.ru_maxrss);
+		std::fprintf(stderr, "Setup and option parsing took %f seconds\n",
 				((double)(c1-c0))/CLOCKS_PER_SEC);
-		fprintf(stderr, "Parsing took %f seconds\n",
+		std::fprintf(stderr, "Parsing took %f seconds\n",
 				((double)(c2-c1))/CLOCKS_PER_SEC);
-		fprintf(stderr, "Checking took %f seconds\n",
+		std::fprintf(stderr, "Checking took %f seconds\n",
 				((double)(c3-c2))/CLOCKS_PER_SEC);
-		fprintf(stderr, "Generating output took %f seconds\n",
+		std::fprintf(stderr, "Generating output took %f seconds\n",
 				((double)(c4-c3))/CLOCKS_PER_SEC);
-		fprintf(stderr, "Total time: %f seconds\n",
+		std::fprintf(stderr, "Total time: %f seconds\n",
 				((double)(c4-c0))/CLOCKS_PER_SEC);
-		// This is not needed, but keeps valgrind quiet.
-		fclose(stdin);
 	}
 	return EXIT_SUCCESS;
 }

--- a/usr.bin/dtc/input_buffer.cc
+++ b/usr.bin/dtc/input_buffer.cc
@@ -33,22 +33,20 @@
  */
 
 #include "input_buffer.hh"
-#include <ctype.h>
-#include <errno.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cctype>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <functional>
 #ifndef NDEBUG
 #include <iostream>
 #endif
 #include <limits>
 
-
 #include <sys/stat.h>
 #include <sys/mman.h>
-#include <assert.h>
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -133,7 +131,7 @@ mmap_input_buffer::~mmap_input_buffer()
 stream_input_buffer::stream_input_buffer() : input_buffer(0, 0)
 {
 	int c;
-	while ((c = fgetc(stdin)) != EOF)
+	while ((c = std::fgetc(stdin)) != EOF)
 	{
 		b.push_back(c);
 	}
@@ -229,7 +227,7 @@ text_input_buffer::handle_include()
 	auto include_buffer = input_buffer::buffer_for_file(include_file, false);
 	if (include_buffer == 0)
 	{
-		for (auto i : include_paths)
+		for (const auto &i : include_paths)
 		{
 			include_file = i + '/' + file;
 			include_buffer = input_buffer::buffer_for_file(include_file, false);
@@ -271,7 +269,7 @@ bool text_input_buffer::read_binary_file(const std::string &filename, byte_buffe
 	auto include_buffer = input_buffer::buffer_for_file(include_file, false);
 	if (include_buffer == 0 && try_include_paths)
 	{
-		for (auto i : include_paths)
+		for (const auto &i : include_paths)
 		{
 			include_file = i + '/' + filename;
 			include_buffer = input_buffer::buffer_for_file(include_file, false);
@@ -287,8 +285,8 @@ bool text_input_buffer::read_binary_file(const std::string &filename, byte_buffe
 	}
 	if (depfile)
 	{
-		putc(' ', depfile);
-		fputs(include_file.c_str(), depfile);
+		std::putc(' ', depfile);
+		std::fputs(include_file.c_str(), depfile);
 	}
 	b.insert(b.begin(), include_buffer->begin(), include_buffer->end());
 	return true;
@@ -1248,7 +1246,7 @@ input_buffer::buffer_for_file(const string &path, bool warn)
 	{
 		if (warn)
 		{
-			fprintf(stderr, "Unable to open file '%s'.  %s\n", path.c_str(), strerror(errno));
+			std::fprintf(stderr, "Unable to open file '%s'.  %s\n", path.c_str(), strerror(errno));
 		}
 		return 0;
 	}
@@ -1257,7 +1255,7 @@ input_buffer::buffer_for_file(const string &path, bool warn)
 	{
 		if (warn)
 		{
-			fprintf(stderr, "File %s is a directory\n", path.c_str());
+			std::fprintf(stderr, "File %s is a directory\n", path.c_str());
 		}
 		close(source);
 		return 0;

--- a/usr.sbin/pmc/cmd_pmc_filter.cc
+++ b/usr.sbin/pmc/cmd_pmc_filter.cc
@@ -41,29 +41,30 @@ __FBSDID("$FreeBSD$");
 #include <sys/user.h>
 #include <sys/wait.h>
 
-#include <assert.h>
 #include <curses.h>
 #include <err.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <kvm.h>
 #include <libgen.h>
-#include <limits.h>
-#include <locale.h>
-#include <math.h>
 #include <pmc.h>
 #include <pmclog.h>
 #include <regex.h>
-#include <signal.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stddef.h>
-#include <string.h>
 #include <sysexits.h>
 #include <unistd.h>
+
+#include <cassert>
+#include <cerrno>
+#include <climits>
+#include <clocale>
+#include <cmath>
+#include <csignal>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstddef>
+#include <cstring>
 
 #include <libpmcstat.h>
 #include "cmd_pmc.h"

--- a/usr.sbin/pmc/cmd_pmc_summary.cc
+++ b/usr.sbin/pmc/cmd_pmc_summary.cc
@@ -41,29 +41,30 @@ __FBSDID("$FreeBSD$");
 #include <sys/user.h>
 #include <sys/wait.h>
 
-#include <assert.h>
 #include <curses.h>
 #include <err.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <kvm.h>
 #include <libgen.h>
-#include <limits.h>
-#include <locale.h>
-#include <math.h>
 #include <pmc.h>
 #include <pmclog.h>
 #include <regex.h>
-#include <signal.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stddef.h>
-#include <string.h>
 #include <sysexits.h>
 #include <unistd.h>
+
+#include <cassert>
+#include <cerrno>
+#include <climits>
+#include <clocale>
+#include <cmath>
+#include <csignal>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstddef>
+#include <cstring>
 
 #include <libpmcstat.h>
 #include "cmd_pmc.h"
@@ -82,7 +83,7 @@ typedef std::pair<uint64_t, std::string> samplename;
 typedef unordered_map <uint32_t, std::vector<samplename>> eventcountmap;
 
 static void __dead2
-usage(void)
+usage(void) noexcept
 {
 	errx(EX_USAGE,
 	    "\t summarize log file\n"
@@ -91,7 +92,7 @@ usage(void)
 }
 
 static int
-pmc_summary_handler(int logfd, int k, bool do_full)
+pmc_summary_handler(int logfd, int k, bool do_full) noexcept
 {
 	struct pmclog_parse_state *ps;
 	struct pmclog_ev ev;
@@ -165,7 +166,7 @@ pmc_summary_handler(int logfd, int k, bool do_full)
 		auto &name = eventnamemap[kv.first];
 		auto rate = ratemap[kv.first];
 		std::cout << name << ":" << std::endl;
-		for (auto i = 0; i < k; i++) {
+		for (auto i = k; i > 0; i--) {
 			auto largest = kv.second.back();
 			kv.second.pop_back();
 			std::cout << "\t" << largest.second << ": " << largest.first*rate << std::endl;
@@ -180,7 +181,7 @@ static struct option longopts[] = {
 	{NULL, 0, NULL, 0}
 };
 
-int
+extern "C" int
 cmd_pmc_summary(int argc, char **argv)
 {
 	int option, logfd, k;
@@ -188,13 +189,14 @@ cmd_pmc_summary(int argc, char **argv)
 
 	do_full = false;
 	k = 5;
-	while ((option = getopt_long(argc, argv, "k:f", longopts, NULL)) != -1) {
+	while (
+	    (option = getopt_long(argc, argv, "k:f", longopts, NULL)) != -1) {
 		switch (option) {
 		case 'f':
-			do_full = 1;
+			do_full = true;
 			break;
 		case 'k':
-			k = atoi(optarg);
+			k = std::atoi(optarg);
 			break;
 		case '?':
 		default:
@@ -204,15 +206,15 @@ cmd_pmc_summary(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 	if (argc != 1) {
-		printf("argc: %d\n", argc);
+		std::printf("argc: %d\n", argc);
 		for (int i = 0; i < argc; i++)
-			printf("%s\n", argv[i]);
+			std::printf("%s\n", argv[i]);
 		usage();
 	}
 	if ((logfd = open(argv[0], O_RDONLY,
-	    S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) < 0)
-		errx(EX_OSERR, "ERROR: Cannot open \"%s\" for reading: %s.", argv[0],
-		    strerror(errno));
+		 S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) < 0)
+		errx(EX_OSERR, "ERROR: Cannot open \"%s\" for reading: %s.",
+		    argv[0], std::strerror(errno));
 
 	return (pmc_summary_handler(logfd, k, do_full));
 }


### PR DESCRIPTION
We don’t need to use integers as booleans or the C standard headers when we have the C++ standard headers and booleans