### PR TITLE
Switch to -O3 flags

### DIFF
--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -166,7 +166,7 @@ CC		?=	c89
 CFLAGS		?=	-O
 .else
 CC		?=	cc
-CFLAGS		?=	-O2 -pipe
+CFLAGS		?=	-O3 -pipe
 .if defined(NO_STRICT_ALIASING)
 CFLAGS		+=	-fno-strict-aliasing
 .endif

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -58,7 +58,7 @@ _COPTFLAGS_EXTRA=-frename-registers
 .else
 _COPTFLAGS_EXTRA=
 .endif
-COPTFLAGS?=-O2 -pipe ${_COPTFLAGS_EXTRA}
+COPTFLAGS?=-O3 -pipe ${_COPTFLAGS_EXTRA}
 .if !empty(COPTFLAGS:M-O[23s]) && empty(COPTFLAGS:M-fno-strict-aliasing)
 COPTFLAGS+= -fno-strict-aliasing
 .endif

--- a/sys/modules/linux/Makefile
+++ b/sys/modules/linux/Makefile
@@ -66,7 +66,7 @@ VDSOFLAGS=-mregparm=0
 .endif
 
 linux${SFX}_locore.o: linux${SFX}_assym.h assym.inc
-	${CC} -c -x assembler-with-cpp -DLOCORE -fPIC -pipe -O2 -Werror \
+	${CC} -c -x assembler-with-cpp -DLOCORE -fPIC -pipe -O3 -Werror \
 	-msoft-float \
 	-fno-common -nostdinc -fasynchronous-unwind-tables \
 	-fno-omit-frame-pointer -foptimize-sibling-calls ${VDSOFLAGS} \
@@ -74,7 +74,7 @@ linux${SFX}_locore.o: linux${SFX}_assym.h assym.inc
 	    ${.IMPSRC} -o ${.TARGET}
 
 linux${SFX}_vdso_gtod.o: linux_vdso_gtod.inc ${VDSODEPS}
-	${CC} -c -fPIC -pipe -O2 -Werror -msoft-float \
+	${CC} -c -fPIC -pipe -O3 -Werror -msoft-float \
 	-fno-common -nostdinc -fasynchronous-unwind-tables \
 	-fno-omit-frame-pointer -foptimize-sibling-calls ${VDSOFLAGS} \
 	-fno-stack-protector -I. -I${SYSDIR} -I${SRCTOP}/include \

--- a/sys/modules/linux64/Makefile
+++ b/sys/modules/linux64/Makefile
@@ -41,14 +41,14 @@ VDSOFLAGS=-mgeneral-regs-only -mcmodel=small -ffixed-x18
 
 linux_locore.o: linux_assym.h assym.inc
 	${CC} -c -x assembler-with-cpp -DLOCORE \
-	-fPIC -pipe -O2 -Werror ${VDSOFLAGS} \
+	-fPIC -pipe -O3 -Werror ${VDSOFLAGS} \
 	-nostdinc -fasynchronous-unwind-tables \
 	-fno-omit-frame-pointer -foptimize-sibling-calls \
 	-fno-stack-protector -I. -I${SYSDIR} -I${SRCTOP}/include \
 	    ${.IMPSRC} -o ${.TARGET}
 
 linux_vdso_gtod.o: linux_vdso_gtod.inc ${VDSODEPS}
-	${CC} -c -fPIC -pipe -O2 -Werror ${VDSOFLAGS} \
+	${CC} -c -fPIC -pipe -O3 -Werror ${VDSOFLAGS} \
 	-nostdinc -fasynchronous-unwind-tables \
 	-fno-omit-frame-pointer -foptimize-sibling-calls \
 	-fno-stack-protector -I. -I${SYSDIR} -I${SRCTOP}/include \

--- a/tools/regression/capsicum/syscalls/Makefile
+++ b/tools/regression/capsicum/syscalls/Makefile
@@ -2,7 +2,7 @@
 
 SYSCALLS=	cap_fcntls_limit cap_getmode cap_ioctls_limit
 
-CFLAGS=		-O2 -pipe -std=gnu99 -fstack-protector
+CFLAGS=		-O3 -pipe -std=gnu99 -fstack-protector
 CFLAGS+=	-Wsystem-headers -Werror -Wall -Wno-format-y2k -W -Wno-unused-parameter
 CFLAGS+=	-Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wreturn-type
 CFLAGS+=	-Wcast-qual -Wwrite-strings -Wswitch -Wshadow -Wunused-parameter


### PR DESCRIPTION
-O2 is good, but I don't see why -O3 is not supported, especially since all tests pass now on -O3.