### PR TITLE
Use unsigned char for mempcpy because unsigned char is a byte according to the C standard

### DIFF
--- a/lib/libc/string/mempcpy.c
+++ b/lib/libc/string/mempcpy.c
@@ -37,5 +37,5 @@ __FBSDID("$FreeBSD$");
 void *
 mempcpy(void *__restrict dst, const void *__restrict src, size_t len)
 {
-	return ((char *)memcpy(dst, src, len) + len);
+	return ((unsigned char *)memcpy(dst, src, len) + len);
 }


### PR DESCRIPTION
Also: mem functions: deal with unsigned numbers

str: deal with signed numbers