### PR TITLE
Don't reset aac_reset_adapter on timedout

### DIFF
--- a/sys/dev/aacraid/aacraid.c
+++ b/sys/dev/aacraid/aacraid.c
@@ -2184,8 +2184,13 @@ aac_timeout(struct aac_softc *sc)
 		}
 	}
 
-	if (timedout) 
-		aac_reset_adapter(sc);
+    if (timedout)
+        /*
+         * Resetting the adapter causes FreeNAS 11.x/12.x to panic with a "command not in queue" error.
+         * Let's not reset the adapter and carry on as if nothing happened.
+         * This is the command we are leaving out:
+         * aac_reset_adapter(sc);
+         */
 	aacraid_print_queues(sc);
 }
 


### PR DESCRIPTION
Credit for this change goes to `SilverNetworks` from https://www.truenas.com/community/threads/idle-reboot-bug-aacraid0-command-0xfffffe00007bdfa0-timeout-after-3857-seconds-shutting-down-controller-done.86761/

The premise of the problem is that if for some reason a disk device behind the aacraid driver isn't sending/receiving any IO, then the `timedout` condition triggers and the call to `aac_reset_adapter(sc)` causes the FreeBSD system to lock up.

This leads to a lot of unintentional behavior, for example in my personal usecase a hard drive sitting behind this raid controller failed a S.M.A.R.T. check. Since the S.M.A.R.T check failed FreeBSD stopped writing/reading data from the disk (as it should) however this invariably trigger the `timedout` which then caused the system to hang. You experience the same problem if for whatever other reason you don't write/read from a disk behind the raid controller (i.e. you have some disks sitting in the system and they aren't mounted but still recognized).