### PR TITLE
rc: Fix firstboot fs mount logic

### DIFF
--- a/libexec/rc/rc
+++ b/libexec/rc/rc
@@ -137,16 +137,16 @@ done
 # Note: this assumes firstboot_sentinel is on / when we have
 # a read-only /, or that it is on media that's writable.
 if [ -e ${firstboot_sentinel} ]; then
-    	checkyesno root_rw_mount && mount -uw /
+	checkyesno root_rw_mount && mount -uw /
 	chflags -R 0 ${firstboot_sentinel}
 	rm -rf ${firstboot_sentinel}
 	if [ -e ${firstboot_sentinel}-reboot ]; then
 		chflags -R 0 ${firstboot_sentinel}-reboot
 		rm -rf ${firstboot_sentinel}-reboot
-    		checkyesno root_rw_mount || mount -ur /
+		checkyesno root_rw_mount || mount -ur /
 		kill -INT 1
 	fi
-    	checkyesno root_rw_mount || mount -ur /
+	checkyesno root_rw_mount || mount -ur /
 fi
 
 echo ''

--- a/libexec/rc/rc
+++ b/libexec/rc/rc
@@ -137,7 +137,7 @@ done
 # Note: this assumes firstboot_sentinel is on / when we have
 # a read-only /, or that it is on media that's writable.
 if [ -e ${firstboot_sentinel} ]; then
-	checkyesno root_rw_mount && mount -uw /
+	checkyesno root_rw_mount || mount -uw /
 	chflags -R 0 ${firstboot_sentinel}
 	rm -rf ${firstboot_sentinel}
 	if [ -e ${firstboot_sentinel}-reboot ]; then


### PR DESCRIPTION
This change was introduced in 40adda8665bbcda1bad7e3a6a3c1031027faf39a, and partially fixed in 1ce07411fae8986f3acc293c9fb9ebee5211056a.

Restore the ability to remove the `firstboot_sentinel` file on read-only mounted file systems.
