### PR TITLE
Enable rc.d/jail within jails

### DIFF
--- a/libexec/rc/rc.d/jail
+++ b/libexec/rc/rc.d/jail
@@ -6,7 +6,7 @@
 # PROVIDE: jail
 # REQUIRE: LOGIN FILESYSTEMS
 # BEFORE: securelevel
-# KEYWORD: nojail shutdown
+# KEYWORD: shutdown
 
 . /etc/rc.subr
 


### PR DESCRIPTION
Jails within jails is a supported. This change allows the script to run
upon startup with a jail. Without this, jails are not automatically
started within jails.