### PR TITLE
Fix compiler warnings about variable types in libcrypt

### DIFF
--- a/lib/libcrypt/crypt-nthash.c
+++ b/lib/libcrypt/crypt-nthash.c
@@ -52,15 +52,15 @@ int
 crypt_nthash(const char *pw, const char *salt __unused, char *buffer)
 {
 	size_t unipwLen;
-	int i;
-	static const char hexconvtab[] = "0123456789abcdef";
+	u_int i;
+	static const char *hexconvtab = "0123456789abcdef";
 	static const char *magic = "$3$";
 	u_int16_t unipw[128];
 	u_char hash[MD4_SIZE];
 	const char *s;
 	MD4_CTX	ctx;
   
-	bzero(unipw, sizeof(unipw)); 
+	memset(unipw, 0, sizeof(unipw));
 	/* convert to unicode (thanx Archie) */
 	unipwLen = 0;
 	for (s = pw; unipwLen < sizeof(unipw) / 2 && *s; s++)

--- a/lib/libcrypt/crypt-sha256.c
+++ b/lib/libcrypt/crypt-sha256.c
@@ -132,7 +132,7 @@ crypt_sha256(const char *key, const char *salt, char *buffer)
 	/* Take the binary representation of the length of the key and for
 	 * every 1 add the alternate sum, for every 0 the key. */
 	for (cnt = key_len; cnt > 0; cnt >>= 1)
-		if ((cnt & 1) != 0)
+		if ((cnt & 1) == 1)
 			SHA256_Update(&ctx, alt_result, 32);
 		else
 			SHA256_Update(&ctx, key, key_len);
@@ -183,21 +183,21 @@ crypt_sha256(const char *key, const char *salt, char *buffer)
 		SHA256_Init(&ctx);
 
 		/* Add key or last result. */
-		if ((cnt & 1) != 0)
+		if ((cnt & 1) == 1)
 			SHA256_Update(&ctx, p_bytes, key_len);
 		else
 			SHA256_Update(&ctx, alt_result, 32);
 
 		/* Add salt for numbers not divisible by 3. */
-		if (cnt % 3 != 0)
+		if (cnt % 3)
 			SHA256_Update(&ctx, s_bytes, salt_len);
 
 		/* Add key for numbers not divisible by 7. */
-		if (cnt % 7 != 0)
+		if (cnt % 7)
 			SHA256_Update(&ctx, p_bytes, key_len);
 
 		/* Add key or last result. */
-		if ((cnt & 1) != 0)
+		if ((cnt & 1) == 1)
 			SHA256_Update(&ctx, alt_result, 32);
 		else
 			SHA256_Update(&ctx, p_bytes, key_len);

--- a/lib/libcrypt/crypt-sha512.c
+++ b/lib/libcrypt/crypt-sha512.c
@@ -131,8 +131,8 @@ crypt_sha512(const char *key, const char *salt, char *buffer)
 
 	/* Take the binary representation of the length of the key and for
 	 * every 1 add the alternate sum, for every 0 the key. */
-	for (cnt = key_len; cnt > 0; cnt >>= 1)
-		if ((cnt & 1) != 0)
+	for (cnt = key_len; cnt; cnt >>= 1)
+		if ((cnt & 1) == 1)
 			SHA512_Update(&ctx, alt_result, 64);
 		else
 			SHA512_Update(&ctx, key, key_len);
@@ -144,7 +144,7 @@ crypt_sha512(const char *key, const char *salt, char *buffer)
 	SHA512_Init(&alt_ctx);
 
 	/* For every character in the password add the entire password. */
-	for (cnt = 0; cnt < key_len; ++cnt)
+	for (cnt = key_len; cnt; --cnt)
 		SHA512_Update(&alt_ctx, key, key_len);
 
 	/* Finish the digest. */
@@ -162,7 +162,7 @@ crypt_sha512(const char *key, const char *salt, char *buffer)
 	SHA512_Init(&alt_ctx);
 
 	/* For every character in the password add the entire password. */
-	for (cnt = 0; cnt < 16 + alt_result[0]; ++cnt)
+	for (cnt = 16 + alt_result[0]; cnt; --cnt)
 		SHA512_Update(&alt_ctx, salt, salt_len);
 
 	/* Finish the digest. */
@@ -178,26 +178,26 @@ crypt_sha512(const char *key, const char *salt, char *buffer)
 
 	/* Repeatedly run the collected hash value through SHA512 to burn CPU
 	 * cycles. */
-	for (cnt = 0; cnt < rounds; ++cnt) {
+	for (cnt = rounds; cnt; --cnt) {
 		/* New context. */
 		SHA512_Init(&ctx);
 
 		/* Add key or last result. */
-		if ((cnt & 1) != 0)
+		if ((cnt & 1) == 1)
 			SHA512_Update(&ctx, p_bytes, key_len);
 		else
 			SHA512_Update(&ctx, alt_result, 64);
 
 		/* Add salt for numbers not divisible by 3. */
-		if (cnt % 3 != 0)
+		if (cnt % 3)
 			SHA512_Update(&ctx, s_bytes, salt_len);
 
 		/* Add key for numbers not divisible by 7. */
-		if (cnt % 7 != 0)
+		if (cnt % 7)
 			SHA512_Update(&ctx, p_bytes, key_len);
 
 		/* Add key or last result. */
-		if ((cnt & 1) != 0)
+		if ((cnt & 1) == 1)
 			SHA512_Update(&ctx, alt_result, 64);
 		else
 			SHA512_Update(&ctx, p_bytes, key_len);
@@ -248,9 +248,16 @@ crypt_sha512(const char *key, const char *salt, char *buffer)
 	 * the SHA512 implementation as well. */
 	SHA512_Init(&ctx);
 	SHA512_Final(alt_result, &ctx);
-	memset(temp_result, '\0', sizeof(temp_result));
-	memset(p_bytes, '\0', key_len);
-	memset(s_bytes, '\0', salt_len);
+
+#ifdef HAVE_MEMSET_S
+	memset_s(temp_result, sizeof(temp_result), 0, sizeof(temp_result));
+	memset_s(p_bytes, key_len, 0, key_len);
+	memset_s(s_bytes, salt_len, 0, salt_len);
+#else
+	memset(temp_result, 0, sizeof(temp_result));
+	memset(p_bytes, 0, key_len);
+	memset(s_bytes, 0, salt_len);
+#endif
 
 	return (0);
 }

--- a/lib/libcrypt/crypt.c
+++ b/lib/libcrypt/crypt.c
@@ -110,7 +110,7 @@ crypt_r(const char *passwd, const char *salt, struct crypt_data *data)
 	const struct crypt_format *cf;
 	int (*func)(const char *, const char *, char *);
 #ifdef HAS_DES
-	int len;
+	size_t len;
 #endif
 
 	for (cf = crypt_formats; cf->name != NULL; ++cf)

--- a/lib/libcrypt/misc.c
+++ b/lib/libcrypt/misc.c
@@ -42,7 +42,7 @@ static char itoa64[] =		/* 0 ... 63 => ascii - 64 */
 void
 _crypt_to64(char *s, u_long v, int n)
 {
-	while (--n >= 0) {
+	for (; n > 0; n--) {
 		*s++ = itoa64[v&0x3f];
 		v >>= 6;
 	}
@@ -52,10 +52,9 @@ void
 b64_from_24bit(uint8_t B2, uint8_t B1, uint8_t B0, int n, char **cp)
 {
 	uint32_t w;
-	int i;
 
 	w = (B2 << 16) | (B1 << 8) | B0;
-	for (i = 0; i < n; i++) {
+	for (; n > 0; n--) {
 		**cp = itoa64[w&0x3f];
 		(*cp)++;
 		w >>= 6;


### PR DESCRIPTION
Made many optimizations, mostly avoiding redundant strlen calls and using memcpy_s to wipe information