### PR TITLE
crypto: fix MAC null check

### DIFF
--- a/sys/opencrypto/cryptodev.c
+++ b/sys/opencrypto/cryptodev.c
@@ -889,6 +889,12 @@ cryptodev_op(struct csession *cse, const struct crypt_op *cop)
 		dst += cse->ivsize;
 	}
 
+	if (cop->mac == NULL && cse->hashsize != 0 && (crp->crp_op & CRYPTO_OP_VERIFY_DIGEST) != 0) {
+                SDT_PROBE1(opencrypto, dev, ioctl, error, __LINE__);
+	        error = EINVAL;
+		goto bail;
+	}
+
 	if (cop->mac != NULL && crp->crp_op & CRYPTO_OP_VERIFY_DIGEST) {
 		error = copyin(cop->mac, cod->buf + crp->crp_digest_start,
 		    cse->hashsize);


### PR DESCRIPTION
Fixed an uninitialized memory bug in crypto device driver reported by syzkaller. Added a check if MAC(digest) is provided by userspace or not and errors out if no MAC is provided but hash and CRYPTO_OP_VERIFY_DIGEST is specified.
To be reviewed by @markjdb 