### PR TITLE
GitHub: Fix cross-builds

### DIFF
--- a/tools/build/cross-build/include/common/sys/cdefs.h
+++ b/tools/build/cross-build/include/common/sys/cdefs.h
@@ -255,3 +255,22 @@
 #define	__BSD_VISIBLE		1
 #define	__ISO_C_VISIBLE		2011
 #define	__EXT1_VISIBLE		1
+
+/* Alignment builtins for better type checking and improved code generation. */
+/* Provide fallback versions for other compilers (GCC/Clang < 10): */
+#if !__has_builtin(__builtin_is_aligned)
+#define __builtin_is_aligned(x, align)	\
+	(((__uintptr_t)x & ((align) - 1)) == 0)
+#endif
+#if !__has_builtin(__builtin_align_up)
+#define __builtin_align_up(x, align)	\
+	((__typeof__(x))(((__uintptr_t)(x)+((align)-1))&(~((align)-1))))
+#endif
+#if !__has_builtin(__builtin_align_down)
+#define __builtin_align_down(x, align)	\
+	((__typeof__(x))((x)&(~((align)-1))))
+#endif
+
+#define __align_up(x, y) __builtin_align_up(x, y)
+#define __align_down(x, y) __builtin_align_down(x, y)
+#define __is_aligned(x, y) __builtin_is_aligned(x, y)


### PR DESCRIPTION
It's time to bother (bi-weekly) @arichardson for GitHub cross-builds, sorry.

This is more an FYI than an actual PR, but this is what I did:

Add `__is_aligned` definition to cross-build's `sys/cdefs.h`

This was introduced in 4e5d32a445f90d37966cd6de571978551654e3f3.

PS: I did not want to hinder @DimitryAndric warning-silencing spree, that's why I decided to wait a while to submit.