### PR TITLE
 update if_ether.c: squash commit 6e49ae2 and c6e3c75 into one

### DIFF
--- a/sys/netinet/if_ether.c
+++ b/sys/netinet/if_ether.c
@@ -418,6 +418,7 @@ arprequest_internal(struct ifnet *ifp, const struct in_addr *sip,
 	linkhdrsize = sizeof(linkhdr);
 	error = arp_fillheader(ifp, ah, 1, linkhdr, &linkhdrsize);
 	if (error != 0 && error != EAFNOSUPPORT) {
+		m_freem(m);
 		ARP_LOG(LOG_ERR, "Failed to calculate ARP header on %s: %d\n",
 		    if_name(ifp), error);
 		return (error);
@@ -1128,7 +1129,7 @@ reply:
 	if (error != 0 && error != EAFNOSUPPORT) {
 		ARP_LOG(LOG_ERR, "Failed to calculate ARP header on %s: %d\n",
 		    if_name(ifp), error);
-		return;
+		goto drop;
 	}
 
 	ro.ro_prepend = linkhdr;

--- a/sys/netinet/if_ether.c
+++ b/sys/netinet/if_ether.c
@@ -849,7 +849,7 @@ in_arpinput(struct mbuf *m)
 	IN_IFADDR_RLOCK(&in_ifa_tracker);
 	LIST_FOREACH(ia, INADDR_HASH(itaddr.s_addr), ia_hash) {
 		if (((bridged && ia->ia_ifp->if_bridge == ifp->if_bridge) ||
-		    ia->ia_ifp == ifp) &&
+		   !bridged /*ia->ia_ifp == ifp*/) &&
 		    itaddr.s_addr == ia->ia_addr.sin_addr.s_addr &&
 		    (ia->ia_ifa.ifa_carp == NULL ||
 		    (*carp_iamatch_p)(&ia->ia_ifa, &enaddr))) {


### PR DESCRIPTION
Free memory before return from arprequest_internal.
In in_arpinput(), if arp_fillheader() fails, it should use goto drop.