### PR TITLE
freebsd-update.8: Add missing option

### DIFF
--- a/usr.sbin/freebsd-update/freebsd-update.8
+++ b/usr.sbin/freebsd-update/freebsd-update.8
@@ -59,13 +59,13 @@ by the
 .Fx
 Release Engineering Team, e.g.,
 .Fx
-11.2-RELEASE and
+12.2-RELEASE and
 .Fx
-12.0-RELEASE, but not
+13.0-RELEASE, but not
 .Fx
-11.2-STABLE or
+12.2-STABLE or
 .Fx
-13.0-CURRENT.
+14.0-CURRENT.
 .Sh OPTIONS
 The following options are supported:
 .Bl -tag -width "-r newrelease"
@@ -95,7 +95,7 @@ Trust an RSA key with SHA256 of
 .Ar KEY .
 (default: read value from configuration file.)
 .It Fl r Ar newrelease
-Specify the new release (e.g., 11.2-RELEASE) to which
+Specify the new release (e.g., 12.2-RELEASE) to which
 .Nm
 should upgrade (upgrade command only).
 .It Fl s Ar server

--- a/usr.sbin/freebsd-update/freebsd-update.8
+++ b/usr.sbin/freebsd-update/freebsd-update.8
@@ -25,7 +25,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd November 14, 2020
+.Dd September 4, 2021
 .Dt FREEBSD-UPDATE 8
 .Os
 .Sh NAME
@@ -42,6 +42,7 @@
 .Op Fl s Ar server
 .Op Fl t Ar address
 .Op Fl -not-running-from-cron
+.Op Fl -currently-running Ar release
 .Cm command ...
 .Sh DESCRIPTION
 The


### PR DESCRIPTION
- Bump +1 version numbers
- Add the missing `--currently-running <release>` option to the synopsis

NB: The changes were made in separate commits, should I squash them, just let me know. Thank you!