### PR TITLE
e1000: Sync DPDK ich8lan

### DIFF
--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -1111,9 +1111,6 @@ em_if_attach_pre(if_ctx_t ctx)
 
 	em_print_fw_version(sc);
 
-	/* Disable ULP support */
-	e1000_disable_ulp_lpt_lp(hw, true);
-
 	/*
 	 * Get Wake-on-Lan and Management info for later use
 	 */


### PR DESCRIPTION
This contains a probable regression for suspend/resume and other issues on I219, break it out so users can help test.

Also of note, I left out two changes to the FreeBSD driver to try and opportunistically use ULP https://cgit.freebsd.org/src/diff/sys/dev/e1000/if_em.c?id=a4378873e9ce1b35b55378c21f8eae69e58c2525

@ricera 