### PR TITLE
Fix bug in syslogd that caused -N to drop SecureMode if specified after -s

### DIFF
--- a/usr.sbin/syslogd/syslogd.c
+++ b/usr.sbin/syslogd/syslogd.c
@@ -677,7 +677,8 @@ main(int argc, char *argv[])
 			break;
 		case 'N':
 			NoBind = 1;
-			SecureMode = 1;
+			if (!SecureMode)
+				SecureMode = 1;
 			break;
 		case 'n':
 			resolve = 0;


### PR DESCRIPTION
This commit should fix the unintuitive behavior where specifying "-ss -N" as opts would drop SecureMode to 1. It might not be the typical use case but I think it's more in line with what a user would expect, plus it's more sane as a security feature being impacted by the order of args looks bad.