### PR TITLE
"freebsd-update fetch", be efficient if no updates

### DIFF
--- a/usr.sbin/freebsd-update/freebsd-update.sh
+++ b/usr.sbin/freebsd-update/freebsd-update.sh
@@ -3134,7 +3134,6 @@ install_setup_rollback () {
 
 # Actually install updates
 install_run () {
-	rm -f tag
 	echo -n "Installing updates..."
 
 	# Make sure we have all the files we should have

--- a/usr.sbin/freebsd-update/freebsd-update.sh
+++ b/usr.sbin/freebsd-update/freebsd-update.sh
@@ -3134,6 +3134,7 @@ install_setup_rollback () {
 
 # Actually install updates
 install_run () {
+	rm -f tag
 	echo -n "Installing updates..."
 
 	# Make sure we have all the files we should have
@@ -3219,6 +3220,7 @@ rollback_files () {
 
 # Actually rollback updates
 rollback_run () {
+	rm -f tag
 	echo -n "Uninstalling updates..."
 
 	# If there are updates waiting to be installed, remove them; we

--- a/usr.sbin/freebsd-update/freebsd-update.sh
+++ b/usr.sbin/freebsd-update/freebsd-update.sh
@@ -2662,8 +2662,6 @@ upgrade_run () {
 	done
 	fetch_tagsanity || return 1
 
-	rm -f fetch_create_manifest.out
-
 	# Fetch the INDEX-OLD and INDEX-ALL.
 	fetch_metadata INDEX-OLD INDEX-ALL || return 1
 
@@ -2766,8 +2764,7 @@ upgrade_run () {
 
 	# Create and populate install manifest directory; and report what
 	# updates are available.
-	fetch_create_manifest > fetch_create_manifest.out || return 1
-	cat fetch_create_manifest.out
+	fetch_create_manifest || return 1
 
 	# Leave a note behind to tell the "install" command that the kernel
 	# needs to be installed before the world.

--- a/usr.sbin/freebsd-update/freebsd-update.sh
+++ b/usr.sbin/freebsd-update/freebsd-update.sh
@@ -2210,7 +2210,7 @@ fetch_run () {
 		if [ -f fetch_create_manifest.out ]; then
 			echo "Updates available to install."
 			echo
-			cat fetch_create_manifest.out
+			cat fetch_create_manifest.out | ${PAGER}
 		else
 			echo
 			echo -n "No updates needed to update system to "

--- a/usr.sbin/freebsd-update/freebsd-update.sh
+++ b/usr.sbin/freebsd-update/freebsd-update.sh
@@ -2205,7 +2205,7 @@ fetch_run () {
 	# further processing, expediting fetch_run.  fetch_run can only
 	# be expedited subsequent to an uninterrupted fetch_run.
 	if [ ! -f fetch_run.pending ] && [ -f tag.new -a -f tag ] &&
-	    cmp -s tag.new tag; then
+	    [ "$BASEDIR" = "/" ] && cmp -s tag.new tag; then
 		echo "No updates are available to fetch."
 		if [ -f fetch_create_manifest.out ]; then
 			echo "Updates available to install."

--- a/usr.sbin/freebsd-update/freebsd-update.sh
+++ b/usr.sbin/freebsd-update/freebsd-update.sh
@@ -2207,11 +2207,20 @@ fetch_run () {
 	if [ ! -f fetch_run.pending ] && [ -f tag.new -a -f tag ] &&
 	    cmp -s tag.new tag; then
 		echo "No updates are available to fetch."
-		[ -f fetch_create_manifest.out ] && cat fetch_create_manifest.out
+		if [ -f fetch_create_manifest.out ]; then
+			echo "Updates available to install."
+			echo
+			cat fetch_create_manifest.out
+		else
+			echo
+			echo -n "No updates needed to update system to "
+			echo "${RELNUM}-p${RELPATCHNUM}."
+		fi
 		rm -f tag.new
 		return 0
 	fi
 	touch fetch_run.pending || return 1
+	rm -f fetch_create_manifest.out
 
 	# Fetch the latest INDEX-NEW and INDEX-OLD files.
 	fetch_metadata INDEX-NEW INDEX-OLD || return 1
@@ -2652,6 +2661,8 @@ upgrade_run () {
 		fetch_pick_server || return 1
 	done
 	fetch_tagsanity || return 1
+
+	rm -f fetch_create_manifest.out
 
 	# Fetch the INDEX-OLD and INDEX-ALL.
 	fetch_metadata INDEX-OLD INDEX-ALL || return 1


### PR DESCRIPTION
When there are no updates available there is no need run through the the entirety of fetch_run ()

This introduces a simple check and its most significant benefit is avoiding the disk intensive phase of "fetch" (i.e. Inspecting system...) as there were no updates anyway.

On IO bound hardware, in my case a Raspberry Pi 3, this improvement has reduced runtime duration of freebsd-update fetch from 1m20s down to 1.5s.

Even on fast SSD hardware freebsd-update fetch currently takes ~15 seconds, this changes reduces the time to sub second.

Again for emphasis: This is for the case when there are no updates. Check early and if it matches, it's done.