### PR TITLE
Remove obsolete amd(8) rc.conf configuration

### DIFF
--- a/libexec/rc/rc.conf
+++ b/libexec/rc/rc.conf
@@ -356,10 +356,6 @@ ftpd_program="/usr/libexec/ftpd" # Path to ftpd, if you want a different one.
 ftpd_flags=""			# Additional flags to stand-alone ftpd.
 
 ### Network daemon (NFS): All need rpcbind_enable="YES" ###
-amd_enable="NO"			# Run amd service with $amd_flags (or NO).
-amd_program="/usr/sbin/amd"	# path to amd, if you want a different one.
-amd_flags="-a /.amd_mnt -l syslog /host /etc/amd.map /net /etc/amd.map"
-amd_map_program="NO"		# Can be set to "ypcat -k amd.master"
 autofs_enable="NO"		# Run autofs daemons.
 automount_flags=""		# Flags to automount(8) (if autofs enabled).
 automountd_flags=""		# Flags to automountd(8) (if autofs enabled).

--- a/share/man/man5/rc.conf.5
+++ b/share/man/man5/rc.conf.5
@@ -2352,39 +2352,6 @@ If
 is set to
 .Dq Li YES ,
 these are the flags to pass to it.
-.It Va amd_enable
-.Pq Vt bool
-If set to
-.Dq Li YES ,
-run the
-.Xr amd 8
-daemon at boot time.
-.It Va amd_flags
-.Pq Vt str
-If
-.Va amd_enable
-is set to
-.Dq Li YES ,
-these are the flags to pass to it.
-See the
-.Xr amd 8
-manpage for more information.
-.It Va amd_map_program
-.Pq Vt str
-If set,
-the specified program is run to get the list of
-.Xr amd 8
-maps.
-For example, if the
-.Xr amd 8
-maps are stored in NIS, one can set this to
-run
-.Xr ypcat 1
-to get a list of
-.Xr amd 8
-maps from the
-.Pa amd.master
-NIS map.
 .It Va update_motd
 .Pq Vt bool
 If set to
@@ -4665,7 +4632,6 @@ it will be made permanently active.
 .Xr security 7 ,
 .Xr tuning 7 ,
 .Xr accton 8 ,
-.Xr amd 8 ,
 .Xr apm 8 ,
 .Xr bsdinstall 8 ,
 .Xr bthidd 8 ,


### PR DESCRIPTION
The script that used these was removed in 13f7dbe822d5f along with amd itself.