### PR TITLE
Change the name of the second parameter of biowait to wmesg

### DIFF
--- a/sys/kern/vfs_bio.c
+++ b/sys/kern/vfs_bio.c
@@ -4398,14 +4398,14 @@ biodone(struct bio *bp)
  * Wait for a BIO to finish.
  */
 int
-biowait(struct bio *bp, const char *wchan)
+biowait(struct bio *bp, const char *wmesg)
 {
 	struct mtx *mtxp;
 
 	mtxp = mtx_pool_find(mtxpool_sleep, bp);
 	mtx_lock(mtxp);
 	while ((bp->bio_flags & BIO_DONE) == 0)
-		msleep(bp, mtxp, PRIBIO, wchan, 0);
+		msleep(bp, mtxp, PRIBIO, wmesg, 0);
 	mtx_unlock(mtxp);
 	if (bp->bio_error != 0)
 		return (bp->bio_error);

--- a/sys/sys/bio.h
+++ b/sys/sys/bio.h
@@ -152,7 +152,7 @@ extern int bio_transient_maxcnt;
 
 void biodone(struct bio *bp);
 void biofinish(struct bio *bp, struct devstat *stat, int error);
-int biowait(struct bio *bp, const char *wchan);
+int biowait(struct bio *bp, const char *wmesg);
 
 #if defined(BUF_TRACKING) || defined(FULL_BUF_TRACKING)
 void biotrack_buf(struct bio *bp, const char *location);


### PR DESCRIPTION
The second parameter of biowait is actually wait message instead of wait channel. The wait channel is the first parameter.