### PR TITLE
USB 32-bit compat

### DIFF
--- a/lib/libusb/Makefile
+++ b/lib/libusb/Makefile
@@ -34,10 +34,6 @@ SRCS+=		libusb10_desc.c
 SRCS+=		libusb10_hotplug.c
 SRCS+=		libusb10_io.c
 
-.if defined(COMPAT_32BIT)
-CFLAGS+=	-DCOMPAT_32BIT
-.endif
-
 PCFILES=	libusb-0.1.pc libusb-1.0.pc libusb-2.0.pc
 
 #
@@ -45,14 +41,14 @@ PCFILES=	libusb-0.1.pc libusb-1.0.pc libusb-2.0.pc
 #
 # Examples:
 # make LIBUSB_GLOBAL_INCLUDE_FILE=libusb_global_linux.h
-# make COMPAT_32BIT=YES \
+# make \
 #   LIBUSB_GLOBAL_INCLUDE_FILE=libusb_global_linux.h \
 #   DEBUG_FLAGS="-g"
 #
 # From Ubuntu 10.04:
 # freebsd-make LIBUSB_GLOBAL_INCLUDE_FILE=libusb_global_linux.h \
 #    PTHREAD_LIBS="-lpthread -lrt"
-# freebsd-make COMPAT32_BIT=YES \
+# freebsd-make \
 #    LIBUSB_GLOBAL_INCLUDE_FILE=libusb_global_linux.h \
 #    PTHREAD_LIBS="-lpthread -lrt"
 #

--- a/lib/libusb/libusb20.c
+++ b/lib/libusb/libusb20.c
@@ -352,7 +352,7 @@ libusb20_tr_clear_stall_sync(struct libusb20_transfer *xfer)
 void
 libusb20_tr_set_buffer(struct libusb20_transfer *xfer, void *buffer, uint16_t frIndex)
 {
-	xfer->ppBuffer[frIndex] = libusb20_pass_ptr(buffer);
+	xfer->ppBuffer[frIndex] = buffer;
 	return;
 }
 
@@ -418,7 +418,7 @@ libusb20_tr_set_total_frames(struct libusb20_transfer *xfer, uint32_t nFrames)
 void
 libusb20_tr_setup_bulk(struct libusb20_transfer *xfer, void *pBuf, uint32_t length, uint32_t timeout)
 {
-	xfer->ppBuffer[0] = libusb20_pass_ptr(pBuf);
+	xfer->ppBuffer[0] = pBuf;
 	xfer->pLength[0] = length;
 	xfer->timeout = timeout;
 	xfer->nFrames = 1;
@@ -430,7 +430,7 @@ libusb20_tr_setup_control(struct libusb20_transfer *xfer, void *psetup, void *pB
 {
 	uint16_t len;
 
-	xfer->ppBuffer[0] = libusb20_pass_ptr(psetup);
+	xfer->ppBuffer[0] = psetup;
 	xfer->pLength[0] = 8;		/* fixed */
 	xfer->timeout = timeout;
 
@@ -438,7 +438,7 @@ libusb20_tr_setup_control(struct libusb20_transfer *xfer, void *psetup, void *pB
 
 	if (len != 0) {
 		xfer->nFrames = 2;
-		xfer->ppBuffer[1] = libusb20_pass_ptr(pBuf);
+		xfer->ppBuffer[1] = pBuf;
 		xfer->pLength[1] = len;
 	} else {
 		xfer->nFrames = 1;
@@ -449,7 +449,7 @@ libusb20_tr_setup_control(struct libusb20_transfer *xfer, void *psetup, void *pB
 void
 libusb20_tr_setup_intr(struct libusb20_transfer *xfer, void *pBuf, uint32_t length, uint32_t timeout)
 {
-	xfer->ppBuffer[0] = libusb20_pass_ptr(pBuf);
+	xfer->ppBuffer[0] = pBuf;
 	xfer->pLength[0] = length;
 	xfer->timeout = timeout;
 	xfer->nFrames = 1;
@@ -463,7 +463,7 @@ libusb20_tr_setup_isoc(struct libusb20_transfer *xfer, void *pBuf, uint32_t leng
 		/* should not happen */
 		return;
 	}
-	xfer->ppBuffer[frIndex] = libusb20_pass_ptr(pBuf);
+	xfer->ppBuffer[frIndex] = pBuf;
 	xfer->pLength[frIndex] = length;
 	return;
 }

--- a/lib/libusb/libusb20_int.h
+++ b/lib/libusb/libusb20_int.h
@@ -33,12 +33,6 @@
 #ifndef _LIBUSB20_INT_H_
 #define	_LIBUSB20_INT_H_
 
-#ifdef COMPAT_32BIT
-#define	libusb20_pass_ptr(ptr)	((uint64_t)(uintptr_t)(ptr))
-#else
-#define	libusb20_pass_ptr(ptr)	(ptr)
-#endif
-
 struct libusb20_device;
 struct libusb20_backend;
 struct libusb20_transfer;
@@ -159,11 +153,7 @@ struct libusb20_transfer {
 	/*
 	 * Pointer to a list of buffer pointers:
 	 */
-#ifdef COMPAT_32BIT
-	uint64_t *ppBuffer;
-#else
 	void  **ppBuffer;
-#endif
 	/*
 	 * Pointer to frame lengths, which are updated to actual length
 	 * after the USB transfer completes:

--- a/lib/libusb/libusb20_ugen20.c
+++ b/lib/libusb/libusb20_ugen20.c
@@ -251,7 +251,7 @@ ugen20_readdir(struct ugen20_urd_state *st)
 repeat:
 	if (st->ptr == NULL) {
 		st->urd.urd_startentry += st->nparsed;
-		st->urd.urd_data = libusb20_pass_ptr(st->buf);
+		st->urd.urd_data = st->buf;
 		st->urd.urd_maxlen = sizeof(st->buf);
 		st->nparsed = 0;
 
@@ -364,7 +364,7 @@ ugen20_tr_renew(struct libusb20_device *pdev)
 
 	memset(&fs_init, 0, sizeof(fs_init));
 
-	fs_init.pEndpoints = libusb20_pass_ptr(pdev->privBeData);
+	fs_init.pEndpoints = pdev->privBeData;
 	fs_init.ep_index_max = nMaxTransfer;
 
 	if (ioctl(pdev->file, IOUSB(USB_FS_INIT), &fs_init)) {
@@ -478,7 +478,7 @@ ugen20_get_config_desc_full(struct libusb20_device *pdev,
 	memset(&cdesc, 0, sizeof(cdesc));
 	memset(&gen_desc, 0, sizeof(gen_desc));
 
-	gen_desc.ugd_data = libusb20_pass_ptr(&cdesc);
+	gen_desc.ugd_data = &cdesc;
 	gen_desc.ugd_maxlen = sizeof(cdesc);
 	gen_desc.ugd_config_index = cfg_index;
 
@@ -499,7 +499,7 @@ ugen20_get_config_desc_full(struct libusb20_device *pdev,
 	/* make sure memory is initialised */
 	memset(ptr, 0, len);
 
-	gen_desc.ugd_data = libusb20_pass_ptr(ptr);
+	gen_desc.ugd_data = ptr;
 	gen_desc.ugd_maxlen = len;
 
 	error = ioctl(pdev->file_ctrl, IOUSB(USB_GET_FULL_DESC), &gen_desc);
@@ -726,7 +726,7 @@ ugen20_do_request_sync(struct libusb20_device *pdev,
 
 	memset(&req, 0, sizeof(req));
 
-	req.ucr_data = libusb20_pass_ptr(data);
+	req.ucr_data = data;
 	if (!(flags & LIBUSB20_TRANSFER_SINGLE_SHORT_NOT_OK)) {
 		req.ucr_flags |= USB_SHORT_XFER_OK;
 	}
@@ -835,8 +835,8 @@ ugen20_tr_open(struct libusb20_transfer *xfer, uint32_t MaxBufSize,
 	xfer->maxPacketLen = temp.fs_open.max_packet_length;
 
 	/* setup buffer and length lists using zero copy */
-	fsep->ppBuffer = libusb20_pass_ptr(xfer->ppBuffer);
-	fsep->pLength = libusb20_pass_ptr(xfer->pLength);
+	fsep->ppBuffer = xfer->ppBuffer;
+	fsep->pLength = xfer->pLength;
 
 	return (0);			/* success */
 }
@@ -956,7 +956,7 @@ ugen20_dev_get_iface_desc(struct libusb20_device *pdev,
 
 	memset(&ugd, 0, sizeof(ugd));
 
-	ugd.ugd_data = libusb20_pass_ptr(buf);
+	ugd.ugd_data = buf;
 	ugd.ugd_maxlen = len;
 	ugd.ugd_iface_index = iface_index;
 

--- a/lib/libusbhid/Makefile
+++ b/lib/libusbhid/Makefile
@@ -19,8 +19,4 @@ SRCS=	descr.c descr_compat.c parse.c usage.c data.c
 
 INCS=	usbhid.h
 
-.if defined(COMPAT_32BIT)
-CFLAGS+=	-DCOMPAT_32BIT
-.endif
-
 .include <bsd.lib.mk>

--- a/lib/libusbhid/data.c
+++ b/lib/libusbhid/data.c
@@ -126,7 +126,7 @@ hid_get_report(int fd, enum hid_kind k, unsigned char *data, unsigned int size)
 	struct usb_gen_descriptor ugd;
 
 	memset(&ugd, 0, sizeof(ugd));
-	ugd.ugd_data = hid_pass_ptr(data);
+	ugd.ugd_data = data;
 	ugd.ugd_maxlen = size;
 	ugd.ugd_report_type = k + 1;
 	return (ioctl(fd, USB_GET_REPORT, &ugd));
@@ -138,7 +138,7 @@ hid_set_report(int fd, enum hid_kind k, unsigned char *data, unsigned int size)
 	struct usb_gen_descriptor ugd;
 
 	memset(&ugd, 0, sizeof(ugd));
-	ugd.ugd_data = hid_pass_ptr(data);
+	ugd.ugd_data = data;
 	ugd.ugd_maxlen = size;
 	ugd.ugd_report_type = k + 1;
 	return (ioctl(fd, USB_SET_REPORT, &ugd));

--- a/lib/libusbhid/descr.c
+++ b/lib/libusbhid/descr.c
@@ -105,7 +105,7 @@ hid_get_report_desc(int fd)
 	memset(&ugd, 0, sizeof(ugd));
 
 	/* get actual length first */
-	ugd.ugd_data = hid_pass_ptr(NULL);
+	ugd.ugd_data = NULL;
 	ugd.ugd_maxlen = 65535;
 	if (ioctl(fd, USB_GET_REPORT_DESC, &ugd) < 0) {
 #ifdef HID_COMPAT7
@@ -126,7 +126,7 @@ hid_get_report_desc(int fd)
 		return (NULL);
 
 	/* fetch actual descriptor */
-	ugd.ugd_data = hid_pass_ptr(data);
+	ugd.ugd_data = data;
 	ugd.ugd_maxlen = ugd.ugd_actlen;
 	if (ioctl(fd, USB_GET_REPORT_DESC, &ugd) < 0) {
 		/* could not read descriptor */

--- a/lib/libusbhid/usbvar.h
+++ b/lib/libusbhid/usbvar.h
@@ -47,10 +47,4 @@ int	hid_get_report_id_compat7(int fd);
 report_desc_t	hid_get_report_desc_compat7(int fd);
 #endif
 
-#ifdef COMPAT_32BIT
-#define	hid_pass_ptr(ptr)	((uint64_t)(uintptr_t)(ptr))
-#else
-#define	hid_pass_ptr(ptr)	(ptr)
-#endif
-
 #endif		/* _USBVAR_H_ */

--- a/sys/dev/hid/hidraw.h
+++ b/sys/dev/hid/hidraw.h
@@ -35,23 +35,9 @@
 #define	HIDRAW_BUFFER_SIZE	64	/* number of input reports buffered */
 #define	HID_MAX_DESCRIPTOR_SIZE	4096	/* artificial limit taken from Linux */
 
-/*
- * Align IOCTL structures to hide differences when running 32-bit
- * programs under 64-bit kernels:
- */
-#ifdef COMPAT_32BIT
-#define	HIDRAW_IOCTL_STRUCT_ALIGN(n) __aligned(n)
-#else
-#define	HIDRAW_IOCTL_STRUCT_ALIGN(n)
-#endif
-
 /* Compatible with usb_gen_descriptor structure */
 struct hidraw_gen_descriptor {
-#ifdef COMPAT_32BIT
-	uint64_t hgd_data;
-#else
 	void   *hgd_data;
-#endif
 	uint16_t hgd_lang_id;
 	uint16_t hgd_maxlen;
 	uint16_t hgd_actlen;
@@ -63,18 +49,18 @@ struct hidraw_gen_descriptor {
 	uint8_t hgd_endpt_index;
 	uint8_t hgd_report_type;
 	uint8_t reserved[8];
-} HIDRAW_IOCTL_STRUCT_ALIGN(8);
+};
 
 struct hidraw_report_descriptor {
 	uint32_t	size;
 	uint8_t		value[HID_MAX_DESCRIPTOR_SIZE];
-} HIDRAW_IOCTL_STRUCT_ALIGN(4);
+};
 
 struct hidraw_devinfo {
 	uint32_t	bustype;
 	int16_t		vendor;
 	int16_t		product;
-} HIDRAW_IOCTL_STRUCT_ALIGN(4);
+};
 
 /* FreeBSD uhid(4)-compatible ioctl interface */
 #define	HIDRAW_GET_REPORT_DESC	_IOWR('U', 21, struct hidraw_gen_descriptor)

--- a/sys/dev/usb/input/uhid_snes.c
+++ b/sys/dev/usb/input/uhid_snes.c
@@ -281,13 +281,30 @@ uhid_snes_ioctl(struct usb_fifo *fifo, u_long cmd, void *data, int fflags)
 {
 	struct uhid_snes_softc *sc = usb_fifo_softc(fifo);
 	struct usb_gen_descriptor *ugd;
+#ifdef COMPAT_FREEBSD32
+	struct usb_gen_descriptor local_ugd;
+	struct usb_gen_descriptor32 *ugd32 = NULL;
+#endif
 	uint32_t size;
 	int error = 0;
 	uint8_t id;
 
+	ugd = data;
+#ifdef COMPAT_FREEBSD32
+	switch (cmd) {
+	case USB_GET_REPORT_DESC32:
+	case USB_GET_REPORT32:
+	case USB_SET_REPORT32:
+		ugd32 = data;
+		ugd = &local_ugd;
+		usb_gen_descriptor_from32(ugd, ugd32);
+		cmd = _IOC_NEWTYPE(cmd, struct usb_gen_descriptor);
+		break;
+	}
+#endif
+
 	switch (cmd) {
 	case USB_GET_REPORT_DESC:
-		ugd = data;
 		if (sc->sc_repdesc_size > ugd->ugd_maxlen) {
 			size = ugd->ugd_maxlen;
 		} else {
@@ -328,7 +345,6 @@ uhid_snes_ioctl(struct usb_fifo *fifo, u_long cmd, void *data, int fflags)
 			error = EPERM;
 			break;
 		}
-		ugd = data;
 		switch (ugd->ugd_report_type) {
 		case UHID_INPUT_REPORT:
 			size = sc->sc_isize;
@@ -356,7 +372,6 @@ uhid_snes_ioctl(struct usb_fifo *fifo, u_long cmd, void *data, int fflags)
 			error = EPERM;
 			break;
 		}
-		ugd = data;
 		switch (ugd->ugd_report_type) {
 		case UHID_INPUT_REPORT:
 			size = sc->sc_isize;
@@ -388,6 +403,11 @@ uhid_snes_ioctl(struct usb_fifo *fifo, u_long cmd, void *data, int fflags)
 		error = EINVAL;
 		break;
 	}
+
+#ifdef COMPAT_FREEBSD32
+	if (ugd32 != NULL)
+		update_usb_gen_descriptor32(ugd32, ugd);
+#endif
 	return (error);
 }
 

--- a/sys/dev/usb/usb_dev.c
+++ b/sys/dev/usb/usb_dev.c
@@ -32,6 +32,9 @@
 #ifdef USB_GLOBAL_INCLUDE_FILE
 #include USB_GLOBAL_INCLUDE_FILE
 #else
+#ifdef COMPAT_FREEBSD32
+#include <sys/abi_compat.h>
+#endif
 #include <sys/stdint.h>
 #include <sys/stddef.h>
 #include <sys/param.h>
@@ -1650,6 +1653,9 @@ usb_static_ioctl(struct cdev *dev, u_long cmd, caddr_t data, int fflag,
 {
 	union {
 		struct usb_read_dir *urd;
+#ifdef COMPAT_FREEBSD32
+		struct usb_read_dir32 *urd32;
+#endif
 		void* data;
 	} u;
 	int err;
@@ -1660,6 +1666,12 @@ usb_static_ioctl(struct cdev *dev, u_long cmd, caddr_t data, int fflag,
 			err = usb_read_symlink(u.urd->urd_data,
 			    u.urd->urd_startentry, u.urd->urd_maxlen);
 			break;
+#ifdef COMPAT_FREEBSD32
+		case USB_READ_DIR32:
+			err = usb_read_symlink(PTRIN(u.urd32->urd_data),
+			    u.urd32->urd_startentry, u.urd32->urd_maxlen);
+			break;
+#endif
 		case USB_DEV_QUIRK_GET:
 		case USB_QUIRK_NAME_GET:
 		case USB_DEV_QUIRK_ADD:

--- a/sys/dev/usb/usb_dev.h
+++ b/sys/dev/usb/usb_dev.h
@@ -123,6 +123,7 @@ struct usb_fifo {
 	void   *priv_sc0;		/* client data */
 	void   *priv_sc1;		/* client data */
 	void   *queue_data;
+	usb_size_t fs_ep_sz;
 	usb_timeout_t timeout;		/* timeout in milliseconds */
 	usb_frlength_t bufsize;		/* BULK and INTERRUPT buffer size */
 	usb_frcount_t nframes;		/* for isochronous mode */

--- a/sys/dev/usb/usb_generic.c
+++ b/sys/dev/usb/usb_generic.c
@@ -119,6 +119,7 @@ static int	ugen_re_enumerate(struct usb_fifo *);
 static int	ugen_iface_ioctl(struct usb_fifo *, u_long, void *, int);
 static uint8_t	ugen_fs_get_complete(struct usb_fifo *, uint8_t *);
 static int	ugen_fs_uninit(struct usb_fifo *f);
+static int	ugen_fs_copyin(struct usb_fifo *, uint8_t, struct usb_fs_endpoint*);
 
 /* structures */
 
@@ -1067,6 +1068,38 @@ ugen_fs_set_complete(struct usb_fifo *f, uint8_t index)
 }
 
 static int
+ugen_fs_getbuffer(void **uptrp, struct usb_fifo *f, void *buffer,
+    usb_frcount_t n)
+{
+	union {
+		void **ppBuffer;
+#ifdef COMPAT_FREEBSD32
+		uint32_t *ppBuffer32;
+#endif
+	} u;
+#ifdef COMPAT_FREEBSD32
+	uint32_t uptr32;
+#endif
+
+	u.ppBuffer = buffer;
+	switch (f->fs_ep_sz) {
+	case sizeof(struct usb_fs_endpoint):
+		if (fueword(u.ppBuffer + n, (long *)uptrp) != 0)
+			return (EFAULT);
+		return (0);
+#ifdef COMPAT_FREEBSD32
+	case sizeof(struct usb_fs_endpoint32):
+		if (fueword32(u.ppBuffer32 + n, &uptr32) != 0)
+			return (EFAULT);
+		*uptrp = PTRIN(uptr32);
+		return (0);
+#endif
+	default:
+		panic("%s: unhandled fs_ep_sz %#x", __func__, f->fs_ep_sz);
+	}
+}
+
+static int
 ugen_fs_copy_in(struct usb_fifo *f, uint8_t ep_index)
 {
 	struct usb_device_request *req;
@@ -1095,8 +1128,7 @@ ugen_fs_copy_in(struct usb_fifo *f, uint8_t ep_index)
 	}
 	mtx_unlock(f->priv_mtx);
 
-	error = copyin(f->fs_ep_ptr +
-	    ep_index, &fs_ep, sizeof(fs_ep));
+	error = ugen_fs_copyin(f, ep_index, &fs_ep);
 	if (error) {
 		return (error);
 	}
@@ -1110,8 +1142,7 @@ ugen_fs_copy_in(struct usb_fifo *f, uint8_t ep_index)
 		xfer->error = USB_ERR_INVAL;
 		goto complete;
 	}
-	error = copyin(fs_ep.ppBuffer,
-	    &uaddr, sizeof(uaddr));
+	error = ugen_fs_getbuffer(&uaddr, f, fs_ep.ppBuffer, 0);
 	if (error) {
 		return (error);
 	}
@@ -1121,10 +1152,8 @@ ugen_fs_copy_in(struct usb_fifo *f, uint8_t ep_index)
 	if (xfer->flags_int.control_xfr) {
 		req = xfer->frbuffers[0].buffer;
 
-		error = copyin(fs_ep.pLength,
-		    &length, sizeof(length));
-		if (error) {
-			return (error);
+		if (fueword32(fs_ep.pLength, &length) != 0) {
+			return (EFAULT);
 		}
 		if (length != sizeof(*req)) {
 			xfer->error = USB_ERR_INVAL;
@@ -1190,9 +1219,7 @@ ugen_fs_copy_in(struct usb_fifo *f, uint8_t ep_index)
 		xfer->flags.stall_pipe = 0;
 
 	for (; n != xfer->nframes; n++) {
-		error = copyin(fs_ep.pLength + n,
-		    &length, sizeof(length));
-		if (error) {
+		if (fueword32(fs_ep.pLength + n, &length) != 0) {
 			break;
 		}
 		usbd_xfer_set_frame_len(xfer, n, length);
@@ -1205,8 +1232,7 @@ ugen_fs_copy_in(struct usb_fifo *f, uint8_t ep_index)
 
 		if (!isread) {
 			/* we need to know the source buffer */
-			error = copyin(fs_ep.ppBuffer + n,
-			    &uaddr, sizeof(uaddr));
+			error = ugen_fs_getbuffer(&uaddr, f, fs_ep.ppBuffer, n);
 			if (error) {
 				break;
 			}
@@ -1239,13 +1265,109 @@ complete:
 	return (0);
 }
 
+static struct usb_fs_endpoint *
+ugen_fs_ep_uptr(struct usb_fifo *f, uint8_t ep_index)
+{
+	return ((struct usb_fs_endpoint *)
+	    ((char *)f->fs_ep_ptr + (ep_index * f->fs_ep_sz)));
+}
+
 static int
-ugen_fs_copy_out_cancelled(struct usb_fs_endpoint *fs_ep_uptr)
+ugen_fs_copyin(struct usb_fifo *f, uint8_t ep_index,
+    struct usb_fs_endpoint* fs_ep)
+{
+#ifdef COMPAT_FREEBSD32
+	struct usb_fs_endpoint32 fs_ep32;
+#endif
+	int error;
+
+	switch (f->fs_ep_sz) {
+	case sizeof(struct usb_fs_endpoint):
+		error = copyin(ugen_fs_ep_uptr(f, ep_index), fs_ep,
+		    f->fs_ep_sz);
+		if (error != 0)
+			return (error);
+		break;
+
+#ifdef COMPAT_FREEBSD32
+	case sizeof(struct usb_fs_endpoint32):
+		error = copyin(ugen_fs_ep_uptr(f, ep_index), &fs_ep32,
+		    f->fs_ep_sz);
+		if (error != 0)
+			return (error);
+		PTRIN_CP(fs_ep32, *fs_ep, ppBuffer);
+		PTRIN_CP(fs_ep32, *fs_ep, pLength);
+		CP(fs_ep32, *fs_ep, nFrames);
+		CP(fs_ep32, *fs_ep, aFrames);
+		CP(fs_ep32, *fs_ep, flags);
+		CP(fs_ep32, *fs_ep, timeout);
+		CP(fs_ep32, *fs_ep, isoc_time_complete);
+		CP(fs_ep32, *fs_ep, status);
+		break;
+#endif
+	default:
+		panic("%s: unhandled fs_ep_sz %#x", __func__, f->fs_ep_sz);
+	}
+
+	return (0);
+}
+
+static int
+ugen_fs_update(const struct usb_fs_endpoint *fs_ep,
+    struct usb_fifo *f, uint8_t ep_index)
+{
+	union {
+		struct usb_fs_endpoint *fs_ep_uptr;
+#ifdef COMPAT_FREEBSD32
+		struct usb_fs_endpoint32 *fs_ep_uptr32;
+#endif
+	} u;
+	uint32_t *aFrames_uptr;
+	uint16_t *isoc_time_complete_uptr;
+	int *status_uptr;
+
+	switch (f->fs_ep_sz) {
+	case sizeof(struct usb_fs_endpoint):
+		u.fs_ep_uptr = ugen_fs_ep_uptr(f, ep_index);
+		aFrames_uptr = &u.fs_ep_uptr->aFrames;
+		isoc_time_complete_uptr = &u.fs_ep_uptr->isoc_time_complete;
+		status_uptr = &u.fs_ep_uptr->status;
+		break;
+#ifdef COMPAT_FREEBSD32
+	case sizeof(struct usb_fs_endpoint32):
+		u.fs_ep_uptr32 = (struct usb_fs_endpoint32 *)
+		    ugen_fs_ep_uptr(f, ep_index);
+		aFrames_uptr = &u.fs_ep_uptr32->aFrames;
+		isoc_time_complete_uptr = &u.fs_ep_uptr32->isoc_time_complete;
+		status_uptr = &u.fs_ep_uptr32->status;
+		break;
+#endif
+	default:
+		panic("%s: unhandled fs_ep_sz %#x", __func__, f->fs_ep_sz);
+	}
+
+	/* update "aFrames" */
+	if (suword32(aFrames_uptr, fs_ep->aFrames) != 0)
+		return (EFAULT);
+
+	/* update "isoc_time_complete" */
+	if (suword16(isoc_time_complete_uptr, fs_ep->isoc_time_complete) != 0)
+		return (EFAULT);
+
+	/* update "status" */
+	if (suword32(status_uptr, fs_ep->status) != 0)
+		return (EFAULT);
+
+	return (0);
+}
+
+static int
+ugen_fs_copy_out_cancelled(struct usb_fifo *f, uint8_t ep_index)
 {
 	struct usb_fs_endpoint fs_ep;
 	int error;
 
-	error = copyin(fs_ep_uptr, &fs_ep, sizeof(fs_ep));
+	error = ugen_fs_copyin(f, ep_index, &fs_ep);
 	if (error)
 		return (error);
 
@@ -1253,24 +1375,7 @@ ugen_fs_copy_out_cancelled(struct usb_fs_endpoint *fs_ep_uptr)
 	fs_ep.aFrames = 0;
 	fs_ep.isoc_time_complete = 0;
 
-	/* update "aFrames" */
-	error = copyout(&fs_ep.aFrames, &fs_ep_uptr->aFrames,
-	    sizeof(fs_ep.aFrames));
-	if (error)
-		goto done;
-
-	/* update "isoc_time_complete" */
-	error = copyout(&fs_ep.isoc_time_complete,
-	    &fs_ep_uptr->isoc_time_complete,
-	    sizeof(fs_ep.isoc_time_complete));
-	if (error)
-		goto done;
-
-	/* update "status" */
-	error = copyout(&fs_ep.status, &fs_ep_uptr->status,
-	    sizeof(fs_ep.status));
-done:
-	return (error);
+	return (ugen_fs_update(&fs_ep, f, ep_index));
 }
 
 static int
@@ -1279,7 +1384,6 @@ ugen_fs_copy_out(struct usb_fifo *f, uint8_t ep_index)
 	struct usb_device_request *req;
 	struct usb_xfer *xfer;
 	struct usb_fs_endpoint fs_ep;
-	struct usb_fs_endpoint *fs_ep_uptr;	/* userland ptr */
 	void *uaddr;			/* userland ptr */
 	void *kaddr;
 	usb_frlength_t offset;
@@ -1302,18 +1406,18 @@ ugen_fs_copy_out(struct usb_fifo *f, uint8_t ep_index)
 	    !xfer->flags_int.started) {
 		mtx_unlock(f->priv_mtx);
 		DPRINTF("Returning fake cancel event\n");
-		return (ugen_fs_copy_out_cancelled(f->fs_ep_ptr + ep_index));
+		return (ugen_fs_copy_out_cancelled(f, ep_index));
 	} else if (usbd_transfer_pending(xfer)) {
 		mtx_unlock(f->priv_mtx);
 		return (EBUSY);		/* should not happen */
 	}
 	mtx_unlock(f->priv_mtx);
 
-	fs_ep_uptr = f->fs_ep_ptr + ep_index;
-	error = copyin(fs_ep_uptr, &fs_ep, sizeof(fs_ep));
+	error = ugen_fs_copyin(f, ep_index, &fs_ep);
 	if (error) {
 		return (error);
 	}
+
 	fs_ep.status = xfer->error;
 	fs_ep.aFrames = xfer->aframes;
 	fs_ep.isoc_time_complete = xfer->isoc_time_complete;
@@ -1350,10 +1454,8 @@ ugen_fs_copy_out(struct usb_fifo *f, uint8_t ep_index)
 
 	for (; n != xfer->nframes; n++) {
 		/* get initial length into "temp" */
-		error = copyin(fs_ep.pLength + n,
-		    &temp, sizeof(temp));
-		if (error) {
-			return (error);
+		if (fueword32(fs_ep.pLength + n, &temp) != 0) {
+			return (EFAULT);
 		}
 		if (temp > rem) {
 			/* the userland length has been corrupted */
@@ -1375,8 +1477,7 @@ ugen_fs_copy_out(struct usb_fifo *f, uint8_t ep_index)
 		}
 		if (isread) {
 			/* we need to know the destination buffer */
-			error = copyin(fs_ep.ppBuffer + n,
-			    &uaddr, sizeof(uaddr));
+			error = ugen_fs_getbuffer(&uaddr, f, fs_ep.ppBuffer, n);
 			if (error) {
 				return (error);
 			}
@@ -1392,7 +1493,7 @@ ugen_fs_copy_out(struct usb_fifo *f, uint8_t ep_index)
 			/* move data */
 			error = copyout(kaddr, uaddr, length);
 			if (error) {
-				return (error);
+				goto complete;
 			}
 		}
 		/*
@@ -1402,31 +1503,13 @@ ugen_fs_copy_out(struct usb_fifo *f, uint8_t ep_index)
 		offset += temp;
 
 		/* update length */
-		error = copyout(&length,
-		    fs_ep.pLength + n, sizeof(length));
-		if (error) {
-			return (error);
-		}
+		if (suword32(fs_ep.pLength + n, length) != 0)
+			goto complete;
 	}
 
 complete:
-	/* update "aFrames" */
-	error = copyout(&fs_ep.aFrames, &fs_ep_uptr->aFrames,
-	    sizeof(fs_ep.aFrames));
-	if (error)
-		goto done;
-
-	/* update "isoc_time_complete" */
-	error = copyout(&fs_ep.isoc_time_complete,
-	    &fs_ep_uptr->isoc_time_complete,
-	    sizeof(fs_ep.isoc_time_complete));
-	if (error)
-		goto done;
-
-	/* update "status" */
-	error = copyout(&fs_ep.status, &fs_ep_uptr->status,
-	    sizeof(fs_ep.status));
-done:
+	if (error == 0)
+		error = ugen_fs_update(&fs_ep, f, ep_index);
 	return (error);
 }
 
@@ -2126,6 +2209,9 @@ ugen_iface_ioctl(struct usb_fifo *f, u_long cmd, void *addr, int fflags)
 static int
 ugen_ioctl_post(struct usb_fifo *f, u_long cmd, void *addr, int fflags)
 {
+#ifdef COMPAT_FREEBSD32
+	struct usb_fs_init local_pinit;
+#endif
 	union {
 		struct usb_interface_descriptor *idesc;
 		struct usb_alt_interface *ai;
@@ -2133,6 +2219,9 @@ ugen_ioctl_post(struct usb_fifo *f, u_long cmd, void *addr, int fflags)
 		struct usb_config_descriptor *cdesc;
 		struct usb_device_stats *stat;
 		struct usb_fs_init *pinit;
+#ifdef COMPAT_FREEBSD32
+		struct usb_fs_init32 *pinit32;
+#endif
 		struct usb_fs_uninit *puninit;
 		struct usb_device_port_path *dpp;
 		uint32_t *ptime;
@@ -2142,12 +2231,25 @@ ugen_ioctl_post(struct usb_fifo *f, u_long cmd, void *addr, int fflags)
 	struct usb_device_descriptor *dtemp;
 	struct usb_config_descriptor *ctemp;
 	struct usb_interface *iface;
+	size_t usb_fs_endpoint_sz = sizeof(struct usb_fs_endpoint);
 	int error = 0;
 	uint8_t n;
 
 	u.addr = addr;
 
 	DPRINTFN(6, "cmd=0x%08lx\n", cmd);
+
+#ifdef COMPAT_FREEBSD32
+	switch (cmd) {
+	case USB_FS_INIT32:
+		PTRIN_CP(*u.pinit32, local_pinit, pEndpoints);
+		CP(*u.pinit32, local_pinit, ep_index_max);
+		u.addr = &local_pinit;
+		cmd = _IOC_NEWTYPE(USB_FS_INIT, struct usb_fs_init);
+		usb_fs_endpoint_sz = sizeof(struct usb_fs_endpoint32);
+		break;
+	}
+#endif
 
 	switch (cmd) {
 	case USB_DISCOVER:
@@ -2376,6 +2478,7 @@ ugen_ioctl_post(struct usb_fifo *f, u_long cmd, void *addr, int fflags)
 		    u.pinit->ep_index_max, M_USB, M_WAITOK | M_ZERO);
 		f->fs_ep_max = u.pinit->ep_index_max;
 		f->fs_ep_ptr = u.pinit->pEndpoints;
+		f->fs_ep_sz = usb_fs_endpoint_sz;
 		break;
 
 	case USB_FS_UNINIT:

--- a/sys/dev/usb/usb_generic.c
+++ b/sys/dev/usb/usb_generic.c
@@ -29,6 +29,9 @@
 #ifdef USB_GLOBAL_INCLUDE_FILE
 #include USB_GLOBAL_INCLUDE_FILE
 #else
+#ifdef COMPAT_FREEBSD32
+#include <sys/abi_compat.h>
+#endif
 #include <sys/stdint.h>
 #include <sys/stddef.h>
 #include <sys/param.h>
@@ -109,6 +112,9 @@ static int	ugen_set_interface(struct usb_fifo *, uint8_t, uint8_t);
 static int	ugen_get_cdesc(struct usb_fifo *, struct usb_gen_descriptor *);
 static int	ugen_get_sdesc(struct usb_fifo *, struct usb_gen_descriptor *);
 static int	ugen_get_iface_driver(struct usb_fifo *f, struct usb_gen_descriptor *ugd);
+#ifdef COMPAT_FREEBSD32
+static int	ugen_get32(u_long cmd, struct usb_fifo *f, struct usb_gen_descriptor32 *ugd32);
+#endif
 static int	ugen_re_enumerate(struct usb_fifo *);
 static int	ugen_iface_ioctl(struct usb_fifo *, u_long, void *, int);
 static uint8_t	ugen_fs_get_complete(struct usb_fifo *, uint8_t *);
@@ -942,6 +948,31 @@ ugen_do_request(struct usb_fifo *f, struct usb_ctl_request *ur)
 	}
 	return (error);
 }
+
+#ifdef COMPAT_FREEBSD32
+static int
+ugen_do_request32(struct usb_fifo *f, struct usb_ctl_request32 *ur32)
+{
+	struct usb_ctl_request ur;
+	int error;
+
+	PTRIN_CP(*ur32, ur, ucr_data);
+	CP(*ur32, ur, ucr_flags);
+	CP(*ur32, ur, ucr_actlen);
+	CP(*ur32, ur, ucr_addr);
+	CP(*ur32, ur, ucr_request);
+
+	error = ugen_do_request(f, &ur);
+
+	/* Don't update ucr_data pointer */
+	CP(ur, *ur32, ucr_flags);
+	CP(ur, *ur32, ucr_actlen);
+	CP(ur, *ur32, ucr_addr);
+	CP(ur, *ur32, ucr_request);
+
+	return (error);
+}
+#endif
 
 /*------------------------------------------------------------------------
  *	ugen_re_enumerate
@@ -2192,6 +2223,14 @@ ugen_ioctl_post(struct usb_fifo *f, u_long cmd, void *addr, int fflags)
 		error = ugen_get_iface_driver(f, addr);
 		break;
 
+#ifdef COMPAT_FREEBSD32
+	case USB_GET_FULL_DESC32:
+	case USB_GET_STRING_DESC32:
+	case USB_GET_IFACE_DRIVER32:
+		error = ugen_get32(cmd, f, addr);
+		break;
+#endif
+
 	case USB_REQUEST:
 	case USB_DO_REQUEST:
 		if (!(fflags & FWRITE)) {
@@ -2200,6 +2239,17 @@ ugen_ioctl_post(struct usb_fifo *f, u_long cmd, void *addr, int fflags)
 		}
 		error = ugen_do_request(f, addr);
 		break;
+
+#ifdef COMPAT_FREEBSD32
+	case USB_REQUEST32:
+	case USB_DO_REQUEST32:
+		if (!(fflags & FWRITE)) {
+			error = EPERM;
+			break;
+		}
+		error = ugen_do_request32(f, addr);
+		break;
+#endif
 
 	case USB_DEVICEINFO:
 	case USB_GET_DEVICEINFO:
@@ -2363,4 +2413,72 @@ ugen_ctrl_fs_callback(struct usb_xfer *xfer, usb_error_t error)
 		break;
 	}
 }
+
+#ifdef COMPAT_FREEBSD32
+void
+usb_gen_descriptor_from32(struct usb_gen_descriptor *ugd,
+    const struct usb_gen_descriptor32 *ugd32)
+{
+	PTRIN_CP(*ugd32, *ugd, ugd_data);
+	CP(*ugd32, *ugd, ugd_lang_id);
+	CP(*ugd32, *ugd, ugd_maxlen);
+	CP(*ugd32, *ugd, ugd_actlen);
+	CP(*ugd32, *ugd, ugd_offset);
+	CP(*ugd32, *ugd, ugd_config_index);
+	CP(*ugd32, *ugd, ugd_string_index);
+	CP(*ugd32, *ugd, ugd_iface_index);
+	CP(*ugd32, *ugd, ugd_altif_index);
+	CP(*ugd32, *ugd, ugd_endpt_index);
+	CP(*ugd32, *ugd, ugd_report_type);
+	/* Don't copy reserved */
+}
+
+void
+update_usb_gen_descriptor32(struct usb_gen_descriptor32 *ugd32,
+    struct usb_gen_descriptor *ugd)
+{
+	/* Don't update ugd_data pointer */
+	CP(*ugd32, *ugd, ugd_lang_id);
+	CP(*ugd32, *ugd, ugd_maxlen);
+	CP(*ugd32, *ugd, ugd_actlen);
+	CP(*ugd32, *ugd, ugd_offset);
+	CP(*ugd32, *ugd, ugd_config_index);
+	CP(*ugd32, *ugd, ugd_string_index);
+	CP(*ugd32, *ugd, ugd_iface_index);
+	CP(*ugd32, *ugd, ugd_altif_index);
+	CP(*ugd32, *ugd, ugd_endpt_index);
+	CP(*ugd32, *ugd, ugd_report_type);
+	/* Don't update reserved */
+}
+
+static int
+ugen_get32(u_long cmd, struct usb_fifo *f, struct usb_gen_descriptor32 *ugd32)
+{
+	struct usb_gen_descriptor ugd;
+	int error;
+
+	usb_gen_descriptor_from32(&ugd, ugd32);
+	switch (cmd) {
+	case USB_GET_FULL_DESC32:
+		error = ugen_get_cdesc(f, &ugd);
+		break;
+
+	case USB_GET_STRING_DESC32:
+		error = ugen_get_sdesc(f, &ugd);
+		break;
+
+	case USB_GET_IFACE_DRIVER32:
+		error = ugen_get_iface_driver(f, &ugd);
+		break;
+	default:
+		/* Can't happen except by programmer error */
+		panic("%s: called with invalid cmd %lx", __func__, cmd);
+	}
+	update_usb_gen_descriptor32(ugd32, &ugd);
+
+	return (error);
+}
+
+#endif /* COMPAT_FREEBSD32 */
+
 #endif	/* USB_HAVE_UGEN */

--- a/sys/dev/usb/usb_ioctl.h
+++ b/sys/dev/usb/usb_ioctl.h
@@ -46,16 +46,6 @@
 #define	USB_GENERIC_NAME "ugen"
 #define	USB_TEMPLATE_SYSCTL "hw.usb.template"	/* integer type */
 
-/*
- * Align IOCTL structures to hide differences when running 32-bit
- * programs under 64-bit kernels:
- */
-#ifdef COMPAT_32BIT
-#define	USB_IOCTL_STRUCT_ALIGN(n) __aligned(n)
-#else
-#define	USB_IOCTL_STRUCT_ALIGN(n)
-#endif
-
 /* Definition of valid template sysctl values */
 
 enum {
@@ -75,38 +65,26 @@ enum {
 };
 
 struct usb_read_dir {
-#ifdef COMPAT_32BIT
-	uint64_t urd_data;
-#else
 	void   *urd_data;
-#endif
 	uint32_t urd_startentry;
 	uint32_t urd_maxlen;
-} USB_IOCTL_STRUCT_ALIGN(8);
+};
 
 struct usb_ctl_request {
-#ifdef COMPAT_32BIT
-	uint64_t ucr_data;
-#else
 	void   *ucr_data;
-#endif
 	uint16_t ucr_flags;
 	uint16_t ucr_actlen;		/* actual length transferred */
 	uint8_t	ucr_addr;		/* zero - currently not used */
 	struct usb_device_request ucr_request;
-} USB_IOCTL_STRUCT_ALIGN(8);
+};
 
 struct usb_alt_interface {
 	uint8_t	uai_interface_index;
 	uint8_t	uai_alt_index;
-} USB_IOCTL_STRUCT_ALIGN(1);
+};
 
 struct usb_gen_descriptor {
-#ifdef COMPAT_32BIT
-	uint64_t ugd_data;
-#else
 	void   *ugd_data;
-#endif
 	uint16_t ugd_lang_id;
 	uint16_t ugd_maxlen;
 	uint16_t ugd_actlen;
@@ -118,7 +96,7 @@ struct usb_gen_descriptor {
 	uint8_t	ugd_endpt_index;
 	uint8_t	ugd_report_type;
 	uint8_t	reserved[8];
-} USB_IOCTL_STRUCT_ALIGN(8);
+};
 
 struct usb_device_info {
 	uint16_t udi_productNo;
@@ -147,7 +125,7 @@ struct usb_device_info {
 	char	udi_vendor[128];
 	char	udi_serial[64];
 	char	udi_release[8];
-} USB_IOCTL_STRUCT_ALIGN(2);
+};
 
 #define	USB_DEVICE_PORT_PATH_MAX 32
 
@@ -156,24 +134,24 @@ struct usb_device_port_path {
 	uint8_t udp_index;		/* which device index */
 	uint8_t udp_port_level;		/* how many levels: 0, 1, 2 ... */
 	uint8_t udp_port_no[USB_DEVICE_PORT_PATH_MAX];
-} USB_IOCTL_STRUCT_ALIGN(1);
+};
 
 struct usb_device_stats {
 	uint32_t uds_requests_ok[4];	/* Indexed by transfer type UE_XXX */
 	uint32_t uds_requests_fail[4];	/* Indexed by transfer type UE_XXX */
-} USB_IOCTL_STRUCT_ALIGN(4);
+};
 
 struct usb_fs_start {
 	uint8_t	ep_index;
-} USB_IOCTL_STRUCT_ALIGN(1);
+};
 
 struct usb_fs_stop {
 	uint8_t	ep_index;
-} USB_IOCTL_STRUCT_ALIGN(1);
+};
 
 struct usb_fs_complete {
 	uint8_t	ep_index;
-} USB_IOCTL_STRUCT_ALIGN(1);
+};
 
 /* This structure is used for all endpoint types */
 struct usb_fs_endpoint {
@@ -181,14 +159,9 @@ struct usb_fs_endpoint {
 	 * NOTE: isochronous USB transfer only use one buffer, but can have
 	 * multiple frame lengths !
 	 */
-#ifdef COMPAT_32BIT
-	uint64_t ppBuffer;
-	uint64_t pLength;
-#else
 	void  **ppBuffer;		/* pointer to userland buffers */
 	uint32_t *pLength;		/* pointer to frame lengths, updated
 					 * to actual length */
-#endif
 	uint32_t nFrames;		/* number of frames */
 	uint32_t aFrames;		/* actual number of frames */
 	uint16_t flags;
@@ -206,22 +179,18 @@ struct usb_fs_endpoint {
 	/* timeout value for no timeout */
 #define	USB_FS_TIMEOUT_NONE 0
 	int	status;			/* see USB_ERR_XXX */
-} USB_IOCTL_STRUCT_ALIGN(8);
+};
 
 struct usb_fs_init {
 	/* userland pointer to endpoints structure */
-#ifdef COMPAT_32BIT
-	uint64_t pEndpoints;
-#else
 	struct usb_fs_endpoint *pEndpoints;
-#endif
 	/* maximum number of endpoints */
 	uint8_t	ep_index_max;
-} USB_IOCTL_STRUCT_ALIGN(8);
+};
 
 struct usb_fs_uninit {
 	uint8_t	dummy;			/* zero */
-} USB_IOCTL_STRUCT_ALIGN(1);
+};
 
 struct usb_fs_open {
 #define	USB_FS_MAX_BUFSIZE (1 << 25)	/* 32 MBytes */
@@ -233,20 +202,20 @@ struct usb_fs_open {
 	uint8_t	dev_index;		/* currently unused */
 	uint8_t	ep_index;
 	uint8_t	ep_no;			/* bEndpointNumber */
-} USB_IOCTL_STRUCT_ALIGN(4);
+};
 
 struct usb_fs_open_stream {
 	struct usb_fs_open fs_open;
 	uint16_t stream_id;		/* stream ID */
-} USB_IOCTL_STRUCT_ALIGN(4);
+};
 
 struct usb_fs_close {
 	uint8_t	ep_index;
-} USB_IOCTL_STRUCT_ALIGN(1);
+};
 
 struct usb_fs_clear_stall_sync {
 	uint8_t	ep_index;
-} USB_IOCTL_STRUCT_ALIGN(1);
+};
 
 struct usb_gen_quirk {
 	uint16_t index;			/* Quirk Index */
@@ -260,7 +229,7 @@ struct usb_gen_quirk {
 	 * UQ_XXX in "usb_quirk.h".
 	 */
 	char	quirkname[64 - 14];
-} USB_IOCTL_STRUCT_ALIGN(2);
+};
 
 /* USB controller */
 #define	USB_REQUEST		_IOWR('U', 1, struct usb_ctl_request)

--- a/sys/dev/usb/usb_ioctl.h
+++ b/sys/dev/usb/usb_ioctl.h
@@ -400,6 +400,24 @@ void	usb_gen_descriptor_from32(struct usb_gen_descriptor *ugd,
 void	update_usb_gen_descriptor32(struct usb_gen_descriptor32 *ugd32,
     struct usb_gen_descriptor *ugd);
 
+struct usb_fs_endpoint32 {
+	uint32_t ppBuffer;		/* void ** */
+	uint32_t pLength;		/* uint32_t * */
+	uint32_t nFrames;
+	uint32_t aFrames;
+	uint16_t flags;
+	uint16_t timeout;
+	uint16_t isoc_time_complete;
+	int	status;
+};
+
+struct usb_fs_init32 {
+	uint32_t pEndpoints;		/* struct usb_fs_endpoint32 * */
+	uint8_t	ep_index_max;
+};
+
+#define	USB_FS_INIT32	_IOC_NEWTYPE(USB_FS_INIT, struct usb_fs_init32)
+
 #endif	/* COMPAT_FREEBSD32 */
 #endif	/* _KERNEL */
 

--- a/sys/dev/usb/usb_ioctl.h
+++ b/sys/dev/usb/usb_ioctl.h
@@ -346,4 +346,61 @@ struct usb_gen_quirk {
 #define	USB_DEV_QUIRK_ADD	_IOW ('Q', 2, struct usb_gen_quirk)
 #define	USB_DEV_QUIRK_REMOVE	_IOW ('Q', 3, struct usb_gen_quirk)
 
+#ifdef _KERNEL
+#ifdef COMPAT_FREEBSD32
+
+struct usb_read_dir32 {
+	uint32_t urd_data;
+	uint32_t urd_startentry;
+	uint32_t urd_maxlen;
+};
+#define	USB_READ_DIR32 \
+    _IOC_NEWTYPE(USB_READ_DIR, struct usb_read_dir32)
+
+struct usb_ctl_request32 {
+	uint32_t ucr_data;
+	uint16_t ucr_flags;
+	uint16_t ucr_actlen;
+	uint8_t ucr_addr;
+	struct usb_device_request ucr_request;
+};
+#define	USB_REQUEST32		_IOC_NEWTYPE(USB_REQUEST, struct usb_ctl_request32)
+#define	USB_DO_REQUEST32	_IOC_NEWTYPE(USB_DO_REQUEST, struct usb_ctl_request32)
+
+struct usb_gen_descriptor32 {
+	uint32_t ugd_data;	/* void * */
+	uint16_t ugd_lang_id;
+	uint16_t ugd_maxlen;
+	uint16_t ugd_actlen;
+	uint16_t ugd_offset;
+	uint8_t	ugd_config_index;
+	uint8_t	ugd_string_index;
+	uint8_t	ugd_iface_index;
+	uint8_t	ugd_altif_index;
+	uint8_t	ugd_endpt_index;
+	uint8_t	ugd_report_type;
+	uint8_t	reserved[8];
+};
+
+#define	USB_GET_REPORT_DESC32 \
+    _IOC_NEWTYPE(USB_GET_REPORT_DESC, struct usb_gen_descriptor32)
+#define	USB_GET_REPORT32 \
+    _IOC_NEWTYPE(USB_GET_REPORT, struct usb_gen_descriptor32)
+#define	USB_SET_REPORT32 \
+    _IOC_NEWTYPE(USB_SET_REPORT, struct usb_gen_descriptor32)
+#define	USB_GET_FULL_DESC32 \
+    _IOC_NEWTYPE(USB_GET_FULL_DESC, struct usb_gen_descriptor32)
+#define	USB_GET_STRING_DESC32 \
+    _IOC_NEWTYPE(USB_GET_STRING_DESC, struct usb_gen_descriptor32)
+#define	USB_GET_IFACE_DRIVER32 \
+    _IOC_NEWTYPE(USB_GET_IFACE_DRIVER, struct usb_gen_descriptor32)
+
+void	usb_gen_descriptor_from32(struct usb_gen_descriptor *ugd,
+    const struct usb_gen_descriptor32 *ugd32);
+void	update_usb_gen_descriptor32(struct usb_gen_descriptor32 *ugd32,
+    struct usb_gen_descriptor *ugd);
+
+#endif	/* COMPAT_FREEBSD32 */
+#endif	/* _KERNEL */
+
 #endif					/* _USB_IOCTL_H_ */


### PR DESCRIPTION
Replace the COMPAT_32BIT hacks in usb ioctls with actual 32-bit compatibility. We'll need this on CheriBSD because making pointers always 64-bit won't help when native pointers are 128-bit.

This compiles, but is completely untested. I'm not really sure how to go about doing that. I have reasonable confidence that the first commit is correct. Lower confidence that the fifo support is correct as it's more complex.