### PR TITLE
file: Fix cross-compilation on Darwin/macOS

### DIFF
--- a/lib/libmagic/config.h
+++ b/lib/libmagic/config.h
@@ -127,7 +127,9 @@
 #define HAVE_NEWLOCALE 1
 
 /* Define to 1 if you have the `pipe2' function. */
+#ifndef __APPLE__ /* Cross building tools on macOS */
 #define HAVE_PIPE2 1
+#endif
 
 /* Define to 1 if you have the `pread' function. */
 #define HAVE_PREAD 1


### PR DESCRIPTION
Darwin/macOS does not have pipe2(2).

Apply a similar guard as in f3d7ace4b235422e5ccff0315f2965ac935241d8 after 43a5ec4eb41567cc92586503212743d89686d78f.