### PR TITLE
report full error string on SSL_connect() failure in rpc.tlsclntd

### DIFF
--- a/usr.sbin/rpc.tlsclntd/rpc.tlsclntd.c
+++ b/usr.sbin/rpc.tlsclntd/rpc.tlsclntd.c
@@ -655,8 +655,8 @@ rpctls_connect(SSL_CTX *ctx, int s, char *certname, u_int certlen, X509 **certp)
 	ret = SSL_connect(ssl);
 	if (ret != 1) {
 		rpctls_verbose_out("rpctls_connect: "
-		    "SSL_connect failed %d\n",
-		    ret);
+		    "SSL_connect failed %d: %s\n",
+		    ret, ERR_error_string(ERR_get_error(), NULL));
 		SSL_free(ssl);
 		return (NULL);
 	}


### PR DESCRIPTION
This change reports full OpenSSL error string on `SSL_connect()` failure in `rpc.tlsclntd`. Looks like this:
```
Jan 10 18:44:21 freebsd rpc.tlsclntd[12198]: rpctls_connect: SSL_connect failed -1: error:1408F10B:SSL routines:ssl3_get_record:wrong version number
```
I realize that:
  - this is not thread safe
  - there is lot of other places in the code that should receive the same treatment
  - it prints only the top level error from the OpenSSL ERR stack