### PR TITLE
fix: Missing comma in a list in `event_rpcgen.py`

### DIFF
--- a/contrib/ntp/sntp/libevent/event_rpcgen.py
+++ b/contrib/ntp/sntp/libevent/event_rpcgen.py
@@ -811,7 +811,7 @@ class EntryStruct(Entry):
             '  had_error = 1;',
             '  goto done;',
             '}',
-            'done:'
+            'done:',
             'if (tmp != NULL)',
             '  evbuffer_free(tmp);',
             'if (had_error) {',


### PR DESCRIPTION
* The comma has most probably been left out unintentionally, leading to string concatenation between the two lines and potential trouble.