### PR TITLE
dtc.1: Mention the existence of -i flag

### DIFF
--- a/usr.bin/dtc/dtc.1
+++ b/usr.bin/dtc/dtc.1
@@ -41,6 +41,7 @@
 .Op Fl @fhsv
 .Op Fl b Ar boot_cpu_id
 .Op Fl d Ar dependency_file
+.Op Fl i Ar include_path
 .Op Fl E Ar [no-]checker_name
 .Op Fl H Ar phandle_format
 .Op Fl I Ar input_format
@@ -79,6 +80,8 @@ This file can be included in a Makefile and will ensure that the output file
 depends on the input file and any files that it includes.
 This argument is only useful when the input is DTS, as only the source format
 has a notion of inclusions.
+.It Fl i Ar include_path
+Adds a path to search for include files.
 .It Fl E Ar [no-]checker_name
 Enable or disable a specified checker.
 The argument is the name of the checker.

--- a/usr.bin/dtc/dtc.1
+++ b/usr.bin/dtc/dtc.1
@@ -367,7 +367,10 @@ metadata required in overlays.
 This utility is intended to be compatible with the device tree compiler
 provided by elinux.org.
 Currently, it implements the subset of features
-required to build FreeBSD and others that have been requested by FreeBSD
+required to build
+.Fx
+and others that have been requested by
+.Fx
 developers.
 .Pp
 The
@@ -375,8 +378,9 @@ The
 input format is not supported.
 This builds a tree from a Linux
 .Pa  /proc/device-tree ,
-a file system hierarchy not found in FreeBSD, which instead exposes the DTB
-directly via a sysctl.
+a file system hierarchy not found in
+.Fx ,
+which instead exposes the DTB directly via a sysctl.
 .Pp
 The warnings and errors supported by the elinux.org tool are not documented.
 This tool supports the warnings described in the


### PR DESCRIPTION
Also, appease `mandoc -T lint`.