### PR TITLE
libefivar: Correct the string expression of UTF8 vendor device path

### DIFF
--- a/lib/libefivar/efivar-dp-format.c
+++ b/lib/libefivar/efivar-dp-format.c
@@ -255,7 +255,7 @@ DevPathToTextVendor (
         UefiDevicePathLibCatPrint (Str, "VenVt100Plus()");
         return ;
       } else if (CompareGuid (&Vendor->Guid, &gEfiVTUTF8Guid)) {
-        UefiDevicePathLibCatPrint (Str, "VenUft8()");
+        UefiDevicePathLibCatPrint (Str, "VenUtf8()");
         return ;
       } else if (CompareGuid (&Vendor->Guid, &gEfiUartDevicePathGuid)) {
         FlowControlMap = (((UART_FLOW_CONTROL_DEVICE_PATH *) Vendor)->FlowControlMap);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=1225

According to UEFI spec, the string expression of UTF8 vendor device node should be displayed as: `VenUtf8()`. Current code displays it as: `VenUft8()` by mistake when convert device path node to text.

This commit is to fix this bug.

Obtained from:	https://github.com/tianocore/edk2/commit/959be180e185869b71db9dad34c3f4bba660d724