### PR TITLE
ofwdump.8: Remove references to eeprom(8)

### DIFF
--- a/usr.sbin/ofwdump/ofwdump.8
+++ b/usr.sbin/ofwdump/ofwdump.8
@@ -23,7 +23,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd October 18, 2002
+.Dd February 26, 2022
 .Dt OFWDUMP 8
 .Os
 .Sh NAME
@@ -92,8 +92,6 @@ property of the
 node as plain string:
 .Pp
 .Dl "ofwdump -P compatible -S /pci"
-.Sh SEE ALSO
-.Xr eeprom 8
 .Sh HISTORY
 The
 .Nm


### PR DESCRIPTION
Somehow missed in bc4fc770af61bb53a50777e1daf9e263e4b50b3f.