### PR TITLE
Fix sbintime conversion divisors

### DIFF
--- a/sys/sys/time.h
+++ b/sys/sys/time.h
@@ -207,7 +207,7 @@ nstosbt(int64_t _ns)
 #ifdef KASSERT
 	KASSERT(_ns >= 0, ("Negative values illegal for nstosbt: %jd", _ns));
 #endif
-	if (_ns >= SBT_1S) {
+	if (_ns >= 1000000000) {
 		sb = (_ns / 1000000000) * SBT_1S;
 		_ns = _ns % 1000000000;
 	}
@@ -231,7 +231,7 @@ ustosbt(int64_t _us)
 #ifdef KASSERT
 	KASSERT(_us >= 0, ("Negative values illegal for ustosbt: %jd", _us));
 #endif
-	if (_us >= SBT_1S) {
+	if (_us >= 1000000) {
 		sb = (_us / 1000000) * SBT_1S;
 		_us = _us % 1000000;
 	}
@@ -255,7 +255,7 @@ mstosbt(int64_t _ms)
 #ifdef KASSERT
 	KASSERT(_ms >= 0, ("Negative values illegal for mstosbt: %jd", _ms));
 #endif
-	if (_ms >= SBT_1S) {
+	if (_ms >= 1000) {
 		sb = (_ms / 1000) * SBT_1S;
 		_ms = _ms % 1000;
 	}


### PR DESCRIPTION
Functions which convert from ms, us and ns divided by SBT_1S constants instead of
dividing by proper conversion factor.