### PR TITLE
bit_count: Fix invalid calculation when _start is not zero

### DIFF
--- a/sys/sys/bitstring.h
+++ b/sys/sys/bitstring.h
@@ -382,7 +382,7 @@ bit_count(bitstr_t *_bitstr, int _start, int _nbits, int *_result)
 	if (_start > 0) {
 		curbitstr_len = (int)_BITSTR_BITS < _nbits ?
 				(int)_BITSTR_BITS : _nbits;
-		mask = _bit_make_mask(_start, _bit_offset(curbitstr_len - 1));
+		mask = _bit_make_mask(_start, _start + _bit_offset(curbitstr_len - 1));
 		_value += __bitcountl(*_curbitstr & mask);
 		_curbitstr++;
 		_nbits -= _BITSTR_BITS;


### PR DESCRIPTION
_bit_make_mask calculation fails when using e.g.

mask = bits 0 to 200 are set
bit_count(mask, 10, 30) returns 20, but should return 30
