### PR TITLE
Add `NULL` check to prevent `panic` in `mixer.c`

### DIFF
--- a/sys/dev/sound/pcm/mixer.c
+++ b/sys/dev/sound/pcm/mixer.c
@@ -1460,6 +1460,8 @@ mixer_oss_mixerinfo(struct cdev *i_dev, oss_mixerinfo *mi)
 	for (i = 0; pcm_devclass != NULL &&
 	    i < devclass_get_maxunit(pcm_devclass); i++) {
 		d = devclass_get_softc(pcm_devclass, i);
+		if (d == NULL)
+			break;
 		if (PCM_DETACHING(d) || !PCM_REGISTERED(d))
 			continue;
 


### PR DESCRIPTION
Without this check a kernel panic is triggered after running the following program:
```c
#include <fcntl.h> 
#include <stdio.h> 
#include <stdlib.h> 
#include <sys/soundcard.h>
#include <unistd.h> 

int
main()
{
	int fd;
	fd = open("/dev/mixer", O_RDWR);
	oss_mixerinfo mi;
	ioctl(fd, SNDCTL_MIXERINFO, &mi);
	return (0);
}
```