### PR TITLE
Fix _REVISION to be always major.minor

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -537,12 +537,12 @@ SRCRELDATE!=	awk '/^\#define[[:space:]]*__FreeBSD_version/ { print $$3 }' \
 VERSION=	FreeBSD ${_REVISION}-${_BRANCH:C/-p[0-9]+$//} ${TARGET_ARCH} ${SRCRELDATE}
 .export VERSION
 .endif
+MAJOR_REVISION=	${_REVISION:R}
 
 .if !defined(PKG_VERSION)
 _STRTIMENOW=	%Y%m%d%H%M%S
 _TIMENOW=	${_STRTIMENOW:gmtime}
 .if ${_BRANCH:MCURRENT*} || ${_BRANCH:MSTABLE*} || ${_BRANCH:MPRERELEASE*}
-_REVISION:=	${_REVISION:R}
 EXTRA_REVISION=	.snap${_TIMENOW}
 .elif ${_BRANCH:MALPHA*}
 EXTRA_REVISION=	.a${_BRANCH:C/ALPHA([0-9]+).*/\1/}.${_TIMENOW}
@@ -553,7 +553,7 @@ EXTRA_REVISION=	.rc${_BRANCH:C/RC([0-9]+).*/\1/}.${_TIMENOW}
 .elif ${_BRANCH:M*-p*}
 EXTRA_REVISION=	p${_BRANCH:C/.*-p([0-9]+$)/\1/}
 .endif
-PKG_VERSION:=	${_REVISION}${EXTRA_REVISION:C/[[:space:]]//g}
+PKG_VERSION:=	${MAJOR_REVISION}${EXTRA_REVISION:C/[[:space:]]//g}
 .endif
 .endif	# !defined(PKG_VERSION)
 
@@ -1885,7 +1885,7 @@ _pkgbootstrap: .PHONY
 # Determine PKG_ABI from newvers.sh if not already set.
 #
 .if !defined(PKG_ABI) && (make(create-world-packages-jobs) || make(create-kernel-packages*) || make(real-update-packages) || make(sign-packages))
-PKG_ABI=${_TYPE}:${_REVISION:S/\..*$//}:${TARGET_ARCH}
+PKG_ABI=${_TYPE}:${MAJOR_REVISION}:${TARGET_ARCH}
 .endif
 PKG_BIN_VERSION!=${PKG_CMD} --version </dev/null 2>/dev/null |\
     awk -F. '/^[0-9.]+$$/ {print $$1 * 10000 + $$2 * 100 + $$3}'


### PR DESCRIPTION
Introduced in commit 613fe53, _REVISION was redefined to be just the
major version (14) instead of major.minor (14.0) iff:

  - PKG_VERSION was not overridden (default), and
  - Branch was -CURRENT, -STABLE, or -PRERELEASE.

This introduced side effects in other parts of the code which expected
_REVISION to be major.minor:

  - make-pkg-package.sh target triple became amd64-portbld-freebsd14
    (should be amd64-portbld-freebsd14.0);
  - Versioned cross dev symlink name became amd64-freebsd14-&lt;tool&gt;
    (should be amd64-freebsd14.0-&lt;tool&gt;)

Also, compounded with commit ea9a92d (which was introduced afterward
and removed minor version from _REVISION incorrectly using :S with a
regex) this also caused pkgbase repo to use a wrong PKG_ABI with a minor
version (FreeBSD:14.0:amd64) when a custom PKG_VERSION was specified.
(Note, without a custom PKG_VERSION the bug was not triggered because in
that case _REVISION was already major-only.)

This commit fixes both problems by introducing and using MAJOR_REVISION
instead of redefining _REVISION.  Existing uses of _REVISION now see
major.minor again, except PKG_ABI (ex: FreeBSD:14:amd64, as described
above) and PKG_VERSION (ex: 14.snap20220311121531) need only the major
version and now use MAJOR_REVISION instead.