### PR TITLE
stge: fix null pointer dereference

### DIFF
--- a/sys/dev/stge/if_stge.c
+++ b/sys/dev/stge/if_stge.c
@@ -699,7 +699,9 @@ stge_detach(device_t dev)
 		bus_teardown_intr(dev, sc->sc_res[1], sc->sc_ih);
 		sc->sc_ih = NULL;
 	}
-	bus_release_resources(dev, sc->sc_spec, sc->sc_res);
+
+	if (sc->sc_spec)
+		bus_release_resources(dev, sc->sc_spec, sc->sc_res);
 
 	mtx_destroy(&sc->sc_mii_mtx);
 	mtx_destroy(&sc->sc_mtx);


### PR DESCRIPTION
stge_attach() could fail at line 464, sc->sc_spec remains NULL when
calling stge_detach(), thus bus_release_resources() at line 704 will
trigger null pointer dereference. We need to check the nulliness before
calling bus_release_resources().

Signed-off-by: Tong Zhang <ztong0001@gmail.com>