### PR TITLE
More complete -m32 support for amd64

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -1062,6 +1062,9 @@ _bootstrap-tools:
 	    -p ${WORLDTMP}/usr >/dev/null
 	${WORLDTMP_MTREE} -f ${.CURDIR}/etc/mtree/BSD.include.dist \
 	    -p ${WORLDTMP}/usr/include >/dev/null
+.if ${TARGET_ARCH} == "amd64"
+	mkdir -p ${WORLDTMP}/usr/include/i386
+.endif
 	ln -sf ${.CURDIR}/sys ${WORLDTMP}
 .if ${MK_DEBUG_FILES} != "no"
 	${WORLDTMP_MTREE} -f ${.CURDIR}/etc/mtree/BSD.debug.dist \
@@ -1395,6 +1398,9 @@ distributeworld installworld stageworld: _installcheck_world .PHONY
 	    -p ${DESTDIR}/${DISTDIR}/${dist}/usr >/dev/null
 	${DESTDIR_MTREE} -f ${.CURDIR}/etc/mtree/BSD.include.dist \
 	    -p ${DESTDIR}/${DISTDIR}/${dist}/usr/include >/dev/null
+.if ${TARGET_ARCH} == "amd64"
+	-mkdir  ${DESTDIR}/${DISTDIR}/usr/include/i386
+.endif
 .if ${MK_DEBUG_FILES} != "no"
 	${DESTDIR_MTREE} -f ${.CURDIR}/etc/mtree/BSD.debug.dist \
 	    -p ${DESTDIR}/${DISTDIR}/${dist}/usr/lib >/dev/null
@@ -1423,6 +1429,9 @@ distributeworld installworld stageworld: _installcheck_world .PHONY
 	    sed -e 's#^\./#./${dist}/usr/#' >> ${METALOG}
 	${IMAKEENV} ${DISTR_MTREE} -C -f ${.CURDIR}/etc/mtree/BSD.include.dist | \
 	    sed -e 's#^\./#./${dist}/usr/include/#' >> ${METALOG}
+.if ${TARGET_ARCH} == "amd64"
+	echo "./${dist}/usr/include/i386 type=dir uname=root gname=wheel mode=0755" >> ${METALOG}
+.endif
 .if defined(_LIBCOMPAT)
 	${IMAKEENV} ${DISTR_MTREE} -C -f ${.CURDIR}/etc/mtree/BSD.lib${libcompat}.dist | \
 	    sed -e 's#^\./#./${dist}/usr/#' >> ${METALOG}
@@ -2852,6 +2861,9 @@ native-xtools-install: .PHONY
 	    -p ${NXBDESTDIR}/usr >/dev/null
 	${DESTDIR_MTREE} -f ${.CURDIR}/etc/mtree/BSD.include.dist \
 	    -p ${NXBDESTDIR}/usr/include >/dev/null
+.if ${TARGET_ARCH} == "amd64"
+	mkdir -p ${NXBDESTDIR}/usr/include/i386
+.endif
 	${_+_}cd ${.CURDIR}; ${NXBMAKE} \
 	    DESTDIR=${NXBDESTDIR} \
 	    -DNO_ROOT \
@@ -3545,6 +3557,9 @@ _xi-mtree: .PHONY
 	    -p ${XDDESTDIR}/usr >/dev/null
 	${DESTDIR_MTREE} -f ${.CURDIR}/etc/mtree/BSD.include.dist \
 	    -p ${XDDESTDIR}/usr/include >/dev/null
+.if ${TARGET_ARCH} == "amd64"
+	mkdir -p ${XDDESTDIR}/usr/include/i386
+.endif
 .if defined(_LIBCOMPAT)
 	${DESTDIR_MTREE} -f ${.CURDIR}/etc/mtree/BSD.lib${libcompat}.dist \
 	    -p ${XDDESTDIR}/usr >/dev/null

--- a/include/Makefile
+++ b/include/Makefile
@@ -8,6 +8,9 @@
 PACKAGE=runtime
 CLEANFILES= osreldate.h version
 SUBDIR= arpa protocols rpcsvc rpc xlocale
+.if ${MACHINE_CPUARCH} == "amd64"
+SUBDIR+=	i386
+.endif
 SUBDIR_PARALLEL=
 INCS=	a.out.h ar.h assert.h bitstring.h complex.h cpio.h _ctype.h ctype.h \
 	db.h \
@@ -338,6 +341,10 @@ compat:
 	mtree -deU ${NO_ROOT:D-W} ${MTREE_FOLLOWS_SYMLINKS} \
 	    -f ${SRCTOP}/etc/mtree/BSD.include.dist \
 	    -p ${SDESTDIR}${INCLUDEDIR} > /dev/null
+.if ${MACHINE_CPUARCH} == "amd64"
+	${INSTALL} -d ${TAG_ARGS} -o ${BINOWN} -g ${BINGRP} -m 755 \
+	    ${SDESTDIR}${INCLUDEDIR}/i386
+.endif
 
 copies: .PHONY .META
 	cd ${SDESTDIR}${INCLUDEDIR}; find ${LDIRS} ${LSUBDIRS} ${LSUBSUBDIRS} crypto \

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -6,6 +6,7 @@ INCS=	\
 	asmacros.h \
 	atomic.h \
 	cpufunc.h \
+	pmap.h \
 	profile.h \
 	segments.h
 INCSDIR=	${INCLUDEDIR}/i386

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -4,6 +4,7 @@
 INCS=	\
 	asm.h \
 	asmacros.h \
+	atomic.h \
 	cpufunc.h \
 	profile.h
 INCSDIR=	${INCLUDEDIR}/i386

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -14,7 +14,8 @@ INCS=	\
 # These kernel-only headers are used by procstat's ZFS support.
 # This should be fixed.
 INCS+=	\
-	pcpu.h
+	pcpu.h \
+	pcpu_aux.h
 INCSDIR=	${INCLUDEDIR}/i386
 
 .include <bsd.prog.mk>

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -6,7 +6,8 @@ INCS=	\
 	asmacros.h \
 	atomic.h \
 	cpufunc.h \
-	profile.h
+	profile.h \
+	segments.h
 INCSDIR=	${INCLUDEDIR}/i386
 
 .include <bsd.prog.mk>

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -7,6 +7,7 @@ INCS=	\
 	atomic.h \
 	cpufunc.h \
 	pmap.h \
+	proc.h \
 	profile.h \
 	segments.h
 INCSDIR=	${INCLUDEDIR}/i386

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -1,0 +1,7 @@
+# i386 headers installed on amd64
+
+.PATH: ${SRCTOP}/sys/i386/include
+INCS=
+INCSDIR=	${INCLUDEDIR}/i386
+
+.include <bsd.prog.mk>

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -9,7 +9,8 @@ INCS=	\
 	pmap.h \
 	proc.h \
 	profile.h \
-	segments.h
+	segments.h \
+	vmparam.h
 INCSDIR=	${INCLUDEDIR}/i386
 
 .include <bsd.prog.mk>

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -1,7 +1,8 @@
 # i386 headers installed on amd64
 
 .PATH: ${SRCTOP}/sys/i386/include
-INCS=
+INCS=	\
+	cpufunc.h
 INCSDIR=	${INCLUDEDIR}/i386
 
 .include <bsd.prog.mk>

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -15,6 +15,7 @@ INCS=	\
 # This should be fixed.
 INCS+=	\
 	counter.h \
+	md_var.h \
 	pcpu.h \
 	pcpu_aux.h
 INCSDIR=	${INCLUDEDIR}/i386

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -2,6 +2,8 @@
 
 .PATH: ${SRCTOP}/sys/i386/include
 INCS=	\
+	asm.h \
+	asmacros.h \
 	cpufunc.h \
 	profile.h
 INCSDIR=	${INCLUDEDIR}/i386

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -2,7 +2,8 @@
 
 .PATH: ${SRCTOP}/sys/i386/include
 INCS=	\
-	cpufunc.h
+	cpufunc.h \
+	profile.h
 INCSDIR=	${INCLUDEDIR}/i386
 
 .include <bsd.prog.mk>

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -11,6 +11,10 @@ INCS=	\
 	profile.h \
 	segments.h \
 	vmparam.h
+# These kernel-only headers are used by procstat's ZFS support.
+# This should be fixed.
+INCS+=	\
+	pcpu.h
 INCSDIR=	${INCLUDEDIR}/i386
 
 .include <bsd.prog.mk>

--- a/include/i386/Makefile
+++ b/include/i386/Makefile
@@ -14,6 +14,7 @@ INCS=	\
 # These kernel-only headers are used by procstat's ZFS support.
 # This should be fixed.
 INCS+=	\
+	counter.h \
 	pcpu.h \
 	pcpu_aux.h
 INCSDIR=	${INCLUDEDIR}/i386

--- a/sys/amd64/include/asm.h
+++ b/sys/amd64/include/asm.h
@@ -35,6 +35,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/asm.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_ASM_H_
 #define	_MACHINE_ASM_H_
 
@@ -110,3 +114,5 @@
 #endif /* !STRIP_FBSDID */
 
 #endif /* !_MACHINE_ASM_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/asmacros.h
+++ b/sys/amd64/include/asmacros.h
@@ -39,6 +39,10 @@
  * $FreeBSD$
  */
 
+#if defined(__i386__)
+#include <i386/asmacros.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_ASMACROS_H_
 #define _MACHINE_ASMACROS_H_
 
@@ -264,3 +268,5 @@ X\vec_name:
 #endif /* __STDC__ */
 
 #endif /* !_MACHINE_ASMACROS_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/atomic.h
+++ b/sys/amd64/include/atomic.h
@@ -27,6 +27,11 @@
  *
  * $FreeBSD$
  */
+
+#ifdef __i386__
+#include <i386/atomic.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_ATOMIC_H_
 #define	_MACHINE_ATOMIC_H_
 
@@ -592,3 +597,5 @@ atomic_swap_long(volatile u_long *p, u_long v)
 #endif /* !SAN_NEEDS_INTERCEPTORS || SAN_RUNTIME */
 
 #endif /* !_MACHINE_ATOMIC_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/counter.h
+++ b/sys/amd64/include/counter.h
@@ -28,6 +28,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/counter.h>
+#else /* !__i386__ */
+
 #ifndef __MACHINE_COUNTER_H__
 #define __MACHINE_COUNTER_H__
 
@@ -90,3 +94,5 @@ counter_u64_add(counter_u64_t c, int64_t inc)
 }
 
 #endif	/* ! __MACHINE_COUNTER_H__ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/cpufunc.h
+++ b/sys/amd64/include/cpufunc.h
@@ -105,16 +105,16 @@ static __inline void
 do_cpuid(u_int ax, u_int *p)
 {
 	__asm __volatile("cpuid"
-			 : "=a" (p[0]), "=b" (p[1]), "=c" (p[2]), "=d" (p[3])
-			 :  "0" (ax));
+	    : "=a" (p[0]), "=b" (p[1]), "=c" (p[2]), "=d" (p[3])
+	    :  "0" (ax));
 }
 
 static __inline void
 cpuid_count(u_int ax, u_int cx, u_int *p)
 {
 	__asm __volatile("cpuid"
-			 : "=a" (p[0]), "=b" (p[1]), "=c" (p[2]), "=d" (p[3])
-			 :  "0" (ax), "c" (cx));
+	    : "=a" (p[0]), "=b" (p[1]), "=c" (p[2]), "=d" (p[3])
+	    :  "0" (ax), "c" (cx));
 }
 
 static __inline void

--- a/sys/amd64/include/cpufunc.h
+++ b/sys/amd64/include/cpufunc.h
@@ -38,6 +38,10 @@
  * used in preference to this.
  */
 
+#ifdef __i386__
+#include <i386/cpufunc.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_CPUFUNC_H_
 #define	_MACHINE_CPUFUNC_H_
 
@@ -966,3 +970,5 @@ int	wrmsr_safe(u_int msr, uint64_t newval);
 #endif
 
 #endif /* !_MACHINE_CPUFUNC_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/md_var.h
+++ b/sys/amd64/include/md_var.h
@@ -31,6 +31,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/md_var.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_MD_VAR_H_
 #define	_MACHINE_MD_VAR_H_
 
@@ -95,3 +99,5 @@ int	set_fpcontext(struct thread *td, struct __mcontext *mcp,
 	    char *xfpustate, size_t xfpustate_len);
 
 #endif /* !_MACHINE_MD_VAR_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/pcpu.h
+++ b/sys/amd64/include/pcpu.h
@@ -28,6 +28,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/pcpu.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_PCPU_H_
 #define	_MACHINE_PCPU_H_
 
@@ -274,3 +278,5 @@ _Static_assert(sizeof(struct monitorbuf) == 128, "2x cache line");
 #endif /* _KERNEL */
 
 #endif /* !_MACHINE_PCPU_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/pcpu_aux.h
+++ b/sys/amd64/include/pcpu_aux.h
@@ -30,6 +30,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/pcpu_aux.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_PCPU_AUX_H_
 #define	_MACHINE_PCPU_AUX_H_
 
@@ -60,3 +64,5 @@ __curthread(void)
 #define	curpcb			(&curthread->td_md.md_pcb)
 
 #endif	/* _MACHINE_PCPU_AUX_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/pmap.h
+++ b/sys/amd64/include/pmap.h
@@ -44,6 +44,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/pmap.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_PMAP_H_
 #define	_MACHINE_PMAP_H_
 
@@ -584,3 +588,5 @@ pmap_pml5e_index(vm_offset_t va)
 #endif /* !LOCORE */
 
 #endif /* !_MACHINE_PMAP_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/proc.h
+++ b/sys/amd64/include/proc.h
@@ -32,6 +32,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/proc.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_PROC_H_
 #define	_MACHINE_PROC_H_
 
@@ -117,3 +121,5 @@ extern int max_ldt_segment;
 #endif  /* _KERNEL */
 
 #endif /* !_MACHINE_PROC_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/profile.h
+++ b/sys/amd64/include/profile.h
@@ -32,6 +32,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/profile.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_PROFILE_H_
 #define	_MACHINE_PROFILE_H_
 
@@ -116,3 +120,5 @@ __END_DECLS
 #endif /* !_KERNEL */
 
 #endif /* !_MACHINE_PROFILE_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/segments.h
+++ b/sys/amd64/include/segments.h
@@ -36,6 +36,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/segments.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_SEGMENTS_H_
 #define	_MACHINE_SEGMENTS_H_
 
@@ -105,3 +109,5 @@ void	update_gdt_fsbase(struct thread *td, uint32_t base);
 #endif /* _KERNEL */
 
 #endif /* !_MACHINE_SEGMENTS_H_ */
+
+#endif /* __i386__ */

--- a/sys/amd64/include/sf_buf.h
+++ b/sys/amd64/include/sf_buf.h
@@ -31,6 +31,7 @@
 #ifndef _MACHINE_SF_BUF_H_
 #define _MACHINE_SF_BUF_H_
 
+#ifdef __amd64__
 /*
  * On this machine, the only purpose for which sf_buf is used is to implement
  * an opaque pointer required by the machine-independent parts of the kernel.
@@ -50,4 +51,5 @@ sf_buf_page(struct sf_buf *sf)
 
 	return ((vm_page_t)sf);
 }
+#endif /* __amd64__ */
 #endif /* !_MACHINE_SF_BUF_H_ */

--- a/sys/amd64/include/vmparam.h
+++ b/sys/amd64/include/vmparam.h
@@ -43,6 +43,10 @@
  * $FreeBSD$
  */
 
+#ifdef __i386__
+#include <i386/vmparam.h>
+#else /* !__i386__ */
+
 #ifndef _MACHINE_VMPARAM_H_
 #define	_MACHINE_VMPARAM_H_ 1
 
@@ -302,3 +306,5 @@
 #define MINIDUMP_PAGE_TRACKING	1
 
 #endif /* _MACHINE_VMPARAM_H_ */
+
+#endif /* __i386__ */

--- a/sys/conf/kern.post.mk
+++ b/sys/conf/kern.post.mk
@@ -360,6 +360,9 @@ _ILINKS+= ${MACHINE_CPUARCH}
 .if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"
 _ILINKS+= x86
 .endif
+.if ${MACHINE_CPUARCH} == "amd64"
+_ILINKS+= i386
+.endif
 
 # Ensure that the link exists without depending on it when it exists.
 # Ensure that debug info references the path in the source tree.

--- a/sys/conf/kmod.mk
+++ b/sys/conf/kmod.mk
@@ -283,6 +283,9 @@ _ILINKS=machine
 .if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"
 _ILINKS+=x86
 .endif
+.if ${MACHINE_CPUARCH} == "amd64"
+_ILINKS+=i386
+.endif
 CLEANFILES+=${_ILINKS}
 
 all: ${PROG}

--- a/sys/i386/include/cpufunc.h
+++ b/sys/i386/include/cpufunc.h
@@ -98,7 +98,6 @@ clts(void)
 static __inline void
 disable_intr(void)
 {
-
 	__asm __volatile("cli" : : : "memory");
 }
 
@@ -147,14 +146,12 @@ cpuid_count(u_int ax, u_int cx, u_int *p)
 static __inline void
 enable_intr(void)
 {
-
 	__asm __volatile("sti");
 }
 
 static __inline void
 cpu_monitor(const void *addr, u_long extensions, u_int hints)
 {
-
 	__asm __volatile("monitor"
 	    : : "a" (addr), "c" (extensions), "d" (hints));
 }
@@ -162,28 +159,24 @@ cpu_monitor(const void *addr, u_long extensions, u_int hints)
 static __inline void
 cpu_mwait(u_long extensions, u_int hints)
 {
-
 	__asm __volatile("mwait" : : "a" (hints), "c" (extensions));
 }
 
 static __inline void
 lfence(void)
 {
-
 	__asm __volatile("lfence" : : : "memory");
 }
 
 static __inline void
 mfence(void)
 {
-
 	__asm __volatile("mfence" : : : "memory");
 }
 
 static __inline void
 sfence(void)
 {
-
 	__asm __volatile("sfence" : : : "memory");
 }
 


### PR DESCRIPTION
This set of patches makes am amd64 sysroot sufficiently compatible to build C startup (csu) code and all libraries in the base system for i386 using the -m32 flag.  The patches use two methods to do this depending on header complexity:
 -  Making a single combined header installed in `/usr/include/x86` which is included by stubs in the amd64 and i386 `machine` directories. Some existing headers do this.
 - Adding a new `i386` include directory on amd64 where the i386 header is installed and included in place of the contents of the amd64 version when targeting i386.