### PR TITLE
WIP: Facilitate the update of blacklistd (blocklistd)

### DIFF
--- a/contrib/blacklist/FreeBSD-update
+++ b/contrib/blacklist/FreeBSD-update
@@ -1,0 +1,48 @@
+FreeBSD still calls blocklistd blacklistd.
+
+In the meantime:
+
+    #!/bin/sh
+
+    # Inside files blocklist -> blacklist
+    # NB: Granted this is wrong for port/debian, but this script is
+    #     already pedestrian.
+    files="$(find contrib/blacklist -print)"
+
+    for file in $files; do
+    	sed -i "" -e 's/blocklist/blacklist/g' "$file"
+    	sed -i "" -e 's/Blocklist/Blacklist/g' "$file"
+    	sed -i "" -e 's/BLOCKLIST/BLACKLIST/g' "$file"
+    done
+
+    # Remove Debian port
+    rm -rf contrib/blacklist/port/debian
+
+    # Remove postfix.diff patch
+    rm -f contrib/blacklist/diff/postfix.diff
+
+    # Filenames blocklist -> blacklist
+    mv contrib/blacklist/bin/blocklistctl.8 contrib/blacklist/bin/blacklistctl.8
+    mv contrib/blacklist/bin/blocklistctl.c contrib/blacklist/bin/blacklistctl.c
+    mv contrib/blacklist/bin/blocklistd.8 contrib/blacklist/bin/blacklistd.8
+    mv contrib/blacklist/bin/blocklistd.c contrib/blacklist/bin/blacklistd.c
+    mv contrib/blacklist/bin/blocklistd.conf.5 contrib/blacklist/bin/blacklistd.conf.5
+    mv contrib/blacklist/etc/blocklistd.conf contrib/blacklist/etc/blacklistd.conf
+    mv contrib/blacklist/etc/rc.d/blocklistd contrib/blacklist/etc/rc.d/blacklistd
+    mv contrib/blacklist/include/blocklist.h contrib/blacklist/include/blacklist.h
+    mv contrib/blacklist/lib/blocklist.c contrib/blacklist/lib/blacklist.c
+    mv contrib/blacklist/lib/libblocklist.3 contrib/blacklist/lib/libblacklist.3
+    mv contrib/blacklist/libexec/blocklistd-helper contrib/blacklist/libexec/blacklistd-helper
+    mv contrib/blacklist/port/debian/blocklist.manpages contrib/blacklist/port/debian/blacklist.manpages
+
+    # /libexec -> /usr/libexec
+    sed -i "" -e 's|/libexec|/usr/libexec|g' contrib/blacklist/bin/blacklistd.8
+
+    # NetBSD: RT_ROUNDUP -> FreeBSD: SA_SIZE (from net/route.h)
+    sed -i "" -e 's/RT_ROUNDUP/SA_SIZE/g' contrib/blacklist/bin/conf.c
+
+    # TODO: Should we add ipf(8) and ipfw(8) as well?
+    sed -i "" -e 's/npfctl/pfctl/g' contrib/blacklist/bin/blacklistd.8
+
+    # TODO: contrib/blacklist/etc/rc.d/blacklistd: should we change it to:
+    # REQUIRE: ipfilter ipfw pf

--- a/contrib/blacklist/Makefile
+++ b/contrib/blacklist/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.2 2015/01/22 17:49:41 christos Exp $
+# $NetBSD: Makefile,v 1.1 2015/01/21 16:16:00 christos Exp $
 
 SUBDIR = lib .WAIT include bin etc libexec
 

--- a/contrib/blacklist/Makefile.inc
+++ b/contrib/blacklist/Makefile.inc
@@ -1,4 +1,4 @@
-#	$NetBSD: Makefile.inc,v 1.3 2015/01/23 03:57:22 christos Exp $
+#	$NetBSD: Makefile.inc,v 1.2 2015/01/22 04:20:50 christos Exp $
 
 WARNS=6
 .if !defined(LIB)

--- a/contrib/blacklist/README
+++ b/contrib/blacklist/README
@@ -1,4 +1,4 @@
-# $NetBSD: README,v 1.8 2017/04/13 17:59:34 christos Exp $
+# $NetBSD: README,v 1.7 2015/01/26 00:34:50 christos Exp $
 
 This package contains library that can be used by network daemons to
 communicate with a packet filter via a daemon to enforce opening and

--- a/contrib/blacklist/TODO
+++ b/contrib/blacklist/TODO
@@ -1,4 +1,4 @@
-# $NetBSD: TODO,v 1.7 2015/01/23 21:34:01 christos Exp $
+# $NetBSD: TODO,v 1.6 2015/01/22 18:15:56 christos Exp $
 
 - don't poll periodically, find the next timeout
 - use the socket also for commands? Or separate socket?
@@ -19,3 +19,46 @@
 	unblock
 - do we need an api in blacklistctl to perform maintenance
 - fix the blacklistctl output to be more user friendly
+
+- figure out some way to do distributed operation securely (perhaps with
+  a helper daemon that authenticates local sockets and then communicates
+  local DB changes to the central server over a secure channel --
+  perhaps blacklistd-helper can have a back-end that can send updates to
+  a central server)
+
+- add "blacklistd -l" to enable filter logging on all rules by default
+
+- add some new options in the config file
+
+	"/all"	- block both TCP and UDP (on the proto field?)
+
+	"/log"	- enable filter logging (if not the default) (on the name field?)
+	"/nolog"- disable filter logging (if not the default) (on the name field?)
+
+  The latter two probably require a new parameter for blacklistd-helper.
+
+- "blacklistd -f" should (also?) be a blacklistctl function!?!?!
+
+- if blacklistd was started with '-r' then a SIGHUP should also do a
+  "control flush $rulename" and then re-add all the filter rules?
+
+- should/could /etc/rc.conf.d/ipfilter be created with the following?
+
+	reload_postcmd=blacklistd_reload
+	start_postcmd=blacklistd_start
+	stop_precmd=blacklistd_stop
+	blacklistd_reload ()
+	{
+		/etc/rc.d/blacklistd reload	# IFF SIGHUP does flush/re-add
+		# /etc/rc.d/blacklistd restart
+	}
+	blacklistd_stop ()
+	{
+		/etc/rc.d/blacklistd stop
+	}
+	blacklistd_start ()
+	{
+		/etc/rc.d/blacklistd start
+	}
+
+  or is there a better way?

--- a/contrib/blacklist/bin/Makefile
+++ b/contrib/blacklist/bin/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.11 2015/01/27 19:40:36 christos Exp $
+# $NetBSD: Makefile,v 1.10 2015/01/22 17:49:41 christos Exp $
 
 BINDIR=/sbin
 

--- a/contrib/blacklist/bin/blacklistctl.8
+++ b/contrib/blacklist/bin/blacklistctl.8
@@ -1,4 +1,4 @@
-.\" $NetBSD: blacklistctl.8,v 1.9 2016/06/08 12:48:37 wiz Exp $
+.\" $NetBSD: blacklistctl.8,v 1.8 2016/06/07 17:31:02 christos Exp $
 .\"
 .\" Copyright (c) 2015 The NetBSD Foundation, Inc.
 .\" All rights reserved.

--- a/contrib/blacklist/bin/blacklistctl.c
+++ b/contrib/blacklist/bin/blacklistctl.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: blacklistctl.c,v 1.23 2018/05/24 19:21:01 christos Exp $	*/
+/*	$NetBSD: blacklistctl.c,v 1.2 2022/06/11 19:23:26 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.
@@ -33,7 +33,7 @@
 #endif
 
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: blacklistctl.c,v 1.23 2018/05/24 19:21:01 christos Exp $");
+__RCSID("$NetBSD: blacklistctl.c,v 1.2 2022/06/11 19:23:26 christos Exp $");
 
 #include <stdio.h>
 #include <time.h>

--- a/contrib/blacklist/bin/blacklistd.8
+++ b/contrib/blacklist/bin/blacklistd.8
@@ -269,6 +269,8 @@ Socket to receive connection notifications.
 .Sh SEE ALSO
 .Xr blacklistd.conf 5 ,
 .Xr blacklistctl 8 ,
+.Xr ipf 8 ,
+.Xr ipfw 8 ,
 .Xr pfctl 8 ,
 .Xr syslogd 8
 .Sh HISTORY

--- a/contrib/blacklist/bin/blacklistd.c
+++ b/contrib/blacklist/bin/blacklistd.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: blacklistd.c,v 1.38 2019/02/27 02:20:18 christos Exp $	*/
+/*	$NetBSD: blacklistd.c,v 1.2 2022/06/11 19:15:58 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.
@@ -32,7 +32,7 @@
 #include "config.h"
 #endif
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: blacklistd.c,v 1.38 2019/02/27 02:20:18 christos Exp $");
+__RCSID("$NetBSD: blacklistd.c,v 1.2 2022/06/11 19:15:58 christos Exp $");
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/contrib/blacklist/bin/conf.c
+++ b/contrib/blacklist/bin/conf.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: conf.c,v 1.24 2016/04/04 15:52:56 christos Exp $	*/
+/*	$NetBSD: conf.c,v 1.2 2022/06/13 15:00:20 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.
@@ -33,7 +33,7 @@
 #endif
 
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: conf.c,v 1.24 2016/04/04 15:52:56 christos Exp $");
+__RCSID("$NetBSD: conf.c,v 1.2 2022/06/13 15:00:20 christos Exp $");
 
 #include <stdio.h>
 #ifdef HAVE_LIBUTIL_H
@@ -46,6 +46,7 @@ __RCSID("$NetBSD: conf.c,v 1.24 2016/04/04 15:52:56 christos Exp $");
 #include <ctype.h>
 #include <inttypes.h>
 #include <netdb.h>
+#include <unistd.h>
 #include <pwd.h>
 #include <syslog.h>
 #include <errno.h>
@@ -55,6 +56,7 @@ __RCSID("$NetBSD: conf.c,v 1.24 2016/04/04 15:52:56 christos Exp $");
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <net/if.h>
+#include <net/route.h>
 #include <sys/socket.h>
 
 #include "bl.h"
@@ -90,7 +92,7 @@ advance(char **p)
 }
 
 static int
-getnum(const char *f, size_t l, bool local, void *rp, const char *name,
+conf_getnum(const char *f, size_t l, bool local, void *rp, const char *name,
     const char *p)
 {
 	int e;
@@ -127,13 +129,14 @@ out:
 }
 
 static int
-getnfail(const char *f, size_t l, bool local, struct conf *c, const char *p)
+conf_getnfail(const char *f, size_t l, bool local, struct conf *c,
+    const char *p)
 {
-	return getnum(f, l, local, &c->c_nfail, "nfail", p);
+	return conf_getnum(f, l, local, &c->c_nfail, "nfail", p);
 }
 
 static int
-getsecs(const char *f, size_t l, bool local, struct conf *c, const char *p)
+conf_getsecs(const char *f, size_t l, bool local, struct conf *c, const char *p)
 {
 	int e;
 	char *ep;
@@ -193,7 +196,7 @@ out:
 }
 
 static int
-getport(const char *f, size_t l, bool local, void *r, const char *p)
+conf_getport(const char *f, size_t l, bool local, void *r, const char *p)
 {
 	struct servent *sv;
 
@@ -207,11 +210,11 @@ getport(const char *f, size_t l, bool local, void *r, const char *p)
 		return 0;
 	}
 
-	return getnum(f, l, local, r, "service", p);
+	return conf_getnum(f, l, local, r, "service", p);
 }
 
 static int
-getmask(const char *f, size_t l, bool local, const char **p, int *mask)
+conf_getmask(const char *f, size_t l, bool local, const char **p, int *mask)
 {
 	char *d;
 	const char *s = *p;
@@ -226,11 +229,12 @@ getmask(const char *f, size_t l, bool local, const char **p, int *mask)
 	}
 
 	*d++ = '\0';
-	return getnum(f, l, local, mask, "mask", d);
+	return conf_getnum(f, l, local, mask, "mask", d);
 }
 
 static int
-gethostport(const char *f, size_t l, bool local, struct conf *c, const char *p)
+conf_gethostport(const char *f, size_t l, bool local, struct conf *c,
+    const char *p)
 {
 	char *d;	// XXX: Ok to write to string.
 	in_port_t *port = NULL;
@@ -249,7 +253,7 @@ gethostport(const char *f, size_t l, bool local, struct conf *c, const char *p)
 	} else
 		pstr = p;
 
-	if (getmask(f, l, local, &pstr, &c->c_lmask) == -1)
+	if (conf_getmask(f, l, local, &pstr, &c->c_lmask) == -1)
 		goto out;
 
 	if (d) {
@@ -300,7 +304,7 @@ gethostport(const char *f, size_t l, bool local, struct conf *c, const char *p)
 		}
 	}
 
-	if (getport(f, l, local, &c->c_port, pstr) == -1)
+	if (conf_getport(f, l, local, &c->c_port, pstr) == -1)
 		return -1;
 
 	if (port && c->c_port != FSTAR && c->c_port != FEQUAL)
@@ -320,7 +324,7 @@ out2:
 }
 
 static int
-getproto(const char *f, size_t l, bool local __unused, struct conf *c,
+conf_getproto(const char *f, size_t l, bool local __unused, struct conf *c,
     const char *p)
 {
 	if (strcmp(p, "stream") == 0) {
@@ -331,22 +335,22 @@ getproto(const char *f, size_t l, bool local __unused, struct conf *c,
 		c->c_proto = IPPROTO_UDP;
 		return 0;
 	}
-	return getnum(f, l, local, &c->c_proto, "protocol", p);
+	return conf_getnum(f, l, local, &c->c_proto, "protocol", p);
 }
 
 static int
-getfamily(const char *f, size_t l, bool local __unused, struct conf *c,
+conf_getfamily(const char *f, size_t l, bool local __unused, struct conf *c,
     const char *p)
 {
 	if (strncmp(p, "tcp", 3) == 0 || strncmp(p, "udp", 3) == 0) {
 		c->c_family = p[3] == '6' ? AF_INET6 : AF_INET;
 		return 0;
 	}
-	return getnum(f, l, local, &c->c_family, "family", p);
+	return conf_getnum(f, l, local, &c->c_family, "family", p);
 }
 
 static int
-getuid(const char *f, size_t l, bool local __unused, struct conf *c,
+conf_getuid(const char *f, size_t l, bool local __unused, struct conf *c,
     const char *p)
 {
 	struct passwd *pw;
@@ -356,15 +360,15 @@ getuid(const char *f, size_t l, bool local __unused, struct conf *c,
 		return 0;
 	}
 
-	return getnum(f, l, local, &c->c_uid, "user", p);
+	return conf_getnum(f, l, local, &c->c_uid, "user", p);
 }
 
 
 static int
-getname(const char *f, size_t l, bool local, struct conf *c,
+conf_getname(const char *f, size_t l, bool local, struct conf *c,
     const char *p)
 {
-	if (getmask(f, l, local, &p, &c->c_rmask) == -1)
+	if (conf_getmask(f, l, local, &p, &c->c_rmask) == -1)
 		return -1;
 
 	if (strcmp(p, "*") == 0) {
@@ -407,19 +411,19 @@ conf_parseline(const char *f, size_t l, char *p, struct conf *c, bool local)
 		p++;
 
 	memset(c, 0, sizeof(*c));
-	e = getvalue(f, l, local, c, &p, gethostport);
+	e = getvalue(f, l, local, c, &p, conf_gethostport);
 	if (e) return -1;
-	e = getvalue(f, l, local, c, &p, getproto);
+	e = getvalue(f, l, local, c, &p, conf_getproto);
 	if (e) return -1;
-	e = getvalue(f, l, local, c, &p, getfamily);
+	e = getvalue(f, l, local, c, &p, conf_getfamily);
 	if (e) return -1;
-	e = getvalue(f, l, local, c, &p, getuid);
+	e = getvalue(f, l, local, c, &p, conf_getuid);
 	if (e) return -1;
-	e = getvalue(f, l, local, c, &p, getname);
+	e = getvalue(f, l, local, c, &p, conf_getname);
 	if (e) return -1;
-	e = getvalue(f, l, local, c, &p, getnfail);
+	e = getvalue(f, l, local, c, &p, conf_getnfail);
 	if (e) return -1;
-	e = getvalue(f, l, local, c, &p, getsecs);
+	e = getvalue(f, l, local, c, &p, conf_getsecs);
 	if (e) return -1;
 
 	return 0;
@@ -998,11 +1002,93 @@ confset_match(const struct confset *cs, struct conf *c,
 	return i;
 }
 
+#ifdef AF_ROUTE
+static int
+conf_route_perm(int fd) {
+#if defined(RTM_IFANNOUNCE) && defined(SA_SIZE)
+	/*
+	 * Send a routing message that is not supported to check for access
+	 * We expect EOPNOTSUPP for having access, since we are sending a
+	 * request the system does not understand and EACCES if we don't have
+	 * access.
+	 */
+	static struct sockaddr_in sin = {
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+		.sin_len = sizeof(sin),
+#endif
+		.sin_family = AF_INET,
+	};
+	char buf[4096];
+	struct rt_msghdr *rtm = (void *)buf;
+	char *cp = (char *)(rtm + 1);
+	size_t l;
+
+#define NEXTADDR(s) \
+	l = SA_SIZE(sizeof(*s)); memmove(cp, s, l); cp += l;
+	memset(buf, 0, sizeof(buf));
+	rtm->rtm_type = RTM_IFANNOUNCE;
+	rtm->rtm_flags = 0;
+	rtm->rtm_addrs = RTA_DST|RTA_GATEWAY;
+	rtm->rtm_version = RTM_VERSION;
+	rtm->rtm_seq = 666;
+	NEXTADDR(&sin);
+	NEXTADDR(&sin);
+	rtm->rtm_msglen = (u_short)((char *)cp - (char *)rtm);
+	if (write(fd, rtm, rtm->rtm_msglen) != -1) {
+		(*lfun)(LOG_ERR, "Writing to routing socket succeeded!");
+		return 0;
+	}
+	switch (errno) {
+	case EACCES:
+		return 0;
+	case EOPNOTSUPP:
+		return 1;
+	default:
+		(*lfun)(LOG_ERR,
+		    "Unexpected error writing to routing socket (%m)");
+		return 0;
+	}
+#else
+	return 0;
+#endif
+}
+#endif
+
+static int
+conf_handle_inet(int fd, const void *lss, struct conf *cr)
+{
+	char buf[BUFSIZ];
+	int proto;
+	socklen_t slen = sizeof(proto);
+
+	if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &proto, &slen) == -1) {
+		(*lfun)(LOG_ERR, "getsockopt failed (%m)");
+		return -1;
+	}
+
+	if (debug) {
+		sockaddr_snprintf(buf, sizeof(buf), "%a:%p", lss);
+		(*lfun)(LOG_DEBUG, "listening socket: %s", buf);
+	}
+
+	switch (proto) {
+	case SOCK_STREAM:
+		cr->c_proto = IPPROTO_TCP;
+		break;
+	case SOCK_DGRAM:
+		cr->c_proto = IPPROTO_UDP;
+		break;
+	default:
+		(*lfun)(LOG_ERR, "unsupported protocol %d", proto);
+		return -1;
+	}
+	return 0;
+}
+
 const struct conf *
 conf_find(int fd, uid_t uid, const struct sockaddr_storage *rss,
     struct conf *cr)
 {
-	int proto;
 	socklen_t slen;
 	struct sockaddr_storage lss;
 	size_t i;
@@ -1016,36 +1102,29 @@ conf_find(int fd, uid_t uid, const struct sockaddr_storage *rss,
 		return NULL;
 	}
 
-	slen = sizeof(proto);
-	if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &proto, &slen) == -1) {
-		(*lfun)(LOG_ERR, "getsockopt failed (%m)");
-		return NULL;
-	}
-
-	if (debug) {
-		sockaddr_snprintf(buf, sizeof(buf), "%a:%p", (void *)&lss);
-		(*lfun)(LOG_DEBUG, "listening socket: %s", buf);
-	}
-
-	switch (proto) {
-	case SOCK_STREAM:
-		cr->c_proto = IPPROTO_TCP;
-		break;
-	case SOCK_DGRAM:
-		cr->c_proto = IPPROTO_UDP;
-		break;
-	default:
-		(*lfun)(LOG_ERR, "unsupported protocol %d", proto);
-		return NULL;
-	}
-
 	switch (lss.ss_family) {
 	case AF_INET:
 		cr->c_port = ntohs(((struct sockaddr_in *)&lss)->sin_port);
+		if (conf_handle_inet(fd, &lss, cr) == -1)
+			return NULL;
 		break;
 	case AF_INET6:
 		cr->c_port = ntohs(((struct sockaddr_in6 *)&lss)->sin6_port);
+		if (conf_handle_inet(fd, &lss, cr) == -1)
+			return NULL;
 		break;
+#ifdef AF_ROUTE
+	case AF_ROUTE:
+		if (!conf_route_perm(fd)) {
+			(*lfun)(LOG_ERR,
+			    "permission denied to routing socket (%m)");
+			return NULL;
+		}
+		cr->c_proto = FSTAR;
+		cr->c_port = FSTAR;
+		memcpy(&lss, rss, sizeof(lss));
+		break;
+#endif
 	default:
 		(*lfun)(LOG_ERR, "unsupported family %d", lss.ss_family);
 		return NULL;

--- a/contrib/blacklist/bin/conf.h
+++ b/contrib/blacklist/bin/conf.h
@@ -1,4 +1,4 @@
-/*	$NetBSD: conf.h,v 1.6 2015/01/27 19:40:36 christos Exp $	*/
+/*	$NetBSD: conf.h,v 1.5 2015/01/21 19:24:03 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.

--- a/contrib/blacklist/bin/internal.c
+++ b/contrib/blacklist/bin/internal.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: internal.c,v 1.5 2015/01/27 19:40:37 christos Exp $	*/
+/*	$NetBSD: internal.c,v 1.4 2015/01/25 20:59:39 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.
@@ -33,7 +33,7 @@
 #endif
 
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: internal.c,v 1.5 2015/01/27 19:40:37 christos Exp $");
+__RCSID("$NetBSD: internal.c,v 1.4 2015/01/25 20:59:39 christos Exp $");
 
 #include <stdio.h>
 #include <syslog.h>

--- a/contrib/blacklist/bin/internal.h
+++ b/contrib/blacklist/bin/internal.h
@@ -1,4 +1,4 @@
-/*	$NetBSD: internal.h,v 1.14 2016/04/04 15:52:56 christos Exp $	*/
+/*	$NetBSD: internal.h,v 1.13 2015/10/14 16:01:29 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.

--- a/contrib/blacklist/bin/run.h
+++ b/contrib/blacklist/bin/run.h
@@ -1,4 +1,4 @@
-/*	$NetBSD: run.h,v 1.5 2015/01/27 19:40:37 christos Exp $	*/
+/*	$NetBSD: run.h,v 1.4 2015/01/22 04:13:04 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.

--- a/contrib/blacklist/bin/state.c
+++ b/contrib/blacklist/bin/state.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: state.c,v 1.19 2016/09/26 19:43:43 christos Exp $	*/
+/*	$NetBSD: state.c,v 1.18 2016/04/04 15:52:56 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.
@@ -33,7 +33,7 @@
 #endif
 
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: state.c,v 1.19 2016/09/26 19:43:43 christos Exp $");
+__RCSID("$NetBSD: state.c,v 1.18 2016/04/04 15:52:56 christos Exp $");
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/contrib/blacklist/bin/state.h
+++ b/contrib/blacklist/bin/state.h
@@ -1,4 +1,4 @@
-/*	$NetBSD: state.h,v 1.5 2015/01/27 19:40:37 christos Exp $	*/
+/*	$NetBSD: state.h,v 1.4 2015/01/24 07:46:20 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.

--- a/contrib/blacklist/bin/support.h
+++ b/contrib/blacklist/bin/support.h
@@ -1,4 +1,4 @@
-/*	$NetBSD: support.h,v 1.7 2016/04/04 15:52:56 christos Exp $	*/
+/*	$NetBSD: support.h,v 1.6 2015/06/02 14:02:10 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.

--- a/contrib/blacklist/etc/Makefile
+++ b/contrib/blacklist/etc/Makefile
@@ -1,4 +1,4 @@
-#	$NetBSD: Makefile,v 1.3 2015/01/26 00:18:40 christos Exp $
+#	$NetBSD: Makefile,v 1.2 2015/01/23 21:33:50 christos Exp $
 
 SUBDIR=rc.d
 

--- a/contrib/blacklist/etc/rc.d/Makefile
+++ b/contrib/blacklist/etc/rc.d/Makefile
@@ -1,4 +1,4 @@
-#	$NetBSD: Makefile,v 1.1 2015/01/22 17:49:41 christos Exp $
+#	$NetBSD$
 
 SCRIPTS=blacklistd
 SCRIPTSDIR=/etc/rc.d

--- a/contrib/blacklist/etc/rc.d/blacklistd
+++ b/contrib/blacklist/etc/rc.d/blacklistd
@@ -1,10 +1,10 @@
 #!/bin/sh
 #
-# $NetBSD: blacklistd,v 1.2 2016/10/17 22:47:16 christos Exp $
+# $NetBSD: blacklistd,v 1.1 2015/01/22 17:49:41 christos Exp $
 #
 
 # PROVIDE: blacklistd
-# REQUIRE: npf
+# REQUIRE: ipfilter ipfw pf
 # BEFORE:  SERVERS
 
 $_rc_subr_loaded . /etc/rc.subr

--- a/contrib/blacklist/include/Makefile
+++ b/contrib/blacklist/include/Makefile
@@ -1,4 +1,4 @@
-#	$NetBSD: Makefile,v 1.1 2015/01/21 16:16:00 christos Exp $
+#	$NetBSD: Makefile,v 1.140 2013/12/11 01:24:08 joerg Exp $
 
 # Doing a make includes builds /usr/include
 

--- a/contrib/blacklist/lib/Makefile
+++ b/contrib/blacklist/lib/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.7 2019/03/08 20:40:05 christos Exp $
+# $NetBSD: Makefile,v 1.6 2016/01/05 13:07:46 christos Exp $
 
 .include <bsd.own.mk>
 

--- a/contrib/blacklist/lib/bl.c
+++ b/contrib/blacklist/lib/bl.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: bl.c,v 1.28 2016/07/29 17:13:09 christos Exp $	*/
+/*	$NetBSD: bl.c,v 1.2 2022/06/12 17:54:15 christos Exp $	*/
 
 /*-
  * Copyright (c) 2014 The NetBSD Foundation, Inc.
@@ -33,7 +33,7 @@
 #endif
 
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: bl.c,v 1.28 2016/07/29 17:13:09 christos Exp $");
+__RCSID("$NetBSD: bl.c,v 1.2 2022/06/12 17:54:15 christos Exp $");
 
 #include <sys/param.h>
 #include <sys/types.h>

--- a/contrib/blacklist/lib/blacklist.c
+++ b/contrib/blacklist/lib/blacklist.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: blacklist.c,v 1.5 2015/01/22 16:19:53 christos Exp $	*/
+/*	$NetBSD: blacklist.c,v 1.6 2019/11/06 20:50:01 christos Exp $	*/
 
 /*-
  * Copyright (c) 2014 The NetBSD Foundation, Inc.
@@ -33,7 +33,7 @@
 #endif
 
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: blacklist.c,v 1.5 2015/01/22 16:19:53 christos Exp $");
+__RCSID("$NetBSD: blacklist.c,v 1.6 2019/11/06 20:50:01 christos Exp $");
 
 #include <stdio.h>
 #include <bl.h>

--- a/contrib/blacklist/libexec/Makefile
+++ b/contrib/blacklist/libexec/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.1 2015/01/22 17:49:41 christos Exp $
+# $NetBSD$
 
 SCRIPTS=        blacklistd-helper
 SCRIPTSDIR=     /libexec

--- a/contrib/blacklist/libexec/blacklistd-helper
+++ b/contrib/blacklist/libexec/blacklistd-helper
@@ -17,12 +17,16 @@ if [ -f "/etc/ipfw-blacklist.rc" ]; then
 fi
 
 if [ -z "$pf" ]; then
-	for f in npf pf ipf; do
-		if [ -f "/etc/$f.conf" ]; then
-			pf="$f"
+	for f in ipf.rules pf.conf; do
+		if [ -f "/etc/$f" ]; then
+			pf="${f%.*}"
 			break
 		fi
 	done
+fi
+
+if [ -z "$pf" -a -x "/sbin/iptables" ]; then
+	pf="iptables"
 fi
 
 if [ -z "$pf" ]; then
@@ -30,11 +34,17 @@ if [ -z "$pf" ]; then
 	exit 1
 fi
 
+flags=
 if [ -n "$3" ]; then
+	raw_proto="$3"
 	proto="proto $3"
+	if [ $3 = "tcp" ]; then
+		flags="flags S/SAFR"
+	fi
 fi
 
 if [ -n "$6" ]; then
+	raw_port="$6"
 	port="port $6"
 fi
 
@@ -52,11 +62,59 @@ case "$1" in
 add)
 	case "$pf" in
 	ipf)
-		/sbin/ipfstat -io | /sbin/ipf -I -f - >/dev/null 2>&1
-		echo block in quick $proto from $addr/$mask to \
-		    any port=$6 head port$6 | \
-		    /sbin/ipf -I -f - -s >/dev/null 2>&1 && echo OK
+		# N.B.:  If you reload /etc/ipf.rules then you need to stop and
+		# restart blacklistd (and make sure blacklistd_flags="-r"):
+		#
+		#	/etc/rc.d/ipfilter reload
+		#	/etc/rc.d/blacklistd restart
+		#
+		# XXX we assume the following rule is present in /etc/ipf.rules:
+		#
+		#	block in proto tcp/udp from any to any head blacklistd
+		#
+		# where "blacklistd" is the default rulename (i.e. "$2")
+		#
+		# This rule can come before any rule that logs connections,
+		# etc., and should be followed by final rules such as:
+		#
+		#	# log all as-yet unblocked incoming TCP connection
+		#	# attempts
+		#	log in proto tcp from any to any flags S/SAFR
+		#	# last "pass" match wins for all non-blocked packets
+		#	pass in all
+		#	pass out all
+		#
+		# I.e. a "pass" rule which will be the final match and override
+		# the "block".  This way the rules added by blacklistd will
+		# actually block packets, and prevent logging of them as
+		# connections, because they include the "quick" flag.
+		#
+		# N.b.:  $port is not included -- abusers are cut off completely
+		# from all services!
+		#
+		# Note RST packets are not returned for blocked SYN packets of
+		# active attacks, so the port will not appear to be closed.
+		# This will probably give away the fact that a firewall has been
+		# triggered to block connections, but it prevents generating
+		# extra outbound traffic, and it may also slow down the attacker
+		# somewhat.
+		#
+		# Note also that we don't block all packets, just new attempts
+		# to open connections (see $flags above).  This allows us to do
+		# counterespionage against the attacker (or continue to make use
+		# of any other services that might be on the same subnet as the
+		# attacker).  However it does not kill any active connections --
+		# we rely on the reporting daemon to do its own protection and
+		# cleanup.
+		#
+		# N.B.:  The generated must exactly match the rule generated for
+		# the "rem" command below!
+		#
+		echo block in log quick $proto \
+		     from $addr/$mask to any $flags group $2 | \
+		    /sbin/ipf -A -f - >/dev/null 2>&1 && echo OK
 		;;
+
 	ipfw)
 		# use $ipfw_offset+$port for rule number
 		rule=$(($ipfw_offset + $6))
@@ -69,10 +127,23 @@ add)
 			table"("$tname")" to any dst-port $6 >/dev/null && \
 			echo OK
 		;;
+
+	iptables)
+		if ! /sbin/iptables --list "$2" >/dev/null 2>&1; then
+			/sbin/iptables --new-chain "$2"
+		fi
+		/sbin/iptables --append INPUT --proto "$raw_proto" \
+		    --dport "$raw_port" --jump "$2"
+		/sbin/iptables --append "$2" --proto "$raw_proto" \
+		    --source "$addr/$mask" --dport "$raw_port" --jump DROP
+		echo OK
+		;;
+
 	npf)
 		/sbin/npfctl rule "$2" add block in final $proto from \
 		    "$addr/$mask" to any $port
 		;;
+
 	pf)
 		# if the filtering rule does not exist, create it
 		/sbin/pfctl -a "$2/$6" -sr 2>/dev/null | \
@@ -83,40 +154,75 @@ add)
 		/sbin/pfctl -qa "$2/$6" -t "port$6" -T add "$addr/$mask" && \
 		    /sbin/pfctl -qk "$addr" && echo OK
 		;;
+
 	esac
 	;;
 rem)
 	case "$pf" in
 	ipf)
-		/sbin/ipfstat -io | /sbin/ipf -I -f - >/dev/null 2>&1
-		echo block in quick $proto from $addr/$mask to \
-		    any port=$6 head port$6 | \
-		    /sbin/ipf -I -r -f - -s >/dev/null 2>&1 && echo OK
+		echo block in log quick $proto \
+		     from $addr/$mask to any $flags group $2 | \
+		    /sbin/ipf -A -r -f - >/dev/null 2>&1 && echo OK
 		;;
+
 	ipfw)
 		/sbin/ipfw table "port$6" delete "$addr/$mask" 2>/dev/null && \
 		    echo OK
 		;;
+
+	iptables)
+		if /sbin/iptables --list "$2" >/dev/null 2>&1; then
+			/sbin/iptables --delete "$2" --proto "$raw_proto" \
+			    --source "$addr/$mask" --dport "$raw_port" \
+			    --jump DROP
+		fi
+		echo OK
+		;;
+
 	npf)
 		/sbin/npfctl rule "$2" rem-id "$7"
 		;;
+
 	pf)
 		/sbin/pfctl -qa "$2/$6" -t "port$6" -T delete "$addr/$mask" && \
 		    echo OK
 		;;
+
 	esac
 	;;
 flush)
 	case "$pf" in
 	ipf)
-		/sbin/ipf -Z -I -Fi -s > /dev/null && echo OK
+		#
+		# XXX this is a slightly convoluted way to remove all the rules
+		# in the group added for "$2" (i.e. normally by default
+		# "blacklistd").
+		#
+		# N.B. WARNING:  This is obviously not reentrant!
+		#
+		/sbin/ipf -I -F a
+		/usr/sbin/ipfstat -io | fgrep -v "group $2" | \
+		    /sbin/ipf -I -f - >/dev/null 2>&1
+		# XXX this MUST be done last and separately as "-s" is executed
+		# _while_ the command arguments are being processed!
+		/sbin/ipf -s && echo OK
 		;;
+
 	ipfw)
 		/sbin/ipfw table "port$6" flush 2>/dev/null && echo OK
 		;;
+
+	iptables)
+		if /sbin/iptables --list "$2" >/dev/null 2>&1; then
+			/sbin/iptables --flush "$2"
+		fi
+		echo OK
+		;;
+
 	npf)
 		/sbin/npfctl rule "$2" flush
 		;;
+
 	pf)
 		# dynamically determine which anchors exist
 		for anchor in $(/sbin/pfctl -a "$2" -s Anchors); do

--- a/contrib/blacklist/port/_strtoi.h
+++ b/contrib/blacklist/port/_strtoi.h
@@ -1,4 +1,4 @@
-/*	$NetBSD: _strtoi.h,v 1.1 2015/01/22 02:15:59 christos Exp $	*/
+/*	$NetBSD: _strtoi.h,v 1.2 2015/01/18 17:55:22 christos Exp $	*/
 
 /*-
  * Copyright (c) 1990, 1993

--- a/contrib/blacklist/port/fgetln.c
+++ b/contrib/blacklist/port/fgetln.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: fgetln.c,v 1.1 2015/01/22 03:48:07 christos Exp $	*/
+/*	$NetBSD: fgetln.c,v 1.9 2008/04/29 06:53:03 martin Exp $	*/
 
 /*-
  * Copyright (c) 1998 The NetBSD Foundation, Inc.

--- a/contrib/blacklist/port/fparseln.c
+++ b/contrib/blacklist/port/fparseln.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: fparseln.c,v 1.1 2015/01/22 03:48:07 christos Exp $	*/
+/*	$NetBSD: fparseln.c,v 1.10 2009/10/21 01:07:45 snj Exp $	*/
 
 /*
  * Copyright (c) 1997 Christos Zoulas.  All rights reserved.
@@ -29,7 +29,7 @@
 
 #include <sys/cdefs.h>
 #if defined(LIBC_SCCS) && !defined(lint)
-__RCSID("$NetBSD: fparseln.c,v 1.1 2015/01/22 03:48:07 christos Exp $");
+__RCSID("$NetBSD: fparseln.c,v 1.10 2009/10/21 01:07:45 snj Exp $");
 #endif /* LIBC_SCCS and not lint */
 
 #include <assert.h>

--- a/contrib/blacklist/port/pidfile.c
+++ b/contrib/blacklist/port/pidfile.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: pidfile.c,v 1.2 2016/04/05 12:28:57 christos Exp $	*/
+/*	$NetBSD: pidfile.c,v 1.1 2015/01/22 16:19:53 christos Exp $	*/
 
 /*-
  * Copyright (c) 1999 The NetBSD Foundation, Inc.
@@ -34,7 +34,7 @@
 
 #include <sys/cdefs.h>
 #if defined(LIBC_SCCS) && !defined(lint)
-__RCSID("$NetBSD: pidfile.c,v 1.2 2016/04/05 12:28:57 christos Exp $");
+__RCSID("$NetBSD: pidfile.c,v 1.1 2015/01/22 16:19:53 christos Exp $");
 #endif
 
 #include <sys/param.h>

--- a/contrib/blacklist/port/popenve.c
+++ b/contrib/blacklist/port/popenve.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: popenve.c,v 1.2 2015/01/22 03:10:50 christos Exp $	*/
+/*	$NetBSD: popenve.c,v 1.1 2015/01/22 01:39:18 christos Exp $	*/
 
 /*
  * Copyright (c) 1988, 1993
@@ -41,7 +41,7 @@
 #if 0
 static char sccsid[] = "@(#)popen.c	8.3 (Berkeley) 5/3/95";
 #else
-__RCSID("$NetBSD: popenve.c,v 1.2 2015/01/22 03:10:50 christos Exp $");
+__RCSID("$NetBSD: popenve.c,v 1.1 2015/01/22 01:39:18 christos Exp $");
 #endif
 #endif /* LIBC_SCCS and not lint */
 

--- a/contrib/blacklist/port/sockaddr_snprintf.c
+++ b/contrib/blacklist/port/sockaddr_snprintf.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: sockaddr_snprintf.c,v 1.11 2016/06/01 22:57:51 christos Exp $	*/
+/*	$NetBSD: sockaddr_snprintf.c,v 1.10 2016/04/05 12:28:57 christos Exp $	*/
 
 /*-
  * Copyright (c) 2004 The NetBSD Foundation, Inc.
@@ -34,7 +34,7 @@
 
 #include <sys/cdefs.h>
 #if defined(LIBC_SCCS) && !defined(lint)
-__RCSID("$NetBSD: sockaddr_snprintf.c,v 1.11 2016/06/01 22:57:51 christos Exp $");
+__RCSID("$NetBSD: sockaddr_snprintf.c,v 1.10 2016/04/05 12:28:57 christos Exp $");
 #endif /* LIBC_SCCS and not lint */
 
 #include <sys/param.h>

--- a/contrib/blacklist/port/strlcat.c
+++ b/contrib/blacklist/port/strlcat.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: strlcat.c,v 1.2 2015/01/22 03:48:07 christos Exp $	*/
+/*	$NetBSD: strlcat.c,v 1.1 2015/01/22 02:36:15 christos Exp $	*/
 /*	$OpenBSD: strlcat.c,v 1.10 2003/04/12 21:56:39 millert Exp $	*/
 
 /*
@@ -24,7 +24,7 @@
 
 #include <sys/cdefs.h>
 #if defined(LIBC_SCCS) && !defined(lint)
-__RCSID("$NetBSD: strlcat.c,v 1.2 2015/01/22 03:48:07 christos Exp $");
+__RCSID("$NetBSD: strlcat.c,v 1.1 2015/01/22 02:36:15 christos Exp $");
 #endif /* LIBC_SCCS and not lint */
 
 #ifdef _LIBC

--- a/contrib/blacklist/port/strlcpy.c
+++ b/contrib/blacklist/port/strlcpy.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: strlcpy.c,v 1.2 2015/01/22 03:48:07 christos Exp $	*/
+/*	$NetBSD: strlcpy.c,v 1.1 2015/01/22 02:36:15 christos Exp $	*/
 /*	$OpenBSD: strlcpy.c,v 1.7 2003/04/12 21:56:39 millert Exp $	*/
 
 /*
@@ -24,7 +24,7 @@
 
 #include <sys/cdefs.h>
 #if defined(LIBC_SCCS) && !defined(lint)
-__RCSID("$NetBSD: strlcpy.c,v 1.2 2015/01/22 03:48:07 christos Exp $");
+__RCSID("$NetBSD: strlcpy.c,v 1.1 2015/01/22 02:36:15 christos Exp $");
 #endif /* LIBC_SCCS and not lint */
 
 #ifdef _LIBC

--- a/contrib/blacklist/port/strtoi.c
+++ b/contrib/blacklist/port/strtoi.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: strtoi.c,v 1.3 2015/01/22 03:10:50 christos Exp $	*/
+/*	$NetBSD: strtoi.c,v 1.2 2015/01/22 02:35:44 christos Exp $	*/
 
 /*-
  * Copyright (c) 2005 The DragonFly Project.  All rights reserved.
@@ -34,7 +34,7 @@
 #endif
 
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: strtoi.c,v 1.3 2015/01/22 03:10:50 christos Exp $");
+__RCSID("$NetBSD: strtoi.c,v 1.2 2015/01/22 02:35:44 christos Exp $");
 
 #if defined(_KERNEL)
 #include <sys/param.h>

--- a/contrib/blacklist/test/Makefile
+++ b/contrib/blacklist/test/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.3 2015/05/30 22:40:38 christos Exp $
+# $NetBSD: Makefile,v 1.2 2015/01/22 05:03:52 christos Exp $
 
 MKMAN=no
 

--- a/contrib/blacklist/test/cltest.c
+++ b/contrib/blacklist/test/cltest.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: cltest.c,v 1.6 2015/01/22 05:44:28 christos Exp $	*/
+/*	$NetBSD: cltest.c,v 1.5 2015/01/22 05:03:52 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.
@@ -33,7 +33,7 @@
 #endif
 
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: cltest.c,v 1.6 2015/01/22 05:44:28 christos Exp $");
+__RCSID("$NetBSD: cltest.c,v 1.5 2015/01/22 05:03:52 christos Exp $");
 
 #include <sys/types.h> 
 #include <sys/socket.h>

--- a/contrib/blacklist/test/srvtest.c
+++ b/contrib/blacklist/test/srvtest.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: srvtest.c,v 1.10 2015/05/30 22:40:38 christos Exp $	*/
+/*	$NetBSD: srvtest.c,v 1.9 2015/01/22 05:35:55 christos Exp $	*/
 
 /*-
  * Copyright (c) 2015 The NetBSD Foundation, Inc.
@@ -33,7 +33,7 @@
 #endif
 
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: srvtest.c,v 1.10 2015/05/30 22:40:38 christos Exp $");
+__RCSID("$NetBSD: srvtest.c,v 1.9 2015/01/22 05:35:55 christos Exp $");
 
 #include <sys/types.h> 
 #include <sys/socket.h>


### PR DESCRIPTION
@emaste: I hope this can actually help facilitate the updating of [zoulasc/blocklistd](https://github.com/zoulasc/blocklist), as we can clearly see where we are lagging.

The first commit, entitled "REMOVE", is just a `FreeBSD-update` file with the instructions to replicate the procedure used.

The second commit is the actual import.

~~The third commit is what we currently have that upstream doesn't. It looks like it should _just work_ on NetBSD as well, but I have yet to test it.~~

# TODO

### Questions

- [x] Is ipf currently supported? (Rekindle [jlduran/blacklistd-integration-tests](https://github.com/jlduran/blacklistd-integration-tests))
  - [ ] For `ipf(8)`, FreeBSD uses `/etc/ipf.rules`, NetBSD uses `/etc/ipf.conf`. `blacklistd-helper` changed the _firewall detection mechanism_ to `/etc/ipfilter.conf`.
- [x] Should we add `ipf(8)` and `ipfw(8)` as well to `blacklistd.8` ~~(currently we are doing `s/npfctl/pfctl/`)~~?
- [x] Should we change the rc script to `# REQUIRE: ipfilter ipfw pf`?

### Pending

- [x] Check if we can upstream https://github.com/freebsd/freebsd-src/commit/549f31e4590e97c7b9ee771a24fd2c84198f0dd8