### PR TITLE
Correct jail_max_af_ips sysctl name

### DIFF
--- a/usr.sbin/jail/jail.8
+++ b/usr.sbin/jail/jail.8
@@ -1260,7 +1260,7 @@ can be used to determine if a process is running inside a jail (value
 is one) or not (value is zero).
 .Pp
 The variable
-.Va security.jail.max_af_ips
+.Va security.jail.jail_max_af_ips
 determines how may address per address family a jail may have.
 The default is 255.
 .Pp


### PR DESCRIPTION
The sysctl is named `security.jail.jail_max_af_ips` with the `jail_` prefix in the final part.