### PR TITLE
fix xargs exit code when run in parallel mode

### DIFF
--- a/usr.bin/xargs/tests/regress.sh
+++ b/usr.bin/xargs/tests/regress.sh
@@ -1,6 +1,6 @@
 # $FreeBSD$
 
-echo 1..16
+echo 1..20
 
 REGRESSION_START($1)
 
@@ -20,5 +20,10 @@ REGRESSION_TEST(`0J', `xargs -0 -J% echo The % again. <${SRCDIR}/regress.0.in')
 REGRESSION_TEST(`0L', `xargs -0 -L2 echo <${SRCDIR}/regress.0.in')
 REGRESSION_TEST(`0P1', `xargs -0 -P1 echo <${SRCDIR}/regress.0.in')
 REGRESSION_TEST(`quotes', `xargs -n1 echo <${SRCDIR}/regress.quotes.in')
+
+REGRESSION_TEST_FREEFORM(`parallel1', `echo /var/empty       /var/empty       | xargs -n1 -P2 test -d; [ $? = 0 ]')
+REGRESSION_TEST_FREEFORM(`parallel2', `echo /var/empty       /var/empty/nodir | xargs -n1 -P2 test -d; [ $? = 1 ]')
+REGRESSION_TEST_FREEFORM(`parallel3', `echo /var/empty/nodir /var/empty       | xargs -n1 -P2 test -d; [ $? = 1 ]')
+REGRESSION_TEST_FREEFORM(`parallel4', `echo /var/empty/nodir /var/empty/nodir | xargs -n1 -P2 test -d; [ $? = 1 ]')
 
 REGRESSION_END()

--- a/usr.bin/xargs/xargs.c
+++ b/usr.bin/xargs/xargs.c
@@ -315,8 +315,10 @@ parse_input(int argc, char *argv[])
 	switch (ch = getchar()) {
 	case EOF:
 		/* No arguments since last exec. */
-		if (p == bbp)
-			xexit(*av, rval);
+		if (p == bbp) {
+			waitchildren(*av, 1);
+			exit(rval);
+		}
 		goto arg1;
 	case ' ':
 	case '\t':
@@ -406,8 +408,10 @@ arg2:
 					*xp++ = *avj;
 			}
 			prerun(argc, av);
-			if (ch == EOF || foundeof)
-				xexit(*av, rval);
+			if (ch == EOF || foundeof) {
+				waitchildren(*av, 1);
+				exit(rval);
+			}
 			p = bbp;
 			xp = bxp;
 			count = 0;


### PR DESCRIPTION
This fixes [bug #267110](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267110) 

When xargs runs in parallel mode (using -P flag), it may sometimes return incorrect exit code. The following code shows current (incorrect) behaviour: 
* `/bin` directory exists, `/foo` directory does not exist. 
* `echo /bin /foo | xargs -n1 -P2 test -d` sometimes returns 0 sometimes returns 1:

```
root@freebsd:~ # test -d /bin
root@freebsd:~ # echo $?
0
root@freebsd:~ # test -d /foo
root@freebsd:~ # echo $?
1
root@freebsd:~ # echo /bin /foo | xargs -n1 -P2 test -d
root@freebsd:~ # echo $?
0
root@freebsd:~ # echo /bin /foo | xargs -n1 -P2 test -d
root@freebsd:~ # echo $?
1
root@freebsd:~ # echo /bin /foo | xargs -n1 -P2 test -d
root@freebsd:~ # echo $?
0
```
