### PR TITLE
Fix strfmon_l(3)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,6 +46,14 @@ task:
   test_script:
   - sh .cirrus-ci/pkg-install.sh qemu-nox11
   - sh tools/boot/ci-qemu-test.sh
+  installworld_script:
+  - make -j$(sysctl -n hw.ncpu) CROSS_TOOLCHAIN=${TOOLCHAIN_PKG} WITHOUT_TOOLCHAIN=yes installworld
+  test_strfmon_script:
+  - kyua test -k /usr/tests/Kyuafile lib/libc/stdlib/strfmon_test
+  always:
+    test_strfmon_report_script:
+    - cd /usr/tests
+    - kyua report --results-file=LATEST --results-filter=failed --verbose
   post_script:
   - df -m
   - du -m -s /usr/obj

--- a/lib/libc/stdlib/strfmon.3
+++ b/lib/libc/stdlib/strfmon.3
@@ -24,11 +24,12 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd October 26, 2022
+.Dd October 28, 2022
 .Dt STRFMON 3
 .Os
 .Sh NAME
-.Nm strfmon
+.Nm strfmon ,
+.Nm strfmon_l
 .Nd convert monetary value to string
 .Sh LIBRARY
 .Lb libc
@@ -161,7 +162,8 @@ The format string is invalid.
 Not enough memory for temporary buffers.
 .El
 .Sh SEE ALSO
-.Xr localeconv 3
+.Xr localeconv 3 ,
+.Xr xlocale 3
 .Sh STANDARDS
 The
 .Fn strfmon

--- a/lib/libc/stdlib/strfmon.c
+++ b/lib/libc/stdlib/strfmon.c
@@ -324,7 +324,7 @@ vstrfmon_l(char * __restrict s, size_t maxsize, locale_t loc,
 		if (cs_precedes == 1) {
 			if (sign_posn == 1 || sign_posn == 3) {
 				PRINTS(signstr);
-				if (sep_by_space == 2)		/* XXX: ? */
+				if (sep_by_space == 2)
 					PRINT(' ');
 			}
 
@@ -363,7 +363,7 @@ vstrfmon_l(char * __restrict s, size_t maxsize, locale_t loc,
 				    || sign_posn == 2
 				    || sign_posn == 4)))
 					PRINT(space_char);
-				PRINTS(currency_symbol); /* XXX: len */
+				PRINTS(currency_symbol);
 				if (sign_posn == 4) {
 					if (sep_by_space == 2)
 						PRINT(' ');
@@ -597,7 +597,7 @@ __format_grouped_double(double value, int *flags,
 	}
 
 	if ((*flags & NEED_GROUPING) &&
-	    thousands_sep_size > 0 &&	/* XXX: need investigation */
+	    thousands_sep_size > 0 &&
 	    *grouping != CHAR_MAX &&
 	    *grouping > 0) {
 		while (avalue_size > (int)*grouping) {

--- a/lib/libc/tests/stdlib/strfmon_test.c
+++ b/lib/libc/tests/stdlib/strfmon_test.c
@@ -211,6 +211,38 @@ ATF_TC_BODY(strfmon_international_currency_code, tc)
 	}
 }
 
+ATF_TC(strfmon_l);
+ATF_TC_HEAD(strfmon_l, tc)
+{
+	atf_tc_set_md_var(tc, "descr",
+	    "checks strfmon_l under different locales");
+}
+ATF_TC_BODY(strfmon_l, tc)
+{
+	const struct {
+		const char *locale;
+		const char *expected;
+	} tests[] = {
+	    { "C", "[ **1234.57 ] [ **1234.57 ]" },
+	    { "de_DE.UTF-8", "[ €**1234.57 ] [ EUR**1234.57 ]" }, /* XXX */
+	    { "en_GB.UTF-8", "[ £**1234.57 ] [ GBP**1234.57 ]" }, /* XXX */
+	};
+	locale_t loc;
+	size_t i;
+	char buf[100];
+
+	for (i = 0; i < nitems(tests); ++i) {
+		loc = newlocale(LC_MONETARY_MASK, tests[i].locale, NULL);
+		ATF_REQUIRE(loc != NULL);
+
+		strfmon_l(buf, sizeof(buf) - 1, loc, "[%^=*#6n] [%=*#6i]",
+		    1234.567, 1234.567);
+		ATF_REQUIRE_STREQ(tests[i].expected, buf);
+
+		freelocale(loc);
+	}
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, strfmon_locale_thousands);
@@ -218,5 +250,6 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, strfmon_cs_precedes_0);
 	ATF_TP_ADD_TC(tp, strfmon_cs_precedes_1);
 	ATF_TP_ADD_TC(tp, strfmon_international_currency_code);
+	ATF_TP_ADD_TC(tp, strfmon_l);
 	return (atf_no_error());
 }

--- a/lib/libc/tests/stdlib/strfmon_test.c
+++ b/lib/libc/tests/stdlib/strfmon_test.c
@@ -224,8 +224,8 @@ ATF_TC_BODY(strfmon_l, tc)
 		const char *expected;
 	} tests[] = {
 	    { "C", "[ **1234.57 ] [ **1234.57 ]" },
-	    { "de_DE.UTF-8", "[ €**1234.57 ] [ EUR**1234.57 ]" }, /* XXX */
-	    { "en_GB.UTF-8", "[ £**1234.57 ] [ GBP**1234.57 ]" }, /* XXX */
+	    { "de_DE.UTF-8", "[ **1234,57 €] [ **1.234,57 EUR]" },
+	    { "en_GB.UTF-8", "[ £**1234.57] [ GBP**1,234.57]" },
 	};
 	locale_t loc;
 	size_t i;

--- a/lib/libc/tests/stdlib/strfmon_test.c
+++ b/lib/libc/tests/stdlib/strfmon_test.c
@@ -55,7 +55,7 @@ ATF_TC_BODY(strfmon_locale_thousands, tc)
 		atf_tc_skip("multi-byte thousands-separator not found");
 
 	n = 1234.56;
-	strfmon(actual, sizeof(actual), "%i", n);
+	strfmon(actual, sizeof(actual) - 1, "%i", n);
 
 	strcpy(expected, "1");
 	strlcat(expected, ts, sizeof(expected));
@@ -95,7 +95,7 @@ ATF_TC_BODY(strfmon_examples, tc)
 	for (i = 0; i < nitems(tests); ++i) {
 		snprintf(format, sizeof(format), "[%s] [%s] [%s]",
 		    tests[i].format, tests[i].format, tests[i].format);
-		strfmon(actual, sizeof(actual), format,
+		strfmon(actual, sizeof(actual) - 1, format,
 		    123.45, -123.45, 3456.781);
 		ATF_CHECK_STREQ_MSG(tests[i].expected, actual,
 		    "[%s]", tests[i].format);
@@ -135,7 +135,7 @@ ATF_TC_BODY(strfmon_cs_precedes_0, tc)
 		for (j = 0; j < 5; ++j) {
 			lc->n_sign_posn = j;
 
-			strfmon(buf, sizeof(buf), "[%n] ", -123.0);
+			strfmon(buf, sizeof(buf) - 1, "[%n] ", -123.0);
 			strlcat(actual, buf, sizeof(actual));
 		}
 
@@ -178,7 +178,7 @@ ATF_TC_BODY(strfmon_cs_precedes_1, tc)
 		for (j = 0; j < 5; ++j) {
 			lc->n_sign_posn = j;
 
-			strfmon(buf, sizeof(buf), "[%n] ", -123.0);
+			strfmon(buf, sizeof(buf) - 1, "[%n] ", -123.0);
 			strlcat(actual, buf, sizeof(actual));
 		}
 
@@ -206,7 +206,7 @@ ATF_TC_BODY(strfmon_international_currency_code, tc)
 		if (setlocale(LC_MONETARY, tests[i].locale) == NULL)
 			atf_tc_skip("unable to setlocale()");
 
-		strfmon(actual, sizeof(actual), "[%i]", 123.45);
+		strfmon(actual, sizeof(actual) - 1, "[%i]", 123.45);
 		ATF_CHECK_STREQ(tests[i].expected, actual);
 	}
 }


### PR DESCRIPTION
Following up #619, fix `strfmon_l` as well.

1. Minor improvements to `strfmon_l(3)` man page.
2. Correctness improvement to the current test.
3. Add a test for `strfmon_l`.
4. Fix `strfmon_l`.
5. Remove `XXX` marks.
6. DROP commit. Used only for testing using Cirrus CI runners.

Tagging @kostikbel, as he kindly reviewed #619.

PR: [267410](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267410)