### PR TITLE
xlocale(3): Link man pages

### DIFF
--- a/lib/libc/locale/Makefile.inc
+++ b/lib/libc/locale/Makefile.inc
@@ -52,11 +52,24 @@ MAN+=	btowc.3 \
 MAN+=	big5.5 euc.5 gb18030.5 gb2312.5 gbk.5 mskanji.5 utf8.5
 
 MLINKS+=btowc.3 wctob.3
-MLINKS+=isdigit.3 isnumber.3
+MLINKS+=digittoint.3 digittoint_l.3
+MLINKS+=isalnum.3 isalnum_l.3
+MLINKS+=isalpha.3 isalpha_l.3
+MLINKS+=isblank.3 isblank_l.3
+MLINKS+=iscntrl.3 iscntrl_l.3
+MLINKS+=isdigit.3 isnumber.3 isdigit.3 isdigit_l.3 isdigit.3 isnumber_l.3
 MLINKS+=isgraph.3 isgraph_l.3
+MLINKS+=isideogram.3 isideogram_l.3
 MLINKS+=islower.3 islower_l.3
+MLINKS+=isphonogram.3 isphonogram_l.3
+MLINKS+=isprint.3 isprint_l.3
 MLINKS+=ispunct.3 ispunct_l.3
+MLINKS+=isrune.3 isrune_l.3
 MLINKS+=isspace.3 isspace_l.3
+MLINKS+=isspecial.3 isspecial_l.3
+MLINKS+=isupper.3 isupper_l.3
+MLINKS+=tolower.3 tolower_l.3
+MLINKS+=toupper.3 toupper_l.3
 MLINKS+=nl_langinfo.3 nl_langinfo_l.3
 MLINKS+=iswalnum.3 iswalpha.3 iswalnum.3 iswascii.3 iswalnum.3 iswblank.3 \
 	iswalnum.3 iswcntrl.3 iswalnum.3 iswdigit.3 iswalnum.3 iswgraph.3 \
@@ -77,7 +90,8 @@ MLINKS+=iswalnum_l.3 iswalpha_l.3 iswalnum_l.3 iswcntrl_l.3 \
 	iswalnum_l.3 iswphonogram_l.3 iswalnum_l.3 iswrune_l.3 \
 	iswalnum_l.3 iswspecial_l.3 iswalnum_l.3 nextwctype_l.3 \
 	iswalnum_l.3 towctrans_l.3 iswalnum_l.3 wctrans_l.3
-MLINKS+=isxdigit.3 ishexnumber.3
+MLINKS+=isxdigit.3 ishexnumber.3 isxdigit.3 isxdigit_l.3 \
+	isxdigit.3 ishexnumber_l.3
 MLINKS+=localeconv.3 localeconv_l.3
 MLINKS+=mbrtowc.3 mbrtoc16.3 mbrtowc.3 mbrtoc32.3
 MLINKS+=mbsrtowcs.3 mbsnrtowcs.3

--- a/lib/libc/locale/ctype_l.3
+++ b/lib/libc/locale/ctype_l.3
@@ -26,14 +26,13 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd March 6, 2012
+.Dd October 28, 2022
 .Dt CTYPE_L 3
 .Os
 .Sh NAME
 .Nm digittoint_l ,
 .Nm isalnum_l ,
 .Nm isalpha_l ,
-.Nm isascii_l ,
 .Nm isblank_l ,
 .Nm iscntrl_l ,
 .Nm isdigit_l ,
@@ -63,8 +62,6 @@
 .Fn isalnum_l "int c" "locale_t loc"
 .Ft int
 .Fn isalpha_l "int c" "locale_t loc"
-.Ft int
-.Fn isascii_l "int c" "locale_t loc"
 .Ft int
 .Fn iscntrl_l "int c" "locale_t loc"
 .Ft int
@@ -110,34 +107,32 @@ specified locale rather than the global or per-thread locale.
 or as true functions in the C library.
 See the specific manual pages for more information.
 .Sh SEE ALSO
-.Xr digittoint 3 ,
-.Xr isalnum 3 ,
-.Xr isalpha 3 ,
-.Xr isascii 3 ,
-.Xr isblank 3 ,
-.Xr iscntrl 3 ,
-.Xr isdigit 3 ,
-.Xr isgraph 3 ,
-.Xr isideogram 3 ,
-.Xr islower 3 ,
-.Xr isphonogram 3 ,
-.Xr isprint 3 ,
-.Xr ispunct 3 ,
-.Xr isrune 3 ,
-.Xr isspace 3 ,
-.Xr isspecial 3 ,
-.Xr isupper 3 ,
-.Xr isxdigit 3 ,
-.Xr tolower 3 ,
-.Xr toupper 3 ,
-.Xr wctype 3 ,
-.Xr xlocale 3
+.Xr digittoint_l 3 ,
+.Xr isalnum_l 3 ,
+.Xr isalpha_l 3 ,
+.Xr isblank_l 3 ,
+.Xr iscntrl_l 3 ,
+.Xr isdigit_l 3 ,
+.Xr isgraph_l 3 ,
+.Xr isideogram_l 3 ,
+.Xr islower_l 3 ,
+.Xr isphonogram_l 3 ,
+.Xr isprint_l 3 ,
+.Xr ispunct_l 3 ,
+.Xr isrune_l 3 ,
+.Xr isspace_l 3 ,
+.Xr isspecial_l 3 ,
+.Xr isupper_l 3 ,
+.Xr isxdigit_l 3 ,
+.Xr tolower_l 3 ,
+.Xr toupper_l 3 ,
+.Xr wctype_l 3 ,
+.Xr xlocale_l 3
 .Sh STANDARDS
 These functions conform to
 .St -p1003.1-2008 ,
 except for
 .Fn digittoint_l ,
-.Fn isascii_l ,
 .Fn ishexnumber_l ,
 .Fn isideogram_l ,
 .Fn isnumber_l ,

--- a/lib/libc/locale/digittoint.3
+++ b/lib/libc/locale/digittoint.3
@@ -28,11 +28,12 @@
 .\"	@(#)digittoint.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd April 6, 2001
+.Dd October 28, 2022
 .Dt DIGITTOINT 3
 .Os
 .Sh NAME
-.Nm digittoint
+.Nm digittoint ,
+.Nm digittoint_l
 .Nd convert a numeric character to its integer value
 .Sh LIBRARY
 .Lb libc
@@ -45,7 +46,9 @@
 .Sh DESCRIPTION
 The
 .Fn digittoint
-function converts a numeric character to its corresponding integer value.
+and
+.Fn digittoint_l
+functions convert a numeric character to its corresponding integer value.
 The character can be any decimal digit or hexadecimal digit.
 With hexadecimal characters, the case of the values does not matter.
 .Pp
@@ -57,12 +60,19 @@ function use the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn digittoint
-function always returns an integer from the range of 0 to 15.
+and
+.Fn digittoint_l
+functions always return an integer from the range of 0 to 15.
 If the given character was not a digit as defined by
-.Xr isxdigit 3 ,
+.Xr isxdigit 3
+or
+.Xr isxdigit_l 3 ,
 the function will return 0.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr isdigit 3 ,
+.Xr isdigit_l 3 ,
 .Xr isxdigit 3 ,
+.Xr isxdigit_l 3 ,
 .Xr xlocale 3

--- a/lib/libc/locale/isalnum.3
+++ b/lib/libc/locale/isalnum.3
@@ -32,11 +32,12 @@
 .\"     @(#)isalnum.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd April 2, 2022
+.Dd October 28, 2022
 .Dt ISALNUM 3
 .Os
 .Sh NAME
-.Nm isalnum
+.Nm isalnum ,
+.Nm isalnum_l
 .Nd alphanumeric character test
 .Sh LIBRARY
 .Lb libc
@@ -49,10 +50,14 @@
 .Sh DESCRIPTION
 The
 .Fn isalnum
-function tests for any character for which
-.Xr isalpha 3
+and
+.Fn isalnum_l
+functions test for any character for which
+.Xr isalpha 3 ,
+.Xr isalpha_l 3
 or
-.Xr isdigit 3
+.Xr isdigit 3 ,
+.Xr isdigit_l 3
 is true.
 The value of the argument must be representable as an
 .Vt "unsigned char"
@@ -85,8 +90,10 @@ function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isalnum
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isalnum_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
 .Sh COMPATIBILITY
 The
 .Bx 4.4
@@ -96,12 +103,18 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswalnum
+or
+.Fn iswalnum_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr isalpha 3 ,
+.Xr isalpha_l 3 ,
 .Xr isdigit 3 ,
+.Xr isdigit_l 3 ,
 .Xr iswalnum 3 ,
+.Xr iswalnum_l 3 ,
 .Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS

--- a/lib/libc/locale/isalpha.3
+++ b/lib/libc/locale/isalpha.3
@@ -32,11 +32,12 @@
 .\"     @(#)isalpha.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd July 17, 2005
+.Dd October 28, 2022
 .Dt ISALPHA 3
 .Os
 .Sh NAME
-.Nm isalpha
+.Nm isalpha ,
+.Nm isalpha_l
 .Nd alphabetic character test
 .Sh LIBRARY
 .Lb libc
@@ -49,10 +50,14 @@
 .Sh DESCRIPTION
 The
 .Fn isalpha
-function tests for any character for which
-.Xr isupper 3
+and
+.Fn isalpha_l
+functions test for any character for which
+.Xr isupper 3 ,
+.Xr isupper_l 3
 or
-.Xr islower 3
+.Xr islower 3 ,
+.Xr islower_l 3
 is true.
 The value of the argument must be representable as an
 .Vt "unsigned char"
@@ -83,8 +88,10 @@ function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isalpha
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isalpha_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
 .Sh COMPATIBILITY
 The
 .Bx 4.4
@@ -94,12 +101,18 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswalpha
+or
+.Fn iswalpha_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr islower 3 ,
+.Xr islower_l 3 ,
 .Xr isupper 3 ,
+.Xr isupper_l 3 ,
 .Xr iswalpha 3 ,
+.Xr iswalpha_l 3 ,
 .Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS

--- a/lib/libc/locale/isblank.3
+++ b/lib/libc/locale/isblank.3
@@ -28,11 +28,12 @@
 .\"     @(#)isblank.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd July 17, 2005
+.Dd October 28, 2022
 .Dt ISBLANK 3
 .Os
 .Sh NAME
-.Nm isblank
+.Nm isblank ,
+.Nm isblank_l
 .Nd space or tab character test
 .Sh LIBRARY
 .Lb libc
@@ -45,7 +46,9 @@
 .Sh DESCRIPTION
 The
 .Fn isblank
-function tests for a space or tab character.
+and
+.Fn isblank_l
+functions test for a space or tab character.
 For any locale, this includes the following standard characters:
 .Bl -column XXXX
 .It Do \et Dc Ta Dq " "
@@ -53,6 +56,8 @@ For any locale, this includes the following standard characters:
 .Pp
 In the "C" locale, a successful
 .Fn isblank
+or
+.Fn isblank_l
 test is limited to these characters only.
 The value of the argument must be representable as an
 .Vt "unsigned char"
@@ -67,8 +72,10 @@ function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isblank
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isblank_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
 .Sh COMPATIBILITY
 The
 .Bx 4.4
@@ -78,10 +85,14 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswblank
+or
+.Fn iswblank_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswblank 3 ,
+.Xr iswblank_l 3 ,
 .Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS

--- a/lib/libc/locale/iscntrl.3
+++ b/lib/libc/locale/iscntrl.3
@@ -32,11 +32,12 @@
 .\"     @(#)iscntrl.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd April 2, 2022
+.Dd October 28, 2022
 .Dt ISCNTRL 3
 .Os
 .Sh NAME
-.Nm iscntrl
+.Nm iscntrl ,
+.Nm iscntrl_l
 .Nd control character test
 .Sh LIBRARY
 .Lb libc
@@ -49,7 +50,9 @@
 .Sh DESCRIPTION
 The
 .Fn iscntrl
-function tests for any control character.
+and
+.Fn iscntrl_l
+functions test for any control character.
 The value of the argument must be representable as an
 .Vt "unsigned char"
 or the value of
@@ -75,8 +78,10 @@ function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn iscntrl
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn iscntrl_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
 .Sh COMPATIBILITY
 The
 .Bx 4.4
@@ -86,10 +91,14 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswcntrl
+or
+.Fn iswcntrl_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswcntrl 3 ,
+.Xr iswcntrl_l 3 ,
 .Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS

--- a/lib/libc/locale/isdigit.3
+++ b/lib/libc/locale/isdigit.3
@@ -32,12 +32,14 @@
 .\"     @(#)isdigit.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd May 4, 2007
+.Dd October 28, 2022
 .Dt ISDIGIT 3
 .Os
 .Sh NAME
 .Nm isdigit ,
-.Nm isnumber
+.Nm isnumber ,
+.Nm isdigit_l ,
+.Nm isnumber_l
 .Nd decimal-digit character test
 .Sh LIBRARY
 .Lb libc
@@ -54,7 +56,9 @@
 .Sh DESCRIPTION
 The
 .Fn isdigit
-function tests for a decimal digit character.
+and
+.Fn isdigit_l
+functions test for a decimal digit character.
 Regardless of locale, this includes the following characters only:
 .Bl -column \&``0''______ \&``0''______ \&``0''______ \&``0''______ \&``0''______
 .It "\&``0''" Ta "``1''" Ta "``2''" Ta "``3''" Ta "``4''"
@@ -63,8 +67,12 @@ Regardless of locale, this includes the following characters only:
 .Pp
 The
 .Fn isnumber
-function behaves similarly to
-.Fn isdigit ,
+and
+.Fn isnumber_l
+functions behave similarly to
+.Fn isdigit
+and
+.Fn isdigit_l ,
 but may recognize additional characters, depending on the current locale
 setting.
 .Pp
@@ -77,9 +85,11 @@ The _l-suffixed versions take an explicit locale argument, whereas the
 non-suffixed versions use the current global or per-thread locale.
 .Sh RETURN VALUES
 The
-.Fn isdigit
+.Fn isdigit ,
+.Fn isdigit_l ,
+.Fn isnumber ,
 and
-.Fn isnumber
+.Fn isnumber_l
 functions return zero if the character tests false and
 return non-zero if the character tests true.
 .Sh COMPATIBILITY
@@ -91,10 +101,14 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswdigit
+or
+.Fn iswdigit_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswdigit 3 ,
+.Xr iswdigit_l 3 ,
 .Xr multibyte 3 ,
 .Xr xlocale 3 ,
 .Xr ascii 7

--- a/lib/libc/locale/isgraph.3
+++ b/lib/libc/locale/isgraph.3
@@ -32,11 +32,12 @@
 .\"     @(#)isgraph.3	8.2 (Berkeley) 12/11/93
 .\" $FreeBSD$
 .\"
-.Dd July 30, 2012
+.Dd October 28, 2022
 .Dt ISGRAPH 3
 .Os
 .Sh NAME
-.Nm isgraph
+.Nm isgraph ,
+.Nm isgraph_l
 .Nd printing character test (space character exclusive)
 .Sh LIBRARY
 .Lb libc
@@ -49,7 +50,9 @@
 .Sh DESCRIPTION
 The
 .Fn isgraph
-function tests for any printing character except space
+and
+.Fn isgraph_l
+functions test for any printing character except space
 .Pq Ql "\~"
 and other
 locale-specific space-like characters.
@@ -103,10 +106,15 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswgraph
+or
+.Fn iswgraph_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswgraph 3 ,
+.Xr iswgraph_l 3 ,
+.Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS
 The

--- a/lib/libc/locale/isideogram.3
+++ b/lib/libc/locale/isideogram.3
@@ -25,11 +25,12 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd March 30, 2004
+.Dd October 28, 2022
 .Dt ISIDEOGRAM 3
 .Os
 .Sh NAME
-.Nm isideogram
+.Nm isideogram ,
+.Nm isideogram_l
 .Nd ideographic character test
 .Sh LIBRARY
 .Lb libc
@@ -37,19 +38,47 @@
 .In ctype.h
 .Ft int
 .Fn isideogram "int c"
+.Ft int
+.Fn isideogram_l "int c" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn isideogram
-function tests for an ideographic character.
+and
+.Fn isideogram_l
+functions test for an ideographic character.
+.Pp
+The
+.Fn isideogram_l
+function takes an explicit locale argument, whereas the
+.Fn isideogram
+function use the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isideogram
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isideogram_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
+.Sh COMPATIBILITY
+The
+.Bx 4.4
+extension of accepting arguments outside of the range of the
+.Vt "unsigned char"
+type in locales with large character sets is considered obsolete
+and may not be supported in future releases.
+The
+.Fn iswideogram
+or
+.Fn iswideogram_l
+function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr isphonogram 3 ,
-.Xr iswideogram 3
+.Xr isphonogram_l 3 ,
+.Xr iswideogram 3 ,
+.Xr iswideogram_l 3 ,
+.Xr xlocale 3
 .Sh HISTORY
 The
 .Fn isideogram

--- a/lib/libc/locale/islower.3
+++ b/lib/libc/locale/islower.3
@@ -32,11 +32,12 @@
 .\"     @(#)islower.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd April 2, 2022
+.Dd October 28, 2022
 .Dt ISLOWER 3
 .Os
 .Sh NAME
-.Nm islower
+.Nm islower ,
+.Nm islower_l
 .Nd lower-case character test
 .Sh LIBRARY
 .Lb libc
@@ -49,7 +50,9 @@
 .Sh DESCRIPTION
 The
 .Fn islower
-function tests for any lower-case letters.
+and
+.Fn islower_l
+functions test for any lower-case letters.
 The value of the argument must be representable as an
 .Vt "unsigned char"
 or the value of
@@ -86,11 +89,17 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswlower
+or
+.Fn iswlower_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswlower 3 ,
+.Xr iswlower_l 3 ,
 .Xr tolower 3 ,
+.Xr tolower_l 3 ,
+.Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS
 The

--- a/lib/libc/locale/isphonogram.3
+++ b/lib/libc/locale/isphonogram.3
@@ -25,11 +25,12 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd March 30, 2004
+.Dd October 28, 2022
 .Dt ISPHONOGRAM 3
 .Os
 .Sh NAME
-.Nm isphonogram
+.Nm isphonogram ,
+.Nm isphonogram_l
 .Nd phonographic character test
 .Sh LIBRARY
 .Lb libc
@@ -37,19 +38,35 @@
 .In ctype.h
 .Ft int
 .Fn isphonogram "int c"
+.Ft int
+.Fn isphonogram_l "int c" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn isphonogram
-function tests for a phonographic character.
+and
+.Fn isphonogram_l
+functions test for a phonographic character.
+.Pp
+The
+.Fn isphonogram_l
+function takes an explicit locale argument, whereas the
+.Fn isphonogram
+function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isphonogram
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isphonogram_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr isideogram 3 ,
-.Xr iswphonogram 3
+.Xr isideogram_l 3 ,
+.Xr iswphonogram 3 ,
+.Xr iswphonogram_l 3 ,
+.Xr xlocale 3
 .Sh HISTORY
 The
 .Fn isphonogram

--- a/lib/libc/locale/isprint.3
+++ b/lib/libc/locale/isprint.3
@@ -32,11 +32,12 @@
 .\"     @(#)isprint.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd April 2, 2022
+.Dd October 28, 2022
 .Dt ISPRINT 3
 .Os
 .Sh NAME
-.Nm isprint
+.Nm isprint ,
+.Nm isprint_l
 .Nd printing character test (space character inclusive)
 .Sh LIBRARY
 .Lb libc
@@ -44,10 +45,14 @@
 .In ctype.h
 .Ft int
 .Fn isprint "int c"
+.Ft int
+.Fn isprint_l "int c" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn isprint
-function tests for any printing character, including space
+and
+.Fn isprint_l
+functions test for any printing character, including space
 .Pq Ql "\ " .
 The value of the argument must be representable as an
 .Vt "unsigned char"
@@ -77,11 +82,19 @@ In the ASCII character set, this includes the following characters
 .It "\&165\ ``u''" Ta "166\ ``v''" Ta "167\ ``w''" Ta "170\ ``x''" Ta "171\ ``y''"
 .It "\&172\ ``z''" Ta "173\ ``{''" Ta "174\ ``|''" Ta "175\ ``}''" Ta "176\ ``~''"
 .El
+.Pp
+The
+.Fn isprint_l
+function takes an explicit locale argument, whereas the
+.Fn isprint
+function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isprint
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isprint_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
 .Sh COMPATIBILITY
 The
 .Bx 4.4
@@ -91,10 +104,15 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswprint
+or
+.Fn iswprint_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswprint 3 ,
+.Xr iswprint_l 3 ,
+.Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS
 The

--- a/lib/libc/locale/ispunct.3
+++ b/lib/libc/locale/ispunct.3
@@ -32,11 +32,12 @@
 .\"	@(#)ispunct.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd April 2, 2022
+.Dd October 28, 2022
 .Dt ISPUNCT 3
 .Os
 .Sh NAME
-.Nm ispunct
+.Nm ispunct ,
+.Nm ispunct_l
 .Nd punctuation character test
 .Sh LIBRARY
 .Lb libc
@@ -49,11 +50,15 @@
 .Sh DESCRIPTION
 The
 .Fn ispunct
-function tests for any printing character except for space
+and
+.Fn ispunct_l
+functions test for any printing character except for space
 .Pq Ql "\ "
 or a
 character for which
 .Xr isalnum 3
+or
+.Xr isalnum_l 3
 is true.
 The value of the argument must be representable as an
 .Vt "unsigned char"
@@ -93,10 +98,15 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswpunct
+or
+.Fn iswpunct_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswpunct 3 ,
+.Xr iswpunct_l 3 ,
+.Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS
 The

--- a/lib/libc/locale/isrune.3
+++ b/lib/libc/locale/isrune.3
@@ -25,11 +25,12 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd March 30, 2004
+.Dd October 28, 2022
 .Dt ISRUNE 3
 .Os
 .Sh NAME
-.Nm isrune
+.Nm isrune ,
+.Nm isrune_l
 .Nd valid character test
 .Sh LIBRARY
 .Lb libc
@@ -37,24 +38,51 @@
 .In ctype.h
 .Ft int
 .Fn isrune "int c"
+.Ft int
+.Fn isrune_l "int c" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn isrune
-function tests for any character that is valid in the current
+and
+.Fn isrune_l
+functions test for any character that is valid in the current
 character set.
 In the
 .Tn ASCII
 character set, this is equivalent to
 .Fn isascii .
+.Pp
+The
+.Fn isrune_l
+function takes an explicit locale argument, whereas the
+.Fn isrune
+function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isrune
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isrune_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
+.Sh COMPATIBILITY
+The
+.Bx 4.4
+extension of accepting arguments outside of the range of the
+.Vt "unsigned char"
+type in locales with large character sets is considered obsolete
+and may not be supported in future releases.
+The
+.Fn iswrune
+or
+.Fn iswrune_l
+function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr isascii 3 ,
 .Xr iswrune 3 ,
+.Xr iswrune_l 3 ,
+.Xr xlocale 3 ,
 .Xr ascii 7
 .Sh HISTORY
 The

--- a/lib/libc/locale/isspace.3
+++ b/lib/libc/locale/isspace.3
@@ -32,11 +32,12 @@
 .\"     @(#)isspace.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd April 2, 2022
+.Dd October 28, 2022
 .Dt ISSPACE 3
 .Os
 .Sh NAME
-.Nm isspace
+.Nm isspace ,
+.Nm isspace_l
 .Nd white-space character test
 .Sh LIBRARY
 .Lb libc
@@ -49,7 +50,9 @@
 .Sh DESCRIPTION
 The
 .Fn isspace
-function tests for white-space characters.
+and
+.Fn isspace_l
+functions test for white-space characters.
 For any locale, this includes the following standard characters:
 .Bl -column \&`\et''___ \&``\et''___ \&``\et''___ \&``\et''___ \&``\et''___ \&``\et''___
 .It "\&``\et''" Ta "``\en''" Ta "``\ev''" Ta "``\ef''" Ta "``\er''" Ta "`` ''"
@@ -57,7 +60,9 @@ For any locale, this includes the following standard characters:
 .Pp
 In the "C" locale,
 .Fn isspace
-returns non-zero for these characters only.
+and
+.Fn isspace_l
+return non-zero for these characters only.
 The value of the argument must be representable as an
 .Vt "unsigned char"
 or the value of
@@ -84,11 +89,16 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswspace
+or
+.Fn iswspace_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswspace 3 ,
+.Xr iswspace_l 3 ,
 .Xr multibyte 3 ,
+.Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS
 The

--- a/lib/libc/locale/isspecial.3
+++ b/lib/libc/locale/isspecial.3
@@ -25,11 +25,12 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd March 30, 2004
+.Dd October 28, 2022
 .Dt ISSPECIAL 3
 .Os
 .Sh NAME
-.Nm isspecial
+.Nm isspecial ,
+.Nm isspecial_l
 .Nd special character test
 .Sh LIBRARY
 .Lb libc
@@ -37,18 +38,45 @@
 .In ctype.h
 .Ft int
 .Fn isspecial "int c"
+.Ft int
+.Fn isspecial_l "int c" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn isspecial
-function tests for a special character.
+and
+.Fn isspecial_l
+functions test for a special character.
+.Pp
+The
+.Fn isspecial_l
+function takes an explicit locale argument, whereas the
+.Fn isspecial
+function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isspecial
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isspecial_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
+.Sh COMPATIBILITY
+The
+.Bx 4.4
+extension of accepting arguments outside of the range of the
+.Vt "unsigned char"
+type in locales with large character sets is considered obsolete
+and may not be supported in future releases.
+The
+.Fn iswspecial
+or
+.Fn iswspecial_l
+function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
-.Xr iswspecial 3
+.Xr ctype_l 3 ,
+.Xr iswspecial 3 ,
+.Xr iswspecial_l 3 ,
+.Xr xlocale 3
 .Sh HISTORY
 The
 .Fn isspecial

--- a/lib/libc/locale/isupper.3
+++ b/lib/libc/locale/isupper.3
@@ -32,11 +32,12 @@
 .\"     @(#)isupper.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd April 2, 2022
+.Dd October 28, 2022
 .Dt ISUPPER 3
 .Os
 .Sh NAME
-.Nm isupper
+.Nm isupper ,
+.Nm isupper_l
 .Nd upper-case character test
 .Sh LIBRARY
 .Lb libc
@@ -44,10 +45,14 @@
 .In ctype.h
 .Ft int
 .Fn isupper "int c"
+.Ft int
+.Fn isupper_l "int c" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn isupper
-function tests for any upper-case letter.
+and
+.Fn isupper_l
+functions test for any upper-case letter.
 The value of the argument must be representable as an
 .Vt "unsigned char"
 or the value of
@@ -63,11 +68,19 @@ In the ASCII character set, this includes the following characters
 .It "\&125\ ``U''" Ta "126\ ``V''" Ta "127\ ``W''" Ta "130\ ``X''" Ta "131\ ``Y''"
 .It "\&132\ ``Z''" Ta \& Ta \& Ta \& Ta \&
 .El
+.Pp
+The
+.Fn isupper_l
+function takes an explicit locale argument, whereas the
+.Fn isupper
+function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isupper
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isupper_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
 .Sh COMPATIBILITY
 The
 .Bx 4.4
@@ -77,11 +90,17 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswupper
+or
+.Fn iswupper_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswupper 3 ,
+.Xr iswupper_l 3 ,
 .Xr toupper 3 ,
+.Xr toupper_l 3 ,
+.Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS
 The

--- a/lib/libc/locale/isxdigit.3
+++ b/lib/libc/locale/isxdigit.3
@@ -32,12 +32,14 @@
 .\"     @(#)isxdigit.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd July 17, 2005
+.Dd October 28, 2022
 .Dt ISXDIGIT 3
 .Os
 .Sh NAME
 .Nm isxdigit ,
-.Nm ishexnumber
+.Nm ishexnumber ,
+.Nm isxdigit_l ,
+.Nm ishexnumber_l
 .Nd hexadecimal-digit character test
 .Sh LIBRARY
 .Lb libc
@@ -47,10 +49,16 @@
 .Fn isxdigit "int c"
 .Ft int
 .Fn ishexnumber "int c"
+.Ft int
+.Fn isxdigit_l "int c" "locale_t loc"
+.Ft int
+.Fn ishexnumber_l "int c" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn isxdigit
-function tests for any hexadecimal-digit character.
+and
+.Fn isxdigit_l
+functions test for any hexadecimal-digit character.
 Regardless of locale, this includes the following characters only:
 .Bl -column \&``0''______ \&``0''______ \&``0''______ \&``0''______ \&``0''______
 .It "\&``0''" Ta "``1''" Ta "``2''" Ta "``3''" Ta "``4''"
@@ -62,8 +70,12 @@ Regardless of locale, this includes the following characters only:
 .Pp
 The
 .Fn ishexnumber
-function behaves similarly to
-.Fn isxdigit ,
+and
+.Fn ishexnumber_l
+functions behave similarly to
+.Fn isxdigit
+and
+.Fn isxdigit_l ,
 but may recognize additional characters,
 depending on the current locale setting.
 .Pp
@@ -71,11 +83,16 @@ The value of the argument must be representable as an
 .Vt "unsigned char"
 or the value of
 .Dv EOF .
+.Pp
+The _l-suffixed versions take an explicit locale argument, whereas the
+non-suffixed versions use the current global or per-thread locale.
 .Sh RETURN VALUES
 The
 .Fn isxdigit
-function returns zero if the character tests false and
-returns non-zero if the character tests true.
+and
+.Fn isxdigit_l
+functions return zero if the character tests false and
+return non-zero if the character tests true.
 .Sh COMPATIBILITY
 The
 .Bx 4.4
@@ -85,10 +102,15 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn iswxdigit
+or
+.Fn iswxdigit_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr iswxdigit 3 ,
+.Xr iswxdigit_l 3 ,
+.Xr xlocale 3 ,
 .Xr ascii 7
 .Sh STANDARDS
 The

--- a/lib/libc/locale/tolower.3
+++ b/lib/libc/locale/tolower.3
@@ -32,11 +32,12 @@
 .\"	@(#)tolower.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd July 25, 2010
+.Dd October 28, 2022
 .Dt TOLOWER 3
 .Os
 .Sh NAME
-.Nm tolower
+.Nm tolower ,
+.Nm tolower_l
 .Nd upper case to lower case letter conversion
 .Sh LIBRARY
 .Lb libc
@@ -44,19 +45,31 @@
 .In ctype.h
 .Ft int
 .Fn tolower "int c"
+.Ft int
+.Fn tolower_l "int c" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn tolower
-function converts an upper-case letter to the corresponding lower-case
+and
+.Fn tolower_l
+functions convert an upper-case letter to the corresponding lower-case
 letter.
 The argument must be representable as an
 .Vt "unsigned char"
 or the value of
 .Dv EOF .
+.Pp
+The
+.Fn tolower_l
+function takes an explicit locale argument, whereas the
+.Fn tolower
+function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 If the argument is an upper-case letter, the
 .Fn tolower
-function returns the corresponding lower-case letter if there is
+and
+.Fn tolower_l
+functions return the corresponding lower-case letter if there is
 one; otherwise, the argument is returned unchanged.
 .Sh COMPATIBILITY
 The
@@ -67,11 +80,17 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn towlower
+or
+.Fn towlower_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr islower 3 ,
-.Xr towlower 3
+.Xr islower_l 3 ,
+.Xr towlower 3 ,
+.Xr towlower_l 3 ,
+.Xr xlocale 3
 .Sh STANDARDS
 The
 .Fn tolower

--- a/lib/libc/locale/toupper.3
+++ b/lib/libc/locale/toupper.3
@@ -32,11 +32,12 @@
 .\"	@(#)toupper.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd July 25, 2010
+.Dd October 28, 2022
 .Dt TOUPPER 3
 .Os
 .Sh NAME
-.Nm toupper
+.Nm toupper ,
+.Nm toupper_l
 .Nd lower case to upper case letter conversion
 .Sh LIBRARY
 .Lb libc
@@ -44,19 +45,31 @@
 .In ctype.h
 .Ft int
 .Fn toupper "int c"
+.Ft int
+.Fn toupper_l "int c" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn toupper
-function converts a lower-case letter to the corresponding
+and
+.Fn toupper_l
+functions convert a lower-case letter to the corresponding
 upper-case letter.
 The argument must be representable as an
 .Vt "unsigned char"
 or the value of
 .Dv EOF .
+.Pp
+The
+.Fn toupper_l
+function takes an explicit locale argument, whereas the
+.Fn toupper
+function uses the current global or per-thread locale.
 .Sh RETURN VALUES
 If the argument is a lower-case letter, the
 .Fn toupper
-function returns the corresponding upper-case letter if there is
+and
+.Fn toupper_l
+functions return the corresponding upper-case letter if there is
 one; otherwise, the argument is returned unchanged.
 .Sh COMPATIBILITY
 The
@@ -67,11 +80,17 @@ type in locales with large character sets is considered obsolete
 and may not be supported in future releases.
 The
 .Fn towupper
+or
+.Fn towupper_l
 function should be used instead.
 .Sh SEE ALSO
 .Xr ctype 3 ,
+.Xr ctype_l 3 ,
 .Xr isupper 3 ,
-.Xr towupper 3
+.Xr isupper_l 3 ,
+.Xr towupper 3 ,
+.Xr towupper_l 3 ,
+.Xr xlocale 3
 .Sh STANDARDS
 The
 .Fn toupper


### PR DESCRIPTION
Essentially this is a followup of c889dd01b9ada00728601de06e8b087a8c751cbb. 

From `xlocale(3)`, this is just `ctype_l`. Others may need a similar treatment, but I'll wait for reviews of this one first.
