### PR TITLE
ping: Remove a vestigial notdef

### DIFF
--- a/sbin/ping/ping.c
+++ b/sbin/ping/ping.c
@@ -1484,22 +1484,6 @@ finish(void)
 		exit(2);
 }
 
-#ifdef notdef
-static char *ttab[] = {
-	"Echo Reply",		/* ip + seq + udata */
-	"Dest Unreachable",	/* net, host, proto, port, frag, sr + IP */
-	"Source Quench",	/* IP */
-	"Redirect",		/* redirect type, gateway, + IP  */
-	"Echo",
-	"Time Exceeded",	/* transit, frag reassem + IP */
-	"Parameter Problem",	/* pointer + IP */
-	"Timestamp",		/* id + seq + three timestamps */
-	"Timestamp Reply",	/* " */
-	"Info Request",		/* id + sq */
-	"Info Reply"		/* " */
-};
-#endif
-
 /*
  * pr_icmph --
  *	Print a descriptive string about an ICMP header.


### PR DESCRIPTION
It was once a function on 4.3BSD, `pr_type()`[^1], used to convert an ICMP "type" field to a printable string.  In 4.4BSD it was superseded by `pr_icmph()`[^2].

NetBSD[^3] and OpenBSD[^4] have already removed it.

[^1]: https://minnie.tuhs.org/cgi-bin/utree.pl?file=4.3BSD/usr/src/etc/ping.c
[^2]: https://minnie.tuhs.org/cgi-bin/utree.pl?file=4.4BSD/usr/src/sbin/ping/ping.c
[^3]: https://github.com/NetBSD/src/commit/203dfd34867991fd002f747d74a96f26ae80d41c
[^4]: https://github.com/openbsd/src/commit/9bbbbbb75d24e3d166ddd0cb6cb4417b78561309