### PR TITLE
Fix possible overflow when comparing wide char types

### DIFF
--- a/lib/libc/string/wcscasecmp.c
+++ b/lib/libc/string/wcscasecmp.c
@@ -41,7 +41,7 @@ wcscasecmp(const wchar_t *s1, const wchar_t *s2)
 		c1 = towlower(*s1);
 		c2 = towlower(*s2);
 		if (c1 != c2)
-			return ((int)c1 - c2);
+			return (int)((unsigned int)c1 - (unsigned int)c2);
 	}
 	return (-*s2);
 }

--- a/lib/libc/string/wcscmp.c
+++ b/lib/libc/string/wcscmp.c
@@ -51,8 +51,8 @@ wcscmp(const wchar_t *s1, const wchar_t *s2)
 {
 
 	while (*s1 == *s2++)
-		if (*s1++ == '\0')
+		if (*s1++ == L'\0')
 			return (0);
-	/* XXX assumes wchar_t = int */
-	return (*(const unsigned int *)s1 - *(const unsigned int *)--s2);
+
+	return (int)((unsigned int)*s1 - (unsigned int)(*(s2 - 1)));
 }

--- a/lib/libc/string/wcsncasecmp.c
+++ b/lib/libc/string/wcsncasecmp.c
@@ -43,9 +43,9 @@ wcsncasecmp(const wchar_t *s1, const wchar_t *s2, size_t n)
 		c1 = towlower(*s1);
 		c2 = towlower(*s2);
 		if (c1 != c2)
-			return ((int)c1 - c2);
+			return (int)((unsigned int)c1 - (unsigned int)c2);
 		if (--n == 0)
 			return (0);
 	}
-	return (-*s2);
+	return (int)(-*s2);
 }

--- a/lib/libc/string/wcsncmp.c
+++ b/lib/libc/string/wcsncmp.c
@@ -47,12 +47,9 @@ wcsncmp(const wchar_t *s1, const wchar_t *s2, size_t n)
 	if (n == 0)
 		return (0);
 	do {
-		if (*s1 != *s2++) {
-			/* XXX assumes wchar_t = int */
-			return (*(const unsigned int *)s1 -
-			    *(const unsigned int *)--s2);
-		}
-		if (*s1++ == 0)
+		if (*s1 != *s2++)
+			return (int)((unsigned int)*s1 - (unsigned int)(*--s2));
+		if (*s1++ == L'\0')
 			break;
 	} while (--n != 0);
 	return (0);


### PR DESCRIPTION
Because wide char types is assumed to be an int, and the return type is an int, subtracting as unsigned integers can cause issues if the value in s1 is large while the value in s2 is small, as the result will overflow and the wrong result will be given.

Example: If *s1 evaluates to a number with its sign bit set, but *s2 evaluates to 1 or a small number, the result may still have its significant bit set, which will return a number smaller than 0 when interpreted as an integer.