### PR TITLE
.github: Switch to v3 of actions/checkout.

### DIFF
--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -34,7 +34,7 @@ jobs:
           - target_arch: aarch64
             target: arm64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install packages (Ubuntu)
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
GitHub is emitting a warning that v2 is deprecated due to using Node.js 12.

Reported by:	GitHub