### PR TITLE
Fix SHA512_224_Final() on little-endian machines

### DIFF
--- a/sys/crypto/sha2/sha512c.c
+++ b/sys/crypto/sha2/sha512c.c
@@ -60,8 +60,8 @@ __FBSDID("$FreeBSD$");
 #else /* BYTE_ORDER != BIG_ENDIAN */
 
 /*
- * Encode a length len/4 vector of (uint64_t) into a length len vector of
- * (unsigned char) in big-endian form.  Assumes len is a multiple of 8.
+ * Encode a length (len + 7)/8 vector of (uint64_t) into a length len vector of
+ * (unsigned char) in big-endian form.  Assumes len is a multiple of 4.
  */
 static void
 be64enc_vect(unsigned char *dst, const uint64_t *src, size_t len)
@@ -70,11 +70,13 @@ be64enc_vect(unsigned char *dst, const uint64_t *src, size_t len)
 
 	for (i = 0; i < len / 8; i++)
 		be64enc(dst + i * 8, src[i]);
+	if (len % 8 == 4)
+		be32enc(dst + len - 4, (uint32_t)(src[len / 8] >> 32));
 }
 
 /*
  * Decode a big-endian length len vector of (unsigned char) into a length
- * len/4 vector of (uint64_t).  Assumes len is a multiple of 8.
+ * len/8 vector of (uint64_t).  Assumes len is a multiple of 8.
  */
 static void
 be64dec_vect(uint64_t *dst, const unsigned char *src, size_t len)


### PR DESCRIPTION
We have

  #define SHA512_224_DIGEST_LENGTH 28

which is not a multiple of 8.

So, for little-endian machines the following code does not work, since the last 32-bits of the digest are not encoded:

static void
be64enc_vect(unsigned char *dst, const uint64_t *src, size_t len) {
        size_t i;

        for (i = 0; i < len / 8; i++)
                be64enc(dst + i * 8, src[i]);
}

Use be32enc() if len is not a multiple of eight.

PR: 266863