### PR TITLE
proposal: ifconfig list fails for unpriv user past 2c24ad3377a

### DIFF
--- a/sbin/ifconfig/ifconfig.c
+++ b/sbin/ifconfig/ifconfig.c
@@ -1729,7 +1729,7 @@ ifmaybeload(const char *name)
 			 */
 			break;
 		case EPERM:
-			/* Ignore EPERM, do not force exit for unpriv user list */
+			/* Ignore EPERM, do not force exit for unpriv user */
 			break;
 
 		default:

--- a/sbin/ifconfig/ifconfig.c
+++ b/sbin/ifconfig/ifconfig.c
@@ -1728,6 +1728,10 @@ ifmaybeload(const char *name)
 			 * names of all drivers (eg mlx4en(4)).
 			 */
 			break;
+		case EPERM:
+			/* Ignore EPERM, do not force exit for unpriv user list */
+			break;
+
 		default:
 			err(1, "kldload(%s)", ifkind);
 		}


### PR DESCRIPTION
Hello Team, 
proposed fix for [bugID:269042](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=269042)

Summary:
since [2c24ad3377a6f58](https://cgit.freebsd.org/src/commit/sbin/ifconfig?id=2c24ad3377a6f584e484656db8390e4eb7cfc119) / [D37873](https://reviews.freebsd.org/D37873) ifconfig exits with permission denied when called by unpriviledged user and kldload(if_xxx) is called. 

With this patch, it just behaves as before, no information is (silently) dropped or missing.

Greetings, 
Michael 