### PR TITLE
fix botched merge in stable/13 posixshm tests

### DIFF
--- a/tests/sys/posixshm/posixshm_test.c
+++ b/tests/sys/posixshm/posixshm_test.c
@@ -1781,13 +1781,8 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, cloexec);
 	ATF_TP_ADD_TC(tp, mode);
 	ATF_TP_ADD_TC(tp, fallocate);
-<<<<<<< HEAD
-||||||| parent of 91ddfd352f59 (posixshm_test: add naive page accounting test)
-	ATF_TP_ADD_TC(tp, fspacectl);
-=======
 	ATF_TP_ADD_TC(tp, fspacectl);
 	ATF_TP_ADD_TC(tp, accounting);
->>>>>>> 91ddfd352f59 (posixshm_test: add naive page accounting test)
 	ATF_TP_ADD_TC(tp, largepage_basic);
 	ATF_TP_ADD_TC(tp, largepage_config);
 	ATF_TP_ADD_TC(tp, largepage_mmap);


### PR DESCRIPTION
the MFC attempt of "posixshm_test: add naive page accounting test" by @kostikbel broke the build.