### PR TITLE
Clarify hardpps() parameter name and comment

### DIFF
--- a/sys/kern/kern_ntptime.c
+++ b/sys/kern/kern_ntptime.c
@@ -733,11 +733,11 @@ hardupdate(offset)
  * variables, except for the actual time and frequency variables, which
  * are determined by this routine and updated atomically.
  *
- * tsp  - time at PPS
- * nsec - hardware counter at PPS
+ * tsp  - time at current PPS event
+ * delta_nsec - time elapsed between the previous and current PPS event
  */
 void
-hardpps(struct timespec *tsp, long nsec)
+hardpps(struct timespec *tsp, long delta_nsec)
 {
 	long u_sec, u_nsec, v_nsec; /* temps */
 	l_fp ftemp;
@@ -774,12 +774,9 @@ hardpps(struct timespec *tsp, long nsec)
 	/*
 	 * Compute the difference between the current and previous
 	 * counter values. If the difference exceeds 0.5 s, assume it
-	 * has wrapped around, so correct 1.0 s. If the result exceeds
-	 * the tick interval, the sample point has crossed a tick
-	 * boundary during the last second, so correct the tick. Very
-	 * intricate.
+	 * has wrapped around, so correct 1.0 s.
 	 */
-	u_nsec = nsec;
+	u_nsec = delta_nsec;
 	if (u_nsec > (NANOSECOND >> 1))
 		u_nsec -= NANOSECOND;
 	else if (u_nsec < -(NANOSECOND >> 1))


### PR DESCRIPTION
Since the following commit

commit 32c203577a5e89ed1e5849d1a5e81abf501cfb50
Author: Poul-Henning Kamp <phk@FreeBSD.org>
Date:   Thu Mar 11 15:09:51 1999 +0000

    Make even more of the PPSAPI implementations generic.

    FLL support in hardpps()

    Various magic shuffles and improved comments

    Style fixes from Bruce.

the "nsec" parameter of hardpps() is a time difference and no longer a time point.  Change the name to "delta_nsec" and adjust the comment.

Remove comment about a clock tick adjustment which is no longer in the code.