### PR TITLE
ADD x86 MSR Data Operand Independent Timing Mode

### DIFF
--- a/sys/x86/include/specialreg.h
+++ b/sys/x86/include/specialreg.h
@@ -544,6 +544,7 @@
 #define	MSR_IA32_FEATURE_CONTROL 0x03a
 #define	MSR_IA32_SPEC_CTRL	0x048
 #define	MSR_IA32_PRED_CMD	0x049
+#define MSR_IA32_UARCH_MISC_CTL	0x00001b01 /* Data Operand Independent Timing Mode */
 #define	MSR_BIOS_UPDT_TRIG	0x079
 #define	MSR_BBL_CR_D0		0x088
 #define	MSR_BBL_CR_D1		0x089


### PR DESCRIPTION
Add msr register MSR_IA32_UARCH_MISC_CTL 
available in Intel Skylake and later CPUs.

This register will be needed in a next step to be able to mitigate a well know  Intel CPU vulnerability. 

https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/best-practices/data-operand-independent-timing-isa-guidance.html

This is a first step to address.
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=269219

The register is there. So add it. Allow to disable it if needed individually.  How to handle it in general in FreeBSD (buildtime/runtime/defaults) may need a some discussion.