### PR TITLE
310.accounting: Verify process accounting is active before log rotation.

### DIFF
--- a/usr.sbin/periodic/etc/daily/310.accounting
+++ b/usr.sbin/periodic/etc/daily/310.accounting
@@ -18,6 +18,11 @@ case "$daily_accounting_enable" in
 	    echo '$daily_accounting_enable is set but /var/account/acct' \
 		"doesn't exist"
 	    rc=2
+	elif [ $(sysctl -n kern.acct_configured) -eq 0 ]
+	then
+	    echo '$daily_accounting_enable is set but' \
+	    'process accounting is not active'
+	    rc=2
 	elif [ -z "$daily_accounting_save" ]
 	then
 	    echo '$daily_accounting_enable is set but ' \


### PR DESCRIPTION
Check if process accounting is active in the periodic script.  If not, exit the periodic script indicating process accounting is not active instead of attempting to rotate the logs.  onerotate_log turns accounting back on regardless of what accounting_enable in rc.conf is set to.

PR: 267464