### PR TITLE
netlink: Fix "version introduced" documentation

### DIFF
--- a/share/man/man3/snl.3
+++ b/share/man/man3/snl.3
@@ -297,7 +297,7 @@ and
 The
 .Dv SNL
 library appeared in
-.Fx 14.0 .
+.Fx 13.2 .
 .Sh AUTHORS
 This library was implemented by
 .An Alexander Chernikov Aq Mt melifaro@FreeBSD.org .

--- a/share/man/man4/genetlink.4
+++ b/share/man/man4/genetlink.4
@@ -138,7 +138,7 @@ The following groups are defined:
 The
 .Dv NETLINK_GENERIC
 protocol family appeared in
-.Fx 14.0 .
+.Fx 13.2 .
 .Sh AUTHORS
 The netlink was implementated by
 .An -nosplit

--- a/share/man/man4/netlink.4
+++ b/share/man/man4/netlink.4
@@ -344,7 +344,7 @@ or
 .Re
 .Sh HISTORY
 The netlink protocol appeared in
-.Fx 14.0 .
+.Fx 13.2 .
 .Sh AUTHORS
 The netlink was implemented by
 .An -nosplit

--- a/share/man/man4/rtnetlink.4
+++ b/share/man/man4/rtnetlink.4
@@ -532,7 +532,7 @@ RTNLGRP_NEIGH	Notifies on ARP/NDP neighbor  arrival/removal/change
 The
 .Dv NETLINK_ROUTE
 protocol family appeared in
-.Fx 14.0 .
+.Fx 13.2 .
 .Sh AUTHORS
 The netlink was implementated by
 .An -nosplit


### PR DESCRIPTION
netlink(4) and associated features will exist in FreeBSD 14.0 but they will also exist in 13.2, an older version, from commits such as 02b958b1 and b309249b.

This commit needs merging to stable/13 and releng/13.2.