### PR TITLE
usr.sbin: Remove trailing semicolon

### DIFF
--- a/usr.sbin/bhyve/acpi.c
+++ b/usr.sbin/bhyve/acpi.c
@@ -101,10 +101,10 @@ struct basl_fio {
 };
 
 #define EFPRINTF(...) \
-	if (fprintf(__VA_ARGS__) < 0) goto err_exit;
+	if (fprintf(__VA_ARGS__) < 0) goto err_exit
 
 #define EFFLUSH(x) \
-	if (fflush(x) != 0) goto err_exit;
+	if (fflush(x) != 0) goto err_exit
 
 /*
  * A list for additional ACPI devices like a TPM.

--- a/usr.sbin/bhyve/ipc.h
+++ b/usr.sbin/bhyve/ipc.h
@@ -41,7 +41,7 @@ struct ipc_command {
 #define IPC_COMMAND(set, name, function)			\
 	static struct ipc_command name ## _ipc_command =	\
 	{ #name, function };					\
-	DATA_SET(set, name ## _ipc_command);
+	DATA_SET(set, name ## _ipc_command)
 
 #define IPC_COMMAND_FOREACH(pvar, set)	SET_FOREACH(pvar, set)
 

--- a/usr.sbin/bhyve/pci_emul.h
+++ b/usr.sbin/bhyve/pci_emul.h
@@ -82,7 +82,7 @@ struct pci_devemu {
 	int	(*pe_resume)(struct pci_devinst *pi);
 
 };
-#define PCI_EMUL_SET(x)   DATA_SET(pci_devemu_set, x);
+#define PCI_EMUL_SET(x)   DATA_SET(pci_devemu_set, x)
 
 enum pcibar_type {
 	PCIBAR_NONE,

--- a/usr.sbin/bhyve/pci_hda.h
+++ b/usr.sbin/bhyve/pci_hda.h
@@ -87,6 +87,6 @@ struct hda_ops {
 		uint8_t dir, uint8_t *buf, size_t count);
 };
 
-#define HDA_EMUL_SET(x)		DATA_SET(hda_codec_class_set, x);
+#define HDA_EMUL_SET(x)		DATA_SET(hda_codec_class_set, x)
 
 #endif	/* _HDA_EMUL_H_ */

--- a/usr.sbin/bhyve/pci_nvme.c
+++ b/usr.sbin/bhyve/pci_nvme.c
@@ -129,7 +129,7 @@ static int nvme_debug = 0;
 /* Encode number of SQ's and CQ's for Set/Get Features */
 #define NVME_FEATURE_NUM_QUEUES(sc) \
 	(ZERO_BASED((sc)->num_squeues) & 0xffff) | \
-	(ZERO_BASED((sc)->num_cqueues) & 0xffff) << 16;
+	(ZERO_BASED((sc)->num_cqueues) & 0xffff) << 16
 
 #define	NVME_DOORBELL_OFFSET	offsetof(struct nvme_registers, doorbell)
 

--- a/usr.sbin/bhyve/usb_emul.h
+++ b/usr.sbin/bhyve/usb_emul.h
@@ -65,7 +65,7 @@ struct usb_devemu {
 	int	(*ue_stop)(void *sc);
 	int	(*ue_snapshot)(void *scarg, struct vm_snapshot_meta *meta);
 };
-#define	USB_EMUL_SET(x)		DATA_SET(usb_emu_set, x);
+#define	USB_EMUL_SET(x)		DATA_SET(usb_emu_set, x)
 
 /*
  * USB device events to notify HCI when state changes

--- a/usr.sbin/lpr/lpd/recvjob.c
+++ b/usr.sbin/lpr/lpd/recvjob.c
@@ -68,7 +68,7 @@ __FBSDID("$FreeBSD$");
 #include "extern.h"
 #include "pathnames.h"
 
-#define ack()	(void) write(STDOUT_FILENO, sp, (size_t)1);
+#define ack()	(void) write(STDOUT_FILENO, sp, (size_t)1)
 
 /*
  * The buffer size to use when reading/writing spool files.

--- a/usr.sbin/pmccontrol/pmccontrol.c
+++ b/usr.sbin/pmccontrol/pmccontrol.c
@@ -101,7 +101,7 @@ static FILE *debug_stream = NULL;
 
 #if DEBUG
 #define DEBUG_MSG(...)					                \
-	(void) fprintf(debug_stream, "[pmccontrol] " __VA_ARGS__);
+	(void) fprintf(debug_stream, "[pmccontrol] " __VA_ARGS__)
 #else
 #define DEBUG_MSG(m)		/*  */
 #endif /* !DEBUG */

--- a/usr.sbin/ppp/ncp.h
+++ b/usr.sbin/ppp/ncp.h
@@ -96,8 +96,8 @@ extern void ncp2initial(struct ncp *);
           ncp_ClearUrgentPorts(&(ncp)->cfg.urgent.tcp)
 #define ncp_ClearUrgentUdpPorts(ncp) \
           ncp_ClearUrgentPorts(&(ncp)->cfg.urgent.udp)
-#define ncp_ClearUrgentTOS(ncp) (ncp)->cfg.urgent.tos = 0;
-#define ncp_SetUrgentTOS(ncp) (ncp)->cfg.urgent.tos = 1;
+#define ncp_ClearUrgentTOS(ncp) (ncp)->cfg.urgent.tos = 0
+#define ncp_SetUrgentTOS(ncp) (ncp)->cfg.urgent.tos = 1
 
 #ifndef NOINET6
 #define isncp(proto) ((proto) == PROTO_IPCP || (proto) == PROTO_IPV6CP)


### PR DESCRIPTION
Macros shouldn't use trailing semicolon.