### PR TITLE
Add a check that the alignment requested by memalign is not zero

### DIFF
--- a/lib/libc/gen/memalign.c
+++ b/lib/libc/gen/memalign.c
@@ -35,5 +35,12 @@ __FBSDID("$FreeBSD$");
 void *
 memalign(size_t align, size_t size)
 {
-	return (aligned_alloc(align, size ? roundup(size, align) : size));
+	/*
+	 * if align is zero then we can't roundup
+	 * in that case leave it to malloc
+	 */
+	if (align != 0)
+		return (aligned_alloc(align, roundup(size, align)));
+	else
+		return (malloc(size));
 }

--- a/lib/libc/gen/memalign.c
+++ b/lib/libc/gen/memalign.c
@@ -35,5 +35,5 @@ __FBSDID("$FreeBSD$");
 void *
 memalign(size_t align, size_t size)
 {
-	return (aligned_alloc(align, roundup(size, align)));
+	return (aligned_alloc(align, size ? roundup(size, align) : size));
 }


### PR DESCRIPTION
If it is zero then the current code will trigger a division by zero SIGFGE and terminate.

See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=269688