### PR TITLE
veriexec: fix declaration without a prototype

### DIFF
--- a/sbin/veriexec/veriexec.c
+++ b/sbin/veriexec/veriexec.c
@@ -50,7 +50,7 @@ const char *Cdir = NULL;
  * @return always returns code 0
  */
 static int
-veriexec_usage()
+veriexec_usage(void)
 {
 	printf("%s",
 	    "Usage:\tveriexec [-h] [-i state] [-C] [-xv state|verbosity] [path]\n");


### PR DESCRIPTION
veriexec_usage takes no parameters, so be explicit about it.

Reported by: gbe@