### PR TITLE
kldxref: skip .pkgsave files

### DIFF
--- a/usr.sbin/kldxref/kldxref.8
+++ b/usr.sbin/kldxref/kldxref.8
@@ -26,7 +26,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd October 9, 2001
+.Dd February 20, 2023
 .Dt KLDXREF 8
 .Os
 .Sh NAME
@@ -50,6 +50,16 @@ command line that contains modules.
 If no hint records are generated for a particular directory, no hint
 file is created, and the preexisting hint file (if there was one in
 that directory) is removed.
+.Pp
+.Nm
+ignores files with at least two "."s in the filename, such as
+.Pa foo.ko.debug
+or
+.Pa bar.ko.pkgsave .
+Note that this means that modules cannot have names such as
+.Pa foo.bar.ko .
+This limitation however, has been lived practice since the beginning of
+FreeBSD's kernel modules.
 .Pp
 The following options are available:
 .Bl -tag -width indent

--- a/usr.sbin/kldxref/kldxref.c
+++ b/usr.sbin/kldxref/kldxref.c
@@ -685,6 +685,7 @@ main(int argc, char *argv[])
 {
 	FTS *ftsp;
 	FTSENT *p;
+	char *dot = NULL;
 	int opt, fts_options, ival;
 	struct stat sb;
 
@@ -752,14 +753,15 @@ main(int argc, char *argv[])
 			fwrite(&ival, sizeof(ival), 1, fxref);
 			reccnt = 0;
 		}
-		/* skip non-files and separate debug files */
+		/* skip non-files.. */
 		if (p->fts_info != FTS_F)
 			continue;
-		if (p->fts_namelen >= 6 &&
-		    strcmp(p->fts_name + p->fts_namelen - 6, ".debug") == 0)
-			continue;
-		if (p->fts_namelen >= 8 &&
-		    strcmp(p->fts_name + p->fts_namelen - 8, ".symbols") == 0)
+		/*
+		 * Skip files that generate errors like .debug, .symbol and .pkgsave
+		 * by generally skipping all files with 2 dots.
+		 */
+		dot = strchr(p->fts_name, '.');
+		if (dot && strchr(dot + 1, '.') != NULL)
 			continue;
 		read_kld(p->fts_path, p->fts_name);
 	}


### PR DESCRIPTION
This should help people transitioning from traditional setups to pkgbase experience a lot less friction.

We do this by skipping all files containing two dots.

Differential Revision: https://reviews.freebsd.org/D27959