### PR TITLE
jail: convert several functions from int to bool

### DIFF
--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -2778,14 +2778,19 @@ prison_find_name(struct prison *mypr, const char *name)
  * PR_IP4 and PR_IP6), or only the single bit is examined, without regard
  * to any other prison data.
  */
-int
+bool
 prison_flag(struct ucred *cred, unsigned flag)
 {
 
-	return (cred->cr_prison->pr_flags & flag);
+	return ((cred->cr_prison->pr_flags & flag) != 0);
 }
 
-int
+/*
+ * See if a prison has the specific allow flag set.
+ * The prison *should* be locked, or only a single bit is examined, without
+ * regard to any other prison data.
+ */
+bool
 prison_allow(struct ucred *cred, unsigned flag)
 {
 
@@ -3513,16 +3518,16 @@ prison_check_nfsd(struct ucred *cred)
 }
 
 /*
- * Return 1 if p2 is a child of p1, otherwise 0.
+ * Return true if p2 is a child of p1, otherwise false.
  */
-int
+bool
 prison_ischild(struct prison *pr1, struct prison *pr2)
 {
 
 	for (pr2 = pr2->pr_parent; pr2 != NULL; pr2 = pr2->pr_parent)
 		if (pr1 == pr2)
-			return (1);
-	return (0);
+			return (true);
+	return (false);
 }
 
 /*
@@ -3557,21 +3562,21 @@ prison_isvalid(struct prison *pr)
 }
 
 /*
- * Return 1 if the passed credential is in a jail and that jail does not
- * have its own virtual network stack, otherwise 0.
+ * Return true if the passed credential is in a jail and that jail does not
+ * have its own virtual network stack, otherwise false.
  */
-int
+bool
 jailed_without_vnet(struct ucred *cred)
 {
 
 	if (!jailed(cred))
-		return (0);
+		return (false);
 #ifdef VIMAGE
 	if (prison_owns_vnet(cred))
-		return (0);
+		return (false);
 #endif
 
-	return (1);
+	return (true);
 }
 
 /*
@@ -3633,9 +3638,9 @@ getjailname(struct ucred *cred, char *name, size_t len)
  * Determine whether the prison represented by cred owns
  * its vnet rather than having it inherited.
  *
- * Returns 1 in case the prison owns the vnet, 0 otherwise.
+ * Returns true in case the prison owns the vnet, false otherwise.
  */
-int
+bool
 prison_owns_vnet(struct ucred *cred)
 {
 
@@ -3643,7 +3648,7 @@ prison_owns_vnet(struct ucred *cred)
 	 * vnets cannot be added/removed after jail creation,
 	 * so no need to lock here.
 	 */
-	return (cred->cr_prison->pr_flags & PR_VNET ? 1 : 0);
+	return ((cred->cr_prison->pr_flags & PR_VNET) != 0);
 }
 #endif
 

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -413,24 +413,24 @@ struct vfsconf;
  */
 #define jailed(cred)	(cred->cr_prison != &prison0)
 
-int jailed_without_vnet(struct ucred *);
+bool jailed_without_vnet(struct ucred *);
 void getcredhostname(struct ucred *, char *, size_t);
 void getcreddomainname(struct ucred *, char *, size_t);
 void getcredhostuuid(struct ucred *, char *, size_t);
 void getcredhostid(struct ucred *, unsigned long *);
 void getjailname(struct ucred *cred, char *name, size_t len);
 void prison0_init(void);
-int prison_allow(struct ucred *, unsigned);
+bool prison_allow(struct ucred *, unsigned);
 int prison_check(struct ucred *cred1, struct ucred *cred2);
 bool prison_check_nfsd(struct ucred *cred);
-int prison_owns_vnet(struct ucred *);
+bool prison_owns_vnet(struct ucred *);
 int prison_canseemount(struct ucred *cred, struct mount *mp);
 void prison_enforce_statfs(struct ucred *cred, struct mount *mp,
     struct statfs *sp);
 struct prison *prison_find(int prid);
 struct prison *prison_find_child(struct prison *, int);
 struct prison *prison_find_name(struct prison *, const char *);
-int prison_flag(struct ucred *, unsigned);
+bool prison_flag(struct ucred *, unsigned);
 void prison_free(struct prison *pr);
 void prison_free_locked(struct prison *pr);
 void prison_hold(struct prison *pr);
@@ -441,7 +441,7 @@ void prison_proc_link(struct prison *, struct proc *);
 void prison_proc_unlink(struct prison *, struct proc *);
 void prison_proc_iterate(struct prison *, void (*)(struct proc *, void *), void *);
 void prison_set_allow(struct ucred *cred, unsigned flag, int enable);
-int prison_ischild(struct prison *, struct prison *);
+bool prison_ischild(struct prison *, struct prison *);
 bool prison_isalive(const struct prison *);
 bool prison_isvalid(struct prison *);
 #if defined(INET) || defined(INET6)
@@ -450,24 +450,24 @@ const void *prison_ip_get0(const struct prison *, const pr_family_t);
 u_int prison_ip_cnt(const struct prison *, const pr_family_t);
 #endif
 #ifdef INET
-int prison_equal_ip4(struct prison *, struct prison *);
+bool prison_equal_ip4(struct prison *, struct prison *);
 int prison_get_ip4(struct ucred *cred, struct in_addr *ia);
 int prison_local_ip4(struct ucred *cred, struct in_addr *ia);
 int prison_remote_ip4(struct ucred *cred, struct in_addr *ia);
 int prison_check_ip4(const struct ucred *, const struct in_addr *);
 int prison_check_ip4_locked(const struct prison *, const struct in_addr *);
-int prison_saddrsel_ip4(struct ucred *, struct in_addr *);
+bool prison_saddrsel_ip4(struct ucred *, struct in_addr *);
 int prison_qcmp_v4(const void *, const void *);
 bool prison_valid_v4(const void *);
 #endif
 #ifdef INET6
-int prison_equal_ip6(struct prison *, struct prison *);
+bool prison_equal_ip6(struct prison *, struct prison *);
 int prison_get_ip6(struct ucred *, struct in6_addr *);
 int prison_local_ip6(struct ucred *, struct in6_addr *, int);
 int prison_remote_ip6(struct ucred *, struct in6_addr *);
 int prison_check_ip6(const struct ucred *, const struct in6_addr *);
 int prison_check_ip6_locked(const struct prison *, const struct in6_addr *);
-int prison_saddrsel_ip6(struct ucred *, struct in6_addr *);
+bool prison_saddrsel_ip6(struct ucred *, struct in6_addr *);
 int prison_qcmp_v6(const void *, const void *);
 bool prison_valid_v6(const void *);
 #endif


### PR DESCRIPTION
these functions exclusively return (0) and (1), so convert them to bool

We also convert some networking related jail functions from int to bool some of which were returning an error that was never used.

Differential Revision: https://reviews.freebsd.org/D29659