### PR TITLE
apic: prevent divide by zero in CPU frequency init

### DIFF
--- a/sys/x86/x86/local_apic.c
+++ b/sys/x86/x86/local_apic.c
@@ -953,7 +953,7 @@ lapic_calibrate_initcount_cpuid_vm(void)
 
 	/* Record divided frequency. */
 	count_freq = freq / lapic_timer_divisor;
-	return (true);
+	return (count_freq != 0);
 }
 
 static uint64_t


### PR DESCRIPTION
If a CPU for some reason returns 0 as CPU frequency, we currently panic on the resulting divide by zero when trying to initialize the CPU(s) via APIC

PR: 269767