### PR TITLE
QuickFix:  allow to build userboot (again) without zfs enabled 

### DIFF
--- a/stand/userboot/userboot/Makefile
+++ b/stand/userboot/userboot/Makefile
@@ -36,9 +36,13 @@ SRCS+=		gfx_fb_stub.c
 
 CFLAGS+=	-Wall
 CFLAGS+=	-I${BOOTSRC}/userboot
+
+.if ${MK_LOADER_ZFS} != "no"
 CFLAGS.main.c+=	-I${BOOTSRC}/libsa/zfs
 CFLAGS.main.c+=	-I${SYSDIR}/contrib/openzfs/include
 CFLAGS.main.c+=	-I${SYSDIR}/contrib/openzfs/include/os/freebsd/zfs
+.endif
+
 CWARNFLAGS.main.c += -Wno-implicit-function-declaration
 CFLAGS.gfx_fb_stub.c += -I${SRCTOP}/contrib/pnglite -I${SRCTOP}/sys/teken
 

--- a/stand/userboot/userboot/main.c
+++ b/stand/userboot/userboot/main.c
@@ -32,13 +32,13 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <setjmp.h>
 #include <sys/disk.h>
-#include <sys/zfs_bootenv.h>
 
 #include "bootstrap.h"
 #include "disk.h"
 #include "libuserboot.h"
 
 #if defined(USERBOOT_ZFS_SUPPORT)
+#include <sys/zfs_bootenv.h>
 #include "libzfs.h"
 
 static void userboot_zfs_probe(void);


### PR DESCRIPTION
This patch allows to build and use userboot (bhyve/process-isolation) again without the need for having full ZFS enabled (eg on targeted/embedded/security appliances).  Would be a nice feature to have this working again for the upcoming 13.2 release. 

ref.: [e307eb94ae520d98](https://cgit.freebsd.org/src/commit/stand/userboot/userboot?id=e307eb94ae520d98dc1d346a0c53667a41beab5d)  and [D25512](https://reviews.freebsd.org/D25512)

Thank you!