### PR TITLE
GitHub: Silence clang-12 cross builds

### DIFF
--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -2,7 +2,7 @@ name: Cross-build Kernel
 
 on:
   push:
-    branches: [ main, 'stable/13' ]
+    branches: [ main, 'stable/13', silence-github-clang-12 ]
   pull_request:
     branches: [ main ]
 

--- a/tools/build/cross-build/include/linux/unistd.h
+++ b/tools/build/cross-build/include/linux/unistd.h
@@ -41,17 +41,9 @@
 /* Ensure that unistd.h pulls in getopt */
 #define __USE_POSIX2
 #endif
-/*
- * Before version 2.25, glibc's unistd.h would define the POSIX subset of
- * getopt.h by defining __need_getopt,  including getopt.h (which would
- * disable the header guard) and then undefining it so later including
- * getopt.h explicitly would define the extensions. However, we wrap getopt,
- * and so the wrapper's #pragma once breaks that. Thus getopt.h must be
- * included before the real unistd.h to ensure we get all the extensions.
- */
-#include <getopt.h>
 #include_next <unistd.h>
 #include <fcntl.h>
+#include <getopt.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
The main idea is to stir a discussion, rather than present this pull request as the actual fix.

Can we just remove clang-12 from the test matrix?

cc/ @jrtc27, @emaste, @bsdjhb (educated guess of reviewers)