### PR TITLE
if_re: Generate an address if there is none in the EEPROM

### DIFF
--- a/sys/dev/re/if_re.c
+++ b/sys/dev/re/if_re.c
@@ -1674,6 +1674,11 @@ re_attach(device_t dev)
 		goto fail;
 	}
 
+	/* If address was not found, create one based on the hostid and name. */
+	if (ETHER_IS_ZERO(eaddr)) {
+		ether_gen_addr(ifp, (struct ether_addr *)eaddr);
+	}
+
 	/*
 	 * Call MI attach routine.
 	 */


### PR DESCRIPTION
There exists hardware that has no ethernet address burned into the EEPROM. Loading if_re on such a HW brings the device up with '00:00:00:00:00:00' as the address, and that doesn't get you too far in a real network.

PR: [262406](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=262406)
Differential Revision: https://reviews.freebsd.org/D34485
Signed-off-by: Evgeni Golov <evgeni@debian.org>