### PR TITLE
man 3 daemon: remove double negation

### DIFF
--- a/lib/libc/gen/daemon.3
+++ b/lib/libc/gen/daemon.3
@@ -48,18 +48,18 @@ The
 function is for programs wishing to detach themselves from the
 controlling terminal and run in the background as system daemons.
 .Pp
-Unless the argument
+If the argument
 .Fa nochdir
-is non-zero,
+is zero,
 .Fn daemon
 changes the current working directory to the root
 .Pq Pa / .
 .Pp
-Unless the argument
+If the argument
 .Fa noclose
-is non-zero,
+is zero,
 .Fn daemon
-will redirect standard input, standard output, and standard error to
+redirects standard input, standard output, and standard error to
 .Pa /dev/null .
 .Pp
 The


### PR DESCRIPTION
Rephrase double negated sentences to improve readability 
OpenBSD has done the same in the past to their man 3 daemon

https://man7.org/linux/man-pages/man3/daemon.3.html