### PR TITLE
arm64/gicv3: Allow us to inherit the LPI mappings

### DIFF
--- a/sys/arm64/arm64/mp_machdep.c
+++ b/sys/arm64/arm64/mp_machdep.c
@@ -570,7 +570,8 @@ start_cpu(u_int cpuid, uint64_t target_cpu, int domain, vm_paddr_t release_addr)
 	naps = atomic_load_int(&aps_started);
 	bootstack = (char *)bootstacks[cpuid] + MP_BOOTSTACK_SIZE;
 
-	printf("Starting CPU %u (%lx)\n", cpuid, target_cpu);
+	if (bootverbose)
+		printf("Starting CPU %u (%lx)\n", cpuid, target_cpu);
 	pa = pmap_extract(kernel_pmap, (vm_offset_t)mpentry);
 
 	/*


### PR DESCRIPTION
Due to bugs in the gicv3 hardware, you can't change the LPI mappings. Add code to read them in if we were booted with LPI enabled and use those instead of what we would allocate.

Be more pedanic about which bits we trust from region registers.

When forced to reuse an address, make sure its reserved.

Ensure what we do the gicv3 workaround only when it is safe to do so. Panic if we're forced to re-use an address that wasn't reserved early in boot. We have no good way if that address was reserved for this purpose and we won't have two users of that address.

When we're kexec'd from Linux, we have to reuse the memory that was assigned to the GICv3 ITS since the device can't be disabled enough to safely change these values without undefined behavior.

Sponsored by:		Netflix