### PR TITLE
xlocale: garbage collect references to strtoq_l/strtouq_l

### DIFF
--- a/lib/libc/locale/xlocale.3
+++ b/lib/libc/locale/xlocale.3
@@ -180,10 +180,8 @@ along with the headers that expose them, is provided here:
 .Xr strtol_l 3 ,
 .Xr strtold_l 3 ,
 .Xr strtoll_l 3 ,
-.Xr strtoq_l 3 ,
 .Xr strtoul_l 3 ,
 .Xr strtoull_l 3 ,
-.Xr strtouq_l 3 ,
 .Xr wcstombs_l 3 ,
 .Xr wctomb_l 3
 .It In string.h

--- a/lib/libc/stdlib/Symbol.map
+++ b/lib/libc/stdlib/Symbol.map
@@ -93,11 +93,9 @@ FBSD_1.3 {
 	strtol_l;
 	strtold_l;
 	strtoll_l;
-	strtoq_l;
 	strtoul_l;
 	strtoull_l;
 	strtoumax_l;
-	strtouq_l;
 };
 
 FBSD_1.4 {


### PR DESCRIPTION
These were explicitly never implemented (see lib/libc/locale/DESIGN.xlocale), but were referenced in the manpage and the symbol map.

Fixes:          3c87aa1d3dc ("Implement xlocale APIs from Darwin")
Reported by:    ld.lld 16 being --no-undefined-version by default
Reviewed by:    theraven
Sponsored by:   https://www.patreon.com/valpackett
Differential Revision: https://reviews.freebsd.org/D38408