### PR TITLE
open.2: describe O_RESOLVE_BENEATH errors correctly

### DIFF
--- a/lib/libc/sys/open.2
+++ b/lib/libc/sys/open.2
@@ -28,7 +28,7 @@
 .\"     @(#)open.2	8.2 (Berkeley) 11/16/93
 .\" $FreeBSD$
 .\"
-.Dd April 22, 2022
+.Dd March 2, 2023
 .Dt OPEN 2
 .Os
 .Sh NAME
@@ -572,12 +572,6 @@ and
 .Dv O_EXEC
 or
 .Dv O_SEARCH .
-.It Bq Er EINVAL
-The
-.Dv O_RESOLVE_BENEATH
-flag is specified and
-.Dv path
-is absolute.
 .It Bq Er EBADF
 The
 .Fa path
@@ -606,19 +600,32 @@ is specified and the process is in capability mode.
 was called and the process is in capability mode.
 .It Bq Er ENOTCAPABLE
 .Fa path
-is an absolute path,
-or contained a ".." component leading to a
-directory outside of the directory hierarchy specified by
-.Fa fd ,
+is an absolute path and the process is in capability mode.
+.It Bq Er ENOTCAPABLE
+.Fa path
+is an absolute path and
+.Dv O_RESOLVE_BENEATH
+is specified.
+.It Bq Er ENOTCAPABLE
+.Fa path
+contains a ".." component leading to a directory outside
+of the directory hierarchy specified by
+.Fa fd
 and the process is in capability mode.
 .It Bq Er ENOTCAPABLE
-The
-.Dv O_RESOLVE_BENEATH
-flag was provided, and the relative
 .Fa path
-escapes the
-.Ar fd
-directory.
+contains a ".." component leading to a directory outside
+of the directory hierarchy specified by
+.Fa fd
+and
+.Dv O_RESOLVE_BENEATH
+is specified.
+.It Bq Er ENOTCAPABLE
+.Fa path
+contains a ".." component, the
+.Dv vfs.lookup_cap_dotdot
+.Xr sysctl 3
+is set, and the process is in capability mode.
 .El
 .Sh SEE ALSO
 .Xr chmod 2 ,


### PR DESCRIPTION
The behavior is the same as in capability mode, it does not actually return EINVAL for absolute lookups:

    openat(AT_FDCWD,"/tmp/test",O_RDONLY|O_DIRECTORY,00) = 3 (0x3)
    openat(3,"../../",O_RDONLY|0x800000,00)          ERR#93 'Capabilities insufficient'
    openat(3,"/etc/passwd",O_RDONLY|0x800000,00)     ERR#93 'Capabilities insufficient'

Fixes:          1f305be43 ("Document {O,AT}_RESOLVE_BENEATH...")
Reviewed by:    kib, pauamma (manpages)
Sponsored by:   https://www.patreon.com/valpackett
Differential Revision: https://reviews.freebsd.org/D38675