### PR TITLE
GitHub: Cross-build full matrix

### DIFF
--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -2,7 +2,7 @@ name: Cross-build Kernel
 
 on:
   push:
-    branches: [ main, 'stable/13' ]
+    branches: [ main, 'stable/13', github-cross-build-full-matrix ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -10,54 +10,48 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: ${{ matrix.target_arch }} ${{ matrix.os }} (${{ matrix.compiler }})
+  cross-build:
+    name: ${{ matrix.target_arch }} ${{ matrix.os }} (clang-${{ matrix.clang_version}})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        clang_version: [12, 13, 14, 15]
+        os: [ macos-latest, ubuntu-latest ]
         target_arch: [ amd64, aarch64 ]
-        os: [ ubuntu-20.04, ubuntu-22.04, macos-latest ]
         include:
-          # TODO: both Ubuntu and macOS have bmake packages, we should try them instead of bootstrapping our own copy.
-          - os: ubuntu-20.04
-            compiler: clang-12
-            cross-bindir: /usr/lib/llvm-12/bin
-            pkgs: bmake libarchive-dev clang-12 lld-12
-          - os: ubuntu-22.04
-            compiler: clang-14
-            cross-bindir: /usr/lib/llvm-14/bin
-            pkgs: bmake libarchive-dev clang-14 lld-14
-          - os: macos-latest
-            compiler: clang-13
-            cross-bindir: /usr/local/opt/llvm@13/bin
-            pkgs: bmake libarchive llvm@13
           - target_arch: amd64
             target: amd64
           - target_arch: aarch64
             target: arm64
     steps:
       - uses: actions/checkout@v3
-      - name: install packages (Ubuntu)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update --quiet || true
-          sudo apt-get -yq --no-install-suggests --no-install-recommends install ${{ matrix.pkgs }}
-      - name: install packages (macOS)
+      - name: Install packages (macOS)
         if: runner.os == 'macOS'
         run: |
           brew update --quiet || true
-          brew install ${{ matrix.pkgs }} || true
-      - name: create environment
+          brew install bmake libarchive llvm@${{ matrix.clang_version }} || true
+      - name: Install packages (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update --quiet || true
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install bmake libarchive-dev clang-${{ matrix.clang_version }} lld-${{ matrix.clang_version }} || true
+      - name: Create environment (macOS)
+        if: runner.os == 'macOS'
         run: |
           echo "GITHUB_WORKSPACE = $GITHUB_WORKSPACE"
-          if [ -n "${{ matrix.cross-bindir }}" ]; then
-            echo "EXTRA_BUILD_ARGS=--cross-bindir=${{ matrix.cross-bindir }}" >> $GITHUB_ENV
-          fi
+          echo "EXTRA_BUILD_ARGS=--cross-bindir=/usr/local/opt/llvm@${{ matrix.clang_version }}/bin" >> $GITHUB_ENV
           mkdir -p ../build
           echo "MAKEOBJDIRPREFIX=${PWD%/*}/build" >> $GITHUB_ENV
-          # heh, works on Linux/BSD/macOS ...
-          echo "NPROC=`getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 1`" >> $GITHUB_ENV
+          echo "NPROC=3" >> $GITHUB_ENV
+      - name: Create environment (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          echo "GITHUB_WORKSPACE = $GITHUB_WORKSPACE"
+          echo "EXTRA_BUILD_ARGS=--cross-bindir=/usr/lib/llvm-${{ matrix.clang_version }}/bin" >> $GITHUB_ENV
+          mkdir -p ../build
+          echo "MAKEOBJDIRPREFIX=${PWD%/*}/build" >> $GITHUB_ENV
+          echo "NPROC=2" >> $GITHUB_ENV
       - name: bootstrap bmake
         run: ./tools/build/make.py --debug $EXTRA_BUILD_ARGS TARGET=${{ matrix.target }} TARGET_ARCH=${{ matrix.target_arch }} -n
       - name: make kernel-toolchain

--- a/README.md
+++ b/README.md
@@ -1,45 +1,28 @@
-FreeBSD Source:
----------------
-This is the top level of the FreeBSD source directory.
+DO NOT COMMIT!
 
-FreeBSD is an operating system used to power modern servers, desktops, and embedded platforms.
-A large community has continually developed it for more than thirty years.
-Its advanced networking, security, and storage features have made FreeBSD the platform of choice for many of the busiest web sites and most pervasive embedded networking and storage devices.
+Just to show off:
 
-For copyright information, please see [the file COPYRIGHT](COPYRIGHT) in this directory.
-Additional copyright information also exists for some sources in this tree - please see the specific source directories for more information.
+| OS     | Architecture | clang-12 | clang-13 | clang-14 | clang-15 |
+| ------:|:------------:|:--------:|:--------:|:--------:|:--------:|
+| macOS  | amd64        | [![Cross-build Kernel][macos-latest-amd64-clang-12-badge]][actions]    | [![Cross-build Kernel][macos-latest-amd64-clang-13-badge]][actions]    | [![Cross-build Kernel][macos-latest-amd64-clang-14-badge]][actions]    | [![Cross-build Kernel][macos-latest-amd64-clang-15-badge]][actions]    |
+| macOS  | aarch64      | [![Cross-build Kernel][macos-latest-aarch64-clang-12-badge]][actions]  | [![Cross-build Kernel][macos-latest-aarch64-clang-13-badge]][actions]  | [![Cross-build Kernel][macos-latest-aarch64-clang-14-badge]][actions]  | [![Cross-build Kernel][macos-latest-aarch64-clang-15-badge]][actions]  |
+| Ubuntu | amd64        | [![Cross-build Kernel][ubuntu-latest-amd64-clang-12-badge]][actions]   | [![Cross-build Kernel][ubuntu-latest-amd64-clang-13-badge]][actions]   | [![Cross-build Kernel][ubuntu-latest-amd64-clang-14-badge]][actions]   | [![Cross-build Kernel][ubuntu-latest-amd64-clang-15-badge]][actions]   |
+| Ubuntu | aarch64      | [![Cross-build Kernel][ubuntu-latest-aarch64-clang-12-badge]][actions] | [![Cross-build Kernel][ubuntu-latest-aarch64-clang-13-badge]][actions] | [![Cross-build Kernel][ubuntu-latest-aarch64-clang-14-badge]][actions] | [![Cross-build Kernel][ubuntu-latest-aarch64-clang-15-badge]][actions] |
 
-The Makefile in this directory supports a number of targets for building components (or all) of the FreeBSD source tree.
-See build(7), config(8), [FreeBSD handbook on building userland](https://docs.freebsd.org/en/books/handbook/cutting-edge/#makeworld), and [Handbook for kernels](https://docs.freebsd.org/en/books/handbook/kernelconfig/) for more information, including setting make(1) variables.
-
-For information on the CPU architectures and platforms supported by FreeBSD, see the [FreeBSD
-website's Platforms page](https://www.freebsd.org/platforms/).
-
-Source Roadmap:
----------------
-| Directory | Description |
-| --------- | ----------- |
-| bin | System/user commands. |
-| cddl | Various commands and libraries under the Common Development and Distribution License. |
-| contrib | Packages contributed by 3rd parties. |
-| crypto | Cryptography stuff (see [crypto/README](crypto/README)). |
-| etc | Template files for /etc. |
-| gnu | Commands and libraries under the GNU General Public License (GPL) or Lesser General Public License (LGPL). Please see [gnu/COPYING](gnu/COPYING) and [gnu/COPYING.LIB](gnu/COPYING.LIB) for more information. |
-| include | System include files. |
-| kerberos5 | Kerberos5 (Heimdal) package. |
-| lib | System libraries. |
-| libexec | System daemons. |
-| release | Release building Makefile & associated tools. |
-| rescue | Build system for statically linked /rescue utilities. |
-| sbin | System commands. |
-| secure | Cryptographic libraries and commands. |
-| share | Shared resources. |
-| stand | Boot loader sources. |
-| sys | Kernel sources (see [sys/README.md](sys/README.md)). |
-| targets | Support for experimental `DIRDEPS_BUILD` |
-| tests | Regression tests which can be run by Kyua.  See [tests/README](tests/README) for additional information. |
-| tools | Utilities for regression testing and miscellaneous tasks. |
-| usr.bin | User commands. |
-| usr.sbin | System administration commands. |
-
-For information on synchronizing your source tree with one or more of the FreeBSD Project's development branches, please see [FreeBSD Handbook](https://docs.freebsd.org/en/books/handbook/cutting-edge/#current-stable).
+[macos-latest-amd64-clang-12-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20macos-latest%20(clang-12)
+[macos-latest-amd64-clang-13-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20macos-latest%20(clang-13)
+[macos-latest-amd64-clang-14-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20macos-latest%20(clang-14)
+[macos-latest-amd64-clang-15-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20macos-latest%20(clang-15)
+[ubuntu-latest-amd64-clang-12-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20ubuntu-latest%20(clang-12)
+[ubuntu-latest-amd64-clang-13-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20ubuntu-latest%20(clang-13)
+[ubuntu-latest-amd64-clang-14-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20ubuntu-latest%20(clang-14)
+[ubuntu-latest-amd64-clang-15-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20ubuntu-latest%20(clang-15)
+[macos-latest-aarch64-clang-12-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20macos-latest%20(clang-12)
+[macos-latest-aarch64-clang-13-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20macos-latest%20(clang-13)
+[macos-latest-aarch64-clang-14-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20macos-latest%20(clang-14)
+[macos-latest-aarch64-clang-15-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20macos-latest%20(clang-15)
+[ubuntu-latest-aarch64-clang-12-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20ubuntu-latest%20(clang-12)
+[ubuntu-latest-aarch64-clang-13-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20ubuntu-latest%20(clang-13)
+[ubuntu-latest-aarch64-clang-14-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20ubuntu-latest%20(clang-14)
+[ubuntu-latest-aarch64-clang-15-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20ubuntu-latest%20(clang-15)
+[actions]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml

--- a/tools/build/cross-build/include/linux/unistd.h
+++ b/tools/build/cross-build/include/linux/unistd.h
@@ -41,17 +41,9 @@
 /* Ensure that unistd.h pulls in getopt */
 #define __USE_POSIX2
 #endif
-/*
- * Before version 2.25, glibc's unistd.h would define the POSIX subset of
- * getopt.h by defining __need_getopt,  including getopt.h (which would
- * disable the header guard) and then undefining it so later including
- * getopt.h explicitly would define the extensions. However, we wrap getopt,
- * and so the wrapper's #pragma once breaks that. Thus getopt.h must be
- * included before the real unistd.h to ensure we get all the extensions.
- */
-#include <getopt.h>
 #include_next <unistd.h>
 #include <fcntl.h>
+#include <getopt.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
Follow up of #668.

Notice all the DROP COMMITs, those are just to show the full matrix passing. As stated in the commit, it could be used in the future, when a build fails, FreeBSD's GitHub bot (aka Beastie) could notify with the following matrix (if all is green, there's no need):

| OS     | Architecture | clang-12 | clang-13 | clang-14 | clang-15 |
| ------:|:------------:|:--------:|:--------:|:--------:|:--------:|
| macOS  | amd64        | [![Cross-build Kernel][macos-latest-amd64-clang-12-badge]][actions]    | [![Cross-build Kernel][macos-latest-amd64-clang-13-badge]][actions]    | [![Cross-build Kernel][macos-latest-amd64-clang-14-badge]][actions]    | [![Cross-build Kernel][macos-latest-amd64-clang-15-badge]][actions]    |
| macOS  | aarch64      | [![Cross-build Kernel][macos-latest-aarch64-clang-12-badge]][actions]  | [![Cross-build Kernel][macos-latest-aarch64-clang-13-badge]][actions]  | [![Cross-build Kernel][macos-latest-aarch64-clang-14-badge]][actions]  | [![Cross-build Kernel][macos-latest-aarch64-clang-15-badge]][actions]  |
| Ubuntu | amd64        | [![Cross-build Kernel][ubuntu-latest-amd64-clang-12-badge]][actions]   | [![Cross-build Kernel][ubuntu-latest-amd64-clang-13-badge]][actions]   | [![Cross-build Kernel][ubuntu-latest-amd64-clang-14-badge]][actions]   | [![Cross-build Kernel][ubuntu-latest-amd64-clang-15-badge]][actions]   |
| Ubuntu | aarch64      | [![Cross-build Kernel][ubuntu-latest-aarch64-clang-12-badge]][actions] | [![Cross-build Kernel][ubuntu-latest-aarch64-clang-13-badge]][actions] | [![Cross-build Kernel][ubuntu-latest-aarch64-clang-14-badge]][actions] | [![Cross-build Kernel][ubuntu-latest-aarch64-clang-15-badge]][actions] |

[macos-latest-amd64-clang-12-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20macos-latest%20(clang-12)
[macos-latest-amd64-clang-13-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20macos-latest%20(clang-13)
[macos-latest-amd64-clang-14-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20macos-latest%20(clang-14)
[macos-latest-amd64-clang-15-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20macos-latest%20(clang-15)
[ubuntu-latest-amd64-clang-12-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20ubuntu-latest%20(clang-12)
[ubuntu-latest-amd64-clang-13-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20ubuntu-latest%20(clang-13)
[ubuntu-latest-amd64-clang-14-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20ubuntu-latest%20(clang-14)
[ubuntu-latest-amd64-clang-15-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=amd64%20ubuntu-latest%20(clang-15)
[macos-latest-aarch64-clang-12-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20macos-latest%20(clang-12)
[macos-latest-aarch64-clang-13-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20macos-latest%20(clang-13)
[macos-latest-aarch64-clang-14-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20macos-latest%20(clang-14)
[macos-latest-aarch64-clang-15-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20macos-latest%20(clang-15)
[ubuntu-latest-aarch64-clang-12-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20ubuntu-latest%20(clang-12)
[ubuntu-latest-aarch64-clang-13-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20ubuntu-latest%20(clang-13)
[ubuntu-latest-aarch64-clang-14-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20ubuntu-latest%20(clang-14)
[ubuntu-latest-aarch64-clang-15-badge]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml/badge.svg?branch=github-cross-build-full-matrix&jobname=aarch64%20ubuntu-latest%20(clang-15)
[actions]: https://github.com/jlduran/freebsd-src/actions/workflows/cross-bootstrap-tools.yml