### PR TITLE
acpica: do not print warning for missing _ADR

### DIFF
--- a/sys/dev/acpica/acpi_pcib_acpi.c
+++ b/sys/dev/acpica/acpi_pcib_acpi.c
@@ -410,8 +410,9 @@ acpi_pcib_acpi_attach(device_t dev)
      */
     status = acpi_GetInteger(sc->ap_handle, "_ADR", &sc->ap_addr);
     if (ACPI_FAILURE(status)) {
-	device_printf(dev, "could not evaluate _ADR - %s\n",
-	    AcpiFormatException(status));
+	if (status != AE_NOT_FOUND)
+	    device_printf(dev, "could not evaluate _ADR - %s\n",
+		AcpiFormatException(status));
 	sc->ap_addr = -1;
     }
 


### PR DESCRIPTION
Started seeing the following after updating to VMware ESXi 8.0:

pcib2: <ACPI Host-PCI bridge> on acpi0
pcib2: could not evaluate _ADR - AE_NOT_FOUND
pci2: <ACPI PCI bus> on pcib2
vmx0: <VMware VMXNET3 Ethernet Adapter> ...

The virtual NIC works fine, and the code comment suggests that missing _ADR is not something fatal, skip printing the message if status is AE_NOT_FOUND.