### PR TITLE
daemon: state management refactoring

### DIFF
--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -80,6 +80,7 @@ struct daemon_state {
 	struct pidfh *child_pidfh;
 	struct log_params * logparams;
 	int keep_cur_workdir;
+	int restart_delay;
 	bool supervision_enabled;
 	bool child_eof;
 	bool restart_enabled;
@@ -163,7 +164,6 @@ main(int argc, char *argv[])
 {
 	char *p = NULL;
 	int ch = 0;
-	int restart_delay = 1;
 	int stdmask = STDOUT_FILENO | STDERR_FILENO;
 	struct log_params logparams = {
 		.syslog_enabled = false,
@@ -188,6 +188,7 @@ main(int argc, char *argv[])
 		.child_eof = false,
 		.restart_enabled = false,
 		.keep_cur_workdir = 1,
+		.restart_delay = 1,
 	};
 	sigset_t mask_orig;
 	sigset_t mask_read;
@@ -278,8 +279,8 @@ main(int argc, char *argv[])
 			break;
 		case 'R':
 			state.restart_enabled = true;
-			restart_delay = strtol(optarg, &p, 0);
-			if (p == optarg || restart_delay < 1) {
+			state.restart_delay = strtol(optarg, &p, 0);
+			if (p == optarg || state.restart_delay < 1) {
 				errx(6, "invalid restart delay");
 			}
 			break;
@@ -491,7 +492,7 @@ restart:
 
 	}
 	if (state.restart_enabled && !terminate) {
-		daemon_sleep(restart_delay, 0);
+		daemon_sleep(state.restart_delay, 0);
 	}
 	if (sigprocmask(SIG_BLOCK, &mask_term, NULL)) {
 		warn("sigprocmask");

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -74,6 +74,7 @@ struct daemon_state {
 	int pipe_fd[2];
 	const char *child_pidfile;
 	const char *parent_pidfile;
+	const char *title;
 	struct pidfh *parent_pidfh;
 	struct pidfh *child_pidfh;
 	struct log_params * logparams;
@@ -159,7 +160,6 @@ int
 main(int argc, char *argv[])
 {
 	char *p = NULL;
-	const char *title = NULL;
 	const char *user = NULL;
 	int ch = 0;
 	int keep_cur_workdir = 1;
@@ -181,6 +181,7 @@ main(int argc, char *argv[])
 		.child_pidfh = NULL,
 		.child_pidfile = NULL,
 		.parent_pidfile = NULL,
+		.title = NULL,
 		.logparams = &logparams,
 		.supervision_enabled = false,
 		.child_eof = false,
@@ -294,7 +295,7 @@ main(int argc, char *argv[])
 			state.supervision_enabled = true;
 			break;
 		case 't':
-			title = optarg;
+			state.title = optarg;
 			break;
 		case 'T':
 			logparams.syslog_tag = optarg;
@@ -318,8 +319,8 @@ main(int argc, char *argv[])
 		usage(1);
 	}
 
-	if (!title) {
-		title = argv[0];
+	if (state.title == NULL) {
+		state.title = argv[0];
 	}
 
 	if (logparams.output_filename) {
@@ -428,7 +429,7 @@ restart:
 	close(state.pipe_fd[1]);
 	state.pipe_fd[1] = -1;
 
-	setproctitle("%s[%d]", title, (int)pid);
+	setproctitle("%s[%d]", state.title, (int)pid);
 	/*
 	 * As we have closed the write end of pipe for parent process,
 	 * we might detect the child's exit by reading EOF. The child

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -96,6 +96,7 @@ static void open_pid_files(const char *, const char *, struct daemon_state *);
 static void do_output(const unsigned char *, size_t, struct daemon_state *);
 static void daemon_sleep(time_t, long);
 static void daemon_terminate(struct daemon_state *, int);
+static void daemon_state_init(struct daemon_state *);
 
 static volatile sig_atomic_t terminate = 0;
 static volatile sig_atomic_t child_gone = 0;
@@ -161,34 +162,13 @@ main(int argc, char *argv[])
 {
 	char *p = NULL;
 	int ch = 0;
-	struct daemon_state state = {
-		.pipe_fd = { -1, -1 },
-		.parent_pidfh = NULL,
-		.child_pidfh = NULL,
-		.child_pidfile = NULL,
-		.parent_pidfile = NULL,
-		.title = NULL,
-		.user = NULL,
-		.supervision_enabled = false,
-		.child_eof = false,
-		.restart_enabled = false,
-		.keep_cur_workdir = 1,
-		.restart_delay = 1,
-		.stdmask = STDOUT_FILENO | STDERR_FILENO,
-		.syslog_enabled = false,
-		.log_reopen = false,
-		.syslog_priority = LOG_NOTICE,
-		.syslog_tag = "daemon",
-		.syslog_facility = LOG_DAEMON,
-		.keep_fds_open = 1,
-		.output_fd = -1,
-		.output_filename = NULL,
-	};
+	struct daemon_state state;
 	sigset_t mask_orig;
 	sigset_t mask_read;
 	sigset_t mask_term;
 	sigset_t mask_susp;
 
+	daemon_state_init(&state);
 	sigemptyset(&mask_susp);
 	sigemptyset(&mask_read);
 	sigemptyset(&mask_term);
@@ -782,4 +762,33 @@ daemon_terminate(struct daemon_state *state, int exitcode)
 	pidfile_remove(state->parent_pidfh);
 
 	exit(exitcode);
+}
+
+static void
+daemon_state_init(struct daemon_state *state)
+{
+	memset(state, 0, sizeof(struct daemon_state));
+	*state = (struct daemon_state) {
+		.pipe_fd = { -1, -1 },
+		.parent_pidfh = NULL,
+		.child_pidfh = NULL,
+		.child_pidfile = NULL,
+		.parent_pidfile = NULL,
+		.title = NULL,
+		.user = NULL,
+		.supervision_enabled = false,
+		.child_eof = false,
+		.restart_enabled = false,
+		.keep_cur_workdir = 1,
+		.restart_delay = 1,
+		.stdmask = STDOUT_FILENO | STDERR_FILENO,
+		.syslog_enabled = false,
+		.log_reopen = false,
+		.syslog_priority = LOG_NOTICE,
+		.syslog_tag = "daemon",
+		.syslog_facility = LOG_DAEMON,
+		.keep_fds_open = 1,
+		.output_fd = -1,
+		.output_filename = NULL,
+	};
 }

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -67,6 +67,7 @@ struct log_params {
 	int keep_fds_open;
 	int output_fd;
 	bool syslog_enabled;
+	bool log_reopen;
 };
 
 struct daemon_state {
@@ -152,7 +153,6 @@ int
 main(int argc, char *argv[])
 {
 	bool supervision_enabled = false;
-	bool log_reopen = false;
 	bool child_eof = false;
 	bool restart_enabled = false;
 	char *p = NULL;
@@ -166,6 +166,7 @@ main(int argc, char *argv[])
 	int stdmask = STDOUT_FILENO | STDERR_FILENO;
 	struct log_params logparams = {
 		.syslog_enabled = false,
+		.log_reopen = false,
 		.syslog_priority = LOG_NOTICE,
 		.syslog_tag = "daemon",
 		.syslog_facility = LOG_DAEMON,
@@ -215,7 +216,7 @@ main(int argc, char *argv[])
 			logparams.keep_fds_open = 0;
 			break;
 		case 'H':
-			log_reopen = true;
+			logparams.log_reopen = true;
 			break;
 		case 'l':
 			logparams.syslog_facility = get_log_mapping(optarg,
@@ -374,7 +375,7 @@ main(int argc, char *argv[])
 		 * not have superuser privileges.
 		 */
 		(void)madvise(NULL, 0, MADV_PROTECT);
-		if (log_reopen && logparams.output_fd >= 0 &&
+		if (logparams.log_reopen && logparams.output_fd >= 0 &&
 		    sigaction(SIGHUP, &act_hup, NULL) == -1) {
 			warn("sigaction");
 			daemon_terminate(&state, 1);

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -72,6 +72,7 @@ struct log_params {
 
 struct daemon_state {
 	int pipe_fd[2];
+	const char *child_pidfile;
 	struct pidfh *parent_pidfh;
 	struct pidfh *child_pidfh;
 	struct log_params * logparams;
@@ -157,7 +158,6 @@ int
 main(int argc, char *argv[])
 {
 	char *p = NULL;
-	const char *child_pidfile = NULL;
 	const char *parent_pidfile = NULL;
 	const char *title = NULL;
 	const char *user = NULL;
@@ -179,6 +179,7 @@ main(int argc, char *argv[])
 		.pipe_fd = { -1, -1 },
 		.parent_pidfh = NULL,
 		.child_pidfh = NULL,
+		.child_pidfile = NULL,
 		.logparams = &logparams,
 		.supervision_enabled = false,
 		.child_eof = false,
@@ -260,7 +261,7 @@ main(int argc, char *argv[])
 			state.supervision_enabled = true;
 			break;
 		case 'p':
-			child_pidfile = optarg;
+			state.child_pidfile = optarg;
 			state.supervision_enabled = true;
 			break;
 		case 'P':
@@ -336,7 +337,7 @@ main(int argc, char *argv[])
 	 * Try to open the pidfile before calling daemon(3),
 	 * to be able to report the error intelligently
 	 */
-	open_pid_files(child_pidfile, parent_pidfile, &state);
+	open_pid_files(state.child_pidfile, parent_pidfile, &state);
 	if (daemon(keep_cur_workdir, logparams.keep_fds_open) == -1) {
 		warn("daemon");
 		daemon_terminate(&state, 1);

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -79,6 +79,7 @@ struct daemon_state {
 	struct pidfh *parent_pidfh;
 	struct pidfh *child_pidfh;
 	struct log_params * logparams;
+	int keep_cur_workdir;
 	bool supervision_enabled;
 	bool child_eof;
 	bool restart_enabled;
@@ -162,7 +163,6 @@ main(int argc, char *argv[])
 {
 	char *p = NULL;
 	int ch = 0;
-	int keep_cur_workdir = 1;
 	int restart_delay = 1;
 	int stdmask = STDOUT_FILENO | STDERR_FILENO;
 	struct log_params logparams = {
@@ -187,6 +187,7 @@ main(int argc, char *argv[])
 		.supervision_enabled = false,
 		.child_eof = false,
 		.restart_enabled = false,
+		.keep_cur_workdir = 1,
 	};
 	sigset_t mask_orig;
 	sigset_t mask_read;
@@ -230,7 +231,7 @@ main(int argc, char *argv[])
 	while ((ch = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {
 		switch (ch) {
 		case 'c':
-			keep_cur_workdir = 0;
+			state.keep_cur_workdir = 0;
 			break;
 		case 'f':
 			logparams.keep_fds_open = 0;
@@ -341,7 +342,7 @@ main(int argc, char *argv[])
 	 * to be able to report the error intelligently
 	 */
 	open_pid_files(state.child_pidfile, state.parent_pidfile, &state);
-	if (daemon(keep_cur_workdir, logparams.keep_fds_open) == -1) {
+	if (daemon(state.keep_cur_workdir, logparams.keep_fds_open) == -1) {
 		warn("daemon");
 		daemon_terminate(&state, 1);
 	}

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -693,12 +693,15 @@ setup_signals(struct daemon_state *state)
 		daemon_terminate(state, 1);
 	}
 
-	/* Setup SIGHUP */
+	/* Setup SIGHUP if configured*/
+	if (state->logparams->log_reopen == false ||
+	    state->logparams->output_fd < 0) {
+		return;
+	}
+
 	act_hup.sa_handler = handle_hup;
 	sigemptyset(&act_hup.sa_mask);
-
-	if (state->logparams->log_reopen && state->logparams->output_fd >= 0 &&
-	    sigaction(SIGHUP, &act_hup, NULL) == -1) {
+	if (sigaction(SIGHUP, &act_hup, NULL) == -1) {
 		warn("sigaction");
 		daemon_terminate(state, 1);
 	}

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -61,6 +61,7 @@ __FBSDID("$FreeBSD$");
 
 struct daemon_state {
 	int pipe_fd[2];
+	char **argv;
 	const char *child_pidfile;
 	const char *parent_pidfile;
 	const char *output_filename;
@@ -291,6 +292,7 @@ main(int argc, char *argv[])
 	}
 	argc -= optind;
 	argv += optind;
+	state.argv = argv;
 
 	if (argc == 0) {
 		usage(1);
@@ -769,6 +771,7 @@ daemon_state_init(struct daemon_state *state)
 {
 	memset(state, 0, sizeof(struct daemon_state));
 	*state = (struct daemon_state) {
+		.argv = NULL,
 		.pipe_fd = { -1, -1 },
 		.parent_pidfh = NULL,
 		.child_pidfh = NULL,

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -75,6 +75,7 @@ struct daemon_state {
 	const char *child_pidfile;
 	const char *parent_pidfile;
 	const char *title;
+	const char *user;
 	struct pidfh *parent_pidfh;
 	struct pidfh *child_pidfh;
 	struct log_params * logparams;
@@ -160,7 +161,6 @@ int
 main(int argc, char *argv[])
 {
 	char *p = NULL;
-	const char *user = NULL;
 	int ch = 0;
 	int keep_cur_workdir = 1;
 	int restart_delay = 1;
@@ -182,6 +182,7 @@ main(int argc, char *argv[])
 		.child_pidfile = NULL,
 		.parent_pidfile = NULL,
 		.title = NULL,
+		.user = NULL,
 		.logparams = &logparams,
 		.supervision_enabled = false,
 		.child_eof = false,
@@ -303,7 +304,7 @@ main(int argc, char *argv[])
 			state.supervision_enabled = true;
 			break;
 		case 'u':
-			user = optarg;
+			state.user = optarg;
 			break;
 		case 'h':
 			usage(0);
@@ -383,8 +384,8 @@ restart:
 	if (pid == 0) {
 		pidfile_write(state.child_pidfh);
 
-		if (user != NULL) {
-			restrict_process(user);
+		if (state.user != NULL) {
+			restrict_process(state.user);
 		}
 		/*
 		 * In supervision mode, the child gets the original sigmask,

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -73,6 +73,7 @@ struct log_params {
 struct daemon_state {
 	int pipe_fd[2];
 	const char *child_pidfile;
+	const char *parent_pidfile;
 	struct pidfh *parent_pidfh;
 	struct pidfh *child_pidfh;
 	struct log_params * logparams;
@@ -158,7 +159,6 @@ int
 main(int argc, char *argv[])
 {
 	char *p = NULL;
-	const char *parent_pidfile = NULL;
 	const char *title = NULL;
 	const char *user = NULL;
 	int ch = 0;
@@ -180,6 +180,7 @@ main(int argc, char *argv[])
 		.parent_pidfh = NULL,
 		.child_pidfh = NULL,
 		.child_pidfile = NULL,
+		.parent_pidfile = NULL,
 		.logparams = &logparams,
 		.supervision_enabled = false,
 		.child_eof = false,
@@ -265,7 +266,7 @@ main(int argc, char *argv[])
 			state.supervision_enabled = true;
 			break;
 		case 'P':
-			parent_pidfile = optarg;
+			state.parent_pidfile = optarg;
 			state.supervision_enabled = true;
 			break;
 		case 'r':
@@ -337,7 +338,7 @@ main(int argc, char *argv[])
 	 * Try to open the pidfile before calling daemon(3),
 	 * to be able to report the error intelligently
 	 */
-	open_pid_files(state.child_pidfile, parent_pidfile, &state);
+	open_pid_files(state.child_pidfile, state.parent_pidfile, &state);
 	if (daemon(keep_cur_workdir, logparams.keep_fds_open) == -1) {
 		warn("daemon");
 		daemon_terminate(&state, 1);


### PR DESCRIPTION
This PR is a refactoring of the state management in daemon.

Currently state management in daemon is sub-optimal for a number of reasons:
- most of the state is concentrated in `main()` - this triggers the following problems
- state initialization and main operation loop are mangled together
- management of the supervised process' desired state (i.e. RUN|TERMINATE) is implicit and transitions are managed by goto jumps to various places in main.

Daemon has a number of outstanding issues that have not been yet resolved. Adding new features or fixing existing bugs is problematic with due to the above outlined issues. I decided to perform code refactoring to resolve current code structure issues to make further improvements easier.

What was done:
- all state moved to `struct daemon_state` to simplify passing it around
- decouple initialization logic (`main()` from main operation loop (`deamon_mainloop()`)
- get rid of goto jumps and replace them with function calls

Daemon's open issues that I am planning to fix once code cleanup is finished:

-  [Bug #268580](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=268580)
-  [Bug #236117](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=236117)
-  [Bug #254511](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=254511)
-  [Bug #212829](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=212829)

P.S. All commits are atomic and each passes kyua tests