### PR TITLE
Automatic epair assignment

### DIFF
--- a/libexec/rc/rc.d/jail
+++ b/libexec/rc/rc.d/jail
@@ -455,7 +455,7 @@ jail_start()
 	_ALL)
 		command=$jail_program
 		rc_flags=$jail_flags
-		command_args="-f $jail_conf -c"
+		command_args="-c"
 		if ! checkyesno jail_parallel_start; then
 			command_args="$command_args -p1"
 		fi
@@ -543,7 +543,7 @@ jail_stop()
 	_ALL)
 		command=$jail_program
 		rc_flags=$jail_flags
-		command_args="-f $jail_conf -r"
+		command_args="-r"
 		if checkyesno jail_reverse_stop; then
 			$jail_jls name | tail -r
 		else

--- a/usr.sbin/jail/jail.c
+++ b/usr.sbin/jail/jail.c
@@ -134,7 +134,6 @@ static const enum intparam stopcommands[] = {
 int
 main(int argc, char **argv)
 {
-	struct stat st;
 	FILE *jfp;
 	struct cfjail *j;
 	char *JidFile;
@@ -152,7 +151,7 @@ main(int argc, char **argv)
 	op = 0;
 	dflag = Rflag = 0;
 	docf = 1;
-	cfname = CONF_FILE;
+	cfname = NULL;
 	JidFile = NULL;
 
 	while ((ch = getopt(argc, argv, "cde:f:hiJ:lmn:p:qrRs:u:U:v")) != -1) {
@@ -294,13 +293,13 @@ main(int argc, char **argv)
 		/* Jail remove, perhaps using the config file */
 		if (!docf || argc == 0)
 			usage();
-		if (!Rflag)
+		docf = !Rflag;
+		if (docf) {
 			for (i = 0; i < argc; i++)
 				if (strchr(argv[i], '='))
 					usage();
-		if ((docf = !Rflag &&
-		     (!strcmp(cfname, "-") || stat(cfname, &st) == 0)))
 			load_config();
+		}
 		note_remove = docf || argc > 1 || wild_jail_name(argv[0]);
 	} else if (argc > 1 || (argc == 1 && strchr(argv[0], '='))) {
 		/* Single jail specified on the command line */

--- a/usr.sbin/jail/jailp.h
+++ b/usr.sbin/jail/jailp.h
@@ -36,8 +36,6 @@
 
 #include <jail.h>
 
-#define CONF_FILE	"/etc/jail.conf"
-
 #define DEP_FROM	0
 #define DEP_TO		1
 

--- a/usr.sbin/jail/jailp.h
+++ b/usr.sbin/jail/jailp.h
@@ -206,7 +206,7 @@ extern int next_command(struct cfjail *j);
 extern int finish_command(struct cfjail *j);
 extern struct cfjail *next_proc(int nonblock);
 
-extern void load_config(void);
+extern void load_config(int start);
 extern struct cfjail *add_jail(void);
 extern void add_param(struct cfjail *j, const struct cfparam *p,
     enum intparam ipnum, const char *value);


### PR DESCRIPTION
**Note: This patch is based on [D39011](https://reviews.freebsd.org/D39011)** 
Idea is to be able to set `vnet.interface = "auto";` and let jail(8) and ifconfig(8) create next available epair.
```
$base = /var/jails;
persist;
vnet;
path = "${base}/${name}";
mount.devfs;
host.domainname = "my.fqdn";
host.hostname = "${name}.${host.domainname}";
vnet.interface = "auto";
$host_interface = "$(echo ${vnet.interface} | sed -e 's/b$/a/')";
devfs_ruleset = 8;
allow.raw_sockets;
depend = network;

exec.clean;
exec.consolelog = "/var/log/jails/${host.hostname}";

exec.prestart  = "ifconfig ${host_interface} group $(echo ${name} | cut -b 1-15)";
exec.prestart += "ifconfig jails addm ${host_interface}";

exec.start  = "ifconfig ${vnet.interface} name eth0";
exec.start += "ifconfig eth0 ether ${mac}";
exec.start += "/bin/sh /etc/rc";

exec.stop  = "/bin/sh /etc/rc.shutdown";
exec.stop += "for iface in $(ifconfig -g epair); do ifconfig \${iface} destroy; done";

j {
  $mac = "58:9c:fc:4e:47:8b";
}
```
The jail root is installed in the following way:
```
zfs create zroot/var/jails
zfs create zroot/var/jails/j
export DISTRIBUTIONS="base.txz"
export BSDINSTALL_CHROOT="/var/jails/j"
bsdinstall distfetch
bsdinstall distextract
```

There are few notable lines in the config:

* vnet.interface = "auto" and it can not yet be an array (eg, vnet.interface += "auto")
* $host_interface assumes vnet.interface is not an array, too
* Interface belonging to a jail is destroyed from within the jail by iterating over all interfaces that are in group `epair`
* The replacement of "auto" is only done in `exec.start`, so if for example `exec.poststop` uses `$host_interface` to destroy epair, it will not work