### PR TITLE
two fixes for regex

### DIFF
--- a/lib/libc/regex/regcomp.c
+++ b/lib/libc/regex/regcomp.c
@@ -329,7 +329,7 @@ regcomp_internal(regex_t * __restrict preg,
 		computejumps(p, g);
 		computematchjumps(p, g);
 		if(g->matchjump == NULL && g->charjump != NULL) {
-			free(g->charjump);
+			free(&g->charjump[CHAR_MIN]);
 			g->charjump = NULL;
 		}
 	}

--- a/lib/libc/regex/regcomp.c
+++ b/lib/libc/regex/regcomp.c
@@ -1138,7 +1138,7 @@ p_b_term(struct parse *p, cset *cs)
 #else
 			if (MB_CUR_MAX > 1) {
 #endif
-				(void)REQUIRE(start <= finish, REG_ERANGE);
+				(void)REQUIRE(p_range_cmp(start, finish) <= 0, REG_ERANGE);
 				CHaddrange(p, cs, start, finish);
 			} else {
 				(void)REQUIRE(p_range_cmp(start, finish) <= 0, REG_ERANGE);


### PR DESCRIPTION
While merging the latest FreeBSD regex into Cygwin, I stumbled over two
problems which I thought make sense upstream as well.

Hope that's ok,
Corinna