### PR TITLE
dhclient: add ability to ignore options in offers

### DIFF
--- a/sbin/dhclient/clparse.c
+++ b/sbin/dhclient/clparse.c
@@ -186,6 +186,7 @@ read_client_leases(void)
  *	hardware-declaration |
  *	REQUEST option-list |
  *	REQUIRE option-list |
+ *	IGNORE option-list |
  *	TIMEOUT number |
  *	RETRY number |
  *	REBOOT number |
@@ -248,6 +249,9 @@ parse_client_statement(FILE *cfile, struct interface_info *ip,
 		memset(config->required_options, 0,
 		    sizeof(config->required_options));
 		parse_option_list(cfile, config->required_options);
+		return;
+	case IGNORE:
+		parse_option_list(cfile, config->ignored_options);
 		return;
 	case TIMEOUT:
 		parse_lease_time(cfile, &config->timeout);

--- a/sbin/dhclient/conflex.c
+++ b/sbin/dhclient/conflex.c
@@ -413,6 +413,8 @@ intern(char *atom, int dfv)
 			return (HOSTNAME);
 		break;
 	case 'i':
+		if (!strcasecmp(atom + 1, "gnore"))
+			return (IGNORE);
 		if (!strcasecmp(atom + 1, "nitial-interval"))
 			return (INITIAL_INTERVAL);
 		if (!strcasecmp(atom + 1, "nterface"))

--- a/sbin/dhclient/dhclient.c
+++ b/sbin/dhclient/dhclient.c
@@ -1039,7 +1039,6 @@ dhcpoffer(struct packet *packet)
 
 	note("%s from %s", name, piaddr(packet->client_addr));
 
-
 	/* If this lease doesn't supply the minimum required parameters,
 	   blow it off. */
 	for (i = 0; ip->client->config->required_options[i]; i++) {
@@ -1141,8 +1140,9 @@ dhcpoffer(struct packet *packet)
 struct client_lease *
 packet_to_lease(struct packet *packet)
 {
+	struct interface_info *ip = packet->interface;
 	struct client_lease *lease;
-	int i;
+	int i, j;
 
 	lease = malloc(sizeof(struct client_lease));
 
@@ -1156,6 +1156,15 @@ packet_to_lease(struct packet *packet)
 	/* Copy the lease options. */
 	for (i = 0; i < 256; i++) {
 		if (packet->options[i].len) {
+			int ignored = 0;
+			for (j = 0; ip->client->config->ignored_options[j]; j++)
+				if (i ==
+				    ip->client->config->ignored_options[j]) {
+					ignored = 1;
+					break;
+				}
+			if (ignored)
+			    continue;
 			lease->options[i].data =
 			    malloc(packet->options[i].len + 1);
 			if (!lease->options[i].data) {

--- a/sbin/dhclient/dhclient.conf.5
+++ b/sbin/dhclient/dhclient.conf.5
@@ -38,7 +38,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd July 21, 2021
+.Dd March 17, 2023
 .Dt DHCLIENT.CONF 5
 .Os
 .Sh NAME
@@ -200,6 +200,11 @@ option other than the default requested lease time, which is two hours.
 The other obvious use for this statement is to send information to the server
 that will allow it to differentiate between this client and other
 clients or kinds of clients.
+.It Ic ignore Oo Ar option Oc Oo , Ar ... option Oc ;
+The
+.Ic ignore
+statement causes the client to disregard the specified options in any offer
+received, as though the server had never sent them at all.
 .El
 .Sh OPTION MODIFIERS
 In some cases, a client may receive option data from the server which

--- a/sbin/dhclient/dhcpd.h
+++ b/sbin/dhclient/dhcpd.h
@@ -159,6 +159,7 @@ struct client_config {
 	u_int8_t		 required_options[256];
 	u_int8_t		 requested_options[256];
 	int			 requested_option_count;
+	u_int8_t		 ignored_options[256];
 	u_int			 vlan_pcp;
 	time_t			 timeout;
 	time_t			 initial_interval;

--- a/sbin/dhclient/dhctoken.h
+++ b/sbin/dhclient/dhctoken.h
@@ -134,6 +134,7 @@
 #define TOKEN_NOT	334
 #define ALWAYS_REPLY_RFC1048 335
 #define VLAN_PCP	336
+#define IGNORE		337
 
 #define is_identifier(x)	((x) >= FIRST_TOKEN &&	\
 				 (x) != STRING &&	\


### PR DESCRIPTION
A machine might exist on multiple networks, all of which offer, say, default routes or name servers. There's no easy way to indicate in the config that those options are only valid for a single interface.

Now, we can write:

    interface "lan0" {
      request routers;
      require routers;
    }
    interface "lan1" {
      ignore routers;
    }

And only take action on default routes offered on lan0.

Sponsored By:	Zenith Electronics LLC
Sponsored By:	Klara, Inc.