### PR TITLE
daemon: repace goto exit with daemon_terminate()

### DIFF
--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -730,7 +730,6 @@ reopen_log(struct daemon_state *state)
 static void
 daemon_state_init(struct daemon_state *state)
 {
-	memset(state, 0, sizeof(struct daemon_state));
 	*state = (struct daemon_state) {
 		.pipe_fd = { -1, -1 },
 		.parent_pidfh = NULL,


### PR DESCRIPTION
Start breaking down big main()
Remove goto exit label and replace it with a function that does cleanup.