### PR TITLE
local-unbound-setup.sh: Prevents updating resolv.conf by means of resolvconf.

### DIFF
--- a/usr.sbin/unbound/setup/local-unbound-setup.sh
+++ b/usr.sbin/unbound/setup/local-unbound-setup.sh
@@ -195,7 +195,9 @@ do_not_edit() {
 gen_resolvconf_conf() {
 	local style="$1"
 	do_not_edit
-	echo "resolv_conf=\"/dev/null\" # prevent updating ${resolv_conf}"
+  echo "name_servers_append=\"127.0.0.1\""
+  echo "resolv_conf_local_only=\"yes\""
+  echo "resolv_conf_options=\"edns0\""
 	if [ "${style}" = "dynamic" ] ; then
 		echo "unbound_conf=\"${forward_conf}\""
 		echo "unbound_pid=\"${pidfile}\""


### PR DESCRIPTION
How it was done before, it broke the `resolvconf -u` command. `Resolvconf` was trying and failing to create `/dev/null.bak`. 
Now it keeps `resolv.conf` constant and pointing to the local resolver, but user is still able to force `forwarders.conf` update.