### PR TITLE
copy_file_range.2: Document EXDEV error

### DIFF
--- a/lib/libc/sys/copy_file_range.2
+++ b/lib/libc/sys/copy_file_range.2
@@ -25,7 +25,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd January 2, 2021
+.Dd April 4, 2023
 .Dt COPY_FILE_RANGE 2
 .Os
 .Sh NAME
@@ -196,6 +196,12 @@ refers to a directory.
 File system that stores
 .Fa outfd
 is full.
+.It Bq Er EXDEV
+The files referred to by
+.Fa infd
+and
+.Fa outfd
+are on different file systems.
 .El
 .Sh SEE ALSO
 .Xr lseek 2

--- a/lib/libc/sys/copy_file_range.2
+++ b/lib/libc/sys/copy_file_range.2
@@ -125,7 +125,6 @@ with the largest
 value possible.
 It is interruptible on most file systems,
 so there is no penalty for using very large len values, even SSIZE_MAX.
-.Pp
 .Sh RETURN VALUES
 If it succeeds, the call returns the number of bytes copied, which can be fewer
 than


### PR DESCRIPTION
Two commits:
- _De rigueur_ mandoc lint pass
- Document `EXDEV` error code in `copy_file_range(2)` (with date bump)
