### PR TITLE
Ignore BIO_FLUSH command if there is no volatile cache to flush

### DIFF
--- a/sys/geom/geom_disk.c
+++ b/sys/geom/geom_disk.c
@@ -71,6 +71,7 @@ struct g_disk_softc {
 	char			led[64];
 	uint32_t		state;
 	struct mtx		 done_mtx;
+	bool                    ignore_flush;
 };
 
 static g_access_t g_disk_access;
@@ -539,7 +540,7 @@ g_disk_start(struct bio *bp)
 		g_trace(G_T_BIO, "g_disk_flushcache(%s)",
 		    bp->bio_to->name);
 		if (!(dp->d_flags & DISKFLAG_CANFLUSHCACHE)) {
-			error = EOPNOTSUPP;
+			error = (sc->ignore_flush) ? 0 : EOPNOTSUPP;
 			break;
 		}
 		/*FALLTHROUGH*/
@@ -760,6 +761,10 @@ g_disk_create(void *arg, int flag)
 		    SYSCTL_CHILDREN(sc->sysctl_tree), OID_AUTO, "flags",
 		    CTLTYPE_STRING | CTLFLAG_RD | CTLFLAG_MPSAFE, dp, 0,
 		    g_disk_sysctl_flags, "A", "Report disk flags");
+		SYSCTL_ADD_BOOL(&sc->sysctl_ctx,
+		    SYSCTL_CHILDREN(sc->sysctl_tree), OID_AUTO, "ignore_flush",
+		    CTLFLAG_RWTUN, &sc->ignore_flush, sizeof(sc->ignore_flush),
+		    "Do not return EOPNOTSUPP if there is no cache to flush");
 	}
 	pp->private = sc;
 	dp->d_geom = gp;

--- a/sys/geom/geom_disk.c
+++ b/sys/geom/geom_disk.c
@@ -71,7 +71,7 @@ struct g_disk_softc {
 	char			led[64];
 	uint32_t		state;
 	struct mtx		 done_mtx;
-	bool                    ignore_flush;
+	bool                    flush_notsup_succeed;
 };
 
 static g_access_t g_disk_access;
@@ -540,7 +540,7 @@ g_disk_start(struct bio *bp)
 		g_trace(G_T_BIO, "g_disk_flushcache(%s)",
 		    bp->bio_to->name);
 		if (!(dp->d_flags & DISKFLAG_CANFLUSHCACHE)) {
-			error = (sc->ignore_flush) ? 0 : EOPNOTSUPP;
+			error = (sc->flush_notsup_succeed) ? 0 : EOPNOTSUPP;
 			break;
 		}
 		/*FALLTHROUGH*/
@@ -762,8 +762,8 @@ g_disk_create(void *arg, int flag)
 		    CTLTYPE_STRING | CTLFLAG_RD | CTLFLAG_MPSAFE, dp, 0,
 		    g_disk_sysctl_flags, "A", "Report disk flags");
 		SYSCTL_ADD_BOOL(&sc->sysctl_ctx,
-		    SYSCTL_CHILDREN(sc->sysctl_tree), OID_AUTO, "ignore_flush",
-		    CTLFLAG_RWTUN, &sc->ignore_flush, sizeof(sc->ignore_flush),
+		    SYSCTL_CHILDREN(sc->sysctl_tree), OID_AUTO, "flush_notsup_succeed",
+		    CTLFLAG_RWTUN, &sc->flush_notsup_succeed, sizeof(sc->flush_notsup_succeed),
 		    "Do not return EOPNOTSUPP if there is no cache to flush");
 	}
 	pp->private = sc;


### PR DESCRIPTION
When a storage device reports that it does not support cache flush, the GEOM
disk layer by default returns ENOTSUPP in response to a BIO_FLUSH command.

On AWS, local volumes do not advertise themselves as having write-cache enabled.
When they are selected for L3 on all HDD nodes, the L3 subsystem may inadvertently
kick these L3 devices if a BIO_FLUSH command fails with an ENOTSUPP return code.
The fix is to make GEOM disk return success (0) when this condition occurs and
add a sysctl to make this error handling config-driven