### PR TITLE
Update UPDATING in main

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -1,4 +1,4 @@
-Updating Information for users of FreeBSD 14.0-CURRENT.
+Updating Information for users of FreeBSD-CURRENT.
 
 This file is maintained and copyrighted by M. Warner Losh <imp@freebsd.org>.
 See end of file for further details.  For commonly done items, please see the

--- a/UPDATING
+++ b/UPDATING
@@ -4,7 +4,7 @@ This file is maintained and copyrighted by M. Warner Losh <imp@freebsd.org>.
 See end of file for further details.  For commonly done items, please see the
 COMMON ITEMS: section later in the file.  These instructions assume that you
 basically know what you are doing.  If not, then please consult the FreeBSD
-Handbook:
+handbook:
 
     https://docs.freebsd.org/en/books/handbook/cutting-edge/#makeworld
 

--- a/UPDATING
+++ b/UPDATING
@@ -1,4 +1,4 @@
-Updating Information for FreeBSD current users.
+Updating Information for users of FreeBSD 14.0-CURRENT.
 
 This file is maintained and copyrighted by M. Warner Losh <imp@freebsd.org>.
 See end of file for further details.  For commonly done items, please see the

--- a/UPDATING
+++ b/UPDATING
@@ -4,9 +4,9 @@ This file is maintained and copyrighted by M. Warner Losh <imp@freebsd.org>.
 See end of file for further details.  For commonly done items, please see the
 COMMON ITEMS: section later in the file.  These instructions assume that you
 basically know what you are doing.  If not, then please consult the FreeBSD
-handbook:
+Handbook:
 
-    https://docs.freebsd.org/en/books/handbook/cutting-edge/#makeworld
+https://docs.freebsd.org/en/books/handbook/cutting-edge/#makeworld
 
 Items affecting the ports and packages system can be found in
 /usr/ports/UPDATING.  Please read that file before updating system packages

--- a/UPDATING
+++ b/UPDATING
@@ -6,7 +6,7 @@ COMMON ITEMS: section later in the file.  These instructions assume that you
 basically know what you are doing.  If not, then please consult the FreeBSD
 Handbook:
 
-https://docs.freebsd.org/en/books/handbook/cutting-edge/#makeworld
+    https://docs.freebsd.org/en/books/handbook/cutting-edge/#makeworld
 
 Items affecting the ports and packages system can be found in
 /usr/ports/UPDATING.  Please read that file before updating system packages


### PR DESCRIPTION
Uppercase H for the _FreeBSD Handbook_.

Change lowercase current to uppercase CURRENT. 

Remove the white space that precedes the link to the relevant section of the Handbook. This is subtle; it improves usability for people who habitually triple-click to select a chunk of text (compared to a double-click to select a word). 