### PR TITLE
Update UPDATING in stable/12

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -1,4 +1,4 @@
-Updating Information for users of FreeBSD stable/12.
+Updating Information for FreeBSD stable/12 users.
 
 This file is maintained and copyrighted by M. Warner Losh <imp@freebsd.org>.
 See end of file for further details.  For commonly done items, please see the

--- a/UPDATING
+++ b/UPDATING
@@ -4,9 +4,9 @@ This file is maintained and copyrighted by M. Warner Losh <imp@freebsd.org>.
 See end of file for further details.  For commonly done items, please see the
 COMMON ITEMS: section later in the file.  These instructions assume that you
 basically know what you are doing.  If not, then please consult the FreeBSD
-Handbook:
+handbook:
 
-https://docs.freebsd.org/en/books/handbook/cutting-edge/#makeworld
+    https://docs.freebsd.org/en/books/handbook/cutting-edge/#makeworld
 
 Items affecting the ports and packages system can be found in
 /usr/ports/UPDATING.  Please read that file before updating system packages

--- a/UPDATING
+++ b/UPDATING
@@ -1,12 +1,12 @@
- Updating Information for FreeBSD stable/12 users.
+Updating Information for users of FreeBSD stable/12.
 
 This file is maintained and copyrighted by M. Warner Losh <imp@freebsd.org>.
 See end of file for further details.  For commonly done items, please see the
 COMMON ITEMS: section later in the file.  These instructions assume that you
 basically know what you are doing.  If not, then please consult the FreeBSD
-handbook:
+Handbook:
 
-    https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/makeworld.html
+https://docs.freebsd.org/en/books/handbook/cutting-edge/#makeworld
 
 Items affecting the ports and packages system can be found in
 /usr/ports/UPDATING.  Please read that file before updating system packages


### PR DESCRIPTION
~~Uppercase H for the _FreeBSD Handbook_.~~ <https://github.com/freebsd/freebsd-src/pull/712#issuecomment-1529785330> prefers lowercase _FreeBSD handbook_.

Update the link to the relevant section of the Handbook, ~~remove the white space to its left.~~ 

Remove the white space from the beginning of line 1. 