### PR TITLE
ofed: Fix build with -Werror -Wdate-time

### DIFF
--- a/contrib/ofed/opensm/opensm/osm_console.c
+++ b/contrib/ofed/opensm/opensm/osm_console.c
@@ -1652,7 +1652,7 @@ static void help_version(FILE * out, int detail)
 
 static void version_parse(char **p_last, osm_opensm_t * p_osm, FILE * out)
 {
-	fprintf(out, "%s build %s %s\n", p_osm->osm_version, __DATE__, __TIME__);
+	fprintf(out, "%s\n", p_osm->osm_version);
 }
 
 /* more parse routines go here */


### PR DESCRIPTION
FreeBSD 14 adds -Werror -Wdate-time to its build which trips up on opensm's build. Remove it from the code, as it doesn't really add much.

This fixes builds WITH_OFED_EXTRA.

PR: 270776
Upstream Pull-Request: https://github.com/linux-rdma/opensm/pull/33