### PR TITLE
ping: pr_iph() improvements

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,54 +1,24 @@
 # $FreeBSD$
 
-compute_engine_instance:
-  # Image list available via
-  # gcloud compute images list --project freebsd-org-cloud-dev --no-standard-images
-  platform: freebsd
-  image_project: freebsd-org-cloud-dev
-  image: freebsd-13-1-release-amd64
-  cpu: 8
-  memory: 8G
-  disk: 40
+freebsd_instance:
+   image_family: freebsd-14-0-snap
 
 task:
-  matrix:
-  - name: World and kernel amd64 build and boot smoke test
-    env:
-      TARGET: amd64
-      TARGET_ARCH: amd64
-      TOOLCHAIN_PKG: llvm15
-  - name: World and kernel arm64 build and boot smoke test
-    trigger_type: manual
-    env:
-      TARGET: arm64
-      TARGET_ARCH: aarch64
-      TOOLCHAIN_PKG: llvm15
-  - name: World and kernel gcc12 amd64 build and boot smoke test
-    trigger_type: manual
-    env:
-      TARGET: amd64
-      TARGET_ARCH: amd64
-      TOOLCHAIN_PKG: amd64-gcc12
-  timeout_in: 120m
   install_script:
-  - sh .cirrus-ci/pkg-install.sh ${TOOLCHAIN_PKG}
+    - pkg delete -y python2
+    - pkg autoremove -y
+    - pkg update
+    - pkg upgrade -y
+    - pkg install -y devel/py-pytest net/scapy
+    - make -C libexec/atf/atf-pytest-wrapper -j$(sysctl -n hw.ncpu) all install
+    - make -C tests/sys/common -j$(sysctl -n hw.ncpu) all install
+    - make -C tests/atf_python -j$(sysctl -n hw.ncpu) all install
+    - cp $CIRRUS_WORKING_DIR/tests/conftest.py /usr/tests
   setup_script:
-  - uname -a
-  - gpart show
-  - df -m
-  - pkg --version
-  - pw useradd user
-  - mkdir -p /usr/obj/$(pwd -P)
-  - chown user:user /usr/obj/$(pwd -P)
-  script:
-  - su user -c "make -j$(sysctl -n hw.ncpu) CROSS_TOOLCHAIN=${TOOLCHAIN_PKG} WITHOUT_TOOLCHAIN=yes buildworld buildkernel"
-  package_script:
-  - su user -c "make CROSS_TOOLCHAIN=${TOOLCHAIN_PKG} WITHOUT_TOOLCHAIN=yes PKG_FORMAT=tar packages"
-  package_check_script:
-  - su user -c "/usr/libexec/flua tools/pkgbase/metalog_reader.lua -c /usr/obj/$(pwd -P)/${TARGET}.${TARGET_ARCH}/worldstage/METALOG"
-  test_script:
-  - sh .cirrus-ci/pkg-install.sh qemu-nox11
-  - sh tools/boot/ci-qemu-test.sh
-  post_script:
-  - df -m
-  - du -m -s /usr/obj
+    - make -C sbin/ping -j$(sysctl -n hw.ncpu) all install
+  test_ping_script:
+    - kyua test -k /usr/tests/Kyuafile sbin/ping/ping_test
+    - kyua test -k /usr/tests/Kyuafile sbin/ping/test_ping.py
+  always:
+    test_ping_report_script:
+      - kyua report --results-file=/usr/tests --results-filter=failed --verbose

--- a/sbin/ping/tests/test_ping.py
+++ b/sbin/ping/tests/test_ping.py
@@ -1132,8 +1132,8 @@ round-trip min/avg/max/stddev = /// ms
                 "stdout": """\
 PING 192.0.2.2 (192.0.2.2): 56 data bytes
 132 bytes from 192.0.2.2: Destination Host Unreachable
-Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst
- 4  f  00 007c 0001   0 0000  40  01 d868 192.0.2.1  192.0.2.2 01010101010101010101010101010101010101010101010101010101010101010101010101010101
+Vr HL TOS  Len   ID Flg  off TTL Pro  cks       Src       Dst Opts
+ 4  f  00 007c 0001   0 0000  40  01 d868 192.0.2.1 192.0.2.2 01010101010101010101010101010101010101010101010101010101010101010101010101010101
 
 
 --- 192.0.2.2 ping statistics ---
@@ -1157,8 +1157,8 @@ Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst
                 "stdout": """\
 PING 192.0.2.2 (192.0.2.2): 56 data bytes
 92 bytes from 192.0.2.2: Destination Host Unreachable
-Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst
- 4  5  00 0054 0001   2 0000  40  01 b6a4 192.0.2.1  192.0.2.2 
+Vr HL TOS  Len   ID Flg  off TTL Pro  cks       Src       Dst
+ 4  5  00 0054 0001   2 0000  40  01 b6a4 192.0.2.1 192.0.2.2
 
 
 --- 192.0.2.2 ping statistics ---
@@ -1230,8 +1230,8 @@ ping: quoted data too short (28 bytes) from 192.0.2.2
                 "stdout": """\
 PING 192.0.2.2 (192.0.2.2): 56 data bytes
 92 bytes from 192.0.2.2: Destination Host Unreachable
-Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst
- 4  5  00 0054 0001   0 0000  40  01 f6a4 192.0.2.1  192.0.2.2 
+Vr HL TOS  Len   ID Flg  off TTL Pro  cks       Src       Dst
+ 4  5  00 0054 0001   0 0000  40  01 f6a4 192.0.2.1 192.0.2.2
 
 
 --- 192.0.2.2 ping statistics ---


### PR DESCRIPTION
Very early on, the `Src`/`Dst` IP addresses were printed in hex notation (`%08x`), which will always be 8-characters wide.  It was later changed to use a dot-decimal notation.  Depending on the IP address length, the `Src` and `Dst` headers may require a different padding.  Use the source and destination IP lengths as padding for the headers.

Also, print an `Opts` (options) header, if there are options present.  It has been abbreviated to `Opts` to match the length of the previous `Data` header, removed in ef9e6dc7eebe9830511602904d3ef5218d964080.

Print the header info such that no trailing spaces are produced.  As some git workflows may automatically trim them, and make the tests fail (see 25b86f8559c2e7076daff56933217e95cd4398d4).

Before
```
Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst
 4  f  00 007c 0001   0 0000  40  01 d868 192.0.2.1  192.0.2.2␣
```

After
```
Vr HL TOS  Len   ID Flg  off TTL Pro  cks       Src       Dst
 4  f  00 007c 0001   0 0000  40  01 d868 192.0.2.1 192.0.2.2
```

And with options:

Before
```
Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst
 4  f  00 007c 0001   0 0000  40  01 d868 192.0.2.1  192.0.2.2 01...
```

After
```
Vr HL TOS  Len   ID Flg  off TTL Pro  cks       Src       Dst Opts
 4  f  00 007c 0001   0 0000  40  01 d868 192.0.2.1 192.0.2.2 01...
```
