### PR TITLE
Fix saving STRUCTURED-DATA in RFC 5424 log format

### DIFF
--- a/usr.sbin/syslogd/syslogd.c
+++ b/usr.sbin/syslogd/syslogd.c
@@ -1123,6 +1123,7 @@ parsemsg_rfc5424(const char *from, int pri, char *msg)
 	FAIL_IF("STRUCTURED-NAME", start == msg);			\
 } while (0)
 	IF_NOT_NILVALUE(structured_data) {
+		structured_data = msg;
 		/* SD-ELEMENT. */
 		while (*msg == '[') {
 			++msg;
@@ -1582,9 +1583,8 @@ evaluate_prop_filter(const struct prop_filter *filter, const char *value)
 
 /*
  * Logs a message to the appropriate log files, users, etc. based on the
- * priority. Log messages are always formatted according to RFC 3164,
- * even if they were in RFC 5424 format originally, The MSGID and
- * STRUCTURED-DATA fields are thus discarded for the time being.
+ * priority. Log messages are formatted according to RFC 3164 or
+ * RFC 5424 in subsequent fprintlog_*() functions.
  */
 static void
 logmsg(int pri, const struct logtime *timestamp, const char *hostname,


### PR DESCRIPTION
When saving log files in RFC 5424 format presence of STRUCTURED-DATA in message caused line to not appear in log file at all, because a variable forgotten to initialize. This could be tested by (slightly modified) example from RFC:

    echo '<165>1 2003-10-11T22:14:15.003Z mymachine.example.com su 12345 ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][id@2 test="tast"] BOM"su root" failed for lonvick on /dev/pts/8" ' | nc -w1 -Uu /var/run/log

While here, update stale information in comment to logmsg() that RFC 5424 log format was not supported.