### PR TITLE
bectl(8): clarifications, expansion

### DIFF
--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -483,6 +483,7 @@ flags.
 \" .El
 .Sh SEE ALSO
 .Xr libbe 3 ,
+.Xr zfsprops 7 ,
 .Xr beinstall.sh 8 ,
 .Xr jail 8 ,
 .Xr zfs 8 ,

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -25,6 +25,8 @@
 .Nd Utility to manage boot environments on ZFS
 .Sh SYNOPSIS
 .Nm
+.Op Fl h\&?
+.Nm
 .Op Fl r Ar beroot
 .Cm activate
 .Op Fl t | Fl T
@@ -89,9 +91,6 @@
 .Brq Cm umount | unmount
 .Op Fl f
 .Ar beName
-.Pp
-.Nm
-.Op Fl h\&?
 .Sh DESCRIPTION
 The
 .Nm
@@ -119,9 +118,12 @@ one of the system's resident disks will require the
 .Fl r
 flag to work.
 .Pp
-The following commands are supported by
-.Nm :
+.Ss Supported Subcommands and Flags
 .Bl -tag -width activate
+.It Xo
+.Fl h | 
+.Fl \&?
+Print usage information.
 .It Xo
 .Cm activate
 .Op Fl t | Fl T
@@ -194,7 +196,7 @@ See
 .Sx Boot Environment Structures
 for a discussion on different layouts.
 .Pp
-No new boot environment is created with this command.
+No new boot environment is created with this subcommand.
 .It Xo
 .Cm destroy
 .Op Fl \&Fo
@@ -398,12 +400,6 @@ will force the unmount if busy.
 Unmount from a temporary mount point will not remove the mount point.
 .El
 .Pp
-.Nm
-prints usage information if
-.Fl h
-or
-.Fl \&?
-is specified.
 .Ss Boot Environment Structures
 The traditional
 .Fx
@@ -476,7 +472,7 @@ In this example,
 is excluded from the boot environment.
 .Pp
 .Nm
-commands that have their own
+subcommands that have their own
 .Fl r
 operate on this second,
 .Dq deep

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -353,6 +353,7 @@ If a nonexistent
 is given,
 .Nm
 will make the directory, including intermediate directories as required.
+.Pp
 If no 
 .Ar mountpoint
 is given,
@@ -361,6 +362,12 @@ will make a directory such as Pa be_mount.c6Sf in Pa /tmp
 .
 Randomness in the last four characters of the directory name will prevent
 mount point conflicts.
+Unmount of an environment, followed by mount of the same environment
+without giving a
+.Ar mountpoint
+, will result in a different randomly-named mountpoint.
+.Pp
+Unmount from a temporary mount point will not remove the mount point.
 .It Cm rename Ar origBeName newBeName
 Rename the given
 .Ar origBeName

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -361,7 +361,8 @@ If no
 .Ar mountpoint
 is given,
 .Nm
-will make a directory such as Pa be_mount.c6Sf in Pa /tmp
+will make a directory such as Pa be_mount.c6Sf
+in Pa /tmp
 .
 Randomness in the last four characters of the directory name will prevent
 mount point conflicts.

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -369,8 +369,7 @@ Randomness in the last four characters of the directory name will prevent
 mount point conflicts.
 Unmount of an environment, followed by mount of the same environment
 without giving a
-.Ar mountpoint
-, will result in a different randomly-named mountpoint.
+.Ar mountpoint , will result in a different randomly-named mountpoint.
 .It Cm rename Ar origBeName newBeName
 Rename the given
 .Ar origBeName

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -97,9 +97,8 @@ The
 command is used to setup and interact with ZFS boot environments, which are
 bootable clones of datasets.
 .Pp
-Boot environments
-allow the system to be upgraded, while preserving the old system environment in
-a separate ZFS dataset.
+A boot environment allows the system to be upgraded, while preserving the
+pre-upgrade system environment.
 .Pp
 .Nm
 itself accepts an

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -359,7 +359,7 @@ is given,
 .Nm
 will make a directory such as Pa be_mount.c6Sf in Pa /tmp
 .
-Randomness to the last four characters of the directory will prevent
+Randomness in the last four characters of the directory name will prevent
 mount point conflicts.
 .It Cm rename Ar origBeName newBeName
 Rename the given

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -325,14 +325,16 @@ Sort boot environments by the given ZFS dataset property.
 The following properties are supported:
 .Pp
 .Bl -tag -width 4n -offset indent -compact
-.It name          (the default)
+.It name (the default)
 .It creation
 .It origin
 .It used
-.It usedds        (usedbydataset)
-.It usedsnap      (usedbysnapshots)
-.It usedrefreserv (usedbyrefreservation)
+.It usedbydataset
+.It usedbyrefreservation
+.It usedbysnapshots
 .El
+.Pp
+Short forms usedds, usedrefreserv and usedsnap are also supported.
 .It Fl C Ar property
 Same as the
 .Fl c

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -348,6 +348,7 @@ or
 option is used.
 .It Cm mount Ar beName Op Ar mountpoint
 Temporarily mount the given boot environment.
+.Pp
 If a nonexistent
 .Ar mountpoint
 is given,

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -361,9 +361,10 @@ If no
 .Ar mountpoint
 is given,
 .Nm
-will make a directory such as Pa be_mount.c6Sf
-in Pa /tmp
-.
+will make a directory such as
+.Pa be_mount.c6Sf
+in
+.Pa /tmp .
 Randomness in the last four characters of the directory name will prevent
 mount point conflicts.
 Unmount of an environment, followed by mount of the same environment

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -350,7 +350,7 @@ or
 .Fl a
 option is used.
 .It Cm mount Ar beName Op Ar mountpoint
-Temporarily mount the given boot environment.
+Mount the given boot environment.
 .Pp
 If a nonexistent
 .Ar mountpoint
@@ -396,7 +396,7 @@ Specifying
 .Fl f
 will force the unmount if busy.
 .Pp
-Unmount from a temporary mount point will not remove the mount point.
+Unmount will not remove the mount point.
 .El
 .Pp
 .Ss Boot Environment Structures

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -353,13 +353,13 @@ Temporarily mount the given boot environment.
 .Pp
 If a nonexistent
 .Ar mountpoint
-is given,
+is given:
 .Nm
 will make the directory, including intermediate directories as required.
 .Pp
 If no 
 .Ar mountpoint
-is given,
+is given:
 .Nm
 will make a directory such as
 .Pa be_mount.c6Sf
@@ -397,6 +397,7 @@ will force the unmount if busy.
 .El
 .Pp
 Unmount from a temporary mount point will not remove the mount point.
+.Pp
 .Nm
 prints usage information if
 .Fl h

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -394,9 +394,9 @@ Unmount the given boot environment, if it is mounted.
 Specifying
 .Fl f
 will force the unmount if busy.
-.El
 .Pp
 Unmount from a temporary mount point will not remove the mount point.
+.El
 .Pp
 .Nm
 prints usage information if

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -370,8 +370,6 @@ Unmount of an environment, followed by mount of the same environment
 without giving a
 .Ar mountpoint
 , will result in a different randomly-named mountpoint.
-.Pp
-Unmount from a temporary mount point will not remove the mount point.
 .It Cm rename Ar origBeName newBeName
 Rename the given
 .Ar origBeName
@@ -397,6 +395,7 @@ Specifying
 will force the unmount if busy.
 .El
 .Pp
+Unmount from a temporary mount point will not remove the mount point.
 .Nm
 prints usage information if
 .Fl h

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -369,7 +369,8 @@ Randomness in the last four characters of the directory name will prevent
 mount point conflicts.
 Unmount of an environment, followed by mount of the same environment
 without giving a
-.Ar mountpoint , will result in a different randomly-named mountpoint.
+.Ar mountpoint ,
+will result in a different randomly-named mountpoint.
 .It Cm rename Ar origBeName newBeName
 Rename the given
 .Ar origBeName

--- a/sbin/bectl/bectl.8
+++ b/sbin/bectl/bectl.8
@@ -321,17 +321,17 @@ arbitrary white space.
 .It Fl s
 Display all snapshots as well.
 .It Fl c Ar property
-Sort boot environments by given property name.
+Sort boot environments by the given ZFS dataset property.
 The following properties are supported:
 .Pp
 .Bl -tag -width 4n -offset indent -compact
-.It name (default output)
+.It name          (the default)
 .It creation
 .It origin
 .It used
-.It usedds
-.It usedsnap
-.It usedrefreserv
+.It usedds        (usedbydataset)
+.It usedsnap      (usedbysnapshots)
+.It usedrefreserv (usedbyrefreservation)
 .El
 .It Fl C Ar property
 Same as the
@@ -347,10 +347,20 @@ or
 .Fl a
 option is used.
 .It Cm mount Ar beName Op Ar mountpoint
-Temporarily mount the boot environment.
-Mount at the specified
+Temporarily mount the given boot environment.
+If a nonexistent
 .Ar mountpoint
-if provided.
+is given,
+.Nm
+will make the directory, including intermediate directories as required.
+If no 
+.Ar mountpoint
+is given,
+.Nm
+will make a directory such as Pa be_mount.c6Sf in Pa /tmp
+.
+Randomness to the last four characters of the directory will prevent
+mount point conflicts.
 .It Cm rename Ar origBeName newBeName
 Rename the given
 .Ar origBeName


### PR DESCRIPTION
Improve the manual page for bectl(8),
<https://man.freebsd.org/cgi/man.cgi?query=bectl&manpath=freebsd-release>.

In parallel: <https://github.com/openzfs/zfs/issues/14810>,

> zfs-list(8), zfsprops(7): abbreviations: not all shortened column names are documented