### PR TITLE
bluetooth/hccontrol: Fix unterminated command list

### DIFF
--- a/usr.sbin/bluetooth/hccontrol/le.c
+++ b/usr.sbin/bluetooth/hccontrol/le.c
@@ -1365,4 +1365,7 @@ struct hci_command le_commands[] = {
 	  "Generate 64 bits of random data",
 	  &le_rand
   },
+  {
+	  NULL,
+  }
 };


### PR DESCRIPTION
Fixes a (usually benign) memory error.