### PR TITLE
ntpd: Support IPv6-only hosts

### DIFF
--- a/usr.sbin/ntp/ntpd/ntp.conf
+++ b/usr.sbin/ntp/ntpd/ntp.conf
@@ -20,24 +20,27 @@
 tos minclock 3 maxclock 6
 
 #
-# The following pool statement will give you a random set of NTP servers
-# geographically close to you.  A single pool statement adds multiple
-# servers from the pool, according to the tos minclock/maxclock targets.
+# The following pool statements will give you a random set of IPv4 and IPv6
+# NTP servers geographically close to you.  A single pool statement adds
+# multiple servers from the pool, according to the tos minclock/maxclock
+# targets.
 # See http://www.pool.ntp.org/ for details.  Note, pool.ntp.org encourages
 # users with a static IP and good upstream NTP servers to add a server
-# to the pool. See http://www.pool.ntp.org/join.html if you are interested.
+# to the pool.  See http://www.pool.ntp.org/join.html if you are interested.
 #
 # The option `iburst' is used for faster initial synchronization.
 #
 pool 0.freebsd.pool.ntp.org iburst
+pool 2.freebsd.pool.ntp.org iburst
 
 #
 # If you want to pick yourself which country's public NTP server
-# you want to sync against, comment out the above pool, uncomment
-# the next one, and replace CC with the country's abbreviation.
-# Make sure that the hostname resolves to a proper IP address!
+# you want to sync against, comment out the above pool statements,
+# uncomment the next ones, and replace CC with the country's abbreviation.
+# Make sure that the hostnames resolves to a proper IP address!
 #
 # pool 0.CC.pool.ntp.org iburst
+# pool 2.CC.pool.ntp.org iburst
 
 #
 # To configure a specific server, such as an organization-wide local


### PR DESCRIPTION
0.pool.* returns only IPv4 addresses.
2.pool.* returns both, IPv6 and IPv4 addresses.

conservatively extend our IPv4 only pool configuration by adding a second pool, which also returns IPv6 addresses.

PR: 270536
Reported by:  Lapo Luchini <lapo@lapo.it>
Differential Revision: https://reviews.freebsd.org/D39954
Pull Request: https://github.com/freebsd/freebsd-src/pull/731