### PR TITLE
newfs: nextnum should be a u_int32_t, not an int

### DIFF
--- a/sbin/newfs/mkfs.c
+++ b/sbin/newfs/mkfs.c
@@ -1230,7 +1230,7 @@ ilog2(int val)
 static u_int32_t
 newfs_random(void)
 {
-	static int nextnum = 1;
+	static u_int32_t nextnum = 1;
 
 	if (Rflag)
 		return (nextnum++);


### PR DESCRIPTION
The function that uses nextnum expects to return a u_int32_t, not a mere int, so let's make nextnum a u_int32_t instead.