### PR TITLE
Mark usage function as __dead2 in programs where it does not return

### DIFF
--- a/bin/chflags/chflags.c
+++ b/bin/chflags/chflags.c
@@ -59,7 +59,7 @@ __FBSDID("$FreeBSD$");
 
 static volatile sig_atomic_t siginfo;
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static void
 siginfo_handler(int sig __unused)

--- a/bin/chio/chio.c
+++ b/bin/chio/chio.c
@@ -60,7 +60,7 @@ __FBSDID("$FreeBSD$");
 #include "defs.h"
 #include "pathnames.h"
 
-static	void usage(void);
+static	void usage(void) __dead2;
 static	void cleanup(void);
 static	u_int16_t parse_element_type(char *);
 static	u_int16_t parse_element_unit(char *);

--- a/bin/chmod/chmod.c
+++ b/bin/chmod/chmod.c
@@ -59,7 +59,7 @@ __FBSDID("$FreeBSD$");
 
 static volatile sig_atomic_t siginfo;
 
-static void usage(void);
+static void usage(void) __dead2;
 static int may_have_nfs4acl(const FTSENT *ent, int hflag);
 
 static void

--- a/bin/cp/extern.h
+++ b/bin/cp/extern.h
@@ -50,5 +50,5 @@ int	copy_special(struct stat *, int);
 int	setfile(struct stat *, int);
 int	preserve_dir_acls(struct stat *, char *, char *);
 int	preserve_fd_acls(int, int);
-void	usage(void);
+void	usage(void) __dead2;
 __END_DECLS

--- a/bin/date/date.c
+++ b/bin/date/date.c
@@ -68,12 +68,12 @@ __FBSDID("$FreeBSD$");
 static time_t tval;
 
 static void badformat(void);
-static void iso8601_usage(const char *);
+static void iso8601_usage(const char *) __dead2;
 static void multipleformats(void);
 static void printdate(const char *);
 static void printisodate(struct tm *);
 static void setthetime(const char *, const char *, int);
-static void usage(void);
+static void usage(void) __dead2;
 
 static const struct iso8601_fmt {
 	const char *refname;

--- a/bin/domainname/domainname.c
+++ b/bin/domainname/domainname.c
@@ -51,7 +51,7 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <unistd.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/bin/kill/kill.c
+++ b/bin/kill/kill.c
@@ -63,7 +63,7 @@ __FBSDID("$FreeBSD$");
 static void nosig(const char *);
 static void printsignals(FILE *);
 static int signame_to_signum(const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/bin/rmdir/rmdir.c
+++ b/bin/rmdir/rmdir.c
@@ -50,7 +50,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 
 static int rm_path(char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 static int pflag;
 static int vflag;

--- a/bin/sleep/sleep.c
+++ b/bin/sleep/sleep.c
@@ -50,7 +50,7 @@ __FBSDID("$FreeBSD$");
 #include <stdlib.h>
 #include <time.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static volatile sig_atomic_t report_requested;
 static void

--- a/libexec/atrun/atrun.c
+++ b/libexec/atrun/atrun.c
@@ -96,7 +96,7 @@ static int debug = 0;
 
 void perr(const char *fmt, ...);
 void perrx(const char *fmt, ...);
-static void usage(void);
+static void usage(void) __dead2;
 
 /* Local functions */
 static int

--- a/libexec/bootpd/bootpgw/bootpgw.c
+++ b/libexec/bootpd/bootpgw/bootpgw.c
@@ -84,7 +84,7 @@ __FBSDID("$FreeBSD$");
  * Externals, forward declarations, and global variables
  */
 
-static void usage(void);
+static void usage(void) __dead2;
 static void handle_reply(void);
 static void handle_request(void);
 

--- a/libexec/bootpd/tools/bootpef/bootpef.c
+++ b/libexec/bootpd/tools/bootpef/bootpef.c
@@ -78,7 +78,7 @@ SOFTWARE.
  */
 
 static void mktagfile(struct host *);
-static void usage(void);
+static void usage(void) __dead2;
 
 /*
  * General

--- a/libexec/rbootd/rbootd.c
+++ b/libexec/rbootd/rbootd.c
@@ -70,7 +70,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 #include "defs.h"
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/libexec/rpc.rwalld/rwalld.c
+++ b/libexec/rpc.rwalld/rwalld.c
@@ -56,7 +56,7 @@ __FBSDID("$FreeBSD$");
 void wallprog_1(struct svc_req *rqstp, SVCXPRT *transp);
 void possess(void);
 void killkids(int sig);
-static void usage(void);
+static void usage(void) __dead2;
 
 int nodaemon = 0;
 int from_inetd = 1;

--- a/sbin/adjkerntz/adjkerntz.c
+++ b/sbin/adjkerntz/adjkerntz.c
@@ -67,7 +67,7 @@ __FBSDID("$FreeBSD$");
 #define REPORT_PERIOD (30*60)
 
 static void fake(int);
-static void usage(void);
+static void usage(void) __dead2;
 
 static void
 fake(int unused __unused)

--- a/sbin/comcontrol/comcontrol.c
+++ b/sbin/comcontrol/comcontrol.c
@@ -42,7 +42,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/types.h>
 #include <sys/ioctl.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static void
 usage(void)

--- a/sbin/fdisk/fdisk.c
+++ b/sbin/fdisk/fdisk.c
@@ -258,7 +258,7 @@ static int decimal(const char *str, int *num, int deflt, uint32_t maxval);
 static int read_config(char *config_file);
 static void reset_boot(void);
 static int sanitize_partition(struct dos_partition *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/sbin/ldconfig/ldconfig.c
+++ b/sbin/ldconfig/ldconfig.c
@@ -50,7 +50,7 @@
 #include "ldconfig.h"
 #include "rtld_paths.h"
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char **argv)

--- a/sbin/mdconfig/mdconfig.c
+++ b/sbin/mdconfig/mdconfig.c
@@ -60,7 +60,7 @@ static struct md_ioctl mdio;
 static enum {UNSET, ATTACH, DETACH, RESIZE, LIST} action = UNSET;
 static int nflag;
 
-static void usage(void);
+static void usage(void) __dead2;
 static void md_set_file(const char *);
 static int md_find(const char *, const char *);
 static int md_query(const char *, const int, const char *);

--- a/sbin/newfs/newfs.c
+++ b/sbin/newfs/newfs.c
@@ -124,7 +124,7 @@ static char	*disktype;
 
 static void getfssize(intmax_t *, const char *p, intmax_t, intmax_t);
 static struct disklabel *getdisklabel(void);
-static void usage(void);
+static void usage(void) __dead2;
 static int expand_number_int(const char *buf, int *num);
 
 ufs2_daddr_t part_ofs; /* partition offset in blocks, used with files */

--- a/sbin/newfs_msdos/newfs_msdos.c
+++ b/sbin/newfs_msdos/newfs_msdos.c
@@ -51,7 +51,7 @@ static const char rcsid[] =
 
 static u_int argtou(const char *, u_int, u_int, const char *);
 static off_t argtooff(const char *, const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 static time_t
 get_tstamp(const char *b)

--- a/sbin/nos-tun/nos-tun.c
+++ b/sbin/nos-tun/nos-tun.c
@@ -89,7 +89,7 @@ static struct ifreq ifrq;
 int net;                          /* socket descriptor */
 int tun;                          /* tunnel descriptor */
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static int
 Set_address(char *addr, struct sockaddr_in *sin)

--- a/sbin/reboot/reboot.c
+++ b/sbin/reboot/reboot.c
@@ -61,7 +61,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 #include <utmpx.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 static u_int get_pageins(void);
 
 static int dohalt;

--- a/sbin/routed/rtquery/rtquery.c
+++ b/sbin/routed/rtquery/rtquery.c
@@ -131,7 +131,7 @@ static void query_loop(char *argv[], int) __attribute((__noreturn__));
 static int getnet(char *, struct netinfo *);
 static u_int std_mask(u_int);
 static int parse_quote(char **, const char *, char *, char *, int);
-static void usage(void);
+static void usage(void) __dead2;
 
 
 int

--- a/sbin/swapon/swapon.c
+++ b/sbin/swapon/swapon.c
@@ -68,7 +68,7 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <unistd.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 static const char *swap_on_off(const char *, int, char *);
 static const char *swap_on_off_gbde(const char *, int);
 static const char *swap_on_off_geli(const char *, char *, int);

--- a/sbin/tunefs/tunefs.c
+++ b/sbin/tunefs/tunefs.c
@@ -80,7 +80,7 @@ static char clrbuf[MAXBSIZE];
 static struct uufsd disk;
 #define	sblock disk.d_fs
 
-static void usage(void);
+static void usage(void) __dead2;
 static void printfs(void);
 static int journal_alloc(int64_t size);
 static void journal_clear(void);

--- a/stand/powerpc/boot1.chrp/boot1.c
+++ b/stand/powerpc/boot1.chrp/boot1.c
@@ -58,7 +58,7 @@ static void exit(int) __dead2;
 static void load(const char *);
 static int dskread(void *, uint64_t, int);
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static void bcopy(const void *src, void *dst, size_t len);
 static void bzero(void *b, size_t len);

--- a/sys/dev/aic7xxx/aicasm/aicasm.c
+++ b/sys/dev/aic7xxx/aicasm/aicasm.c
@@ -75,7 +75,7 @@ typedef struct patch {
 
 STAILQ_HEAD(patch_list, patch) patches;
 
-static void usage(void);
+static void usage(void) __dead2;
 static void back_patch(void);
 static void output_code(void);
 static void output_listing(char *ifilename);

--- a/tests/sys/cddl/zfs/bin/file_write.c
+++ b/tests/sys/cddl/zfs/bin/file_write.c
@@ -38,7 +38,7 @@ static unsigned char bigbuffer[BIGBUFFERSIZE];
  * See header file for defaults.
  */
 
-static void usage(void);
+static void usage(void) __dead2;
 static char *execname;
 
 int

--- a/tests/sys/netinet/libalias/perf.c
+++ b/tests/sys/netinet/libalias/perf.c
@@ -38,7 +38,7 @@
 #include "util.h"
 #include <alias.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 #define	timevalcmp(tv, uv, cmp)			\
 	(((tv).tv_sec == (uv).tv_sec)		\

--- a/tools/regression/sysvshm/shmtest.c
+++ b/tools/regression/sysvshm/shmtest.c
@@ -54,7 +54,7 @@ static void sigsys_handler(int);
 static void sigchld_handler(int);
 static void cleanup(void);
 static void receiver(void);
-static void usage(void);
+static void usage(void) __dead2;
 
 static const char *m_str = "The quick brown fox jumped over the lazy dog.";
 

--- a/tools/tools/switch_tls/switch_tls.c
+++ b/tools/tools/switch_tls/switch_tls.c
@@ -61,7 +61,7 @@ static bool tcpswitchall(const char *, int);
 static bool tcpswitchbyname(const char *, const char *, const char *,
     const char *, int);
 static bool tcpswitchconn(const struct in_conninfo *, int);
-static void usage(void);
+static void usage(void) __dead2;
 
 /*
  * Switch a tcp connection.

--- a/usr.bin/asa/asa.c
+++ b/usr.bin/asa/asa.c
@@ -47,7 +47,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 
 static void asa(FILE *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/banner/banner.c
+++ b/usr.bin/banner/banner.c
@@ -1026,7 +1026,7 @@ static char	print[DWIDTH];
 static int	debug, i, j, linen, max, nchars, pc, term, trace, x, y;
 static int	width = DWIDTH;	/* -w option: scrunch letters to 80 columns */
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/biff/biff.c
+++ b/usr.bin/biff/biff.c
@@ -51,7 +51,7 @@ __FBSDID("$FreeBSD$");
 #include <stdlib.h>
 #include <unistd.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/bintrans/uuencode.c
+++ b/usr.bin/bintrans/uuencode.c
@@ -70,7 +70,7 @@ extern int main_base64_encode(const char *, const char *);
 static void encode(void);
 static void base64_encode(void);
 static int arg_to_col(const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 static FILE *output;
 static int mode;

--- a/usr.bin/brandelf/brandelf.c
+++ b/usr.bin/brandelf/brandelf.c
@@ -52,7 +52,7 @@ __FBSDID("$FreeBSD$");
 static int elftype(const char *);
 static const char *iselftype(int);
 static void printelftypes(void);
-static void usage(void);
+static void usage(void) __dead2;
 
 struct ELFtypes {
 	const char *str;

--- a/usr.bin/c99/c99.c
+++ b/usr.bin/c99/c99.c
@@ -50,7 +50,7 @@ static u_int cargs, nargs;
 
 static void addarg(const char *);
 static void addlib(const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/chat/chat.c
+++ b/usr.bin/chat/chat.c
@@ -145,7 +145,7 @@ static int say_next, hup_next;
 
 void *dup_mem(void *b, size_t c);
 void *copy_of(char *s);
-static void usage(void);
+static void usage(void) __dead2;
 void chat_logf(const char *fmt, ...);
 void fatal(int code, const char *fmt, ...);
 SIGTYPE sigalrm(int signo);

--- a/usr.bin/chkey/chkey.c
+++ b/usr.bin/chkey/chkey.c
@@ -74,7 +74,7 @@ static char PKFILE[] = "/etc/publickey";
 #endif	/* YP */
 static char ROOTKEY[] = "/etc/.rootkey";
 
-static void usage(void);
+static void usage(void) __dead2;
 extern int yp_update(char *, char *, int, char *, size_t, char *, size_t);
 
 int

--- a/usr.bin/cksum/cksum.c
+++ b/usr.bin/cksum/cksum.c
@@ -58,7 +58,7 @@ __FBSDID("$FreeBSD$");
 
 #include "extern.h"
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char **argv)

--- a/usr.bin/cmp/cmp.c
+++ b/usr.bin/cmp/cmp.c
@@ -86,7 +86,7 @@ siginfo(int signo)
 }
 #endif
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static bool
 parse_iskipspec(char *spec, off_t *skip1, off_t *skip2)

--- a/usr.bin/colrm/colrm.c
+++ b/usr.bin/colrm/colrm.c
@@ -58,7 +58,7 @@ __FBSDID("$FreeBSD$");
 #define	TAB	8
 
 void check(FILE *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/cpuset/cpuset.c
+++ b/usr.bin/cpuset/cpuset.c
@@ -69,7 +69,7 @@ static id_t id;
 static cpulevel_t level;
 static cpuwhich_t which;
 
-static void usage(void);
+static void usage(void) __dead2;
 
 struct numa_policy {
 	const char 	*name;

--- a/usr.bin/ctags/ctags.c
+++ b/usr.bin/ctags/ctags.c
@@ -87,7 +87,7 @@ char	lbuf[LINE_MAX];
 
 void	init(void);
 void	find_entries(char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char **argv)

--- a/usr.bin/elfctl/elfctl.c
+++ b/usr.bin/elfctl/elfctl.c
@@ -56,7 +56,7 @@ static bool edit_file_features(Elf *, int, int, char *, bool);
 static bool get_file_features(Elf *, int, int, uint32_t *, uint64_t *, bool);
 static void print_features(void);
 static bool print_file_features(Elf *, int, int, char *, bool);
-static void usage(void);
+static void usage(void) __dead2;
 
 struct ControlFeatures {
 	const char *alias;

--- a/usr.bin/elfdump/elfdump.c
+++ b/usr.bin/elfdump/elfdump.c
@@ -473,7 +473,7 @@ static void elf_print_got(Elf32_Ehdr *e, void *sh);
 static void elf_print_hash(Elf32_Ehdr *e, void *sh);
 static void elf_print_note(Elf32_Ehdr *e, void *sh);
 
-static void usage(void);
+static void usage(void) __dead2;
 
 /*
  * Helpers for ELF files with shnum or shstrndx values that don't fit in the

--- a/usr.bin/env/env.c
+++ b/usr.bin/env/env.c
@@ -62,7 +62,7 @@ extern char **environ;
 
 int	 env_verbosity;
 
-static void usage(void);
+static void usage(void) __dead2;
 
 /*
  * Exit codes.

--- a/usr.bin/find/main.c
+++ b/usr.bin/find/main.c
@@ -71,7 +71,7 @@ int mindepth = -1, maxdepth = -1; /* minimum and maximum depth */
 int regexp_flags = REG_BASIC;	/* use the "basic" regexp by default*/
 int exitstatus;
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/finger/finger.c
+++ b/usr.bin/finger/finger.c
@@ -98,7 +98,7 @@ int invoker_root = 0;
 
 static void loginlist(void);
 static int option(int, char **);
-static void usage(void);
+static void usage(void) __dead2;
 static void userlist(int, char **);
 
 static int

--- a/usr.bin/fold/fold.c
+++ b/usr.bin/fold/fold.c
@@ -61,7 +61,7 @@ __FBSDID("$FreeBSD$");
 
 void fold(int);
 static int newpos(int, wint_t);
-static void usage(void);
+static void usage(void) __dead2;
 
 static int bflag;		/* Count bytes, not columns */
 static int sflag;		/* Split on word boundaries */

--- a/usr.bin/fortune/strfile/strfile.c
+++ b/usr.bin/fortune/strfile/strfile.c
@@ -126,7 +126,7 @@ static int stable_collate_range_cmp(int, int);
 static void do_order(void);
 static void getargs(int, char **);
 static void randomize(void);
-static void usage(void);
+static void usage(void) __dead2;
 
 /*
  * main:

--- a/usr.bin/from/from.c
+++ b/usr.bin/from/from.c
@@ -54,7 +54,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 
 static int match(const char *, const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char **argv)

--- a/usr.bin/grdc/grdc.c
+++ b/usr.bin/grdc/grdc.c
@@ -43,7 +43,7 @@ static void set(int, int);
 static void standt(int);
 static void movto(int, int);
 static void sighndl(int);
-static void usage(void);
+static void usage(void) __dead2;
 
 static void
 sighndl(int signo)

--- a/usr.bin/head/head.c
+++ b/usr.bin/head/head.c
@@ -71,7 +71,7 @@ __FBSDID("$FreeBSD$");
 static void head(FILE *, intmax_t);
 static void head_bytes(FILE *, off_t);
 static void obsolete(char *[]);
-static void usage(void);
+static void usage(void) __dead2;
 
 static const struct option long_opts[] =
 {

--- a/usr.bin/join/join.c
+++ b/usr.bin/join/join.c
@@ -114,7 +114,7 @@ static void outoneline(INPUT *, LINE *);
 static void outtwoline(INPUT *, LINE *, INPUT *, LINE *);
 static void slurp(INPUT *);
 static wchar_t *towcs(const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/ktrace/ktrace.c
+++ b/usr.bin/ktrace/ktrace.c
@@ -67,7 +67,7 @@ static int pid;
 
 static void no_ktrace(int);
 static void set_pid_clear(const char *, enum clear);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/ktrdump/ktrdump.c
+++ b/usr.bin/ktrdump/ktrdump.c
@@ -53,7 +53,7 @@ __FBSDID("$FreeBSD$");
 #define	USAGE \
 	"usage: ktrdump [-cflqrtH] [-i ktrfile] [-M core] [-N system] [-o outfile]\n"
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static struct nlist nl[] = {
 	{ .n_name = "_ktr_version" },

--- a/usr.bin/leave/leave.c
+++ b/usr.bin/leave/leave.c
@@ -52,7 +52,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 
 static void doalarm(u_int);
-static void usage(void);
+static void usage(void) __dead2;
 
 /*
  * leave [[+]hhmm]

--- a/usr.bin/limits/limits.c
+++ b/usr.bin/limits/limits.c
@@ -257,7 +257,7 @@ static struct {
 #define RCS_STRING  "tfdscmlunbvpwko"
 
 static rlim_t resource_num(int which, int ch, const char *str);
-static void usage(void);
+static void usage(void) __dead2;
 static int getshelltype(void);
 static void print_limit(rlim_t limit, unsigned divisor, const char *inf,
 			const char *pfx, const char *sfx, const char *which);

--- a/usr.bin/lock/lock.c
+++ b/usr.bin/lock/lock.c
@@ -81,7 +81,7 @@ __FBSDID("$FreeBSD$");
 static void quit(int);
 static void bye(int);
 static void hi(int);
-static void usage(void);
+static void usage(void) __dead2;
 
 static struct timeval	timeout;
 static struct timeval	zerotime;

--- a/usr.bin/lockf/lockf.c
+++ b/usr.bin/lockf/lockf.c
@@ -44,7 +44,7 @@ static int acquire_lock(const char *name, int flags);
 static void cleanup(void);
 static void killed(int sig);
 static void timeout(int sig);
-static void usage(void);
+static void usage(void) __dead2;
 static void wait_for_lock(const char *name);
 
 static const char *lockname;

--- a/usr.bin/look/look.c
+++ b/usr.bin/look/look.c
@@ -89,7 +89,7 @@ static int	 look(wchar_t *, unsigned char *, unsigned char *);
 static wchar_t	*prepkey(const char *, wchar_t);
 static void	 print_from(wchar_t *, unsigned char *, unsigned char *);
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static struct option longopts[] = {
 	{ "alternative",no_argument,	NULL, 'a' },

--- a/usr.bin/mesg/mesg.c
+++ b/usr.bin/mesg/mesg.c
@@ -57,7 +57,7 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <unistd.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/mkfifo/mkfifo.c
+++ b/usr.bin/mkfifo/mkfifo.c
@@ -56,7 +56,7 @@ __FBSDID("$FreeBSD$");
 #define	BASEMODE	S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | \
 			S_IROTH | S_IWOTH
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static int f_mode;
 

--- a/usr.bin/mktemp/mktemp.c
+++ b/usr.bin/mktemp/mktemp.c
@@ -50,7 +50,7 @@ static const char rcsid[] =
 	"$FreeBSD$";
 #endif /* not lint */
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static const struct option long_opts[] = {
 	{"directory",	no_argument,	NULL,	'd'},

--- a/usr.bin/mkuzip/mkuzip.c
+++ b/usr.bin/mkuzip/mkuzip.c
@@ -99,7 +99,7 @@ static const struct mkuz_format uzip_fmts[] = {
 };
 
 static struct mkuz_blk *readblock(int, u_int32_t);
-static void usage(void);
+static void usage(void) __dead2;
 static void cleanup(void);
 
 static char *cleanfile = NULL;

--- a/usr.bin/mt/mt.c
+++ b/usr.bin/mt/mt.c
@@ -180,7 +180,7 @@ static const struct commands {
 static const char *getblksiz(int);
 static void printreg(const char *, u_int, const char *);
 static void status(struct mtget *);
-static void usage(void);
+static void usage(void) __dead2;
 const char *get_driver_state_str(int dsreg);
 static void st_status (struct mtget *);
 static int mt_locate(int argc, char **argv, int mtfd, const char *tape);

--- a/usr.bin/netstat/main.c
+++ b/usr.bin/netstat/main.c
@@ -192,7 +192,7 @@ static struct protox *protoprotox[] = {
 					 NULL };
 
 static void printproto(struct protox *, const char *, bool *);
-static void usage(void);
+static void usage(void) __dead2;
 static struct protox *name2protox(const char *);
 static struct protox *knownname(const char *);
 

--- a/usr.bin/newkey/newkey.c
+++ b/usr.bin/newkey/newkey.c
@@ -90,7 +90,7 @@ static char PKFILE[] = "/etc/publickey";
 static const char *err_string(int);
 #endif	/* YP */
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/nfsstat/nfsstat.c
+++ b/usr.bin/nfsstat/nfsstat.c
@@ -109,7 +109,7 @@ static int extra_output = 0;
 
 static void intpr(int, int);
 static void printhdr(int, int, int);
-static void usage(void);
+static void usage(void) __dead2;
 static char *sperc1(int, int);
 static char *sperc2(int, int);
 static void exp_intpr(int, int, int);

--- a/usr.bin/nohup/nohup.c
+++ b/usr.bin/nohup/nohup.c
@@ -56,7 +56,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 
 static void dofile(void);
-static void usage(void);
+static void usage(void) __dead2;
 
 #define	FILENAME	"nohup.out"
 /*

--- a/usr.bin/paste/paste.c
+++ b/usr.bin/paste/paste.c
@@ -65,7 +65,7 @@ static int delimcnt;
 static int parallel(char **);
 static int sequential(char **);
 static int tr(wchar_t *);
-static void usage(void);
+static void usage(void) __dead2;
 
 static wchar_t tab[] = L"\t";
 

--- a/usr.bin/perror/perror.c
+++ b/usr.bin/perror/perror.c
@@ -37,7 +37,7 @@ __FBSDID("$FreeBSD$");
 #include <locale.h>
 #include <sys/errno.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int 
 main(int argc, char **argv)

--- a/usr.bin/quota/quota.c
+++ b/usr.bin/quota/quota.c
@@ -86,7 +86,7 @@ struct quotause {
 
 static char *timeprt(int64_t seconds);
 static struct quotause *getprivs(long id, int quotatype);
-static void usage(void);
+static void usage(void) __dead2;
 static int showuid(u_long uid);
 static int showgid(u_long gid);
 static int showusrname(char *name);

--- a/usr.bin/random/random.c
+++ b/usr.bin/random/random.c
@@ -61,7 +61,7 @@ __FBSDID("$FreeBSD$");
 
 #include "randomize_fd.h"
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/rev/rev.c
+++ b/usr.bin/rev/rev.c
@@ -55,7 +55,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 #include <wchar.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/rpcgen/rpc_main.c
+++ b/usr.bin/rpcgen/rpc_main.c
@@ -64,7 +64,7 @@ static void clnt_output(const char *, const char *, int, const char * );
 static char *generate_guard(const char *);
 static void c_initialize(void);
 
-static void usage(void);
+static void usage(void) __dead2;
 static void options_usage(void);
 static int do_registers(int, const char **);
 static int parseargs(int, const char **, struct commandline *);

--- a/usr.bin/rwall/rwall.c
+++ b/usr.bin/rwall/rwall.c
@@ -71,7 +71,7 @@ static char *mbuf;
 static char notty[] = "no tty";
 
 static void	makemsg(const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 /* ARGSUSED */
 int

--- a/usr.bin/rwho/rwho.c
+++ b/usr.bin/rwho/rwho.c
@@ -83,7 +83,7 @@ static struct	myutmp {
 static time_t	now;
 static int	aflg;
 
-static void usage(void);
+static void usage(void) __dead2;
 static int utmpcmp(const void *, const void *);
 
 int

--- a/usr.bin/script/script.c
+++ b/usr.bin/script/script.c
@@ -102,7 +102,7 @@ static void finish(void);
 static void record(FILE *, char *, size_t, int);
 static void consume(FILE *, off_t, char *, int);
 static void playback(FILE *) __dead2;
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/sed/main.c
+++ b/usr.bin/sed/main.c
@@ -121,7 +121,7 @@ u_long linenum;
 
 static void add_compunit(enum e_cut, char *);
 static void add_file(char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/showmount/showmount.c
+++ b/usr.bin/showmount/showmount.c
@@ -97,7 +97,7 @@ static struct exportslist *exportslist;
 static int type = 0;
 
 void print_dump(struct mountlist *);
-static void usage(void);
+static void usage(void) __dead2;
 int xdr_mntdump(XDR *, struct mountlist **);
 int xdr_exportslist(XDR *, struct exportslist **);
 int tcp_callrpc(const char *host, int prognum, int versnum, int procnum,

--- a/usr.bin/split/split.c
+++ b/usr.bin/split/split.c
@@ -82,7 +82,7 @@ static void newfile(void);
 static void split1(void);
 static void split2(void);
 static void split3(void);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char **argv)

--- a/usr.bin/tail/tail.c
+++ b/usr.bin/tail/tail.c
@@ -70,7 +70,7 @@ int Fflag, fflag, qflag, rflag, rval, no_files, vflag;
 fileargs_t *fa;
 
 static void obsolete(char **);
-static void usage(void);
+static void usage(void) __dead2;
 
 static const struct option long_opts[] =
 {

--- a/usr.bin/tee/tee.c
+++ b/usr.bin/tee/tee.c
@@ -66,7 +66,7 @@ struct entry {
 static STAILQ_HEAD(, entry) head = STAILQ_HEAD_INITIALIZER(head);
 
 static void add(int, const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/time/time.c
+++ b/usr.bin/time/time.c
@@ -66,7 +66,7 @@ static void humantime(FILE *, long, long);
 static void showtime(FILE *, struct timespec *, struct timespec *,
     struct rusage *);
 static void siginfo(int);
-static void usage(void);
+static void usage(void) __dead2;
 
 static sig_atomic_t siginfo_recvd;
 static char decimal_point;

--- a/usr.bin/tr/tr.c
+++ b/usr.bin/tr/tr.c
@@ -67,7 +67,7 @@ static STR s1 = { STRING1, NORMAL, 0, OOBCH, 0, { 0, OOBCH }, NULL, NULL };
 static STR s2 = { STRING2, NORMAL, 0, OOBCH, 0, { 0, OOBCH }, NULL, NULL };
 
 static struct cset *setup(char *, STR *, int, int);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char **argv)

--- a/usr.bin/tty/tty.c
+++ b/usr.bin/tty/tty.c
@@ -48,7 +48,7 @@ __FBSDID("$FreeBSD$");
 #include <stdlib.h>
 #include <unistd.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.bin/ul/ul.c
+++ b/usr.bin/ul/ul.c
@@ -89,7 +89,7 @@ static int	halfpos;
 static int	upln;
 static int	iflag;
 
-static void usage(void);
+static void usage(void) __dead2;
 static void setnewmode(int);
 static void initcap(void);
 static void reverse(void);

--- a/usr.bin/uname/uname.c
+++ b/usr.bin/uname/uname.c
@@ -85,7 +85,7 @@ static void native_uservers(void);
 static void native_buildid(void);
 static void print_uname(u_int);
 static void setup_get(void);
-static void usage(void);
+static void usage(void) __dead2;
 
 static char *buildid, *ident, *platform, *hostname, *arch, *release, *sysname,
     *version, *kernvers, *uservers;

--- a/usr.bin/unexpand/unexpand.c
+++ b/usr.bin/unexpand/unexpand.c
@@ -62,7 +62,7 @@ static int	nstops;
 static int	tabstops[100];
 
 static void getstops(const char *);
-static void usage(void);
+static void usage(void) __dead2;
 static int tabify(const char *);
 
 int

--- a/usr.bin/usbhidctl/usbhid.c
+++ b/usr.bin/usbhidctl/usbhid.c
@@ -58,7 +58,7 @@ static int hexdump = 0;
 static int wflag = 0;
 static int zflag = 0;
 
-static void usage(void);
+static void usage(void) __dead2;
 static void dumpitem(const char *label, struct hid_item *h);
 static void dumpitems(report_desc_t r);
 static void prdata(u_char *buf, struct hid_item *h);

--- a/usr.bin/wall/wall.c
+++ b/usr.bin/wall/wall.c
@@ -70,7 +70,7 @@ static const char sccsid[] = "@(#)wall.c	8.2 (Berkeley) 11/16/93";
 #include "ttymsg.h"
 
 static void makemsg(char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 static struct wallgroup {
 	struct wallgroup *next;

--- a/usr.bin/what/what.c
+++ b/usr.bin/what/what.c
@@ -49,7 +49,7 @@ static const char sccsid[] = "@(#)what.c	8.1 (Berkeley) 6/6/93";
 #include <stdlib.h>
 #include <unistd.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 static bool search(bool, bool, FILE *);
 
 int

--- a/usr.bin/whois/whois.c
+++ b/usr.bin/whois/whois.c
@@ -159,7 +159,7 @@ static const char *port = DEFAULT_PORT;
 static const char *choose_server(char *);
 static struct addrinfo *gethostinfo(const char *, const char *, int);
 static void s_asprintf(char **ret, const char *format, ...) __printflike(2, 3);
-static void usage(void);
+static void usage(void) __dead2;
 static void whois(const char *, const char *, const char *, int);
 
 int

--- a/usr.bin/write/write.c
+++ b/usr.bin/write/write.c
@@ -71,7 +71,7 @@ __FBSDID("$FreeBSD$");
 
 void done(int);
 void do_write(int, char *, char *, const char *);
-static void usage(void);
+static void usage(void) __dead2;
 int term_chk(int, char *, int *, time_t *, int);
 void wr_fputs(wchar_t *s);
 void search_utmp(int, char *, char *, char *, uid_t);

--- a/usr.bin/xstr/xstr.c
+++ b/usr.bin/xstr/xstr.c
@@ -84,7 +84,7 @@ static int xgetc(FILE *);
 static off_t hashit(char *, int);
 static off_t yankstr(char **);
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static void flushsh(void);
 static void found(int, off_t, char *);

--- a/usr.sbin/accton/accton.c
+++ b/usr.sbin/accton/accton.c
@@ -50,7 +50,7 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <unistd.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.sbin/arp/arp.c
+++ b/usr.sbin/arp/arp.c
@@ -90,7 +90,7 @@ static void nuke_entries(uint32_t ifindex, struct in_addr addr);
 static int print_entries(uint32_t ifindex, struct in_addr addr);
 
 static int delete(char *host);
-static void usage(void);
+static void usage(void) __dead2;
 static int set(int argc, char **argv);
 static int get(char *host);
 static int file(char *name);

--- a/usr.sbin/bluetooth/bthidcontrol/bthidcontrol.c
+++ b/usr.sbin/bluetooth/bthidcontrol/bthidcontrol.c
@@ -48,7 +48,7 @@
 static int do_bthid_command(bdaddr_p bdaddr, int argc, char **argv);
 static struct bthid_command * find_bthid_command(char const *command, struct bthid_command *category);
 static void print_bthid_command(struct bthid_command *category);
-static void usage(void);
+static void usage(void) __dead2;
 
 int32_t hid_sdp_query(bdaddr_t const *local, bdaddr_t const *remote, int32_t *error);
 

--- a/usr.sbin/bluetooth/btpand/btpand.c
+++ b/usr.sbin/bluetooth/btpand/btpand.c
@@ -72,9 +72,9 @@ static const struct {
 	{ "GN",	  SDP_SERVICE_CLASS_GN,   "Group Network"		  },
 };
 
-static void main_exit(int);
+static void main_exit(int) __dead2;
 static void main_detach(void);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.sbin/boot0cfg/boot0cfg.c
+++ b/usr.sbin/boot0cfg/boot0cfg.c
@@ -107,7 +107,7 @@ static int boot0bs(const u_int8_t *);
 static void stropt(const char *, int *, int *);
 static int argtoi(const char *, int, int, int);
 static int set_bell(u_int8_t *, int, int);
-static void usage(void);
+static void usage(void) __dead2;
 
 static unsigned vol_id[5];	/* 4 plus 1 for flag */
 

--- a/usr.sbin/bootparamd/bootparamd/main.c
+++ b/usr.sbin/bootparamd/bootparamd/main.c
@@ -39,7 +39,7 @@ const char *bootpfile = "/etc/bootparams";
 
 static struct sockaddr_in my_addr;
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char **argv)

--- a/usr.sbin/bootparamd/callbootd/callbootd.c
+++ b/usr.sbin/bootparamd/callbootd/callbootd.c
@@ -30,7 +30,7 @@ static char cln[MAX_MACHINE_NAME+1];
 static char dmn[MAX_MACHINE_NAME+1];
 static char path[MAX_PATH_LEN+1];
 
-static void usage(void);
+static void usage(void) __dead2;
 int printgetfile(bp_getfile_res *);
 int printwhoami(bp_whoami_res *);
 

--- a/usr.sbin/btxld/btxld.c
+++ b/usr.sbin/btxld/btxld.c
@@ -127,7 +127,7 @@ static unsigned int optfmt(const char *);
 static uint32_t optaddr(const char *);
 static int optpage(const char *, int);
 static void Warn(const char *, const char *, ...);
-static void usage(void);
+static void usage(void) __dead2;
 
 /*
  * A link editor for BTX clients.

--- a/usr.sbin/chroot/chroot.c
+++ b/usr.sbin/chroot/chroot.c
@@ -58,7 +58,7 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <unistd.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.sbin/ckdist/ckdist.c
+++ b/usr.sbin/ckdist/ckdist.c
@@ -86,7 +86,7 @@ static const char *stripath(const char *path);
 static int distfile(const char *path);
 static int disttype(const char *name);
 static int fail(const char *path, const char *msg);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.sbin/crunch/crunchide/crunchide.c
+++ b/usr.sbin/crunch/crunchide/crunchide.c
@@ -76,7 +76,7 @@ __FBSDID("$FreeBSD$");
 
 static const char *pname = "crunchide";
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static void add_to_keep_list(char *symbol);
 static void add_file_to_keep_list(char *filename);

--- a/usr.sbin/edquota/edquota.c
+++ b/usr.sbin/edquota/edquota.c
@@ -110,7 +110,7 @@ struct quotause *getprivs(long, int, char *);
 void putprivs(long, struct quotause *);
 int readprivs(struct quotause *, char *);
 int readtimes(struct quotause *, char *);
-static void usage(void);
+static void usage(void) __dead2;
 int writetimes(struct quotause *, int, int);
 int writeprivs(struct quotause *, int, char *, int);
 

--- a/usr.sbin/efitable/efitable.c
+++ b/usr.sbin/efitable/efitable.c
@@ -48,7 +48,7 @@ __FBSDID("$FreeBSD$");
 
 static void efi_table_print_esrt(const void *data);
 static void efi_table_print_prop(const void *data);
-static void usage(void);
+static void usage(void) __dead2;
 
 struct efi_table_op {
 	char name[TABLE_MAX_LEN];

--- a/usr.sbin/fdcontrol/fdcontrol.c
+++ b/usr.sbin/fdcontrol/fdcontrol.c
@@ -47,7 +47,7 @@ static	int format, verbose, show = 1, showfmt;
 static	char *fmtstring;
 
 static void showdev(enum fd_drivetype, const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 static void
 usage(void)

--- a/usr.sbin/gstat/gstat.c
+++ b/usr.sbin/gstat/gstat.c
@@ -66,7 +66,7 @@ static int flag_I = 1000000;
 			printw(__VA_ARGS__);				\
 	} while(0)
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static const char*
 el_prompt(void)

--- a/usr.sbin/iostat/iostat.c
+++ b/usr.sbin/iostat/iostat.c
@@ -149,7 +149,7 @@ static int dflag = 0, Iflag = 0, Cflag = 0, Tflag = 0, oflag = 0, Kflag = 0;
 static int xflag = 0, zflag = 0;
 
 /* local function declarations */
-static void usage(void);
+static void usage(void) __dead2;
 static void needhdr(int signo);
 static void needresize(int signo);
 static void needreturn(int signo);
@@ -173,6 +173,7 @@ usage(void)
 	fprintf(stderr, "usage: iostat [-CdhIKoTxz?] [-c count] [-M core]"
 		" [-n devs] [-N system]\n"
 		"\t      [-t type,if,pass] [-w wait] [drives]\n");
+	exit(1);
 }
 
 int
@@ -261,8 +262,6 @@ main(int argc, char **argv)
 				break;
 			default:
 				usage();
-				exit(1);
-				break;
 		}
 	}
 

--- a/usr.sbin/ip6addrctl/ip6addrctl.c
+++ b/usr.sbin/ip6addrctl/ip6addrctl.c
@@ -62,7 +62,7 @@ struct policyqueue {
 TAILQ_HEAD(policyhead, policyqueue);
 static struct policyhead policyhead;
 
-static void usage(void);
+static void usage(void) __dead2;
 static void get_policy(void);
 static void dump_policy(void);
 static int mask2plen(struct sockaddr_in6 *);

--- a/usr.sbin/jail/jail.c
+++ b/usr.sbin/jail/jail.c
@@ -73,7 +73,7 @@ static void print_jail(FILE *fp, struct cfjail *j, int oldcl, int running);
 static void print_param(FILE *fp, const struct cfparam *p, int sep, int doname);
 static void show_jails(void);
 static void quoted_print(FILE *fp, char *str);
-static void usage(void);
+static void usage(void) __dead2;
 
 static struct permspec perm_sysctl[] = {
     { "security.jail.set_hostname_allowed", KP_ALLOW_SET_HOSTNAME, 0 },

--- a/usr.sbin/ndp/ndp.c
+++ b/usr.sbin/ndp/ndp.c
@@ -138,7 +138,7 @@ static int delete(char *);
 static int dump(struct sockaddr_in6 *, int);
 static struct in6_nbrinfo *getnbrinfo(struct in6_addr *, int, int);
 static int ndp_ether_aton(char *, u_char *);
-static void usage(void);
+static void usage(void) __dead2;
 static void ifinfo(char *, int, char **);
 static void rtrlist(void);
 static void plist(void);

--- a/usr.sbin/newsyslog/newsyslog.c
+++ b/usr.sbin/newsyslog/newsyslog.c
@@ -281,7 +281,7 @@ static struct conf_entry *init_entry(const char *fname,
 		struct conf_entry *src_entry);
 static void parse_args(int argc, char **argv);
 static int parse_doption(const char *doption);
-static void usage(void);
+static void usage(void) __dead2;
 static int log_trim(const char *logname, const struct conf_entry *log_ent);
 static int age_old_log(const char *file);
 static void savelog(char *from, char *to);

--- a/usr.sbin/nfsdumpstate/nfsdumpstate.c
+++ b/usr.sbin/nfsdumpstate/nfsdumpstate.c
@@ -56,7 +56,7 @@ __FBSDID("$FreeBSD$");
 
 static void dump_lockstate(char *);
 static void dump_openstate(void);
-static void usage(void);
+static void usage(void) __dead2;
 static char *open_flags(uint32_t);
 static char *deleg_flags(uint32_t);
 static char *lock_flags(uint32_t);

--- a/usr.sbin/nfsrevoke/nfsrevoke.c
+++ b/usr.sbin/nfsrevoke/nfsrevoke.c
@@ -57,7 +57,7 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <unistd.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char **argv)

--- a/usr.sbin/nscd/nscd.c
+++ b/usr.sbin/nscd/nscd.c
@@ -85,7 +85,7 @@ static void process_socket_event(struct kevent *, struct runtime_env *,
 static void process_timer_event(struct kevent *, struct runtime_env *,
 	struct configuration *);
 static void *processing_thread(void *);
-static void usage(void);
+static void usage(void) __dead2;
 
 void get_time_func(struct timeval *);
 

--- a/usr.sbin/nvram/nvram.c
+++ b/usr.sbin/nvram/nvram.c
@@ -41,7 +41,7 @@
 
 #define	DEVICE_NAME	(_PATH_DEV "powermac_nvram")
 
-static void usage(void);
+static void usage(void) __dead2;
 static int remove_var(uint8_t *, int, const char *);
 static int append_var(uint8_t *, int, const char *, const char *);
 

--- a/usr.sbin/pnfsdscopymr/pnfsdscopymr.c
+++ b/usr.sbin/pnfsdscopymr/pnfsdscopymr.c
@@ -53,7 +53,7 @@ __FBSDID("$FreeBSD$");
 #include <fs/nfs/nfs.h>
 #include <fs/nfs/nfsrvstate.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static struct option longopts[] = {
 	{ "migrate",	required_argument,	NULL,	'm'	},

--- a/usr.sbin/pnfsdsfile/pnfsdsfile.c
+++ b/usr.sbin/pnfsdsfile/pnfsdsfile.c
@@ -46,7 +46,7 @@ __FBSDID("$FreeBSD$");
 #include <fs/nfs/nfs.h>
 #include <fs/nfs/nfsrvstate.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static struct option longopts[] = {
 	{ "changeds",	required_argument,	NULL,	'c'	},

--- a/usr.sbin/pnfsdskill/pnfsdskill.c
+++ b/usr.sbin/pnfsdskill/pnfsdskill.c
@@ -43,7 +43,7 @@ __FBSDID("$FreeBSD$");
 #include <fs/nfs/nfskpiport.h>
 #include <fs/nfs/nfs.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 static struct option longopts[] = {
 	{ "force",	no_argument,	NULL,	'f'	},

--- a/usr.sbin/quotaon/quotaon.c
+++ b/usr.sbin/quotaon/quotaon.c
@@ -70,7 +70,7 @@ static int	vflag;		/* verbose */
 
 static int oneof(char *, char *[], int);
 static int quotaonoff(struct fstab *fs, int, int);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char **argv)

--- a/usr.sbin/repquota/repquota.c
+++ b/usr.sbin/repquota/repquota.c
@@ -104,7 +104,7 @@ int oneof(char *, char *[], int);
 int repquota(struct fstab *, int);
 char *timeprt(time_t);
 static void prthumanval(int64_t bytes);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.sbin/rip6query/rip6query.c
+++ b/usr.sbin/rip6query/rip6query.c
@@ -62,7 +62,7 @@ static struct rip6	*ripbuf;
 #define	RIPSIZE(n)	(sizeof(struct rip6) + (n-1) * sizeof(struct netinfo6))
 
 int main(int, char **);
-static void usage(void);
+static void usage(void) __dead2;
 static const char *sa_n2a(struct sockaddr *);
 static const char *inet6_n2a(struct in6_addr *);
 
@@ -90,7 +90,6 @@ main(int argc, char *argv[])
 			break;
 		default:
 			usage();
-			exit(1);
 			/*NOTREACHED*/
 		}
 	}
@@ -99,7 +98,6 @@ main(int argc, char *argv[])
 
 	if (argc != 1) {
 		usage();
-		exit(1);
 	}
 
 	if ((s = socket(AF_INET6, SOCK_DGRAM, 0)) < 0) {
@@ -168,13 +166,14 @@ main(int argc, char *argv[])
 		}
 	} while (len == RIPSIZE(24));
 
-	exit(0);
+	return 0;
 }
 
 static void
 usage(void)
 {
 	fprintf(stderr, "usage: rip6query [-I iface] address\n");
+	exit(1);
 }
 
 /* getnameinfo() is preferred as we may be able to show ifindex as ifname */

--- a/usr.sbin/rtprio/rtprio.c
+++ b/usr.sbin/rtprio/rtprio.c
@@ -49,7 +49,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 
 static int parseint(const char *, const char *);
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.sbin/rwhod/rwhod.c
+++ b/usr.sbin/rwhod/rwhod.c
@@ -137,7 +137,7 @@ void	run_as(uid_t *uid, gid_t *gid);
 void	quit(const char *msg);
 void	sender_process(void);
 int	verify(char *name, int maxlen);
-static void usage(void);
+static void usage(void) __dead2;
 
 #ifdef DEBUG
 char	*interval(int time, char *updown);

--- a/usr.sbin/setfib/setfib.c
+++ b/usr.sbin/setfib/setfib.c
@@ -45,7 +45,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/socket.h>
 #include <sys/sysctl.h>
 
-static void usage(void);
+static void usage(void) __dead2;
 
 int
 main(int argc, char *argv[])

--- a/usr.sbin/spray/spray.c
+++ b/usr.sbin/spray/spray.c
@@ -47,7 +47,7 @@ static const char rcsid[] =
 #define SPRAYOVERHEAD	86
 #endif
 
-static void usage(void);
+static void usage(void) __dead2;
 static void print_xferstats(unsigned int, int, double);
 
 /* spray buffer */

--- a/usr.sbin/tcpdrop/tcpdrop.c
+++ b/usr.sbin/tcpdrop/tcpdrop.c
@@ -58,7 +58,7 @@ static bool tcpdropall(const char *, const char *, int);
 static bool tcpdropbyname(const char *, const char *, const char *,
     const char *);
 static bool tcpdropconn(const struct in_conninfo *);
-static void usage(void);
+static void usage(void) __dead2;
 
 /*
  * Drop a tcp connection.


### PR DESCRIPTION
In most cases, usage does not return, so mark them as __dead2. For the cases where they do return, they have not been marked __dead2. Yes, all cases were checked.