### PR TITLE
bug: efi_print_global only checks for the first 5 letters of "Driver"

### DIFF
--- a/stand/efi/libefi/env.c
+++ b/stand/efi/libefi/env.c
@@ -537,7 +537,7 @@ efi_print_global(const CHAR16 *varnamearg, uint8_t *data, UINTN datasz)
 		goto done;
 	}
 	if (strncmp("Boot", var, 4) == 0 ||
-	    strncmp("Driver", var, 5) == 0 ||
+	    strncmp("Driver", var, 6) == 0 ||
 	    strncmp("SysPrep", var, 7) == 0 ||
 	    strncmp("OsRecovery", var, 10) == 0) {
 		UINT16 filepathlistlen;


### PR DESCRIPTION
As a result, it is only really checking for the word Drive, making "Drive" appended to anything else considered for efi env.