### PR TITLE
Correct size parameter to strncmp

### DIFF
--- a/usr.sbin/mptutil/mpt_volume.c
+++ b/usr.sbin/mptutil/mpt_volume.c
@@ -246,9 +246,9 @@ volume_cache(int ac, char **av)
 	Settings = volume->VolumeSettings.Settings;
 
 	NewSettings = Settings;
-	if (strncmp(av[2], "enable", sizeof("enable")) == 0)
+	if (strncmp(av[2], "enable", strlen("enable")) == 0)
 		NewSettings |= 0x01;
-	if (strncmp(av[2], "disable", sizeof("disable")) == 0)
+	else if (strncmp(av[2], "disable", strlen("disable")) == 0)
 		NewSettings &= ~0x01;
 
 	if (NewSettings == Settings) {


### PR DESCRIPTION
Wrong value passed to strncmp means only enable and disable are accepted, when enabled and disabled are supposed to also be accepted.