### PR TITLE
tap(4): allow full-duplex and non-zero speed

### DIFF
--- a/sys/net/if_tuntap.c
+++ b/sys/net/if_tuntap.c
@@ -1341,7 +1341,7 @@ tunifioctl(struct ifnet *ifp, u_long cmd, caddr_t data)
 		dummy = ifmr->ifm_count;
 		ifmr->ifm_count = 1;
 		ifmr->ifm_status = IFM_AVALID;
-		ifmr->ifm_active = IFM_ETHER;
+		ifmr->ifm_active = IFM_ETHER | IFM_FDX | IFM_1000_T;
 		if (tp->tun_flags & TUN_OPEN)
 			ifmr->ifm_status |= IFM_ACTIVE;
 		ifmr->ifm_current = ifmr->ifm_active;


### PR DESCRIPTION
tap(4) devices advertise themselves as just 'ethernet autoselect', without duplex or speed capabilities.
This advertisement makes them unable to be aggregated into lacp-based lagg(4):
- lacp code requires underlying interfaces to be full-duplex, else interface will not participate in lacp at all
- lacp code requires underlying interface to have non-zero speed, else this interface can not be selected as active aggregator

PR#: 217374
Reported by: Alexandre Snarskii <snar@snar.spb.ru>
Co-authored-by: Mina Galić <freebsd@igalic.co>