### PR TITLE
ifconfig: skip calling fnmatch once the result no longer matters

### DIFF
--- a/sbin/ifconfig/ifconfig.c
+++ b/sbin/ifconfig/ifconfig.c
@@ -910,11 +910,11 @@ group_member(const char *ifname, const char *match, const char *nomatch)
 	matched = false;
 	nomatched = true;
 	for (ifg = ifgr.ifgr_groups; ifg && len >= sizeof(*ifg); ifg++) {
-		len -= sizeof(struct ifg_req);
-		if (match)
-			matched |= !fnmatch(match, ifg->ifgrq_group, 0);
-		if (nomatch)
-			nomatched &= fnmatch(nomatch, ifg->ifgrq_group, 0);
+		len -= sizeof(*ifg);
+		if (match && !matched)
+			matched = !fnmatch(match, ifg->ifgrq_group, 0);
+		if (nomatch && nomatched)
+			nomatched = fnmatch(nomatch, ifg->ifgrq_group, 0);
 	}
 	free(ifgr.ifgr_groups);
 


### PR DESCRIPTION
Because fnmatch has no side effects, we can safely avoid calling fnmatch if the end result does not matter anyway (the compiler cannot see this, so it calls fnmatch in the event it has side-effects).