### PR TITLE
add missing comments

### DIFF
--- a/stand/efi/loader/arch/amd64/elf64_freebsd.c
+++ b/stand/efi/loader/arch/amd64/elf64_freebsd.c
@@ -169,7 +169,7 @@ elf64_exec(struct preloaded_file *fp)
 	trampoline = (void *)trampcode;
 
 	if (copy_staging == COPY_STAGING_ENABLE) {
-		PT4 = (pml4_entry_t *)0x0000000040000000;
+		PT4 = (pml4_entry_t *)0x0000000040000000; /* 1G */
 		err = BS->AllocatePages(AllocateMaxAddress, EfiLoaderData, 3,
 		    (EFI_PHYSICAL_ADDRESS *)&PT4);
 		if (EFI_ERROR(err)) {

--- a/stand/kboot/arch/amd64/elf64_freebsd.c
+++ b/stand/kboot/arch/amd64/elf64_freebsd.c
@@ -238,7 +238,7 @@ elf64_exec(struct preloaded_file *fp)
 
 #ifdef EFI
 	if (copy_staging == COPY_STAGING_ENABLE) {
-		PT4 = (pml4_entry_t *)0x0000000040000000;
+		PT4 = (pml4_entry_t *)0x0000000040000000; /* 1G */
 		err = BS->AllocatePages(AllocateMaxAddress, EfiLoaderData, 3,
 		    (EFI_PHYSICAL_ADDRESS *)&PT4);
 		if (EFI_ERROR(err)) {


### PR DESCRIPTION
`PT4 = (pml4_entry_t *)0x0000000100000000;` is followed by `/* 4G */`.
Add a corresponding comment after `PT4 = (pml4_entry_t *)0x0000000040000000;`