### PR TITLE
dumpon: Request the OpenSSL 1.1 API

### DIFF
--- a/sbin/dumpon/Makefile
+++ b/sbin/dumpon/Makefile
@@ -8,6 +8,7 @@ PROG=	dumpon
 .if ${MK_OPENSSL} != "no"
 LIBADD=	crypto
 CFLAGS+=-DHAVE_CRYPTO
+CFLAGS+=-DOPENSSL_API_COMPAT=0x10100000L
 .endif
 
 MAN=	dumpon.8

--- a/sbin/dumpon/dumpon.c
+++ b/sbin/dumpon/dumpon.c
@@ -565,8 +565,10 @@ main(int argc, char *argv[])
 #ifdef HAVE_CRYPTO
 	if (cipher != KERNELDUMP_ENC_NONE && pubkeyfile == NULL) {
 		errx(EX_USAGE, "-C option requires a public key file.");
+# if OPENSSL_API_COMPAT < 0x10100000L
 	} else if (pubkeyfile != NULL) {
 		ERR_load_crypto_strings();
+# endif
 	}
 #else
 	if (pubkeyfile != NULL)


### PR DESCRIPTION
OPENSSL_API_COMPAT can be used to specify the OpenSSL API version in use for the purpose of hiding deprecated interfaces and enabling the appropriate deprecation notices.

This change is a NFC while we're still using OpenSSL 1.1.1 but will avoid deprecation warnings upon the switch to OpenSSL 3.0.

A future update may migrate to use the OpenSSL 3.0 APIs.

PR:		271615
Sponsored by:	The FreeBSD Foundation