### PR TITLE
unbound: Request the OpenSSL 1.1 API

### DIFF
--- a/contrib/unbound/daemon/daemon.c
+++ b/contrib/unbound/daemon/daemon.c
@@ -914,11 +914,15 @@ daemon_delete(struct daemon* daemon)
 #    endif
 #  endif
 #  ifdef HAVE_OPENSSL_CONFIG
+#   ifdef HAVE_EVP_CLEANUP
 	EVP_cleanup();
+#   endif
 #  if (OPENSSL_VERSION_NUMBER < 0x10100000) && !defined(OPENSSL_NO_ENGINE) && defined(HAVE_ENGINE_CLEANUP)
 	ENGINE_cleanup();
 #  endif
+#  if OPENSSL_API_COMPAT < 0x10100000L
 	CONF_modules_free();
+#  endif
 #  endif
 #  ifdef HAVE_CRYPTO_CLEANUP_ALL_EX_DATA
 	CRYPTO_cleanup_all_ex_data(); /* safe, no more threads right now */

--- a/usr.sbin/unbound/anchor/Makefile
+++ b/usr.sbin/unbound/anchor/Makefile
@@ -11,6 +11,7 @@ PROG=	local-unbound-anchor
 SRCS=	unbound-anchor.c
 CFLAGS+=	-I${UNBOUNDDIR} -I${LDNSDIR} -I${EXPATDIR}/lib
 CFLAGS+=	-I${.CURDIR:H} -I${.CURDIR}
+CFLAGS+=	-DOPENSSL_API_COMPAT=0x10100000L
 LIBADD=	unbound bsdxml ssl crypto pthread
 MAN=	local-unbound-anchor.8
 

--- a/usr.sbin/unbound/control/Makefile
+++ b/usr.sbin/unbound/control/Makefile
@@ -10,6 +10,7 @@ PROG=	local-unbound-control
 SRCS=	ub_event.c unbound-control.c worker_cb.c
 CFLAGS+=	-I${UNBOUNDDIR} -I${LDNSDIR}
 CFLAGS+=	-I${.CURDIR:H} -I${.CURDIR}
+CFLAGS+=	-DOPENSSL_API_COMPAT=0x10100000L
 LIBADD=	unbound crypto ssl pthread
 MAN=	local-unbound-control.8
 

--- a/usr.sbin/unbound/daemon/Makefile
+++ b/usr.sbin/unbound/daemon/Makefile
@@ -11,6 +11,7 @@ SRCS=	acl_list.c cachedump.c daemon.c remote.c shm_main.c stats.c \
 	ub_event.c unbound.c worker.c
 CFLAGS+=	-I${UNBOUNDDIR} -I${LDNSDIR}
 CFLAGS+=	-I${.CURDIR:H} -I${.CURDIR}
+CFLAGS+=	-DOPENSSL_API_COMPAT=0x10100000L
 LIBADD=	unbound util ssl crypto pthread
 MAN=	local-unbound.8 local-unbound.conf.5
 


### PR DESCRIPTION
OPENSSL_API_COMPAT can be used to specify the OpenSSL API version in use for the purpose of hiding deprecated interfaces and enabling the appropriate deprecation notices.

This change is a NFC while we're still using OpenSSL 1.1.1 but will avoid deprecation warnings upon the switch to OpenSSL 3.0.

A future update may migrate to use the OpenSSL 3.0 APIs.

PR:		271615
Sponsored by:	The FreeBSD Foundation