### PR TITLE
stand/lua: per-product conf if requested via product_vars

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -27,6 +27,27 @@ NOTE TO PEOPLE WHO THINK THAT FreeBSD 15.x IS SLOW:
 	world, or to merely disable the most expensive debugging functionality
 	at runtime, run "ln -s 'abort:false,junk:false' /etc/malloc.conf".)
 
+20240118:
+	Loader now also read configuration files listed in local_loader_conf_files.
+	Files listed here are the last ones read. And /boot/loader.conf.local was
+	moved from loader_conf_files to local_loader_conf_files leaving only
+	loader.conf and device.hints in loader_conf_files by default.
+
+	The following sequencing is applied:
+
+	1. Bootstrap:
+	    /boot/defaults/loader.conf
+
+	2. Read loader_conf_files files:
+	    /boot/device.hints
+	    /boot/loader.conf
+
+	3. Read loader_conf_dirs files:
+	    /boot/loader.conf.d/*.conf
+
+	4. And finally, rread local_loader_conf_files files:
+	    /boot/loader.conf.local
+
 20231120:
 	If you have an arm64 system that uses ACPI, you will need to update your
 	loader.efi in the ESP when you update past this point.  Detection of ACPI

--- a/stand/defaults/loader.conf
+++ b/stand/defaults/loader.conf
@@ -13,8 +13,9 @@ exec="echo Loading /boot/defaults/loader.conf"
 kernel="kernel"		# /boot sub-directory containing kernel and modules
 bootfile="kernel"	# Kernel name (possibly absolute path)
 kernel_options=""	# Flags to be passed to the kernel
-loader_conf_files="/boot/device.hints /boot/loader.conf /boot/loader.conf.local"
+loader_conf_files="/boot/device.hints /boot/loader.conf"
 loader_conf_dirs="/boot/loader.conf.d"
+local_loader_conf_files="/boot/loader.conf.local"
 nextboot_conf="/boot/nextboot.conf"
 verbose_loading="NO"		# Set to YES for verbose loader output
 

--- a/stand/defaults/loader.conf.5
+++ b/stand/defaults/loader.conf.5
@@ -21,7 +21,7 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.Dd January 9, 2024
+.Dd January 18, 2024
 .Dt LOADER.CONF 5
 .Os
 .Sh NAME
@@ -131,6 +131,10 @@ Space separated list of directories to process for configuration files.
 The lua-based loader will process files with a
 .Dq .conf
 suffix that are placed in these directories.
+Files found here are processed after the ones listed in
+.Va loader_conf_files
+but before the ones found in
+.Va local_loader_conf_files .
 .It Ar loader_conf_files
 Defines additional configuration files to be processed right after the
 present file.
@@ -138,6 +142,13 @@ present file.
 should be treated as write-only.
 One cannot depend on any value remaining in the loader environment or carried
 over into the kernel environment.
+.It Ar local_loader_conf_files
+Space separated list of additional configuration files to be processed at last,
+i.e., after
+.Va loader_conf_files
+and
+.Va loader_conf_dirs
+are processed.
 .It Ar product_vars
 When set, must be a space separated list of environment variable names to walk
 through to guess product information.
@@ -274,6 +285,14 @@ default settings can be ignored.
 The few of them which are important
 or useful are:
 .Bl -tag -width bootfile -offset indent
+.It Va local_loader_conf_files
+.Pq Dq /boot/loader.conf.local
+Ensure
+.Va loader.conf.local
+can always be used to override settings from files found in
+.Va loader_conf_files
+and
+.Va loader_conf_dirs .
 .It Va bitmap_load
 .Pq Dq NO
 If set to
@@ -454,13 +473,18 @@ It is not available in the default Forth-based loader.
 .Sh FILES
 .Bl -tag -width /boot/defaults/loader.conf -compact
 .It Pa /boot/defaults/loader.conf
-default settings \(em do not change this file.
+Default settings \(em do not change this file.
 .It Pa /boot/loader.conf
-user defined settings.
+User defined settings.
 .It Pa /boot/loader.conf.lua
-user defined settings written in lua.
+User defined settings written in lua.
+.It Pa /boot/loader.conf.d/*.conf
+User defined settings split in separate files.
+.It Pa /boot/loader.conf.d/*.lua
+User defined settings written in lua and split in separate files.
 .It Pa /boot/loader.conf.local
-machine-specific settings for sites with a common loader.conf.
+Machine-specific settings for sites with a common loader.conf. Allow to override
+settings defined in other files.
 .El
 .Sh SEE ALSO
 .Xr loader.conf.lua 5 ,

--- a/stand/defaults/loader.conf.5
+++ b/stand/defaults/loader.conf.5
@@ -21,7 +21,7 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.Dd July 31, 2021
+.Dd January 9, 2024
 .Dt LOADER.CONF 5
 .Os
 .Sh NAME
@@ -138,6 +138,38 @@ present file.
 should be treated as write-only.
 One cannot depend on any value remaining in the loader environment or carried
 over into the kernel environment.
+.It Ar product_vars
+When set, must be a space separated list of environment variable names to walk
+through to guess product information.
+The order matters as reading a config file override the previously defined
+values.
+Undefined variables are silently ignored.
+.Pp
+When product information can be guessed, for each product information found,
+append
+.Pa /boot/loader.conf.d/PRODUCT
+to
+.Ar loader_conf_dirs .
+It can be typically used as follow:
+.Bd -literal
+smbios.system.planar.maker="PLANAR_MAKER"
+smbios.system.planar.product="PLANAR_PRODUCT"
+smbios.system.product="PRODUCT"
+uboot.m_product="M_PRODUCT"
+product_vars="smbios.system.planar.maker smbios.system.planar.product smbios.system.product uboot.m_product"
+.Ed
+.Pp
+to read files found in the following directories, in that order:
+.Bl -bullet -compact
+.It
+.Pa /boot/loader.conf.d/PLANAR_MAKER
+.It
+.Pa /boot/loader.conf.d/PLANAR_PRODUCT
+.It
+.Pa /boot/loader.conf.d/PRODUCT
+.It
+.Pa /boot/loader.conf.d/M_PRODUCT
+.El
 .It Ar kernel
 Name of the kernel to be loaded.
 If no kernel name is set, no additional

--- a/stand/lua/config.lua
+++ b/stand/lua/config.lua
@@ -630,8 +630,7 @@ function config.readConf(file, loaded_files)
 		return
 	end
 
-	-- We'll process loader_conf_dirs at the top-level readConf
-	local load_conf_dirs = next(loaded_files) == nil
+	local top_level = next(loaded_files) == nil -- Are we the top-level readConf?
 	print("Loading " .. file)
 
 	-- The final value of loader_conf_files is not important, so just
@@ -656,7 +655,7 @@ function config.readConf(file, loaded_files)
 		end
 	end
 
-	if load_conf_dirs then
+	if top_level then
 		local loader_conf_dirs = getEnv("loader_conf_dirs")
 
 		-- If product_vars is set, it must be a list of environment variable names
@@ -682,6 +681,7 @@ function config.readConf(file, loaded_files)
 			end
 		end
 
+		-- Process "loader_conf_dirs" extra-directories
 		if loader_conf_dirs ~= nil then
 			for name in loader_conf_dirs:gmatch("[%w%p]+") do
 				if lfs.attributes(name, "mode") ~= "directory" then
@@ -698,6 +698,15 @@ function config.readConf(file, loaded_files)
 					end
 				end
 				::nextdir::
+			end
+		end
+
+		-- Always allow overriding with local config files, e.g.,
+		-- /boot/loader.conf.local.
+		local local_loader_conf_files = getEnv("local_loader_conf_files")
+		if local_loader_conf_files then
+			for name in local_loader_conf_files:gmatch("[%w%p]+") do
+				config.readConf(name, loaded_files)
 			end
 		end
 	end

--- a/stand/lua/config.lua.8
+++ b/stand/lua/config.lua.8
@@ -64,9 +64,13 @@ as a configuration file
 .Po e.g., as
 .Pa loader.conf
 .Pc
-and then processing files listed in
+and then process files listed in the
 .Ev loader_conf_files
-variable
+variable. Additionnaly, the top-level call to readConf will process files listed in the 
+.Ev loader_conf_dirs
+and
+.Ev local_loader_conf_files
+variables
 .Po see
 .Xr loader.conf 5
 .Pc .


### PR DESCRIPTION
This patch allow for picking loader configuration files according to the product (in the sense of `smbios.system.product`).

If `product_vars` is set, it must be a space separated list of environment variable names to walk through to guess the product. And if a product can be guessed, prepend:
- `/boot/PRODUCT.conf` to `loader_conf_files`
- and `/boot/loader.conf.d/PRODUCT` to `loader_conf_dirs`

I made `product_vars` a list to let have a single value suitable for a range of different products. 

For example, you can use it with `smbios.system.product uboot.m_product`  if you have U-Boot exposing the product this way. 

I plan to propose applying this idea to pick DTB on ARM platforms too.