### PR TITLE
hier(7): improvement, modernisation

### DIFF
--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -182,10 +182,15 @@ statically-linked programs for emergency recovery; see
 .It Pa /root/
 home directory of the root user
 .It Pa /sbin/
-system programs and administration utilities
-fundamental to both single-user and multi-user environments
+system programs and administration utilities that are fundamental to
+single-user and multi-user modes
 .It Pa /tmp/
-temporary files that are not guaranteed to persist across system reboots
+temporary files that may be removed by
+.Xr rc 8 ;
+see the
+.It Va clear_tmp_enable
+variable of
+.Xr rc.conf 5
 .It Pa /usr/
 contains the majority of user utilities and applications
 .Pp
@@ -590,7 +595,8 @@ line printer spooling directories
 .El
 .Pp
 .It Pa tmp/
-temporary files that are not removed during boot
+temporary files that are not removed by
+.Xr rc 8
 .Pp
 .Bl -tag -width "vi.recover/" -compact
 .It Pa vi.recover/

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -414,7 +414,7 @@ console screen maps
 .Pp
 .It Pa sysroot/
 files necessary for the -sysroot compiler/linker argument to build non-native
-binaries.
+binaries
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa VERSION/

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -28,7 +28,7 @@
 .\"	@(#)hier.7	8.1 (Berkeley) 6/5/93
 .\" $FreeBSD$
 .\"
-.Dd June 7, 2023
+.Dd June 10, 2023
 .Dt HIER 7
 .Os
 .Sh NAME

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -72,7 +72,7 @@ and
 .Xr dtc 1
 .It Pa zfs/
 .Xr zfs 8
-zpool cache files
+pool cache files
 .El
 .It Pa /compat/
 normally a link to

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -60,8 +60,8 @@ mount point for the EFI System Partition (ESP) on UEFI systems
 loadable kernel modules containing binary firmware for hardware that needs
 firmware downloaded to it to function
 .It Pa kernel/
-pure kernel executable (the operating system loaded into memory
-at boot time) and kernel modules
+pure kernel executable (the operating system loaded into memory at boot time)
+and kernel modules
 .It Pa modules/
 third-party loadable kernel modules, such as the ones installed from
 .Xr ports 7
@@ -86,8 +86,7 @@ device special files managed by
 .Pp
 .Bl -tag -width "nvmecontrol/" -compact
 .It Pa fd/
-file descriptor files;
-see
+file descriptor files; see
 .Xr fd 4
 .El
 .It Pa /etc/
@@ -97,42 +96,34 @@ system configuration files and scripts
 .It Pa bluetooth/
 bluetooth configuration files
 .It Pa defaults/
-default system configuration files;
-see
+default system configuration files; see
 .Xr rc 8
 .It Pa localtime
-local timezone information;
-see
+local timezone information; see
 .Xr ctime 3
 .It Pa mail/
 sendmail control files
 .It Pa mtree/
-mtree configuration files;
-see
+mtree configuration files; see
 .Xr mtree 8
 .It Pa pam.d/
-configuration files for the Pluggable Authentication Modules (PAM)
-library
+configuration files for the Pluggable Authentication Modules (PAM) library
 .It Pa periodic/
 scripts that are run daily, weekly, and monthly, via
 .Xr cron 8 ;
 see
 .Xr periodic 8
 .It Pa ppp/
-ppp configuration files;
-see
+ppp configuration files; see
 .Xr ppp 8
 .It Pa rc.d/
-system and daemon startup/control scripts;
-see
+system and daemon startup/control scripts; see
 .Xr rc 8
 .It Pa security/
-OpenBSM audit configuration files;
-see
+OpenBSM audit configuration files; see
 .Xr audit 8
 .It Pa ssh/
-OpenSSH configuration files;
-see
+OpenSSH configuration files; see
 .Xr ssh 1
 .It Pa ssl/
 OpenSSL configuration files
@@ -169,29 +160,23 @@ critical system utilities needed for binaries in
 and
 .Pa /sbin
 .It Pa /media/
-contains subdirectories to be used as mount points
-for removable media such as USB drives, CDs and DVDs
+contains subdirectories to be used as mount points for removable media such as
+USB drives, CDs and DVDs
 .It Pa /mnt/
 empty directory commonly used by
 system administrators as a temporary mount point
 .It Pa /net/
-automounted NFS shares;
-see
+automounted NFS shares; see
 .Xr auto_master 5
 .It Pa /nonexistent/
-a non-existent directory;
-by convention, it serves as a home directory
-for special user accounts
-that need no home directory;
-see also
+a non-existent directory; by convention, it serves as a home directory for
+special user accounts that need no home directory; see also
 .Pa /var/empty/
 .It Pa /proc/
-process file system;
-see
+process file system; see
 .Xr procfs 5
 .It Pa /rescue/
-statically linked programs for emergency recovery;
-see
+statically linked programs for emergency recovery; see
 .Xr rescue 8
 .It Pa /root/
 root's HOME directory
@@ -207,13 +192,11 @@ contains the majority of user utilities and applications
 .It Pa bin/
 common utilities, programming tools, and applications
 .It Pa compat/
-files needed to support binary compatibility with other operating systems;
-see
+files needed to support binary compatibility with other operating systems; see
 .Xr linux 4
 .It Pa freebsd-dist/
 distribution files
-.Pq like base.txz ;
-see
+.Pq like base.txz ; see
 .Xr release 7
 and
 .Xr bsdinstall 8
@@ -243,13 +226,12 @@ miscellaneous utility data files
 .It Pa gcc/
 GCC configuration data
 .It Pa ldscripts/
-linker scripts;
-see
+linker scripts; see
 .Xr ld 1
 .It Pa pkgconfig/
 .Xr pc 5 Pq Pa ports/devel/pkgconf
-files: collections of compiler flags, linker flags, and other
-information relevant to library use
+files: collections of compiler flags, linker flags, and other information
+relevant to library use
 .El
 .Pp
 .It Pa libexec/
@@ -261,14 +243,12 @@ utilities to manipulate a.out executables
 .It Pa elf/
 utilities to manipulate ELF executables
 .It Pa lpr/
-utilities and filters for LP print system;
-see
+utilities and filters for LP print system; see
 .Xr lpr 1
 .It Pa sendmail/
 the
 .Xr sendmail 8
-binary;
-see
+binary; see
 .Xr mailwrapper 8
 .It Pa sm.bin/
 restricted shell for
@@ -289,8 +269,7 @@ the general layout sketched out by
 for
 .Pa /usr
 should be used.
-Exceptions are the
-ports documentation
+Exceptions are the ports documentation
 .Po in
 .Pa share/doc/<port>/ Ns Pc ,
 and
@@ -300,8 +279,7 @@ and
 .It Pa obj/
 architecture-specific target tree produced by building
 .Fx
-from source;
-see
+from source; see
 .Xr build 7
 .It Pa ports/
 .Fx
@@ -314,8 +292,7 @@ architecture-independent files
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa calendar/
-a variety of pre-fab calendar files;
-see
+a variety of pre-fab calendar files; see
 .Xr calendar 1
 .It Pa dict/
 word lists; see
@@ -349,8 +326,7 @@ and
 .El
 .Pp
 .It Pa locale/
-localization files;
-see
+localization files; see
 .Xr setlocale 3
 .It Pa man/
 manual pages
@@ -361,14 +337,12 @@ miscellaneous system-wide files
 .It Pa fonts/
 ???
 .It Pa termcap
-terminal characteristics database;
-see
+terminal characteristics database; see
 .Xr termcap 5
 .El
 .Pp
 .It Pa mk/
-templates for make;
-see
+templates for make; see
 .Xr make 1
 .It Pa nls/
 national language support files
@@ -442,8 +416,7 @@ matches
 .El
 .Pp
 .It Pa tabset/
-tab description files for a variety of terminals; used in
-the termcap file;
+tab description files for a variety of terminals; used in the termcap file;
 see
 .Xr termcap 5
 .It Pa vi/
@@ -455,8 +428,7 @@ files used by vt; see
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa fonts/
-console fonts;
-see
+console fonts; see
 .Xr vidcontrol 1
 and
 .Xr vidfont 1
@@ -497,14 +469,12 @@ system accounting files
 .Pp
 .Bl -tag -width "freebsd-update/" -compact
 .It Pa acct
-execution accounting file;
-see
+execution accounting file; see
 .Xr acct 5
 .El
 .Pp
 .It Pa at/
-timed command scheduling files;
-see
+timed command scheduling files; see
 .Xr at 1
 .Pp
 .Bl -tag -width Fl -compact
@@ -531,14 +501,12 @@ default directory to store kernel crash dumps; see
 and
 .Xr savecore 8
 .It Pa cron/
-files used by cron;
-see
+files used by cron; see
 .Xr cron 8
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa tabs/
-crontab files;
-see
+crontab files; see
 .Xr crontab 5
 .El
 .Pp
@@ -565,20 +533,17 @@ miscellaneous system log files
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa utx.lastlogin
-last login log;
-see
+last login log; see
 .Xr getutxent 3
 .It Pa utx.log
-login/logout log;
-see
+login/logout log; see
 .Xr getutxent 3
 .El
 .Pp
 .It Pa mail/
 user mailbox files
 .It Pa msgs/
-system messages database;
-see
+system messages database; see
 .Xr msgs 1
 .It Pa preserve/
 temporary storage for files following a crash of an editor; see
@@ -600,14 +565,12 @@ writable by the
 group for command connection sockets; see
 .Xr ppp 8
 .It Pa utx.active
-database of current users;
-see
+database of current users; see
 .Xr getutxent 3
 .El
 .Pp
 .It Pa rwho/
-rwho data files;
-see
+rwho data files; see
 .Xr rwhod 8 ,
 .Xr rwho 1 ,
 and
@@ -617,16 +580,13 @@ miscellaneous printer and mail system spooling directories
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa clientmqueue/
-undelivered submission mail queue;
-see
+undelivered submission mail queue; see
 .Xr sendmail 8
 .It Pa ftp/
-ftp root directory;
-see
+ftp root directory; see
 .Xr ftpd 8
 .It Pa mqueue/
-undelivered mail queue;
-see
+undelivered mail queue; see
 .Xr sendmail 8
 .It Pa output/
 line printer spooling directories
@@ -649,9 +609,8 @@ the NIS maps; see
 .Sh NOTES
 This manual page documents the default
 .Fx
-file system layout, but
-the actual hierarchy on a given system is defined at the system
-administrator's discretion.
+file system layout, but the actual hierarchy on a given system is defined at
+the system administrator's discretion.
 A well-maintained installation will include a customized version of
 this document.
 .Sh SEE ALSO

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -584,7 +584,7 @@ see
 temporary home of files preserved after an accidental death
 of an editor;
 see
-.Xr ex 1
+.Xr vi 1
 .It Pa quotas/
 file system quota information files
 .It Pa run/

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -334,8 +334,6 @@ manual pages
 miscellaneous system-wide files
 .Pp
 .Bl -tag -width Fl -compact
-.It Pa fonts/
-???
 .It Pa termcap
 terminal characteristics database; see
 .Xr termcap 5

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -464,7 +464,7 @@ multi-purpose log, temporary, transient, and spool files
 .It Pa account/
 system accounting files
 .Pp
-.Bl -tag -width "freebsd-update/" -compact
+.Bl -tag -width Fl -compact
 .It Pa acct
 execution accounting file; see
 .Xr acct 5
@@ -510,7 +510,7 @@ crontab files; see
 .It Pa db/
 miscellaneous automatically generated system-specific database files
 .Pp
-.Bl -tag -width Fl -compact
+.Bl -tag -width "freebsd-update/" -compact
 .It Pa freebsd-update/
 .Xr freebsd-update 8
 work directory for temporary files and downloaded updates
@@ -529,7 +529,7 @@ Kerberos server databases; see
 .It Pa log/
 miscellaneous system log files
 .Pp
-.Bl -tag -width Fl -compact
+.Bl -tag -width "utx.lastlogin" -compact
 .It Pa utx.lastlogin
 last login log; see
 .Xr getutxent 3
@@ -576,7 +576,7 @@ and
 .It Pa spool/
 miscellaneous printer and mail system spooling directories
 .Pp
-.Bl -tag -width Fl -compact
+.Bl -tag -width "clientmqueue/" -compact
 .It Pa clientmqueue/
 undelivered submission mail queue; see
 .Xr sendmail 8
@@ -593,7 +593,7 @@ line printer spooling directories
 .It Pa tmp/
 temporary files that are kept between system reboots
 .Pp
-.Bl -tag -width Fl -compact
+.Bl -tag -width "vi.recover/" -compact
 .It Pa vi.recover/
 .Xr vi 1
 recovery files

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -28,7 +28,7 @@
 .\"	@(#)hier.7	8.1 (Berkeley) 6/5/93
 .\" $FreeBSD$
 .\"
-.Dd May 30, 2023
+.Dd June 05, 2023
 .Dt HIER 7
 .Os
 .Sh NAME

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -291,7 +291,7 @@ architecture-independent files
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa calendar/
-a variety of pre-fab calendar files; see
+system-wide calendar files; see
 .Xr calendar 1
 .It Pa dict/
 word lists; see

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -549,8 +549,7 @@ user mailbox files
 system messages database; see
 .Xr msgs 1
 .It Pa preserve/
-temporary storage for files following a crash of an editor; see
-.Xr vi 1
+unused, present for historical reasons
 .It Pa quotas/
 file system quota information files
 .It Pa run/

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -35,19 +35,19 @@
 .Nm hier
 .Nd layout of file systems
 .Sh SYNOPSIS
-A sketch of the file system hierarchy.
+An overview of the file system hierarchy.
 .Sh DESCRIPTION
 .Bl -tag -width "/libexec/"
 .It Pa /
-root directory of the file system
+root directory
 .It Pa /bin/
-user utilities fundamental to both single-user and multi-user environments
+user utilities that are fundamental to single-user and multi-user modes
 .It Pa /boot/
-programs and configuration files used during operating system bootstrap
+programs and configuration files used during bootstrap of the operating system
 .Pp
 .Bl -tag -width "nvmecontrol/" -compact
 .It Pa defaults/
-default bootstrapping configuration files; see
+default bootstrap configuration files; see
 .Xr loader.conf 5
 .It Pa dtb/
 compiled flattened device tree (FDT) files; see
@@ -57,13 +57,13 @@ and
 .It Pa efi/
 mount point for the EFI System Partition (ESP) on UEFI systems
 .It Pa firmware/
-loadable kernel modules containing binary firmware for hardware that needs
-firmware downloaded to it to function
+loadable kernel modules containing binary firmware, for hardware to which
+firmware must be downloaded
 .It Pa kernel/
 pure kernel executable (the operating system loaded into memory at boot time)
 and kernel modules
 .It Pa modules/
-third-party loadable kernel modules, such as the ones installed from
+third-party loadable kernel modules, such as those associated with
 .Xr ports 7
 .It Pa overlays/
 compiled flattened device tree (FDT) overlays; see
@@ -81,7 +81,7 @@ If not, then the
 .Pa /usr/compat
 comments apply
 .It Pa /dev/
-device special files managed by
+the normal mount point for
 .Xr devfs 5
 .Pp
 .Bl -tag -width "nvmecontrol/" -compact
@@ -102,14 +102,16 @@ default system configuration files; see
 local timezone information; see
 .Xr ctime 3
 .It Pa mail/
-sendmail control files
+.Xr sendmail 8
+control files
 .It Pa mtree/
-mtree configuration files; see
 .Xr mtree 8
+configuration files
 .It Pa pam.d/
-configuration files for the Pluggable Authentication Modules (PAM) library
+configuration files for the Pluggable Authentication Modules (PAM) library; see
+.Xr pam 3
 .It Pa periodic/
-scripts that are run daily, weekly, and monthly, via
+scripts that are run daily, weekly, or monthly by
 .Xr cron 8 ;
 see
 .Xr periodic 8
@@ -129,13 +131,12 @@ OpenSSH configuration files; see
 OpenSSL configuration files
 .El
 .It Pa /home/
-users' HOME directories;
-the layout is not standardized, but a typical interactive user
+users' home directories; whilst the layout is not standardized, the typical home for an interactive user
 .Dv beastie
-might receive their own directory
-.Pa /home/beastie
+would be
+.Pa /home/beastie/
 .It Pa /lib/
-critical system libraries needed for binaries in
+system libraries that are critial to binaries in
 .Pa /bin
 and
 .Pa /sbin
@@ -155,12 +156,12 @@ vendor-specific libraries to extend the
 utility
 .El
 .It Pa /libexec/
-critical system utilities needed for binaries in
+system utilities that are critial to binaries in
 .Pa /bin
 and
 .Pa /sbin
 .It Pa /media/
-contains subdirectories to be used as mount points for removable media such as
+contains subdirectories that are mount points for removable media such as
 USB drives, CDs and DVDs
 .It Pa /mnt/
 empty directory commonly used by system administrators as a temporary mount
@@ -169,17 +170,17 @@ point
 automounted NFS shares; see
 .Xr auto_master 5
 .It Pa /nonexistent/
-a non-existent directory; by convention, it serves as a home directory for
-special user accounts that need no home directory; see also
+a non-existent directory; conventionally, a home directory for special user
+accounts that do not require a home directory.  See also
 .Pa /var/empty/
 .It Pa /proc/
 process file system; see
 .Xr procfs 5
 .It Pa /rescue/
-statically linked programs for emergency recovery; see
+statically-linked programs for emergency recovery; see
 .Xr rescue 8
 .It Pa /root/
-root's HOME directory
+home directory of the root user
 .It Pa /sbin/
 system programs and administration utilities
 fundamental to both single-user and multi-user environments
@@ -229,12 +230,12 @@ linker scripts; see
 .Xr ld 1
 .It Pa pkgconfig/
 .Xr pc 5 Pq Pa ports/devel/pkgconf
-files: collections of compiler flags, linker flags, and other information
+files; collections of compiler flags, linker flags, and other information
 relevant to library use
 .El
 .Pp
 .It Pa libexec/
-system daemons & system utilities (executed by other programs)
+system daemons and system utilities that are executed by other programs
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa aout/
@@ -285,7 +286,7 @@ from source; see
 ports collection; see
 .Xr ports 7
 .It Pa sbin/
-system daemons & system utilities (executed by users)
+system daemons and system utilities that are executed by users
 .It Pa share/
 architecture-independent files
 .Pp
@@ -312,7 +313,7 @@ various examples for users and programmers
 .It Pa firmware/
 firmware images loaded by userland programs
 .It Pa games/
-ASCII text files used by various games
+used by various games
 .It Pa keys/
 known trusted and revoked keys
 .Pp
@@ -365,8 +366,8 @@ MIB files
 .El
 .Pp
 .It Pa syscons/
-files used by syscons; see
 .Xr syscons 4
+files
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa fonts/
@@ -420,8 +421,8 @@ see
 localization support and utilities for
 .Xr vi 1
 .It Pa vt/
-files used by vt; see
 .Xr vt 4
+files
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa fonts/
@@ -458,7 +459,7 @@ test suite; see
 .Xr tests 7
 .El
 .It Pa /var/
-multi-purpose log, temporary, transient, and spool files
+log, temporary, transient, and spool files
 .Pp
 .Bl -tag -width "preserve/" -compact
 .It Pa account/
@@ -476,15 +477,15 @@ timed command scheduling files; see
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa jobs/
-directory containing job files
+job files
 .It Pa spool/
-directory containing output spool files
+output spool files
 .El
 .Pp
 .It Pa backups/
 miscellaneous backup files
 .It Pa cache/
-miscellaneous cached files
+miscellaneous cache files
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa pkg/
@@ -493,34 +494,33 @@ cached packages for
 .El
 .Pp
 .It Pa crash/
-default directory to store kernel crash dumps; see
+default directory for kernel crash dumps; see
 .Xr crash 8
 and
 .Xr savecore 8
 .It Pa cron/
-files used by cron; see
 .Xr cron 8
+files
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa tabs/
-crontab files; see
 .Xr crontab 5
+files
 .El
 .Pp
 .It Pa db/
-miscellaneous automatically generated system-specific database files
+miscellaneous automatically-generated system-specific database files
 .Pp
 .Bl -tag -width "freebsd-update/" -compact
 .It Pa freebsd-update/
+temporary files and downloads for
 .Xr freebsd-update 8
-work directory for temporary files and downloaded updates
 .El
 .Pp
 .It Pa empty/
-empty directory for use by programs that need a specifically empty directory.
-Used for instance by
+for use by programs that require an empty directory.
+Uses include privilege separation by
 .Xr sshd 8
-for privilege separation
 .It Pa games/
 miscellaneous game status and score files
 .It Pa heimdal/
@@ -549,8 +549,7 @@ temporary storage for files following a crash of an editor; see
 .It Pa quotas/
 file system quota information files
 .It Pa run/
-system information files describing various info about
-system since it was booted
+files containing information about the operating system since it was booted
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa bhyve/
@@ -591,7 +590,7 @@ line printer spooling directories
 .El
 .Pp
 .It Pa tmp/
-temporary files that are kept between system reboots
+temporary files that are not removed during boot
 .Pp
 .Bl -tag -width "vi.recover/" -compact
 .It Pa vi.recover/
@@ -607,8 +606,9 @@ the NIS maps; see
 .Sh NOTES
 This manual page documents the default
 .Fx
-file system layout, but the actual hierarchy on a given system is defined at
-the system administrator's discretion.
+file system layout.
+The actual hierarchy on a given system is defined at the system
+administrator's discretion.
 A well-maintained installation will include a customized version of
 this document.
 .Sh SEE ALSO

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -50,12 +50,12 @@ programs and configuration files used during operating system bootstrap
 default bootstrapping configuration files; see
 .Xr loader.conf 5
 .It Pa dtb/
-Compiled flattened device tree (FDT) files; see
+compiled flattened device tree (FDT) files; see
 .Xr fdt 4
 and
 .Xr dtc 1
 .It Pa efi/
-Mount point for EFI System Partition (ESP) on UEFI systems
+mount point for the EFI System Partition (ESP) on UEFI systems
 .It Pa firmware/
 loadable kernel modules containing binary firmware for hardware that needs
 firmware downloaded to it to function
@@ -66,7 +66,7 @@ at boot time) and kernel modules
 third-party loadable kernel modules, such as the ones installed from
 .Xr ports 7
 .It Pa overlays/
-Compiled flattened device tree (FDT) overlays; see
+compiled flattened device tree (FDT) overlays; see
 .Xr fdt 4
 and
 .Xr dtc 1
@@ -105,7 +105,7 @@ local timezone information;
 see
 .Xr ctime 3
 .It Pa mail/
-Sendmail control files
+sendmail control files
 .It Pa mtree/
 mtree configuration files;
 see
@@ -476,7 +476,7 @@ The layout of the source tree is described by the top-level
 file.
 .Pp
 .It Pa tests/
-The
+the
 .Fx
 test suite; see
 .Xr tests 7

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -202,7 +202,6 @@ and
 .Xr bsdinstall 8
 .It Pa include/
 standard C include files
-.Pp
 .It Pa lib/
 shared and archive
 .Xr ar 1 Ns -type

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -114,7 +114,7 @@ scripts that are run daily, weekly, and monthly, via
 see
 .Xr periodic 8
 .It Pa ppp/
-ppp configuration files; see
+PPP configuration files; see
 .Xr ppp 8
 .It Pa rc.d/
 system and daemon startup/control scripts; see

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -581,9 +581,7 @@ system messages database;
 see
 .Xr msgs 1
 .It Pa preserve/
-temporary home of files preserved after an accidental death
-of an editor;
-see
+temporary storage for files following a crash of an editor; see
 .Xr vi 1
 .It Pa quotas/
 file system quota information files
@@ -639,7 +637,8 @@ temporary files that are kept between system reboots
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa vi.recover/
-the directory where recovery files are stored
+.Xr vi 1
+recovery files
 .El
 .Pp
 .It Pa yp/

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -45,7 +45,7 @@ user utilities fundamental to both single-user and multi-user environments
 .It Pa /boot/
 programs and configuration files used during operating system bootstrap
 .Pp
-.Bl -tag -width "defaults/" -compact
+.Bl -tag -width "nvmecontrol/" -compact
 .It Pa defaults/
 default bootstrapping configuration files; see
 .Xr loader.conf 5
@@ -84,7 +84,7 @@ comments apply
 device special files managed by
 .Xr devfs 5
 .Pp
-.Bl -tag -width "defaults/" -compact
+.Bl -tag -width "nvmecontrol/" -compact
 .It Pa fd/
 file descriptor files;
 see
@@ -93,7 +93,7 @@ see
 .It Pa /etc/
 system configuration files and scripts
 .Pp
-.Bl -tag -width "defaults/" -compact
+.Bl -tag -width "nvmecontrol/" -compact
 .It Pa bluetooth/
 bluetooth configuration files
 .It Pa defaults/
@@ -149,7 +149,7 @@ critical system libraries needed for binaries in
 and
 .Pa /sbin
 .Pp
-.Bl -tag -width "defaults/" -compact
+.Bl -tag -width "nvmecontrol/" -compact
 .It Pa casper/
 service-specific
 .Xr libcasper 3
@@ -319,9 +319,9 @@ a variety of pre-fab calendar files;
 see
 .Xr calendar 1
 .It Pa dict/
-word lists;
-see
+word lists; see
 .Xr look 1
+.Pp
 .Bl -tag -width Fl -compact
 .It Pa freebsd
 .Fx Ns -specific
@@ -329,6 +329,7 @@ terms, proper names, and jargon
 .It Pa web2
 words from Webster's Second International
 .El
+.Pp
 .It Pa doc/
 miscellaneous documentation
 .It Pa examples/
@@ -339,6 +340,7 @@ firmware images loaded by userland programs
 ASCII text files used by various games
 .It Pa keys/
 known trusted and revoked keys
+.Pp
 .Bl -tag -width Fl -compact
 .It Pa pkg/
 fingerprints for
@@ -346,6 +348,7 @@ fingerprints for
 and
 .Xr pkg 8
 .El
+.Pp
 .It Pa locale/
 localization files;
 see
@@ -354,6 +357,7 @@ see
 manual pages
 .It Pa misc/
 miscellaneous system-wide ASCII text files
+.Pp
 .Bl -tag -width Fl -compact
 .It Pa fonts/
 ???
@@ -362,6 +366,7 @@ terminal characteristics database;
 see
 .Xr termcap 5
 .El
+.Pp
 .It Pa mk/
 templates for make;
 see
@@ -380,6 +385,7 @@ example
 (dot) files for new accounts
 .It Pa snmp/
 MIBs, example files and tree definitions for the SNMP daemon
+.Pp
 .Bl -tag -width Fl -compact
 .It Pa defs/
 tree definition files for use with
@@ -387,29 +393,30 @@ tree definition files for use with
 .It Pa mibs/
 MIB files
 .El
+.Pp
 .It Pa syscons/
-files used by syscons;
-see
+files used by syscons; see
 .Xr syscons 4
+.Pp
 .Bl -tag -width Fl -compact
 .It Pa fonts/
-console fonts;
-see
+console fonts; see
 .Xr vidcontrol 1
 and
 .Xr vidfont 1
 .It Pa keymaps/
-console keyboard maps;
-see
+console keyboard maps; see
 .Xr kbdcontrol 1
 and
 .Xr kbdmap 1
 .It Pa scrnmaps/
 console screen maps
 .El
+.Pp
 .It Pa sysroot/
 files necessary for the -sysroot compiler/linker argument to build non-native
 binaries.
+.Pp
 .Bl -tag -width Fl -compact
 .It Pa VERSION/
 files for
@@ -420,6 +427,7 @@ By convention,
 matches
 .Xr uname 1
 .Fl r .
+.Pp
 .Bl -tag -width Fl -compact
 .It Pa MACHINE.MACHINE_ARCH/
 represent the binary ABI for these files.
@@ -433,6 +441,7 @@ matches
 .Fl p .
 .El
 .El
+.Pp
 .It Pa tabset/
 tab description files for a variety of terminals; used in
 the termcap file;
@@ -442,9 +451,9 @@ see
 localization support and utilities for
 .Xr vi 1
 .It Pa vt/
-files used by vt;
-see
+files used by vt; see
 .Xr vt 4
+.Pp
 .Bl -tag -width Fl -compact
 .It Pa fonts/
 console fonts;
@@ -453,17 +462,16 @@ see
 and
 .Xr vidfont 1
 .It Pa keymaps/
-console keyboard maps;
-see
+console keyboard maps; see
 .Xr kbdcontrol 1
 and
 .Xr kbdmap 1
 .\" .It Pa scrnmaps/
 .\" console screen maps
 .El
+.Pp
 .It Pa zoneinfo/
-timezone configuration information;
-see
+timezone configuration information; see
 .Xr tzfile 5
 .El
 .Pp
@@ -484,11 +492,11 @@ test suite; see
 .It Pa /var/
 multi-purpose log, temporary, transient, and spool files
 .Pp
-.Bl -tag -width "defaults/" -compact
+.Bl -tag -width "preserve/" -compact
 .It Pa account/
 system accounting files
 .Pp
-.Bl -tag -width Fl -compact
+.Bl -tag -width "freebsd-update/" -compact
 .It Pa acct
 execution accounting file;
 see
@@ -537,6 +545,7 @@ see
 .Pp
 .It Pa db/
 miscellaneous automatically generated system-specific database files
+.Pp
 .Bl -tag -width Fl -compact
 .It Pa freebsd-update/
 .Xr freebsd-update 8

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -355,7 +355,7 @@ see
 .It Pa man/
 manual pages
 .It Pa misc/
-miscellaneous system-wide ASCII text files
+miscellaneous system-wide files
 .Pp
 .Bl -tag -width Fl -compact
 .It Pa fonts/

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -28,7 +28,7 @@
 .\"	@(#)hier.7	8.1 (Berkeley) 6/5/93
 .\" $FreeBSD$
 .\"
-.Dd June 05, 2023
+.Dd June 7, 2023
 .Dt HIER 7
 .Os
 .Sh NAME

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -170,8 +170,7 @@ and
 .Pa /sbin
 .It Pa /media/
 contains subdirectories to be used as mount points
-for removable media such as CDs, USB drives, and
-floppy disks
+for removable media such as USB drives, CDs and DVDs
 .It Pa /mnt/
 empty directory commonly used by
 system administrators as a temporary mount point

--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -163,8 +163,8 @@ and
 contains subdirectories to be used as mount points for removable media such as
 USB drives, CDs and DVDs
 .It Pa /mnt/
-empty directory commonly used by
-system administrators as a temporary mount point
+empty directory commonly used by system administrators as a temporary mount
+point
 .It Pa /net/
 automounted NFS shares; see
 .Xr auto_master 5
@@ -515,6 +515,7 @@ miscellaneous automatically generated system-specific database files
 .Xr freebsd-update 8
 work directory for temporary files and downloaded updates
 .El
+.Pp
 .It Pa empty/
 empty directory for use by programs that need a specifically empty directory.
 Used for instance by


### PR DESCRIPTION
hier(7): improvement, modernisation

Consistent use of lowercase, spacing between sections, etc.

Cease mentioning floppy disks.

De-list /usr/share/misc/fonts/, which has been ??? (without a description) for twenty-seven years.

Change zpool to pool.

Uppercase PPP for Point-to-Point Protocol.

A few other improvements to wording, including avoidance of the phrase pre-fab.

Update the descriptions of: 

* /tmp/
* /usr/share/misc/
* /var/preserve/
* /var/tmp/
* /var/tmp/vi.recover/.

Refer to vi(1) instead of ex(1).

https://bugs.freebsd.org/261349

PR:                      261349
Pull request:            https://github.com/freebsd/freebsd-src/pull/763

----

The 30th May edition, rendered: <https://reviews.freebsd.org/paste/raw/572/>