### PR TITLE
od(1): fix skip error handling

### DIFF
--- a/usr.bin/hexdump/display.c
+++ b/usr.bin/hexdump/display.c
@@ -263,7 +263,7 @@ get(void)
 		 * block and set the end flag.
 		 */
 		if (!length || (ateof && !next((char **)NULL))) {
-			if (odmode && address < skip)
+			if (odmode && skip)
 				errx(1, "cannot skip past end of input");
 			if (need == blocksize)
 				return((u_char *)NULL);


### PR DESCRIPTION
PR: [271832](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271832)

The current check doesn't seem to make sense. The file size is subtracted from skip in doskip(), so if it's nonzero and we reached the end, throw an error.