### PR TITLE
ntp: Fixed undefined behavior of the shift operator

### DIFF
--- a/sys/kern/kern_ntptime.c
+++ b/sys/kern/kern_ntptime.c
@@ -73,7 +73,13 @@ typedef int64_t l_fp;
 #define L_MPY(v, a)	((v) *= (a))
 #define L_CLR(v)	((v) = 0)
 #define L_ISNEG(v)	((v) < 0)
-#define L_LINT(v, a)	((v) = (int64_t)(a) << 32)
+#define L_LINT(v, a) \
+	do { \
+		if ((a) < 0) \
+			((v) = -((int64_t)(-(a)) << 32)); \
+		else \
+			((v) = (int64_t)(a) << 32); \
+	} while (0)
 #define L_GINT(v)	((v) < 0 ? -(-(v) >> 32) : (v) >> 32)
 
 /*


### PR DESCRIPTION
L_LINT macro is used with negative numbers (e.g `L_LINT(time_freq, -MAXFREQ)`) so it could cause undefined behavior.
So it should be similar to the L_RSHIFT(v, n) macro.