### PR TITLE
uipc_syscalls: removed unnecessary check in accept1() function

### DIFF
--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -298,15 +298,13 @@ accept1(struct thread *td, int s, struct sockaddr *uname, socklen_t *anamelen,
 	if (error != 0)
 		return (error);
 
-	if (error == 0 && uname != NULL) {
 #ifdef COMPAT_OLDSOCK
-		if (SV_PROC_FLAG(td->td_proc, SV_AOUT) &&
-		    (flags & ACCEPT4_COMPAT) != 0)
-			((struct osockaddr *)name)->sa_family =
-			    name->sa_family;
+	if (SV_PROC_FLAG(td->td_proc, SV_AOUT) &&
+	    (flags & ACCEPT4_COMPAT) != 0)
+		((struct osockaddr *)name)->sa_family =
+		    name->sa_family;
 #endif
-		error = copyout(name, uname, namelen);
-	}
+	error = copyout(name, uname, namelen);
 	if (error == 0)
 		error = copyout(&namelen, anamelen,
 		    sizeof(namelen));


### PR DESCRIPTION
Lines 289 and 298 already contain checks of uname and error values.
So the expression `(error == 0 && uname != NULL)` is always true.