### PR TITLE
fix qcom_cpu_kpssv2 compile on ASUS_AC1300

### DIFF
--- a/sys/arm/qualcomm/qcom_cpu_kpssv2.c
+++ b/sys/arm/qualcomm/qcom_cpu_kpssv2.c
@@ -72,7 +72,7 @@ loop_delay(int usec)
  * This is the KPSSv2 (eg IPQ4018) regulator path for CPU
  * and shared L2 cache power-on.
  */
-boolean_t
+bool
 qcom_cpu_kpssv2_regulator_start(u_int id, phandle_t node)
 {
 	phandle_t acc_phandle, l2_phandle, saw_phandle;


### PR DESCRIPTION
follow afdb42987ca82869eeaecf6dc25c2b6fb7b8370e and change the return type
from boolean_t to bool for the definition, too.

PR: 271932
Reported by: Mina Galić
Fixes: afdb42987ca82869eeaecf6dc25c2b6fb7b8370e
Pull Request: https://github.com/freebsd/freebsd-src/pull/776