### PR TITLE
loader.efi: Remove redundant error message

### DIFF
--- a/stand/efi/loader/main.c
+++ b/stand/efi/loader/main.c
@@ -1062,10 +1062,8 @@ main(int argc, CHAR16 *argv[])
 	 */
 	boot_howto_to_env(howto);
 
-	if (efi_copy_init()) {
-		printf("failed to allocate staging area\n");
+	if (efi_copy_init())
 		return (EFI_BUFFER_TOO_SMALL);
-	}
 
 	if ((s = getenv("fail_timeout")) != NULL)
 		fail_timeout = strtol(s, NULL, 10);


### PR DESCRIPTION
`efi_copy_init` already prints an error message (with more information) if it fails.