### PR TITLE
geli: fix setkey behavior on detached providers

### DIFF
--- a/lib/geom/eli/geom_eli.c
+++ b/lib/geom/eli/geom_eli.c
@@ -1363,6 +1363,12 @@ eli_setkey_detached(struct gctl_req *req, const char *prov,
 		return;
 	}
 
+	/*
+	 * The previous eli_genkey() set cached_passphrase, we do not want
+	 * to use that for the new passphrase so always prompt for it
+	 */
+	memset(cached_passphrase, 0, sizeof(cached_passphrase));
+
 	/* Generate key for Master Key decryption. */
 	if (eli_genkey_single(req, md, key, false) == NULL) {
 		explicit_bzero(key, sizeof(key));


### PR DESCRIPTION
wipe out cached_passphrase (using memset(3) for clarity) to allow
geli(8) setkey to correctly function on detached providers.

PR: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=254966
Reported by:  rob2g2
Submitted by:  Arjan de Vet <freebsd@devet.org>
Pull Request: https://github.com/freebsd/freebsd-src/pull/780