### PR TITLE
netlink: add unregister call when cleanup

### DIFF
--- a/sys/netlink/netlink_generic.c
+++ b/sys/netlink/netlink_generic.c
@@ -297,6 +297,7 @@ SYSINIT(genl_load_all, SI_SUB_PROTO_DOMAIN, SI_ORDER_THIRD, genl_load_all, NULL)
 static void
 genl_unload(void *u __unused)
 {
+	netlink_unregister_proto(NETLINK_GENERIC);
 	EVENTHANDLER_DEREGISTER(genl_family_event, family_event_tag);
 	genl_unregister_family(CTRL_FAMILY_NAME);
 	NET_EPOCH_WAIT();

--- a/sys/netlink/netlink_route.c
+++ b/sys/netlink/netlink_route.c
@@ -135,6 +135,7 @@ static void
 rtnl_unload(void *u __unused)
 {
 	netlink_callback_p = nlbridge_orig_p;
+	netlink_unregister_proto(NETLINK_ROUTE);
 	rtnl_ifaces_destroy();
 	rtnl_neighs_destroy();
 


### PR DESCRIPTION
For protocols that use netlink (generic and route for now), the unint handler seems to have forgotten to call unregister, which will cause the assertion the next time the module is loaded.

This patch adds unregister call to netlink_unregister_proto() for those handlers to avoid bad things happen.

Fixes: 7e5bf68495cc ("netlink: add netlink support")