### PR TITLE
hwpmc(4): instead of manual edition, use sysrc(8)

### DIFF
--- a/share/man/man4/hwpmc.4
+++ b/share/man/man4/hwpmc.4
@@ -47,11 +47,9 @@ Additionally, for i386 systems:
 .Cd "device apic"
 .Ed
 .Pp
-To load the driver as a module at boot time, place the
-following line in
-.Xr rc.conf 5 :
+To load the driver as a module at boot time:
 .Bd -literal -offset indent
-kld_list="${kld_list} hwpmc"
+sysrc kld_list+="hwpmc"
 .Ed
 .Pp
 Alternatively, to compile this driver into the kernel:

--- a/share/man/man4/hwpmc.4
+++ b/share/man/man4/hwpmc.4
@@ -49,7 +49,7 @@ Additionally, for i386 systems:
 .Pp
 To load the driver as a module at boot time:
 .Bd -literal -offset indent
-sysrc kld_list+="hwpmc"
+sysrc kld_list+=hwpmc
 .Ed
 .Pp
 Alternatively, to compile this driver into the kernel:

--- a/share/man/man4/hwpmc.4
+++ b/share/man/man4/hwpmc.4
@@ -52,7 +52,7 @@ To load the driver as a module at boot time:
 sysrc kld_list+=hwpmc
 .Ed
 .Pp
-Alternatively, to compile this driver into the kernel:
+Alternatively, to compile the driver into the kernel:
 .Bd -ragged -offset indent
 .Cd "device hwpmc"
 .Ed


### PR DESCRIPTION
Exemplifying safe use of sysrc(8) has become commonplace in documentation such as the FreeBSD Handbook.