### PR TITLE
man(1): use gzcat for .gz files

### DIFF
--- a/usr.bin/man/man.sh
+++ b/usr.bin/man/man.sh
@@ -910,7 +910,7 @@ setup_cattool() {
 	case "$1" in
 	*.bz)	cattool='/usr/bin/bzcat' ;;
 	*.bz2)	cattool='/usr/bin/bzcat' ;;
-	*.gz)	cattool='/usr/bin/zcat' ;;
+	*.gz)	cattool='/usr/bin/gzcat' ;;
 	*.lzma)	cattool='/usr/bin/lzcat' ;;
 	*.xz)	cattool='/usr/bin/xzcat' ;;
 	*.zst)	cattool='/usr/bin/zstdcat' ;;


### PR DESCRIPTION
POSIX zcat appends the .Z suffix to file arguments causing the command to fail with .gz files.