### PR TITLE
xargs: fix -R so that it accepts negative numbers again

### DIFF
--- a/usr.bin/xargs/tests/Makefile
+++ b/usr.bin/xargs/tests/Makefile
@@ -15,6 +15,7 @@ ${PACKAGE}FILES+=		regress.J.out
 ${PACKAGE}FILES+=		regress.L.out
 ${PACKAGE}FILES+=		regress.P1.out
 ${PACKAGE}FILES+=		regress.R.out
+${PACKAGE}FILES+=		regress.R-1.out
 ${PACKAGE}FILES+=		regress.in
 ${PACKAGE}FILES+=		regress.n1.out
 ${PACKAGE}FILES+=		regress.n2.out

--- a/usr.bin/xargs/tests/regress.R-1.out
+++ b/usr.bin/xargs/tests/regress.R-1.out
@@ -1,0 +1,4 @@
+The quick brown quick brown quick brown quick brownquick brown quick brown quick brown
+The fox jumped fox jumped fox jumped fox jumpedfox jumped fox jumped fox jumped
+The over the lazy over the lazy over the lazy over the lazyover the lazy over the lazy over the lazy
+The dog dog dog dogdog dog dog

--- a/usr.bin/xargs/tests/regress.sh
+++ b/usr.bin/xargs/tests/regress.sh
@@ -1,6 +1,6 @@
 # $FreeBSD$
 
-echo 1..20
+echo 1..21
 
 REGRESSION_START($1)
 
@@ -10,6 +10,7 @@ REGRESSION_TEST(`J', `xargs -J% echo The % again. <${SRCDIR}/regress.in')
 REGRESSION_TEST(`L', `xargs -L3 echo <${SRCDIR}/regress.in')
 REGRESSION_TEST(`P1', `xargs -P1 echo <${SRCDIR}/regress.in')
 REGRESSION_TEST(`R', `xargs -I% -R1 echo The % % % %% % % <${SRCDIR}/regress.in')
+REGRESSION_TEST(`R-1', `xargs -I% -R-1 echo The % % % %% % % <${SRCDIR}/regress.in')
 REGRESSION_TEST(`n1', `xargs -n1 echo <${SRCDIR}/regress.in')
 REGRESSION_TEST(`n2', `xargs -n2 echo <${SRCDIR}/regress.in')
 REGRESSION_TEST(`n2P0',`xargs -n2 -P0 echo <${SRCDIR}/regress.in | sort')

--- a/usr.bin/xargs/xargs.c
+++ b/usr.bin/xargs/xargs.c
@@ -200,7 +200,7 @@ main(int argc, char *argv[])
 			pflag = 1;
 			break;
 		case 'R':
-			Rflag = (int)strtonum(optarg, 0, INT_MAX, &errstr);
+			Rflag = (int)strtonum(optarg, INT_MIN, INT_MAX, &errstr);
 			if (errstr)
 				errx(1, "-%c %s: %s", ch, optarg, errstr);
 			break;

--- a/usr.bin/xargs/xargs.c
+++ b/usr.bin/xargs/xargs.c
@@ -174,7 +174,7 @@ main(int argc, char *argv[])
 			replstr = optarg;
 			break;
 		case 'L':
-			Lflag = (int)strtonum(optarg, 0, INT_MAX, &errstr);
+			Lflag = (int)strtonum(optarg, 1, INT_MAX, &errstr);
 			if (errstr)
 				errx(1, "-%c %s: %s", ch, optarg, errstr);
 			break;
@@ -203,6 +203,8 @@ main(int argc, char *argv[])
 			Rflag = (int)strtonum(optarg, INT_MIN, INT_MAX, &errstr);
 			if (errstr)
 				errx(1, "-%c %s: %s", ch, optarg, errstr);
+			if (!Rflag)
+				errx(1, "-%c %s: %s", ch, optarg, "must be non-zero");
 			break;
 		case 'r':
 			/* GNU compatibility */


### PR DESCRIPTION
fbc445addf9 converted the parsing of arguments to strtonum but made the accepted range for -R too restrictive. As documented in the man page, it should accept negative numbers: " If replacements is negative, the number of arguments in which to replace is unbounded."
So this is working in 13.2 and works again with the commit:
`$ echo hello | xargs -I % -R-1 echo % % % % % %`
`hello hello hello hello hello hello`

At the same time fix a bug for -R0: after parsing the arguments there is this code
        `if (Iflag && !Rflag)`
                `Rflag = 5;`
So -R0 is interpreted as "this flag is unset, use the default value".  Since -R0 doesn't make sense logically, I added an errx right after the strtonum call. 

A similar issue exists with -L0. There is this code
        `if (Iflag || Lflag)`
                `xflag = 1;`
which means that for -L0 xflag isn't set. The only other place where Lflag appears is `(Lflag <= count && xflag)`. So -L0 hasn't any effect at all. Since "call utility for every 0 lines" doesn't make sense, I changed the acceptable range for -L  to positive integers.