### PR TITLE
Make memcpy C99 compliant

### DIFF
--- a/lib/libc/string/memcpy.3
+++ b/lib/libc/string/memcpy.3
@@ -32,7 +32,7 @@
 .\"     @(#)memcpy.3	8.1 (Berkeley) 6/4/93
 .\" $FreeBSD$
 .\"
-.Dd July 14, 2021
+.Dd July 4, 2023
 .Dt MEMCPY 3
 .Os
 .Sh NAME
@@ -43,9 +43,9 @@
 .Sh SYNOPSIS
 .In string.h
 .Ft void *
-.Fn memcpy "void *dst" "const void *src" "size_t len"
+.Fn memcpy "void *__restrict dst" "const void *__restrict src" "size_t len"
 .Ft void *
-.Fn mempcpy "void *dst" "const void *src" "size_t len"
+.Fn mempcpy "void *__restrict dst" "const void *__restrict src" "size_t len"
 .Sh DESCRIPTION
 The
 .Fn memcpy


### PR DESCRIPTION
memcpy should have restrict in its prototype definition because that is the C99 standard.

We also must not break the assumptions made by making memcpy restrict.