### PR TITLE
gpart(8): slices are out of context for GPT

### DIFF
--- a/lib/geom/part/gpart.8
+++ b/lib/geom/part/gpart.8
@@ -1429,7 +1429,7 @@ sizes of up to 256 kB.
 .Pp
 Finally, we create and format an 8 GB
 .Cm freebsd-ufs
-partition for the root filesystem, leaving the rest of the slice free
+partition for the root filesystem, leaving the rest of the device free
 for additional filesystems:
 .Bd -literal -offset indent
 /sbin/gpart add -s 8G -t freebsd-ufs ada0

--- a/lib/geom/part/gpart.8
+++ b/lib/geom/part/gpart.8
@@ -24,7 +24,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd June 1, 2023
+.Dd July 7, 2023
 .Dt GPART 8
 .Os
 .Sh NAME


### PR DESCRIPTION
Creation of a partition leaves free the rest of the device (not the slice).

Fixes: ae1b731b5df0 Rewrite the GPT and MBR examples.  For GPT, ensure that the boot partition is large enough for gptzfsboot, which has doubled in size since 10.