### PR TITLE
etc/rc.d/routing: use find_system_scripts

### DIFF
--- a/libexec/rc/rc.d/routing
+++ b/libexec/rc/rc.d/routing
@@ -336,8 +336,9 @@ _check_dynamicrouting()
 		skip="$skip -s nojail"
 	fi
 	[ -n "$local_startup" ] && find_local_scripts_new
+	[ -n "$system_rc" ] && find_system_scripts
 	
-	for file in $( rcorder ${skip} /etc/rc.d/* ${local_rc} 2>/dev/null |
+	for file in $( rcorder ${skip} ${system_rc} ${local_rc} 2>/dev/null |
 		       xargs grep -lE '^# PROVIDE:.*\<dynamicrouting\>' ); do
 		(set -- enabled; . $file) && return 0;
 	done


### PR DESCRIPTION
In 3693d9140e05aba9942232df13468f51a6cde136 /etc/rc switched to using find_system_scripts rather than directly including /etc/rc.d/* in the list of scripts to run in order to skip .pkgsave files.  Follow suit in etc/rc.d/routing.