### PR TITLE
Mmccam vs minimal

### DIFF
--- a/sys/amd64/conf/GENERIC-MMCCAM
+++ b/sys/amd64/conf/GENERIC-MMCCAM
@@ -12,12 +12,8 @@ ident		GENERIC-MMCCAM
 
 options 	MMCCAM
 
-# Add CAMDEBUG stuff
+# Allow for CAM debugging
 options 	CAMDEBUG
-options 	CAM_DEBUG_FLAGS=(CAM_DEBUG_INFO|CAM_DEBUG_PROBE|CAM_DEBUG_PERIPH)
-
-# pass(4) device
-device		pass
 
 nodevice	mmc
 nodevice	mmcsd

--- a/sys/amd64/conf/GENERIC-MMCCAM
+++ b/sys/amd64/conf/GENERIC-MMCCAM
@@ -1,33 +1,23 @@
-# MMCCAM is the kernel config for doing MMC on CAM development
-# and testing on bhyve
+#
+# GENERIC-MMCCAM
+#
+# Custom kernel for GENERIC plus MMCCAM as opposed to the prior MMC stack.
+#
 
 #NO_UNIVERSE
 
-include         MINIMAL
+include		GENERIC
 
 ident		GENERIC-MMCCAM
-
-# Access GPT-formatted and labeled root volume
-options 	GEOM_LABEL
-
-# UART -- for bhyve console
-device          uart
-
-# VirtIO support, needed for bhyve
-device		virtio			# Generic VirtIO bus (required)
-device		virtio_pci		# VirtIO PCI device
-device		vtnet			# VirtIO Ethernet device
-device		virtio_blk		# VirtIO Block device
-device		virtio_scsi		# VirtIO SCSI device
-device		virtio_balloon		# VirtIO Memory Balloon device
-
-# CAM-specific stuff
-device		pass
-device		scbus
-device		da
 
 options 	MMCCAM
 
 # Add CAMDEBUG stuff
 options 	CAMDEBUG
 options 	CAM_DEBUG_FLAGS=(CAM_DEBUG_INFO|CAM_DEBUG_PROBE|CAM_DEBUG_PERIPH)
+
+# pass(4) device
+device		pass
+
+nodevice	mmc
+nodevice	mmcsd

--- a/sys/amd64/conf/MINIMAL-MMCCAM
+++ b/sys/amd64/conf/MINIMAL-MMCCAM
@@ -29,6 +29,5 @@ device		da
 
 options 	MMCCAM
 
-# Add CAMDEBUG stuff
+# Allow for CAM debugging
 options 	CAMDEBUG
-options 	CAM_DEBUG_FLAGS=(CAM_DEBUG_INFO|CAM_DEBUG_PROBE|CAM_DEBUG_PERIPH)

--- a/sys/amd64/conf/MINIMAL-MMCCAM
+++ b/sys/amd64/conf/MINIMAL-MMCCAM
@@ -1,0 +1,34 @@
+#
+# MINIMAL-MMCCAM
+#
+
+#NO_UNIVERSE
+
+include         MINIMAL
+
+ident		MINIMAL-MMCCAM
+
+# Access GPT-formatted and labeled root volume
+options 	GEOM_LABEL
+
+# UART -- for bhyve console
+device          uart
+
+# VirtIO support, needed for bhyve
+device		virtio			# Generic VirtIO bus (required)
+device		virtio_pci		# VirtIO PCI device
+device		vtnet			# VirtIO Ethernet device
+device		virtio_blk		# VirtIO Block device
+device		virtio_scsi		# VirtIO SCSI device
+device		virtio_balloon		# VirtIO Memory Balloon device
+
+# CAM-specific stuff
+device		pass
+device		scbus
+device		da
+
+options 	MMCCAM
+
+# Add CAMDEBUG stuff
+options 	CAMDEBUG
+options 	CAM_DEBUG_FLAGS=(CAM_DEBUG_INFO|CAM_DEBUG_PROBE|CAM_DEBUG_PERIPH)

--- a/sys/arm/conf/GENERIC-MMCCAM
+++ b/sys/arm/conf/GENERIC-MMCCAM
@@ -12,12 +12,8 @@ ident		GENERIC-MMCCAM
 
 options 	MMCCAM
 
-# Add CAMDEBUG stuff
+# Allow for CAM debugging
 options 	CAMDEBUG
-options 	CAM_DEBUG_FLAGS=(CAM_DEBUG_INFO|CAM_DEBUG_PROBE|CAM_DEBUG_PERIPH)
-
-# pass(4) device
-device		pass
 
 nodevice	mmc
 nodevice	mmcsd

--- a/sys/arm/conf/GENERIC-MMCCAM
+++ b/sys/arm/conf/GENERIC-MMCCAM
@@ -1,5 +1,5 @@
 #
-# GEMERIC-MMCCAM
+# GENERIC-MMCCAM
 #
 # Custom kernel for GENERIC plus MMCCAM as opposed to the prior MMC stack.
 #

--- a/sys/arm64/conf/GENERIC-MMCCAM
+++ b/sys/arm64/conf/GENERIC-MMCCAM
@@ -10,13 +10,10 @@
 include		GENERIC
 ident		GENERIC-MMCCAM
 
-# Add CAMDEBUG stuff
-options 	CAMDEBUG
-options 	CAM_DEBUG_FLAGS=(CAM_DEBUG_INFO|CAM_DEBUG_PROBE|CAM_DEBUG_PERIPH)
-
-# pass(4) device
-device		pass
 options 	MMCCAM
+
+# Allow for CAM debugging
+options 	CAMDEBUG
 
 nodevice	mmc
 nodevice	mmcsd


### PR DESCRIPTION
- switch amd64's GENERIC-MMCCAM to GENERIC
- restore the old GENERIC-MMCCAM as MINIMAL-MMCCAM
- remove CAMDEBUG_FLAGS, while keeping CAMDEBUG itself.