### PR TITLE
Adhesive bandage fix for libcrypto with gcc12

### DIFF
--- a/secure/lib/libcrypto/Makefile
+++ b/secure/lib/libcrypto/Makefile
@@ -611,6 +611,8 @@ buildinf.h: Makefile
 
 PICFLAG+=	-DOPENSSL_PIC
 
+LDFLAGS+=	-Wl,-znoexecstack
+
 .if defined(ASM_${MACHINE_CPUARCH})
 .PATH:	${SRCTOP}/secure/lib/libcrypto/arch/${MACHINE_CPUARCH}
 .if defined(ASM_amd64)

--- a/secure/lib/libcrypto/engines/Makefile
+++ b/secure/lib/libcrypto/engines/Makefile
@@ -6,4 +6,6 @@ SUBDIR+=	padlock
 .endif
 SUBDIR_PARALLEL=
 
+LDFLAGS+=	-Wl,-znoexecstack
+
 .include <bsd.subdir.mk>

--- a/secure/lib/libcrypto/engines/padlock/Makefile
+++ b/secure/lib/libcrypto/engines/padlock/Makefile
@@ -11,6 +11,8 @@ SRCS+=	e_padlock-x86.S
 
 LDFLAGS.bfd+=	-Wl,-znoexecstack
 
+LDFLAGS+=	-Wl,-znoexecstack
+
 .PATH:	${SRCTOP}/secure/lib/libcrypto/arch/${MACHINE_CPUARCH}
 
 .include <bsd.lib.mk>

--- a/secure/lib/libcrypto/modules/fips/Makefile
+++ b/secure/lib/libcrypto/modules/fips/Makefile
@@ -4,6 +4,8 @@ SHLIB_NAME?=	fips.so
 
 CFLAGS+=	-DFIPS_MODULE
 
+LDFLAGS+=	-Wl,-znoexecstack
+
 SRCS+=	fips_entry.c fipsprov.c self_test.c self_test_kats.c
 
 .include "../../Makefile.common"


### PR DESCRIPTION
Sprinkle `-z noexecstack` into libcrypto's LDFLAGS when compiling with GCC.

---

(To illustrate a point in https://reviews.freebsd.org/D41101)