### PR TITLE
Remove the unnecessary goto parse from the mixer binary

### DIFF
--- a/usr.sbin/mixer/mixer.c
+++ b/usr.sbin/mixer/mixer.c
@@ -117,15 +117,12 @@ main(int argc, char *argv[])
 
 	initctls(m);
 
-	if (dflag && set_dunit(m, dunit) < 0)
-		goto parse;
-	if (sflag) {
+	if (((!dflag || set_dunit(m, dunit) >= 0) && sflag)) {
 		printrecsrc(m, oflag);
 		(void)mixer_close(m);
 		return (0);
 	}
 
-parse:
 	while (argc > 0) {
 		if ((p = strdup(*argv)) == NULL)
 			err(1, "strdup(%s)", *argv);


### PR DESCRIPTION
In usr.sbin/mixer/mixer.c:120 there is an if statement that executes a goto to the label `parse` which occurs right after another if statement. As far as I can tell, the first if statement and it's corresponding goto and label can be removed if the negation of what it checks is checked in the if statement that follows. This is what this PR does.