### PR TITLE
usr.bin/lastcomm: fix timestamp display

### DIFF
--- a/usr.bin/lastcomm/lastcomm.c
+++ b/usr.bin/lastcomm/lastcomm.c
@@ -193,7 +193,7 @@ main(int argc, char *argv[])
 				    localtime(&ab.ac_btime));
 				(void)printf(" %s", buf);
 			} else
-				(void)printf(" %.16s", ctime(&ab.ac_btime));
+				(void)printf(" %.19s", ctime(&ab.ac_btime));
 		}
 		
 		/* exit time (starting time + elapsed time )*/
@@ -205,7 +205,7 @@ main(int argc, char *argv[])
 				    localtime(&t));
 				(void)printf(" %s", buf);
 			} else
-				(void)printf(" %.16s", ctime(&t));
+				(void)printf(" %.19s", ctime(&t));
 		}
 		printf("\n");
  	}


### PR DESCRIPTION
usr.bin/lastcomm: fix timestamp display 

Adjust the lastcomm command to output timestamps with a precision of seconds.

Reported by: Dr. Andreas Longwitz 
Sponsored by: DSS Gmbh