### PR TITLE
if_bridge: avoid process non-local targeted packages via pf 

### DIFF
--- a/sys/net/if_bridge.c
+++ b/sys/net/if_bridge.c
@@ -2610,7 +2610,7 @@ bridge_input(struct ifnet *ifp, struct mbuf *m)
 		}
 
 		/* Do not process none-local-targeted packets */
-  		if(!V_pfil_local_phys) {
+  		if (!V_pfil_local_phys) {
 			m_freem(m);
 			return(NULL);
 		}

--- a/sys/net/if_bridge.c
+++ b/sys/net/if_bridge.c
@@ -2609,6 +2609,12 @@ bridge_input(struct ifnet *ifp, struct mbuf *m)
 			sc->sc_if_input(bifp, mc2);
 		}
 
+		/* Do not process none-local-targeted packets */
+  		if(!V_pfil_local_phys) {
+			m_freem(m);
+			return(NULL);
+		}
+
 		/* Return the original packet for local processing. */
 		return (m);
 	}


### PR DESCRIPTION
if_bridge: avoid process non-local targeted packages via pf 

Do not process multicast packages via pf that are not targeted to the local physical interface here.

details / discussion / bug report  (2019):
https://lists.freebsd.org/pipermail/freebsd-pf/2019-December/009275.html

Reported by: Dr. Andreas Longwitz 
Sponsored by: DSS GmbH