### PR TITLE
Enable remaining NCT6116D GPIO groups

### DIFF
--- a/sys/dev/nctgpio/nctgpio.c
+++ b/sys/dev/nctgpio/nctgpio.c
@@ -637,7 +637,7 @@ struct nct_device {
 	{
 		.devid   = 0xd282,
 		.descr   = "GPIO on Nuvoton NCT6112D/NCT6114D/NCT6116D",
-		.ngroups = 2,
+		.ngroups = 9,
 		.groups  = {
 			{
 				.grpnum      = 0,
@@ -646,7 +646,7 @@ struct nct_device {
 				.enable_reg  = 0x30,
 				.enable_mask = 0x01,
 				.data_ldn    = 0x07,
-				.ppod_reg    = 0xe0, /* FIXME Need to check for this group. */
+				.ppod_reg    = 0xe0,
 				.caps        = NCT_GPIO_CAPS,
 				.npins       = 8,
 				.iobase      = 0xe0,
@@ -658,7 +658,7 @@ struct nct_device {
 				.enable_reg  = 0x30,
 				.enable_mask = 0x02,
 				.data_ldn    = 0x07,
-				.ppod_reg    = 0xe1, /* FIXME Need to check for this group. */
+				.ppod_reg    = 0xe1,
 				.caps        = NCT_GPIO_CAPS,
 				.npins       = 8,
 				.iobase      = 0xe4,
@@ -670,7 +670,7 @@ struct nct_device {
 				.enable_reg  = 0x30,
 				.enable_mask = 0x04,
 				.data_ldn    = 0x07,
-				.ppod_reg    = 0xe1, /* FIXME Need to check for this group. */
+				.ppod_reg    = 0xe1,
 				.caps        = NCT_GPIO_CAPS,
 				.npins       = 8,
 				.iobase      = 0xe8,
@@ -682,7 +682,7 @@ struct nct_device {
 				.enable_reg  = 0x30,
 				.enable_mask = 0x08,
 				.data_ldn    = 0x07,
-				.ppod_reg    = 0xe1, /* FIXME Need to check for this group. */
+				.ppod_reg    = 0xe1,
 				.caps        = NCT_GPIO_CAPS,
 				.npins       = 8,
 				.iobase      = 0xec,
@@ -694,7 +694,7 @@ struct nct_device {
 				.enable_reg  = 0x30,
 				.enable_mask = 0x10,
 				.data_ldn    = 0x07,
-				.ppod_reg    = 0xe1, /* FIXME Need to check for this group. */
+				.ppod_reg    = 0xe1,
 				.caps        = NCT_GPIO_CAPS,
 				.npins       = 8,
 				.iobase      = 0xf0,
@@ -706,7 +706,7 @@ struct nct_device {
 				.enable_reg  = 0x30,
 				.enable_mask = 0x20,
 				.data_ldn    = 0x07,
-				.ppod_reg    = 0xe1, /* FIXME Need to check for this group. */
+				.ppod_reg    = 0xe1,
 				.caps        = NCT_GPIO_CAPS,
 				.npins       = 8,
 				.iobase      = 0xf4,
@@ -718,7 +718,7 @@ struct nct_device {
 				.enable_reg  = 0x30,
 				.enable_mask = 0x40,
 				.data_ldn    = 0x07,
-				.ppod_reg    = 0xe1, /* FIXME Need to check for this group. */
+				.ppod_reg    = 0xe1,
 				.caps        = NCT_GPIO_CAPS,
 				.npins       = 8,
 				.iobase      = 0xf8,
@@ -730,7 +730,7 @@ struct nct_device {
 				.enable_reg  = 0x30,
 				.enable_mask = 0x80,
 				.data_ldn    = 0x07,
-				.ppod_reg    = 0xe1, /* FIXME Need to check for this group. */
+				.ppod_reg    = 0xe1,
 				.caps        = NCT_GPIO_CAPS,
 				.npins       = 8,
 				.iobase      = 0xfc,
@@ -742,7 +742,7 @@ struct nct_device {
 				.enable_reg  = 0x30,
 				.enable_mask = 0x01,
 				.data_ldn    = 0x09,
-				.ppod_reg    = 0xe1, /* FIXME Need to check for this group. */
+				.ppod_reg    = 0xe1,
 				.caps        = NCT_GPIO_CAPS,
 				.npins       = 8,
 				.iobase      = 0xf0,

--- a/sys/dev/ncthwm/ncthwm.c
+++ b/sys/dev/ncthwm/ncthwm.c
@@ -158,7 +158,7 @@ ncthwm_query_fan_speed(SYSCTL_HANDLER_ARGS)
 	NCTHWM_VERBOSE_PRINTF(sc->dev, "%s: read %u from bank %u offset 0x%x-0x%x\n",
 		fan->name, val, sc->nctdevp->fan_bank, fan->high_byte_offset, fan->low_byte_offset);
 
-	return (sysctl_handle_int(oidp, &val, 0, req));
+	return (sysctl_handle_16(oidp, &val, 0, req));
 }
 
 static int


### PR DESCRIPTION
Further tested the NCT6116D. Looks OK to enable the remaining GPIO groups and remove the FIXMEs about PP/OD.
Also fix `ncthwm`'s sysctl handling to properly match its type.