### PR TITLE
rc(8): angle brackets to avoid link breakage

### DIFF
--- a/share/man/man8/rc.8
+++ b/share/man/man8/rc.8
@@ -31,7 +31,7 @@
 .\"     @(#)rc.8	8.2 (Berkeley) 12/11/93
 .\" $FreeBSD$
 .\"
-.Dd June 1, 2023
+.Dd August 5, 2023
 .Dt RC 8
 .Os
 .Sh NAME

--- a/share/man/man8/rc.8
+++ b/share/man/man8/rc.8
@@ -585,8 +585,8 @@ is unnecessary, but is often included.
 .Xr sysrc 8
 .Pp
 .Rs
-.%T "Practical rc.d scripting in BSD"
-.%U "https://docs.freebsd.org/en/articles/rc-scripting/"
+.%T Practical rc.d scripting in BSD
+.%U <https://docs.freebsd.org/en/articles/rc-scripting/>
 .Re
 .Sh HISTORY
 The


### PR DESCRIPTION
<https://datatracker.ietf.org/doc/html/rfc3986#appendix-C>

Double-quotes are not suitably effective. Instead, use angle brackets.

Whilst here:

- remove superfluous quotation marks from the %T title.