### PR TITLE
bsd.prog.mk: Link with --fatal-warnings like bsd.lib.mk

### DIFF
--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -71,6 +71,14 @@ LDFLAGS+= -Wl,-zretpolineplt
 # LLD sensibly defaults to -znoexecstack, so do the same for BFD
 LDFLAGS.bfd+= -Wl,-znoexecstack
 
+.if ${LINKER_TYPE} != "mac"
+.if defined(LD_FATAL_WARNINGS) && ${LD_FATAL_WARNINGS} == "no"
+LDFLAGS+=	-Wl,--no-fatal-warnings
+.else
+LDFLAGS+=	-Wl,--fatal-warnings
+.endif
+.endif
+
 # Initialize stack variables on function entry
 .if ${MK_INIT_ALL_ZERO} == "yes"
 .if ${COMPILER_FEATURES:Minit-all}


### PR DESCRIPTION
Testing cross-OS bootstrapping