### PR TITLE
tests: soxstack: Silence GCC warnings

### DIFF
--- a/tests/sys/vm/soxstack/soxstack.c
+++ b/tests/sys/vm/soxstack/soxstack.c
@@ -38,7 +38,7 @@ checkstack(void)
 		kve = &freep[i];
 		if (stack < kve->kve_start || stack > kve->kve_end)
 			continue;
-		if ((kve->kve_flags & _STACK_FLAG_GROWS) != 0 &&
+		if ((kve->kve_flags &(_STACK_FLAG_GROWS)) != 0 &&
 		    (kve->kve_protection & KVME_PROT_EXEC) != 0)
 			stack = 0;
 		break;


### PR DESCRIPTION
GCC12 complains about:
```
/tmp/cirrus-ci-build/tests/sys/vm/soxstack/soxstack.c: In function 'checkstack':
/tmp/cirrus-ci-build/tests/sys/vm/soxstack/soxstack.c:41:37: error: suggest parentheses around arithmetic in operand of '|' [-Werror=parentheses]
   41 |                 if ((kve->kve_flags & _STACK_FLAG_GROWS) != 0 &&
      |                                     ^
```
cc/ @lemul, @emaste 