### PR TITLE
ath_pci.4: Remove missing link

### DIFF
--- a/share/man/man4/Makefile
+++ b/share/man/man4/Makefile
@@ -622,7 +622,6 @@ MLINKS+=altera_atse.4 atse.4
 MLINKS+=altera_sdcard.4 altera_sdcardc.4
 MLINKS+=altq.4 ALTQ.4
 MLINKS+=ath.4 if_ath.4
-MLINKS+=ath_pci.4 if_ath_pci.4
 MLINKS+=aue.4 if_aue.4
 MLINKS+=axe.4 if_axe.4
 MLINKS+=bce.4 if_bce.4


### PR DESCRIPTION
Commit 4c1ab22d1596ba3c1dc3e501e25011c44994de36 created the link for ath_pci.4 -> if_ath_pci.4, therefore it was missed when reverting in 37c8ee8847faa53432809cae2ecc11b80c4eab2f.

Fixes:	37c8ee8847faa53432809cae2ecc11b80c4eab2f

cc/ @sparkplug, @emaste 