### PR TITLE
ls.1 : Mention -v incompatability with -s and -t

### DIFF
--- a/bin/ls/ls.1
+++ b/bin/ls/ls.1
@@ -460,9 +460,9 @@ options all override each other; the last one specified determines
 the file time used.
 .Pp
 The
-.Fl S
+.Fl S , t
 and
-.Fl t
+.Fl v
 options override each other; the last one specified determines
 the sort order used.
 .Pp

--- a/bin/ls/ls.1
+++ b/bin/ls/ls.1
@@ -928,7 +928,7 @@ command appeared in
 The
 .Fl v
 option was added in
-.Fx 14.0 .
+.Fx 13.2 .
 .Sh BUGS
 To maintain backward compatibility, the relationships between the many
 options are quite complex.

--- a/bin/ls/ls.1
+++ b/bin/ls/ls.1
@@ -127,8 +127,7 @@ a percent sign
 after each whiteout,
 and a vertical bar
 .Pq Ql \&|
-after each that is a
-.Tn FIFO .
+after each that is a FIFO.
 .It Fl G
 Enable colorized output.
 This option is equivalent to defining
@@ -206,7 +205,7 @@ dot
 As
 .Fl B ,
 but use
-.Tn C
+.Xr c 7
 escape codes whenever possible.
 This option is not defined in
 .St -p1003.1-2008 .
@@ -229,8 +228,7 @@ If
 .Ev TERM
 is unset or set to an invalid terminal, then
 .Nm
-will fall back to explicit
-.Tn ANSI
+will fall back to explicit ANSI
 escape sequences without the help of
 .Xr termcap 5 .
 .Cm always
@@ -566,8 +564,7 @@ Character special file.
 Directory.
 .It Sy l
 Symbolic link.
-.It Sy p
-.Tn FIFO .
+.It Sy p FIFO .
 .It Sy s
 Socket.
 .It Sy w
@@ -666,9 +663,7 @@ See
 .Sx The Long Format
 subsection for more information.
 .It Ev CLICOLOR
-Use
-.Tn ANSI
-color sequences to distinguish file types.
+Use ANSI color sequences to distinguish file types.
 See
 .Ev LSCOLORS
 below.
@@ -787,9 +782,7 @@ default foreground or background
 default foreground or background, with an underline or bold
 .El
 .Pp
-Note that the above are standard
-.Tn ANSI
-colors.
+Note that the above are standard ANSI colors.
 The actual display may differ
 depending on the color capabilities of the terminal in use.
 .Pp
@@ -913,10 +906,8 @@ and
 .Fl ,
 are non-standard extensions.
 .Pp
-The ACL support is compatible with
-.Tn IEEE
-Std\~1003.2c
-.Pq Dq Tn POSIX Ns .2c
+The ACL support is compatible with IEEE Std\~1003.2c
+.Pq Dq POSIX Ns .2c
 Draft\~17
 (withdrawn).
 .Sh HISTORY


### PR DESCRIPTION
Github CI check fails on something unrelated. I think actually this needs to be a traditional patch going through bugzilla, so I'm going to close this.