### PR TITLE
auto_master.5: improve description, bump date

### DIFF
--- a/usr.sbin/autofs/auto_master.5
+++ b/usr.sbin/autofs/auto_master.5
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 28, 2018
+.Dd August 18, 2023
 .Dt AUTO_MASTER 5
 .Os
 .Sh NAME
 .Nm auto_master
-.Nd auto_master and map file format
+.Nd autofs automounter configuration and map file format
 .Sh DESCRIPTION
 The automounter configuration consists of the
 .Nm


### PR DESCRIPTION
This patch bumps the date and changes the document description of File Formats Manual page auto_master.5 from:

auto_master – auto_master and map file format

to:

auto_master – autofs automounter configuration and map file format

This is more descriptive, <72 characters, and serves to save a step when looking for auto_master but you forgot or never knew what it's called so you try "automount" or "autofs". This page is linked on the others, but with this change they will all come up together when searched for with either term. Also no keywords have been removed from the manual's name.

Sorry for the previous pulls. Is correct GitHub procedure to fork and make commits their own branch?