### PR TITLE
document pmap_kextract/vtophys

### DIFF
--- a/share/man/man9/Makefile
+++ b/share/man/man9/Makefile
@@ -268,6 +268,7 @@ MAN=	accept_filter.9 \
 	pmap_copy.9 \
 	pmap_enter.9 \
 	pmap_extract.9 \
+	pmap_kextract.9 \
 	pmap_growkernel.9 \
 	pmap_init.9 \
 	pmap_is_modified.9 \
@@ -1808,6 +1809,7 @@ MLINKS+=PHOLD.9 PRELE.9 \
 	PHOLD.9 PROC_ASSERT_NOT_HELD.9
 MLINKS+=pmap_copy.9 pmap_copy_page.9
 MLINKS+=pmap_extract.9 pmap_extract_and_hold.9
+MLINKS+=pmap_kextract.9 vtophys.9
 MLINKS+=pmap_init.9 pmap_init2.9
 MLINKS+=pmap_is_modified.9 pmap_ts_referenced.9
 MLINKS+=pmap_pinit.9 pmap_pinit0.9 \

--- a/share/man/man9/pmap.9
+++ b/share/man/man9/pmap.9
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 30, 2016
+.Dd August 24, 2023
 .Dt PMAP 9
 .Os
 .Sh NAME
@@ -97,6 +97,7 @@ operation.
 .Xr pmap_init2 9 ,
 .Xr pmap_is_modified 9 ,
 .Xr pmap_is_prefaultable 9 ,
+.Xr pmap_kextract 9 ,
 .Xr pmap_map 9 ,
 .Xr pmap_mincore 9 ,
 .Xr pmap_object_init_pt 9 ,

--- a/share/man/man9/pmap_kextract.9
+++ b/share/man/man9/pmap_kextract.9
@@ -52,8 +52,7 @@ However, if supplied with an illegitimate value for
 .Fa va
 it will return 0 on arm64, and
 .Xr panic 9
-on armv6 and riscv.
-Note that such platform dependent behaviours are subject to change.
+on arm and riscv.
 .Sh SEE ALSO
 .Xr pmap 9
 .Sh AUTHORS

--- a/share/man/man9/pmap_kextract.9
+++ b/share/man/man9/pmap_kextract.9
@@ -49,12 +49,12 @@ associated with the kernel virtual address
 .Fn pmap_kextract
 generally does not fail.
 However, if supplied with an illegitimate value for
-.Fa va
-it will return 0 on arm64, and
-.Xr panic 9
-on arm and riscv.
+.Fa va ,
+the function may return zero, an invalid non-zero value, or call
+.Xr panic 9 .
 .Sh SEE ALSO
-.Xr pmap 9
+.Xr pmap 9 ,
+.Xr pmap_extract 9
 .Sh AUTHORS
 .An -nosplit
 This manual page was written by

--- a/share/man/man9/pmap_kextract.9
+++ b/share/man/man9/pmap_kextract.9
@@ -12,7 +12,7 @@
 .Sh NAME
 .Nm pmap_kextract ,
 .Nm vtophys
-.Nd extract from kernel page table to a physical address
+.Nd extract a physical address from the kernel page table
 .Sh SYNOPSIS
 .In sys/param.h
 .In vm/vm.h
@@ -28,17 +28,23 @@
 .Sh DESCRIPTION
 The
 .Fn pmap_kextract
-function, and its alias
-.Fn vtophys ,
-map a kernel virtual address to a physical page.
+function retrieves the underlying physical memory address corresponding to the given kernel virtual address
+.Fa va .
+The value of
+.Fa va
+must correlate to an active mapping in the kernel address space.
+.Pp
+.Fn vtophys
+is an alias for
+.Fn pmap_kextract
+and behaves identically.
 .Sh RETURN VALUES
 The
 .Fn pmap_kextract
-function will return the physical page address
-.Ft ( vm_paddr_t )
+function will return the physical address
+.Pq Vt vm_paddr_t
 associated with the kernel virtual address
-.Fa va
-inside the physical map of the address space.
+.Fa va .
 In case of failure,
 .Fn pmap_kextract
 will

--- a/share/man/man9/pmap_kextract.9
+++ b/share/man/man9/pmap_kextract.9
@@ -45,13 +45,15 @@ function will return the physical address
 .Pq Vt vm_paddr_t
 associated with the kernel virtual address
 .Fa va .
-In case of failure,
+.Pp
 .Fn pmap_kextract
-will
+generally does not fail.
+However, if supplied with an illegitimate value for
+.Fa va
+it will return 0 on arm64, and
 .Xr panic 9
-on armv6 and riscv, where most other platforms would
-.Xr KASSERT 9 .
-The function will return 0 on arm64.
+on armv6 and riscv.
+Note that such platform dependent behaviours are subject to change.
 .Sh SEE ALSO
 .Xr pmap 9
 .Sh AUTHORS

--- a/share/man/man9/pmap_kextract.9
+++ b/share/man/man9/pmap_kextract.9
@@ -1,0 +1,58 @@
+.\"
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
+.\" Copyright (c) 2023 The FreeBSD Foundation
+.\"
+.\" This manual page was written by Mina Galić <FreeBSD@igalic.co> under
+.\" sponsorship from the FreeBSD Foundation.
+.\"
+.Dd August 24, 2023
+.Dt PMAP_KEXTRACT 9
+.Os
+.Sh NAME
+.Nm pmap_kextract ,
+.Nm vtophys
+.Nd extract from kernel page table to a physical address
+.Sh SYNOPSIS
+.In sys/param.h
+.In vm/vm.h
+.In vm/pmap.h
+.Ft vm_paddr_t
+.Fo pmap_kextract
+.Fa "vm_offset_t va"
+.Fc
+.Ft vm_paddr_t
+.Fo vtophys
+.Fa "vm_offset_t va"
+.Fc
+.Sh DESCRIPTION
+The
+.Fn pmap_kextract
+function, and its alias
+.Fn vtophys ,
+map a kernel virtual address to a physical page.
+.Sh RETURN VALUES
+The
+.Fn pmap_kextract
+function will return the physical page address
+.Ft ( vm_paddr_t )
+associated with the kernel virtual address
+.Fa va
+inside the physical map of the address space.
+In case of failure,
+.Fn pmap_kextract
+will
+.Xr panic 9
+on armv6 and riscv, where most other platforms would
+.Xr KASSERT 9 .
+The function will return 0 on arm64.
+.Sh SEE ALSO
+.Xr pmap 9
+.Sh AUTHORS
+.An -nosplit
+This manual page was written by
+.An Mina Galić Aq Mt FreeBSD@igalic.co ,
+based on the
+.Xr pmap_extract 9
+page written by
+.An Bruce M Simpson Aq Mt bms@spc.org .

--- a/sys/amd64/amd64/pmap.c
+++ b/sys/amd64/amd64/pmap.c
@@ -3846,7 +3846,7 @@ pmap_flush_cache_phys_range(vm_paddr_t spa, vm_paddr_t epa, vm_memattr_t mattr)
  *		Extract the physical page address associated
  *		with the given map/virtual_address pair.
  */
-vm_paddr_t 
+vm_paddr_t
 pmap_extract(pmap_t pmap, vm_offset_t va)
 {
 	pdp_entry_t *pdpe;
@@ -3933,6 +3933,12 @@ out:
 	return (m);
 }
 
+/*
+ *	Routine:	pmap_kextract
+ *	Function:
+ *		Extract from the kernel page table the physical address
+ *		that is mapped by the given virtual address "va".
+ */
 vm_paddr_t
 pmap_kextract(vm_offset_t va)
 {

--- a/sys/amd64/amd64/pmap.c
+++ b/sys/amd64/amd64/pmap.c
@@ -3936,8 +3936,8 @@ out:
 /*
  *	Routine:	pmap_kextract
  *	Function:
- *		Extract from the kernel page table the physical address
- *		that is mapped by the given virtual address "va".
+ *		Extract the physical page address associated with the given kernel
+ *		virtual address.
  */
 vm_paddr_t
 pmap_kextract(vm_offset_t va)

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -1950,8 +1950,10 @@ pmap_klookup(vm_offset_t va, vm_paddr_t *pa)
 }
 
 /*
- *  Extract from the kernel page table the physical address
- *  that is mapped by the given virtual address "va".
+ *	Routine:	pmap_kextract
+ *	Function:
+ *		Extract the physical page address associated with the given kernel
+ *		virtual address.
  */
 vm_paddr_t
 pmap_kextract(vm_offset_t va)

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -1949,6 +1949,10 @@ pmap_klookup(vm_offset_t va, vm_paddr_t *pa)
 	return (true);
 }
 
+/*
+ *  Extract from the kernel page table the physical address
+ *  that is mapped by the given virtual address "va".
+ */
 vm_paddr_t
 pmap_kextract(vm_offset_t va)
 {

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -970,6 +970,10 @@ pmap_extract_and_hold(pmap_t pmap, vm_offset_t va, vm_prot_t prot)
 	return (m);
 }
 
+/*
+ *  Extract from the kernel page table the physical address
+ *  that is mapped by the given virtual address "va".
+ */
 vm_paddr_t
 pmap_kextract(vm_offset_t va)
 {

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -971,8 +971,10 @@ pmap_extract_and_hold(pmap_t pmap, vm_offset_t va, vm_prot_t prot)
 }
 
 /*
- *  Extract from the kernel page table the physical address
- *  that is mapped by the given virtual address "va".
+ *	Routine:	pmap_kextract
+ *	Function:
+ *		Extract the physical page address associated with the given kernel
+ *		virtual address.
  */
 vm_paddr_t
 pmap_kextract(vm_offset_t va)


### PR DESCRIPTION
The main body of this pull request is documenting pmap_kextract(9) function and its vtophys(9) alias.

The need to understand pmap_kextract(9) arose from trying to understand virtio code which I am trying to document, and as such this a small side-step in my cloud-init project, where lately I have been working on a virtio vsock driver.

Sponsored by: The FreeBSD Foundation