### PR TITLE
fopen.3: Fixed typo in the documentation of fmemopen

### DIFF
--- a/lib/libc/stdio/fopen.3
+++ b/lib/libc/stdio/fopen.3
@@ -51,7 +51,7 @@
 .Ft FILE *
 .Fn freopen "const char *path" "const char *mode" "FILE *stream"
 .Ft FILE *
-.Fn fmemopen "void *restrict *buf" "size_t size" "const char * restrict mode"
+.Fn fmemopen "void * restrict buf" "size_t size" "const char * restrict mode"
 .Sh DESCRIPTION
 The
 .Fn fopen


### PR DESCRIPTION
The declaration of `fmemopen` in the [documentation](https://github.com/freebsd/freebsd-src/blob/47d997021fbc7b662e9507deec1897d514d1224c/lib/libc/stdio/fopen.3#L54) is inconsistent with the declaration in the [header file](https://github.com/freebsd/freebsd-src/blob/47d997021fbc7b662e9507deec1897d514d1224c/include/stdio.h#L372). Specifically:

```
FILE * fmemopen(void *restrict *buf, size_t size, const char * restrict mode);
```

versus

```
FILE* fmemopen(void * __restrict buf, size_t size, const char * __restrict mode)
```

Note the two * (stars). This pull request fixes this. 