### PR TITLE
networking.7 : create network quickstart guide

### DIFF
--- a/share/man/man7/Makefile
+++ b/share/man/man7/Makefile
@@ -46,6 +46,11 @@ MLINKS+= c.7 c11.7
 MLINKS+= c.7 c17.7
 MLINKS+= c.7 c2x.7
 
+.if ${MK_INET} != "no"
+MAN+=	networking.7
+MLINKS+= networking.7 wifi.7
+.endif
+
 .if ${MK_TESTS} != "no"
 ATF=	${SRCTOP}/contrib/atf
 .PATH:	${ATF}/doc

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -24,16 +24,31 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 29, 2023
+.Dd September 12, 2023
 .Dt "NETWORKING" 7
 .Os
 .Sh NAME
 .Nm networking ,
 .Nm wifi
 .Nd quickstart guide to connecting to a network
+.Sh DESCRIPTION
+.Fx
+names network interfaces according to the driver that loads them.
+In the following examples, it is assumed that we are connecting to Ethernet
+with the first interface found by the
+.Xr em 4
+driver, and Wi-Fi with the first interface found by the
+.Xr iwn 4
+driver, though your equipment almost certainly will vary.
 .Sh EXAMPLES
 .Ss Connecting to an Ethernet network with DHCP:
 .Dl # dhclient em0
+.Ss Connecting to a cellular network with USB tethering:
+Load the USB tethering driver,
+.Xr urndis 4 :
+.Dl # kldload urndis
+Ask for a DHCP lease on the USB tethering interface:
+.Dl # dhclient ue0
 .Ss Connecting to a Wi-Fi network:
 Identify your Wi-Fi hardware:
 .Dl % sysctl net.wlan.devices
@@ -43,7 +58,7 @@ Set that interface to negotiate a DHCP lease with
 .Xr wpa_supplicant 8 :
 .Dl # sysrc ifconfig_wlan0="WPA SYNCDHCP"
 Enter the details of the Wi-Fi network:
-.Dl # echo "network={ssid="myssid" psk="mypsk"} >> wpa_supplicant.conf
+.Dl # wpa_passphrase myssid mypsk >> wpa_supplicant.conf
 Restart the network interface daemon:
 .Dl # service netif restart
 .Ss Scanning for Wi-Fi networks:
@@ -54,7 +69,22 @@ Restart the network interface daemon:
 .Xr bsdconfig 8 ,
 .Xr dhclient 8 ,
 .Xr ifconfig 8 ,
+.Xr wpa_passphrase 8 ,
 .Xr wpa_supplicant 8
 .Pp
+The Advanced Networking chapter of the
 .Fx
-The Advanced Networking chapter of the FreeBSD Handbook
+Handbook.
+.Sh CAVEATS
+Shell Special Characters in the ssid or psk will need to be escaped for
+.Xr wpa_passphrase 8 ,
+commonly using
+.Ql / ,
+see the manual page for your shell for more details.
+.Pp
+Currently
+.Ql service netif restart
+does not restart routing.
+A common workaround is to issue
+.Ql service netif restart && service routing restart
+instead.

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -39,7 +39,8 @@ Identify your Wi-Fi hardware:
 .Dl % sysctl net.wlan.devices
 Configure your Wi-Fi hardware as wlan0 interface:
 .Dl # sysrc wlans_iwn0="wlan0"
-Set that interface to negotiate a dhcp lease with wpa supplicant:
+Set that interface to negotiate a DHCP lease with
+.Xr wpa_supplicant 8 :
 .Dl # sysrc ifconfig_wlan0="WPA SYNCDHCP"
 Enter the details of the Wi-Fi network:
 .Dl # echo "network={ssid="myssid" psk="mypsk"} >> wpa_supplicant.conf

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -34,18 +34,18 @@
 .Sh EXAMPLES
 .Ss Connecting to an ethernet network with DHCP:
 .Dl # dhclient em0
-.Ss Connecting to a wifi network:
-Identify your wifi hardware:
+.Ss Connecting to a Wi-Fi network:
+Identify your Wi-Fi hardware:
 .Dl % sysctl net.wlan.devices
-Configure your wifi hardware as wlan0 interface:
+Configure your Wi-Fi hardware as wlan0 interface:
 .Dl # sysrc wlans_iwn0="wlan0"
 Set that interface to negotiate a dhcp lease with wpa supplicant:
 .Dl # sysrc ifconfig_wlan0="WPA SYNCDHCP"
-Enter the wifi network's details:
+Enter the details of the Wi-Fi network:
 .Dl # echo "network={ssid="myssid" psk="mypsk"} >> wpa_supplicant.conf
 Restart the network interface daemon:
 .Dl # service netif restart
-.Ss Scanning for wifi networks:
+.Ss Scanning for Wi-Fi networks:
 .Dl % ifconfig wlan0 scan
 .Ss Airplane mode:
 .Dl # service netif stop

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -32,7 +32,7 @@
 .Nm wifi
 .Nd quickstart guide to connecting to a network
 .Sh EXAMPLES
-.Ss Connecting to an ethernet network with DHCP:
+.Ss Connecting to an Ethernet network with DHCP:
 .Dl # dhclient em0
 .Ss Connecting to a Wi-Fi network:
 Identify your Wi-Fi hardware:

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -32,39 +32,68 @@
 .Nm wifi
 .Nd quickstart guide to connecting to a network
 .Sh DESCRIPTION
-.Fx
-names network interfaces according to the driver that loads them.
 In the following examples, it is assumed that we are connecting to Ethernet
 with the first interface found by the
 .Xr em 4
 driver, and Wi-Fi with the first interface found by the
 .Xr iwn 4
-driver, though your equipment almost certainly will vary.
+driver, though your hardware will vary.
 .Sh EXAMPLES
-.Ss Connecting to an Ethernet network with DHCP:
-.Dl # dhclient em0
-.Ss Connecting to a cellular network with USB tethering:
+.Bl -tag -width 0n
+.It Sy Connecting to an Ethernet network with DHCP:
+.Bd -literal -offset 2n
+.Ic # dhclient em0
+.Ed
+.It Sy Connecting to a cellular network with USB tethering:
+.Pp
 Load the USB tethering driver,
 .Xr urndis 4 :
-.Dl # kldload urndis
+.Bd -literal -offset 2n
+.Ic # kldload urndis
+.Ed
+.Pp
 Ask for a DHCP lease on the USB tethering interface:
-.Dl # dhclient ue0
-.Ss Connecting to a Wi-Fi network:
+.Bd -literal -offset 2n
+.Ic # dhclient ue0
+.Ed
+.It Sy Connecting to a Wi-Fi network:
+.Pp
 Identify your Wi-Fi hardware:
-.Dl % sysctl net.wlan.devices
+.Bd -literal -offset 2n
+.Ic % sysctl net.wlan.devices
+.Ed
+.Pp
 Configure your Wi-Fi hardware as wlan0 interface:
-.Dl # sysrc wlans_iwn0="wlan0"
+.Ed
+.Bd -literal -offset 2n
+.Ic # sysrc wlans_iwn0="wlan0"
+.Ed
+.Pp
 Set that interface to negotiate a DHCP lease with
 .Xr wpa_supplicant 8 :
-.Dl # sysrc ifconfig_wlan0="WPA SYNCDHCP"
+.Bd -literal -offset 2n
+.Ic # sysrc ifconfig_wlan0="WPA SYNCDHCP"
+.Ed
+.Pp
 Enter the details of the Wi-Fi network:
-.Dl # wpa_passphrase myssid mypsk >> wpa_supplicant.conf
+.Bd -literal -offset 2n
+.Ic # wpa_passphrase "myssid" "mypassphrase" >> wpa_supplicant.conf
+.Ed
+.Pp
 Restart the network interface daemon:
-.Dl # service netif restart
-.Ss Scanning for Wi-Fi networks:
-.Dl % ifconfig wlan0 scan
-.Ss Airplane mode:
-.Dl # service netif stop
+.Bd -literal -offset 2n
+.Ic # service netif restart
+.Ed
+.Pp
+.It Sy Scanning for Wi-Fi networks:
+.Bd -literal -offset 2n
+.Ic % ifconfig wlan0 scan
+.Ed
+.It Sy Airplane mode:
+.Bd -literal -offset 2n
+.Ic # service netif stop
+.Ed
+.El
 .Sh SEE ALSO
 .Xr bsdconfig 8 ,
 .Xr dhclient 8 ,
@@ -76,15 +105,19 @@ The Advanced Networking chapter of the
 .Fx
 Handbook.
 .Sh CAVEATS
-Shell Special Characters in the SSID or PSK will need to be escaped for
+Shell Special Characters in the
+.Ar SSID
+or
+.Ar passphrase
+will need to be escaped for
 .Xr wpa_passphrase 8 ,
 commonly using
-.Ql / ,
+.Ql \e ,
 see the manual page for your shell for more details.
 .Pp
 Currently
-.Ql service netif restart
+.Ql Ic service netif restart
 does not restart routing.
 A common workaround is to issue
-.Ql service netif restart && service routing restart
+.Ql Ic service netif restart && service routing restart
 instead.

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -76,7 +76,7 @@ The Advanced Networking chapter of the
 .Fx
 Handbook.
 .Sh CAVEATS
-Shell Special Characters in the ssid or psk will need to be escaped for
+Shell Special Characters in the SSID or PSK will need to be escaped for
 .Xr wpa_passphrase 8 ,
 commonly using
 .Ql / ,

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd September 12, 2023
+.Dd September 15, 2023
 .Dt "NETWORKING" 7
 .Os
 .Sh NAME
@@ -77,7 +77,7 @@ Set that interface to negotiate a DHCP lease with
 .Pp
 Enter the details of the Wi-Fi network:
 .Bd -literal -offset 2n
-.Ic # wpa_passphrase "myssid" "mypassphrase" >> wpa_supplicant.conf
+.Ic # wpa_passphrase \(dqmyssid\(dq \(dqmypassphrase\(dq >> wpa_supplicant.conf
 .Ed
 .Pp
 Restart the network interface daemon:
@@ -98,8 +98,7 @@ Restart the network interface daemon:
 .Xr bsdconfig 8 ,
 .Xr dhclient 8 ,
 .Xr ifconfig 8 ,
-.Xr wpa_passphrase 8 ,
-.Xr wpa_supplicant 8
+.Xr wpa_passphrase 8
 .Pp
 The Advanced Networking chapter of the
 .Fx

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -57,4 +57,4 @@ Restart the network interface daemon:
 .Xr wpa_supplicant 8
 .Pp
 .Fx
-handbook chapter 42: Advanced Networking
+The Advanced Networking chapter of the FreeBSD Handbook

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -1,0 +1,59 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
+.\" Copyright (c) 2023 Alexander Ziaee
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.\"
+.Dd August 29, 2023
+.Dt "NETWORKING" 7
+.Os
+.Sh NAME
+.Nm networking ,
+.Nm wifi
+.Nd quickstart guide to connecting to a network
+.Sh EXAMPLES
+.Ss Connecting to an ethernet network with DHCP:
+.Dl # dhclient em0
+.Ss Connecting to a wifi network:
+Identify your wifi hardware:
+.Dl % sysctl net.wlan.devices
+Configure your wifi hardware as wlan0 interface:
+.Dl # sysrc wlans_iwn0="wlan0"
+Set that interface to negotiate a dhcp lease with wpa supplicant:
+.Dl # sysrc ifconfig_wlan0="WPA SYNCDHCP"
+Enter the wifi network's details:
+.Dl # echo "network={ssid="myssid" psk="mypsk"} >> wpa_supplicant.conf
+Restart the network interface daemon:
+.Dl # service netif restart
+.Ss Scanning for wifi networks:
+.Dl % ifconfig wlan0 scan
+.Ss Airplane mode:
+.Dl # service netif stop
+.Sh SEE ALSO
+.Xr bsdconfig 8 ,
+.Xr dhclient 8 ,
+.Xr ifconfig 8 ,
+.Xr wpa_supplicant 8
+.Pp
+.Fx
+handbook chapter 42: Advanced Networking

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -1,30 +1,9 @@
 .\"-
 .\" SPDX-License-Identifier: BSD-2-Clause
 .\"
-.\" Copyright (c) 2023 Alexander Ziaee
+.\" Copyright (c) 2024 Alexander Ziaee <concussious@runbox.com>
 .\"
-.\" Redistribution and use in source and binary forms, with or without
-.\" modification, are permitted provided that the following conditions
-.\" are met:
-.\" 1. Redistributions of source code must retain the above copyright
-.\"    notice, this list of conditions and the following disclaimer.
-.\" 2. Redistributions in binary form must reproduce the above copyright
-.\"    notice, this list of conditions and the following disclaimer in the
-.\"    documentation and/or other materials provided with the distribution.
-.\"
-.\" THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
-.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
-.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-.\" SUCH DAMAGE.
-.\"
-.Dd September 15, 2023
+.Dd January 08, 2024
 .Dt "NETWORKING" 7
 .Os
 .Sh NAME


### PR DESCRIPTION
Now that the handbook has been moved to ports, I think it's very nice to have a network quickstart guide in-band, in base, in the system manual. If the user uses any of the following terms "man -k {network,networking,wifi,quickstart}" this page will come up, which is I think a very, very common use case for new users.

FreeBSD is the server star, but new users will need to play with it on their laptops before trying to use it in production, right?

Currently, this document explains connecting to a basic Ethernet network, USB tethering, a basic wifi network, scanning for wifi networks, and airplane mode, as well as linking to a few other relevant pages and sections, including the handbook.