### PR TITLE
urndis(4): retrospective, address for hselasky

### DIFF
--- a/share/man/man4/urndis.4
+++ b/share/man/man4/urndis.4
@@ -103,4 +103,4 @@ and
 It was ported to
 .Fx
 by
-.An Hans Petter Selasky Aq Mt hps@FreeBSD.org .
+.An Hans Petter Selasky Aq Mt hselasky@FreeBSD.org .


### PR DESCRIPTION
https://bugs.freebsd.org/273530#c3

PR:     273530
Fixes:  08c9016bc61b Add a manpage for the urndis driver.

