### PR TITLE
release: Update vagrant configuration

### DIFF
--- a/release/tools/vagrant.conf
+++ b/release/tools/vagrant.conf
@@ -52,10 +52,11 @@ vagrant_common () {
 	# Configure sudo to allow the vagrant user
 	echo 'vagrant ALL=(ALL:ALL) NOPASSWD: ALL' >> ${DESTDIR}/usr/local/etc/sudoers
 
-	# Configure the vagrant ssh key
+	# Configure the vagrant ssh keys
 	mkdir ${DESTDIR}/home/vagrant/.ssh
 	chmod 700 ${DESTDIR}/home/vagrant/.ssh
 	echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" > ${DESTDIR}/home/vagrant/.ssh/authorized_keys
+	echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN1YdxBpNlzxDqfJyw/QKow1F+wvG9hXGoqiysfJOn5Y vagrant insecure public key" >> ${DESTDIR}/home/vagrant/.ssh/authorized_keys
 	chown -R 1001 ${DESTDIR}/home/vagrant/.ssh
 	chmod 600 ${DESTDIR}/home/vagrant/.ssh/authorized_keys
 

--- a/release/tools/vagrant.conf
+++ b/release/tools/vagrant.conf
@@ -50,7 +50,7 @@ vagrant_common () {
 		usermod root -h 0
 
 	# Configure sudo to allow the vagrant user
-	echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> ${DESTDIR}/usr/local/etc/sudoers
+	echo 'vagrant ALL=(ALL:ALL) NOPASSWD: ALL' >> ${DESTDIR}/usr/local/etc/sudoers
 
 	# Configure the vagrant ssh key
 	mkdir ${DESTDIR}/home/vagrant/.ssh


### PR DESCRIPTION
## Allow `sudo -g anyone` and `sudo -u anyone -g anytwo`

When only the user `(ALL)` is specified explicitly, and the group is implied, only `sudo -u` works.  Specifying both the user and group, like `(ALL:ALL)`, is required to:

1. Use `sudo -g` by itself (with no `-u user`).
2. Use `sudo -u` and `-g` together, with a `-g group` that is different from the `-u user`'s primary group.

Obtained from:	https://github.com/sudo-project/sudo/commit/1d13533ea3cda05ec666c45c6c533b614fdd97aa

> [!NOTE]
> I would prefer to create a file (`${DESTDIR}/usr/local/etc/sudoers.d/vagrant`), as this allows for an easy overwrite of the `sudoers` file when the `sudo` package is updated:
> ```sh
> # Configure sudo to allow the vagrant user
> echo 'vagrant ALL=(ALL:ALL) NOPASSWD: ALL' > ${DESTDIR}/usr/local/etc/sudoers.d/vagrant
> chmod 0440 ${DESTDIR}/usr/local/etc/sudoers.d/vagrant
> ```

## Add the Ed25519 vagrant insecure key

See: https://github.com/hashicorp/vagrant/commit/b40f6e5fdae1113518e9c92f96dfcd364b646ff9