### PR TITLE
libcrypto: fix the FIPS provider on amd64

### DIFF
--- a/secure/lib/libcrypto/modules/fips/Makefile
+++ b/secure/lib/libcrypto/modules/fips/Makefile
@@ -32,25 +32,25 @@ SRCS+=	mem_clr.c
 .endif
 
 # crypto/aes
-SRCS+=	aes_cbc.c aes_cfb.c aes_ecb.c aes_ige.c aes_misc.c aes_ofb.c aes_wrap.c
+SRCS+=	aes_cfb.c aes_ecb.c aes_ige.c aes_misc.c aes_ofb.c aes_wrap.c
 .if defined(ASM_aarch64)
-SRCS+=	aes_core.c aesv8-armx.S vpaes-armv8.S
+SRCS+=	aes_cbc.c aes_core.c aesv8-armx.S vpaes-armv8.S
 ACFLAGS.aesv8-armx.S=	-march=armv8-a+crypto
 .elif defined(ASM_amd64)
-SRCS+=	aes_core.c aesni-mb-x86_64.S aesni-sha1-x86_64.S aesni-sha256-x86_64.S
-SRCS+=	aesni-x86_64.S vpaes-x86_64.S
+SRCS+=	aesni-mb-x86_64.S aesni-sha1-x86_64.S aesni-sha256-x86_64.S
+SRCS+=	aesni-x86_64.S aes-x86_64.S bsaes-x86_64.S vpaes-x86_64.S
 .elif defined(ASM_arm)
-SRCS+=	aes-armv4.S aesv8-armx.S bsaes-armv7.S
+SRCS+=	aes-armv4.S aes_cbc.c aesv8-armx.S bsaes-armv7.S
 .elif defined(ASM_i386)
 SRCS+=	aes_core.c aesni-x86.S vpaes-x86.S
 .elif defined(ASM_powerpc)
-SRCS+=	aes_core.c aes-ppc.S vpaes-ppc.S aesp8-ppc.S
+SRCS+=	aes_cbc.c aes_core.c aes-ppc.S vpaes-ppc.S aesp8-ppc.S
 .elif defined(ASM_powerpc64)
-SRCS+=	aes_core.c aes-ppc.S vpaes-ppc.S aesp8-ppc.S
+SRCS+=	aes_cbc.c aes_core.c aes-ppc.S vpaes-ppc.S aesp8-ppc.S
 .elif defined(ASM_powerpc64le)
-SRCS+=	aes_core.c aes-ppc.S vpaes-ppc.S aesp8-ppc.S
+SRCS+=	aes_cbc.c aes_core.c aes-ppc.S vpaes-ppc.S aesp8-ppc.S
 .else
-SRCS+=	aes_core.c
+SRCS+=	aes_cbc.c aes_core.c
 .endif
 
 # crypto/bn


### PR DESCRIPTION
Summary:
This corrects the list of source files required for the FIPS provider, as tested on a amd64 host. This still requires testing on the other architectures.

Test Plan:
```
# openssl fipsinstall -out /etc/ssl/fipsmodule.cnf -module /usr/lib/ossl-modules/fips.so
# vi /etc/ssl/openssl.cnf
[enable the FIPS module]
# echo test | openssl aes-256-cbc -provider fips -a -pbkdf2
enter AES-256-CBC encryption password:
Verifying - enter AES-256-CBC encryption password:
U2FsdGVkX199k8PlM+6jTPK4AARYYVR3BXF+a1bCLCk=
```

Subscribers: imp

Differential Revision: https://reviews.freebsd.org/D41719