### PR TITLE
file: Fix cross-compilation on Darwin/macOS

### DIFF
--- a/lib/libmagic/config.h
+++ b/lib/libmagic/config.h
@@ -20,7 +20,9 @@
 #define HAVE_ASPRINTF 1
 
 /* Define to 1 if you have the <byteswap.h> header file. */
+#ifndef __APPLE__ /* Cross building tools on macOS */
 #define HAVE_BYTESWAP_H 1
+#endif
 
 /* Define to 1 if you have the <bzlib.h> header file. */
 /* #undef HAVE_BZLIB_H */


### PR DESCRIPTION
Apply an `#ifndef __APPLE__` conditional directive after 898496ee09ed2b7d25f6807edc4515628196ec0a, as Darwin/macOS does not have `byteswap.h`, to fix cross-builds.