### PR TITLE
include/math.h: fix warning with -Wconversion

### DIFF
--- a/lib/msun/src/math.h
+++ b/lib/msun/src/math.h
@@ -78,9 +78,9 @@ extern const union __nan_un {
 
 #if __STDC_VERSION__ >= 201112L || __has_extension(c_generic_selections)
 #define	__fp_type_select(x, f, d, ld) __extension__ _Generic((x),	\
-    float: f(x),							\
-    double: d(x),							\
-    long double: ld(x))
+    float: f,								\
+    double: d,								\
+    long double: ld)(x)
 #elif __GNUC_PREREQ__(3, 1) && !defined(__cplusplus)
 #define	__fp_type_select(x, f, d, ld) __builtin_choose_expr(		\
     __builtin_types_compatible_p(__typeof(x), long double), ld(x),	\


### PR DESCRIPTION
The way the __fp_type_select macro uses the _Generic expression causes gcc to throw a warning on valid code if the -Wconversion flag is used.

For example, consider the following program:

    #include <math.h>
    int main()
    {
    	double x = 1.0;
    	isnan(x);
    	return 0;
    }

which throws a warning:

    $ gcc -Wconversion a.c
    a.c:5:15: warning: conversion from 'double' to 'float' may change value [-Wfloat-conversion]
        5 |         isnan(x);
          |               ^

This happens because the functions are invoked inside of the _Generic. Looking at the example of _Generic in the C11 specification, one sees that the parameters are outside of the _Generic expression (see page 79 here: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf).

Reference: https://stackoverflow.com/a/68309379