### PR TITLE
libcrypto: link engines and the legacy provider to libcrypto

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -2980,7 +2980,7 @@ libraries: .MAKE .PHONY
 	${_+_}cd ${.CURDIR}; \
 	    ${MAKE} -f Makefile.inc1 _prereq_libs; \
 	    ${MAKE} -f Makefile.inc1 _startup_libs; \
-	    ${MAKE} -f Makefile.inc1 _prebuild_libs; \
+	    ${MAKE} -f Makefile.inc1 _prebuild_libs -DLIBCRYPTO_WITHOUT_SUBDIRS; \
 	    ${MAKE} -f Makefile.inc1 _generic_libs
 
 #

--- a/secure/lib/libcrypto/Makefile
+++ b/secure/lib/libcrypto/Makefile
@@ -1,6 +1,8 @@
 
 SHLIBDIR?=	/lib
+.if !defined(LIBCRYPTO_WITHOUT_SUBDIRS)
 SUBDIR=		engines modules
+.endif
 
 .include <bsd.own.mk>
 .include <src.opts.mk>

--- a/secure/lib/libcrypto/engines/Makefile.inc
+++ b/secure/lib/libcrypto/engines/Makefile.inc
@@ -16,6 +16,8 @@ CFLAGS+=	-DB_ENDIAN
 .endif
 CFLAGS+=	-DNDEBUG
 
+LIBADD=		crypto
+
 .PATH: ${LCRYPTO_SRC}/engines
 
 WARNS?=		0

--- a/secure/lib/libcrypto/modules/legacy/Makefile
+++ b/secure/lib/libcrypto/modules/legacy/Makefile
@@ -1,5 +1,6 @@
 
 SHLIB_NAME?=	legacy.so
+LIBADD=		crypto
 
 SRCS+=	legacyprov.c prov_running.c
 


### PR DESCRIPTION
The most efficient way to ship OpenSSL's legacy provider module and engines is to have them link to libcrypto.so. This can break the build since they are created in a sub-directory of secure/lib/libcrypto, and may be ready to link before libcrypto.so is available.

This commit introduces a LIBCRYPTO_WITHOUT_SUBDIRS define, ensuring libcrypto.so builds in its usual early phase without any OpenSSL provider module or engines. They are then completed as expected later.