### PR TITLE
Cirrus CI: Only trigger on pull requests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,6 +23,7 @@ task:
       TOOLCHAIN: llvm15
       TOOLCHAIN_PKG: ${TOOLCHAIN}-lite
   - name: amd64-llvm16 World and kernel build and boot smoke test
+    only_if: $CIRRUS_BRANCH =~ 'pull/.*'
     env:
       TARGET: amd64
       TARGET_ARCH: amd64
@@ -63,7 +64,7 @@ task:
       TOOLCHAIN_PKG: ${TOOLCHAIN}
       EXTRA_MAKE_FLAGS: -s
   - name: amd64-gcc12 World and kernel build and boot smoke test (FreeBSD repo)
-    only_if: $CIRRUS_REPO_FULL_NAME == 'freebsd/freebsd-src'
+    only_if: $CIRRUS_REPO_FULL_NAME == 'freebsd/freebsd-src' && $CIRRUS_BRANCH =~ 'pull/.*'
     env:
       TARGET: amd64
       TARGET_ARCH: amd64


### PR DESCRIPTION
Since Cirrus Labs is limiting their free usage tier [^1], limit CI runs on pull requests only.  Otherwise, we might deplete our monthly quota within a few days.

[^1]: https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/