### PR TITLE
Cirrus CI: Trigger on pull requests or downstream repos

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,6 +23,7 @@ task:
       TOOLCHAIN: llvm15
       TOOLCHAIN_PKG: ${TOOLCHAIN}-lite
   - name: amd64-llvm16 World and kernel build and boot smoke test
+    only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src' || $CIRRUS_BRANCH =~ 'pull/.*'
     env:
       TARGET: amd64
       TARGET_ARCH: amd64


### PR DESCRIPTION
Since Cirrus Labs is limiting their free usage tier[^1], limit CI runs on pull requests only.  Otherwise, we might deplete our monthly quota within a few days.

Adapt the task amd64-llvm16 to execute on downstream repos or on pull requests only.

Other alternatives will be further studied.

[^1]: https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/