### PR TITLE
usr.bin/sort/coll.h: Use C99 flexible arrays

### DIFF
--- a/usr.bin/sort/coll.h
+++ b/usr.bin/sort/coll.h
@@ -103,7 +103,7 @@ struct key_hint
 struct key_value
 {
 	struct bwstring		*k; /* key string */
-	struct key_hint		 hint[0]; /* key sort hint */
+	struct key_hint		 hint[]; /* key sort hint */
 } __packed;
 
 /*
@@ -111,7 +111,7 @@ struct key_value
  */
 struct keys_array
 {
-	struct key_value	 key[0];
+	struct key_value	 key[];
 };
 
 /*


### PR DESCRIPTION
Use C99 flexible arrays instead of older style of zero-length arrays.