### PR TITLE
isa_common: Fix msg on "non-PNP ISA device"

### DIFF
--- a/sys/isa/isa_common.c
+++ b/sys/isa/isa_common.c
@@ -570,7 +570,7 @@ isa_probe_children(device_t dev)
 		    strcmp(kern_ident, "GENERIC") == 0 &&
 		    device_is_attached(child))
 			device_printf(child,
-			    "non-PNP ISA device will be removed from GENERIC in FreeBSD 14.\n");
+			    "non-PNP ISA device will be removed from GENERIC in next FreeBSD release.\n");
 	}
 
 	/*


### PR DESCRIPTION
Fix "non-PNP ISA device will be removed from GENERIC in FreeBSD 14." displayed with dmsg on FreeBSD 14-RC1.
While on it, remove unneeded white spaces and tabs.