### PR TITLE
Optimize bitwise operations where possible

### DIFF
--- a/sys/arm/allwinner/aw_gpio.c
+++ b/sys/arm/allwinner/aw_gpio.c
@@ -768,10 +768,7 @@ aw_gpio_pin_toggle(device_t dev, uint32_t pin)
 
 	AW_GPIO_LOCK(sc);
 	data = AW_GPIO_READ(sc, AW_GPIO_GP_DAT(bank));
-	if (data & (1 << pin))
-		data &= ~(1 << pin);
-	else
-		data |= (1 << pin);
+	data ^= (1 << pin);
 	AW_GPIO_WRITE(sc, AW_GPIO_GP_DAT(bank), data);
 	AW_GPIO_UNLOCK(sc);
 

--- a/sys/dev/ixl/i40e_common.c
+++ b/sys/dev/ixl/i40e_common.c
@@ -3800,7 +3800,7 @@ static void i40e_parse_discover_capabilities(struct i40e_hw *hw, void *buff,
 				     enum i40e_admin_queue_opc list_type_opc)
 {
 	struct i40e_aqc_list_capabilities_element_resp *cap;
-	u32 valid_functions, num_functions;
+	u32 num_functions;
 	u32 number, logical_id, phys_id;
 	struct i40e_hw_capabilities *p;
 	enum i40e_status_code status;
@@ -4124,13 +4124,7 @@ static void i40e_parse_discover_capabilities(struct i40e_hw *hw, void *buff,
 		}
 	}
 
-	valid_functions = p->valid_functions;
-	num_functions = 0;
-	while (valid_functions) {
-		if (valid_functions & 1)
-			num_functions++;
-		valid_functions >>= 1;
-	}
+	num_functions = bitcount32(p->valid_functions);
 
 	/* partition id is 1-based, and functions are evenly spread
 	 * across the ports as partitions

--- a/sys/netpfil/pf/pf_if.c
+++ b/sys/netpfil/pf/pf_if.c
@@ -981,17 +981,16 @@ static int
 pfi_unmask(void *addr)
 {
 	struct pf_addr *m = addr;
-	int i = 31, j = 0, b = 0;
+	int i = 0, b = 0;
 	u_int32_t tmp;
 
-	while (j < 4 && m->addr32[j] == 0xffffffff) {
+	while (i < 4 && m->addr32[i] == 0xffffffff) {
 		b += 32;
-		j++;
+		i++;
 	}
-	if (j < 4) {
-		tmp = ntohl(m->addr32[j]);
-		for (i = 31; tmp & (1 << i); --i)
-			b++;
+	if (i < 4) {
+		tmp = ntohl(m->addr32[i]);
+		b += __buitlin_clz(tmp);
 	}
 	return (b);
 }

--- a/usr.bin/primes/spsp.c
+++ b/usr.bin/primes/spsp.c
@@ -76,13 +76,11 @@ spsp(uint64_t n, uint64_t p)
 {
 	uint64_t x;
 	uint64_t r = n - 1;
-	int k = 0;
+	unsigned int k;
 
 	/* Compute n - 1 = 2^k * r. */
-	while ((r & 1) == 0) {
-		k++;
-		r >>= 1;
-	}
+	k = __builtin_ctzll(r);
+	r >>= k;
 
 	/* Compute x = p^r mod n.  If x = 1, n is a p-spsp. */
 	x = powmod(p, r, n);

--- a/usr.bin/sdiotool/cam_sdio.c
+++ b/usr.bin/sdiotool/cam_sdio.c
@@ -172,7 +172,7 @@ sdio_read_bool_for_func(struct cam_device *dev, uint32_t addr, uint8_t func_numb
 	if (ret < 0)
 		return ret;
 
-	*is_enab = (resp & (1 << func_number)) > 0 ? 1 : 0;
+	*is_enab = (resp >> func_number) & 1;
 
 	return (0);
 }
@@ -186,9 +186,9 @@ sdio_set_bool_for_func(struct cam_device *dev, uint32_t addr, uint8_t func_numbe
 	ret = sdio_rw_direct(dev, 0, addr, 0, NULL, &resp);
 	if (ret != 0)
 		return ret;
+	is_enabled = (resp >> func_number) & 1;
 
-	is_enabled = resp & (1 << func_number);
-	if ((is_enabled !=0 && enable == 1) || (is_enabled == 0 && enable == 0))
+	if (is_enabled == enable) // Are the two equal?
 		return 0;
 
 	if (enable)


### PR DESCRIPTION
We can use compiler intrinsics to do this instead of doing it manually.