### PR TITLE
Optimize bitwise operations in pfctl

### DIFF
--- a/sbin/pfctl/pf_print_state.c
+++ b/sbin/pfctl/pf_print_state.c
@@ -447,17 +447,17 @@ print_state(struct pfctl_state *s, int opts)
 int
 unmask(struct pf_addr *m, sa_family_t af)
 {
-	int i = 31, j = 0, b = 0;
+	int b = 0;
+	unsigned int i = 0;
 	u_int32_t tmp;
 
-	while (j < 4 && m->addr32[j] == 0xffffffff) {
+	while (i < 4 && m->addr32[i] == 0xffffffff) {
 		b += 32;
-		j++;
+		i++;
 	}
-	if (j < 4) {
-		tmp = ntohl(m->addr32[j]);
-		for (i = 31; tmp & (1 << i); --i)
-			b++;
+	if (i < 4) {
+		tmp = ntohl(m->addr32[i]);
+		b += __builtin_clz(~tmp);
 	}
 	return (b);
 }

--- a/sbin/pfctl/pfctl_optimize.c
+++ b/sbin/pfctl/pfctl_optimize.c
@@ -1525,7 +1525,7 @@ interface_group(const char *ifname)
 void
 comparable_rule(struct pfctl_rule *dst, const struct pfctl_rule *src, int type)
 {
-	int i;
+	size_t i;
 	/*
 	 * To simplify the comparison, we just zero out the fields that are
 	 * allowed to be different and then do a simple memcmp()

--- a/sbin/pfctl/pfctl_parser.c
+++ b/sbin/pfctl/pfctl_parser.c
@@ -224,7 +224,7 @@ pfctl_parser_init(void)
 const struct icmptypeent *
 geticmptypebynumber(u_int8_t type, sa_family_t af)
 {
-	unsigned int	i;
+	size_t	i;
 
 	if (af != AF_INET6) {
 		for (i=0; i < nitems(icmp_type); i++) {
@@ -243,7 +243,7 @@ geticmptypebynumber(u_int8_t type, sa_family_t af)
 const struct icmptypeent *
 geticmptypebyname(char *w, sa_family_t af)
 {
-	unsigned int	i;
+	size_t	i;
 
 	if (af != AF_INET6) {
 		for (i=0; i < nitems(icmp_type); i++) {
@@ -262,7 +262,7 @@ geticmptypebyname(char *w, sa_family_t af)
 const struct icmpcodeent *
 geticmpcodebynumber(u_int8_t type, u_int8_t code, sa_family_t af)
 {
-	unsigned int	i;
+	size_t	i;
 
 	if (af != AF_INET6) {
 		for (i=0; i < nitems(icmp_code); i++) {
@@ -283,7 +283,7 @@ geticmpcodebynumber(u_int8_t type, u_int8_t code, sa_family_t af)
 const struct icmpcodeent *
 geticmpcodebyname(u_long type, char *w, sa_family_t af)
 {
-	unsigned int	i;
+	size_t	i;
 
 	if (af != AF_INET6) {
 		for (i=0; i < nitems(icmp_code); i++) {
@@ -362,7 +362,7 @@ print_ugid(u_int8_t op, unsigned u1, unsigned u2, const char *t, unsigned umax)
 void
 print_flags(u_int8_t f)
 {
-	int	i;
+	unsigned int	i;
 
 	for (i = 0; tcpflags[i]; ++i)
 		if (f & (1 << i))
@@ -700,7 +700,7 @@ print_src_node(struct pf_src_node *sn, int opts)
 static void
 print_eth_addr(const struct pfctl_eth_addr *a)
 {
-	int i, masklen = ETHER_ADDR_LEN * 8;
+	size_t i, masklen = ETHER_ADDR_LEN * 8;
 	bool seen_unset = false;
 
 	for (i = 0; i < ETHER_ADDR_LEN; i++) {
@@ -737,7 +737,7 @@ print_eth_addr(const struct pfctl_eth_addr *a)
 		return;
 
 	if (i == (ETHER_ADDR_LEN * 8)) {
-		printf("/%d", masklen);
+		printf("/%zu", masklen);
 		return;
 	}
 

--- a/sbin/pfctl/pfctl_table.c
+++ b/sbin/pfctl/pfctl_table.c
@@ -607,7 +607,7 @@ void
 print_iface(struct pfi_kif *p, int opts)
 {
 	time_t	tzero = p->pfik_tzero;
-	int	i, af, dir, act;
+	unsigned int	i, af, dir, act;
 
 	printf("%s", p->pfik_name);
 	if (opts & PF_OPT_VERBOSE) {


### PR DESCRIPTION
We can use compiler intrinsics to do this instead of doing it manually.