### PR TITLE
ping tests: Fix test on i386 platforms

### DIFF
--- a/sbin/ping/tests/test_ping.py
+++ b/sbin/ping/tests/test_ping.py
@@ -51,7 +51,7 @@ def build_response_packet(echo, ip, icmp, oip_ihl, special):
         # Build a package with a timestamp of INT_MAX
         # (time-warped package)
         payload_no_timestamp = sc.bytes_hex(load)[16:]
-        load = (b"\xff" * 8) + sc.hex_bytes(payload_no_timestamp)
+        load = b"\x7f" + (b"\xff" * 7) + sc.hex_bytes(payload_no_timestamp)
     if special == "wrong":
         # Build a package with a wrong last byte
         payload_no_last_byte = sc.bytes_hex(load)[:-2]


### PR DESCRIPTION
Actually use `INT_MAX` (`0x7fffffff`), not `UINT_MAX` (`0xffffffff`) to avoid overflowing `time_t` and missing the test.

Reported by:	Jenkins
Reviewed by:	markj
Differential Revision: https://reviews.freebsd.org/D42268

---
cc/ @markjdb 