### PR TITLE
if_tuntap: Make bpf interop consistent with if_loop

### DIFF
--- a/sys/net/if_tuntap.c
+++ b/sys/net/if_tuntap.c
@@ -1408,7 +1408,7 @@ tunoutput(struct ifnet *ifp, struct mbuf *m0, const struct sockaddr *dst,
 	}
 
 	/* BPF writes need to be handled specially. */
-	if (dst->sa_family == AF_UNSPEC)
+	if (dst->sa_family == AF_UNSPEC || dst->sa_family == pseudo_AF_HDRCMPLT)
 		bcopy(dst->sa_data, &af, sizeof(af));
 	else
 		af = RO_GET_FAMILY(ro, dst);


### PR DESCRIPTION
The pseudo_AF_HDRCMPLT check is already being done in if_loop and just needed to be ported over to if_tuntap.

PR:	256587