### PR TITLE
Update the GitHub actions

### DIFF
--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -2,7 +2,7 @@ name: Cross-build Kernel
 
 on:
   push:
-    branches: [ main, 'stable/13' ]
+    branches: [ main, 'stable/14', 'stable/13' ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, 'stable/14', 'stable/13' ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Add stable/14 to the pushed branches to build and allow manually running actions.

For manually run actions the `workflow_dispatch` change needs to be in the default branch of a clone.