### PR TITLE
Update regdomain.xml

### DIFF
--- a/lib/lib80211/regdomain.xml
+++ b/lib/lib80211/regdomain.xml
@@ -47,42 +47,42 @@
   <netband mode="11b">
     <band>
       <freqband ref="F1_2412_2462"/>
-      <maxpower>30</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_B</flags>
     </band>
   </netband>
   <netband mode="11g">
     <band>
       <freqband ref="F1_2412_2462"/>
-      <maxpower>30</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_G</flags>
     </band>
   </netband>
   <netband mode="11a">
     <band>
       <freqband ref="F1_5180_5240"/>
-      <maxpower>17</maxpower>
+      <maxpower>40</maxpower>
     </band>
     <band>
       <freqband ref="F1_5745_5805"/>
-      <maxpower>23</maxpower>
+      <maxpower>40</maxpower>
     </band>
     <band>
       <freqband ref="F1_5825_5825"/>
-      <maxpower>23</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_PASSIVE</flags>
     </band>
   </netband>
   <netband mode="11ng">
     <band>
       <freqband ref="F1_2412_2462"/>
-      <maxpower>30</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_G</flags>
       <flags>IEEE80211_CHAN_HT20</flags>
     </band>
     <band>
       <freqband ref="H4_2412_2462"/>
-      <maxpower>30</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_G</flags>
       <flags>IEEE80211_CHAN_HT40</flags>
     </band>
@@ -90,59 +90,59 @@
   <netband mode="11na">
     <band>
       <freqband ref="F1_5180_5240"/>
-      <maxpower>17</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT20</flags>
     </band>
     <band>
       <freqband ref="H4_5180_5240"/>
-      <maxpower>17</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT40</flags>
     </band>
     <band>
       <freqband ref="F1_5745_5805"/>
-      <maxpower>23</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT20</flags>
     </band>
     <band>
       <freqband ref="H4_5745_5805"/>
-      <maxpower>23</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT40</flags>
     </band>
   </netband>
   <netband mode="11ac">
     <band>
       <freqband ref="AC1_5180_5240_20"/>
-      <maxpower>17</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT20</flags>
       <flags>IEEE80211_CHAN_VHT20</flags>
     </band>
     <band>
       <freqband ref="AC1_5180_5240_40"/>
-      <maxpower>17</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT40</flags>
       <flags>IEEE80211_CHAN_VHT40</flags>
     </band>
     <band>
       <freqband ref="AC1_5180_5240_80"/>
-      <maxpower>17</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT40</flags>
       <flags>IEEE80211_CHAN_VHT80</flags>
     </band>
     <band>
       <freqband ref="AC1_5745_5805_20"/>
-      <maxpower>17</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT20</flags>
       <flags>IEEE80211_CHAN_VHT20</flags>
     </band>
     <band>
       <freqband ref="AC1_5745_5805_40"/>
-      <maxpower>17</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT40</flags>
       <flags>IEEE80211_CHAN_VHT40</flags>
     </band>
     <band>
       <freqband ref="AC1_5745_5805_80"/>
-      <maxpower>17</maxpower>
+      <maxpower>40</maxpower>
       <flags>IEEE80211_CHAN_HT40</flags>
       <flags>IEEE80211_CHAN_VHT80</flags>
     </band>


### PR DESCRIPTION
I wanted to bring this to your attention. I noticed and learned that the regdomain.xml file shows very low values for 11ng and 11na. This file sets the max power range from as low as 17 to a max value of 30. Is this of concern to lower the max power on WiFi cards to such a low value? I assume this limits use of this strictly to studio apartments. I myself have owned many AP devices that gave the consumer greater control over the transmit and receive power. Understandably many APs give consumers a level of control for AP power levels. The power levels in many other AP systems allow consumer control, why has this been limited to such a low value? FCC controls the frequency range correct. 17 percent seems like it has been degraded for a unknown or accidental reason. . .

17 percent of max power utilization to me seems to really limit the WiFi functionality. Does anyone else agree this seems a bit to low?

With 40 it has much more coverage.