### PR TITLE
zfs tests: Silence clang warning

### DIFF
--- a/tests/sys/cddl/zfs/tests/txg_integrity/fsync_integrity.c
+++ b/tests/sys/cddl/zfs/tests/txg_integrity/fsync_integrity.c
@@ -106,7 +106,7 @@ typedef struct {
 
 typedef struct {
 	int thread_num;
-	pattern_t* pat;
+	const pattern_t* pat;
 } thread_data_t;
 
 
@@ -354,7 +354,7 @@ verify_file(int fd, const pattern_t* p_pat){
 
 /* Writes a special marker to every byte within the chunk */
 static void
-write_chunk(pattern_t* p_pat, int chunk_idx, int thread_num)
+write_chunk(const pattern_t* p_pat, int chunk_idx, int thread_num)
 {
   uint32_t chunk_start, chunk_end;
   get_chunk_range(p_pat, chunk_idx, &chunk_start, &chunk_end);


### PR DESCRIPTION
https://ci.freebsd.org/job/FreeBSD-main-amd64-build/27583/warnings10Result/package.-1545205141/

Reported by:	clang