### PR TITLE
{cut,diff,head,join,patch,xargs}: use getline() instead of fgetln()

### DIFF
--- a/usr.bin/cut/cut.c
+++ b/usr.bin/cut/cut.c
@@ -275,14 +275,15 @@ b_cut(FILE *fp, const char *fname __unused)
 static int
 b_n_cut(FILE *fp, const char *fname)
 {
-	size_t col, i, lbuflen;
-	char *lbuf;
+	size_t col, i, bufsize = 0;
+	ssize_t lbuflen;
+	char *lbuf = NULL;
 	int canwrite, clen, warned;
 	mbstate_t mbs;
 
 	memset(&mbs, 0, sizeof(mbs));
 	warned = 0;
-	while ((lbuf = fgetln(fp, &lbuflen)) != NULL) {
+	while ((lbuflen = getline(&lbuf, &bufsize, fp)) >= 0) {
 		for (col = 0; lbuflen > 0; col += clen) {
 			if ((clen = mbrlen(lbuf, lbuflen, &mbs)) < 0) {
 				if (!warned) {
@@ -331,6 +332,7 @@ b_n_cut(FILE *fp, const char *fname)
 		if (lbuflen > 0)
 			putchar('\n');
 	}
+	free(lbuf);
 	return (warned);
 }
 
@@ -389,21 +391,22 @@ f_cut(FILE *fp, const char *fname)
 	int field, i, isdelim;
 	char *pos, *p;
 	int output;
-	char *lbuf, *mlbuf;
-	size_t clen, lbuflen, reallen;
+	char *lbuf = NULL;
+	size_t clen, bufsize = 0, reallen;
+	ssize_t lbuflen;
 
-	mlbuf = NULL;
-	while ((lbuf = fgetln(fp, &lbuflen)) != NULL) {
+	while ((lbuflen = getline(&lbuf, &bufsize, fp)) >= 0) {
 		reallen = lbuflen;
 		/* Assert EOL has a newline. */
-		if (*(lbuf + lbuflen - 1) != '\n') {
+		if (lbuflen > 0 && *(lbuf + lbuflen - 1) != '\n') {
 			/* Can't have > 1 line with no trailing newline. */
-			mlbuf = malloc(lbuflen + 1);
-			if (mlbuf == NULL)
-				err(1, "malloc");
-			memcpy(mlbuf, lbuf, lbuflen);
-			*(mlbuf + lbuflen) = '\n';
-			lbuf = mlbuf;
+			if ((ssize_t)bufsize < (lbuflen + 1)) {
+				bufsize = lbuflen + 1;
+				lbuf = realloc(lbuf, bufsize);
+			}
+			if (lbuf == NULL)
+				err(1, "realloc");
+			lbuf[lbuflen] = '\n';
 			reallen++;
 		}
 		output = 0;
@@ -411,7 +414,7 @@ f_cut(FILE *fp, const char *fname)
 			clen = mbrtowc(&ch, p, lbuf + reallen - p, NULL);
 			if (clen == (size_t)-1 || clen == (size_t)-2) {
 				warnc(EILSEQ, "%s", fname);
-				free(mlbuf);
+				free(lbuf);
 				return (1);
 			}
 			if (clen == 0)
@@ -438,7 +441,7 @@ f_cut(FILE *fp, const char *fname)
 				    NULL);
 				if (clen == (size_t)-1 || clen == (size_t)-2) {
 					warnc(EILSEQ, "%s", fname);
-					free(mlbuf);
+					free(lbuf);
 					return (1);
 				}
 				if (clen == 0)
@@ -470,7 +473,7 @@ f_cut(FILE *fp, const char *fname)
 		}
 		(void)putchar('\n');
 	}
-	free(mlbuf);
+	free(lbuf);
 	return (0);
 }
 

--- a/usr.bin/diff/diff.c
+++ b/usr.bin/diff/diff.c
@@ -487,20 +487,23 @@ static void
 read_excludes_file(char *file)
 {
 	FILE *fp;
-	char *buf, *pattern;
-	size_t len;
+	char *pattern = NULL;
+	size_t blen = 0;
+	ssize_t len;
 
 	if (strcmp(file, "-") == 0)
 		fp = stdin;
 	else if ((fp = fopen(file, "r")) == NULL)
 		err(2, "%s", file);
-	while ((buf = fgetln(fp, &len)) != NULL) {
-		if (buf[len - 1] == '\n')
-			len--;
-		if ((pattern = strndup(buf, len)) == NULL)
-			err(2, "xstrndup");
+	while ((len = getline(&pattern, &blen, fp)) >= 0) {
+		if ((len > 0) && (pattern[len - 1] == '\n'))
+			pattern[len - 1] = '\0';
 		push_excludes(pattern);
+		/* we allocate a new string per line */
+		pattern = NULL;
+		blen = 0;
 	}
+	free(pattern);
 	if (strcmp(file, "-") != 0)
 		fclose(fp);
 }

--- a/usr.bin/head/head.c
+++ b/usr.bin/head/head.c
@@ -168,12 +168,13 @@ main(int argc, char *argv[])
 static void
 head(FILE *fp, intmax_t cnt)
 {
-	char *cp;
-	size_t error, readlen;
+	char *cp = NULL;
+	size_t error, bufsize = 0;
+	ssize_t readlen;
 
-	while (cnt != 0 && (cp = fgetln(fp, &readlen)) != NULL) {
+	while (cnt != 0 && (readlen = getline(&cp, &bufsize, fp)) >= 0) {
 		error = fwrite(cp, sizeof(char), readlen, stdout);
-		if (error != readlen)
+		if ((ssize_t)error != readlen)
 			err(1, "stdout");
 		cnt--;
 	}

--- a/usr.bin/join/join.c
+++ b/usr.bin/join/join.c
@@ -274,9 +274,10 @@ static void
 slurp(INPUT *F)
 {
 	LINE *lp, *lastlp, tmp;
-	size_t len;
+	size_t blen = 0;
+	ssize_t len;
 	int cnt;
-	char *bp, *fieldp;
+	char *bp, *buf = NULL, *fieldp;
 
 	/*
 	 * Read all of the lines from an input file that have the same
@@ -319,21 +320,21 @@ slurp(INPUT *F)
 			F->pushbool = 0;
 			continue;
 		}
-		if ((bp = fgetln(F->fp, &len)) == NULL)
+		if ((len = getline(&buf, &blen, F->fp)) < 0) {
+			free(buf);
 			return;
-		if (lp->linealloc <= len + 1) {
+		}
+		if (lp->linealloc <= (size_t)(len + 1)) {
 			lp->linealloc += MAX(100, len + 1 - lp->linealloc);
 			if ((lp->line =
 			    realloc(lp->line, lp->linealloc)) == NULL)
 				err(1, NULL);
 		}
-		memmove(lp->line, bp, len);
+		memmove(lp->line, buf, len);
 
 		/* Replace trailing newline, if it exists. */
-		if (bp[len - 1] == '\n')
+		if (buf[len - 1] == '\n')
 			lp->line[len - 1] = '\0';
-		else
-			lp->line[len] = '\0';
 		bp = lp->line;
 
 		/* Split the line into fields, allocate space as necessary. */
@@ -357,6 +358,7 @@ slurp(INPUT *F)
 			break;
 		}
 	}
+	free(buf);
 }
 
 static char *

--- a/usr.bin/patch/pch.c
+++ b/usr.bin/patch/pch.c
@@ -1213,14 +1213,15 @@ hunk_done:
 size_t
 pgets(bool do_indent)
 {
-	char *line;
-	size_t len = 0;
+	char *line = NULL;
+	ssize_t len = 0;
+	size_t buflen = 0;
 	int indent = 0, skipped = 0;
 
-	line = fgetln(pfp, &len);
-	if (line != NULL) {
-		if (len + 1 > buf_size) {
-			while (len + 1 > buf_size)
+	if ((len = getline(&line, &buflen, pfp)) >= 0) {
+		char *linep = line;
+		if ((size_t)(len + 1) > buf_size) {
+			while ((size_t)(len + 1) > buf_size)
 				buf_size *= 2;
 			free(buf);
 			buf = malloc(buf_size);
@@ -1239,8 +1240,10 @@ pgets(bool do_indent)
 		}
 		memcpy(buf, line, len - skipped);
 		buf[len - skipped] = '\0';
+		line = linep;
 	}
-	return len;
+	free(line);
+	return (len > 0) ? len : 0;
 }
 
 

--- a/usr.bin/xargs/xargs.c
+++ b/usr.bin/xargs/xargs.c
@@ -782,22 +782,22 @@ static int
 prompt(void)
 {
 	regex_t cre;
-	size_t rsize;
+	size_t rsize = 0;
 	int match;
-	char *response;
+	char *response = NULL;
 	FILE *ttyfp;
 
 	if ((ttyfp = fopen(_PATH_TTY, "r")) == NULL)
 		return (2);	/* Indicate that the TTY failed to open. */
 	(void)fprintf(stderr, "?...");
 	(void)fflush(stderr);
-	if ((response = fgetln(ttyfp, &rsize)) == NULL ||
+	if (getline(&response, &rsize, ttyfp) < 0 ||
 	    regcomp(&cre, nl_langinfo(YESEXPR), REG_EXTENDED) != 0) {
 		(void)fclose(ttyfp);
 		return (0);
 	}
-	response[rsize - 1] = '\0';
 	match = regexec(&cre, response, 0, NULL, 0);
+	free(response);
 	(void)fclose(ttyfp);
 	regfree(&cre);
 	return (match == 0);


### PR DESCRIPTION
This replaces various uses of fgetln() with getline(). The main reason for this is portability, making things easier for people who want to compile these tools on non-FreeBSD systems.

I appreciate that's probably not the top concern for FreeBSD base tools, but fgetln() is impossible to port to most platforms, as concurrent access is essentially impossible to implement fully correct without the line buffer on the FILE struct. Other than this, many generic FreeBSD tools compile fairly cleanly on Linux with a few small changes.

Most uses of fgetln() pre-date getline() support (added in 2009 with 69099ba2ec8b), and there's been some previous patches (ee3ca711a898 8c98e6b1a7f3 1a2a4fc8ce1b) for other tools.

Obtained from:	https://github.com/dcantrell/bsdutils and
              	https://github.com/chimera-linux/chimerautils
Signed-off-by: Martin Tournoij <martin@arp242.net>