### PR TITLE
ncal(1): print the correct option name when -B is specified twice

### DIFF
--- a/usr.bin/ncal/ncal.c
+++ b/usr.bin/ncal/ncal.c
@@ -271,7 +271,7 @@ main(int argc, char *argv[])
 			break;
 		case 'B':
 			if (flag_before > 0)
-				errx(EX_USAGE, "Double -A specified");
+				errx(EX_USAGE, "Double -B specified");
 			flag_before = strtol(optarg, NULL, 10);
 			if (flag_before <= 0)
 				errx(EX_USAGE,


### PR DESCRIPTION
When using the -B option twice, ncal currently prints the wrong option name, i.e. it warns that -A was specified twice:

```
$ ncal -B1 -B1
ncal: Double -A specified
```