### PR TITLE
sound(4): Fix OSS API requests for more than 8 channels.

### DIFF
--- a/sys/dev/sound/pcm/dsp.c
+++ b/sys/dev/sound/pcm/dsp.c
@@ -1502,24 +1502,31 @@ dsp_ioctl(struct cdev *i_dev, u_long cmd, caddr_t arg, int mode,
 
     	case SOUND_PCM_WRITE_CHANNELS:
 /*	case SNDCTL_DSP_CHANNELS: ( == SOUND_PCM_WRITE_CHANNELS) */
-		if (*arg_i < 0) {
+		if (*arg_i < 0 || *arg_i > AFMT_CHANNEL_MAX) {
 			*arg_i = 0;
 			ret = EINVAL;
 			break;
 		}
 		if (*arg_i != 0) {
-			struct pcmchan_matrix *m;
-			uint32_t ext;
+			uint32_t ext = 0;
 
 			tmp = 0;
-			if (*arg_i > SND_CHN_MAX)
-				*arg_i = SND_CHN_MAX;
+			/*
+			 * Map channel number to surround sound formats.
+			 * Devices that need bitperfect mode to operate
+			 * (e.g. more than SND_CHN_MAX channels) are not
+			 * subject to any mapping.
+			 */
+			if (!(dsp_get_flags(i_dev) & SD_F_BITPERFECT)) {
+				struct pcmchan_matrix *m;
 
-			m = feeder_matrix_default_channel_map(*arg_i);
-			if (m != NULL)
-				ext = m->ext;
-			else
-				ext = 0;
+				if (*arg_i > SND_CHN_MAX)
+					*arg_i = SND_CHN_MAX;
+
+				m = feeder_matrix_default_channel_map(*arg_i);
+				if (m != NULL)
+					ext = m->ext;
+			}
 
 			PCM_ACQUIRE_QUICK(d);
 	  		if (wrch) {


### PR DESCRIPTION
Audio devices with more than 8 channels need bitperfect mode to operate, the vchan processing chain is limited to 8 channels. For these devices, let applications properly select a certain number of channels supported by the driver, instead of mapping the request to a vchan format.

Please note that with this patch
 - execution path only changes for device drivers that set the bitperfect flag
 - in any case the requested number of channels is limited to what the `AFMT_` audio format supports
 - further down the number of channels has to match one of the configurations of the driver anyway

`snd_uaudio(4)` is currently the only candidate that sets the bitperfect flag (for more than 8 channels), and could be affected by this issue. But it doesn't offer yet to select different device configurations depending on the number of channels requested.

My motivation is to bring in improvements of `snd_hdspe(4)` where this problem prevents applications from properly selecting a specific number of channels. See [here](https://github.com/0EVSG/snd_hdspe_alt).