### PR TITLE
Optimize ring buffer increments

### DIFF
--- a/sys/dev/arcmsr/arcmsr.c
+++ b/sys/dev/arcmsr/arcmsr.c
@@ -1138,13 +1138,11 @@ static void arcmsr_post_srb(struct AdapterControlBlock *acb, struct CommandContr
 			pinbound_srb->length = srb->arc_cdb_size >> 2;
 			arcmsr_cdb->Context = (u_int32_t)srb->cdb_phyaddr;
 			if (postq_index & 0x4000) {
-				index_stripped = postq_index & 0xFF;
-				index_stripped += 1;
+				index_stripped = postq_index + 1;
 				index_stripped %= ARCMSR_MAX_HBD_POSTQUEUE;
 				phbdmu->postq_index = index_stripped ? (index_stripped | 0x4000) : index_stripped;
 			} else {
-				index_stripped = postq_index;
-				index_stripped += 1;
+				index_stripped = postq_index + 1;
 				index_stripped %= ARCMSR_MAX_HBD_POSTQUEUE;
 				phbdmu->postq_index = index_stripped ? index_stripped : (index_stripped | 0x4000);
 			}
@@ -1532,11 +1530,12 @@ static u_int32_t arcmsr_Read_iop_rqbuffer_data(struct AdapterControlBlock *acb,
 	iop_data = (u_int8_t *)prbuffer->data;
 	iop_len = (u_int32_t)prbuffer->data_len;
 	while (iop_len > 0) {
-		pQbuffer = &acb->rqbuffer[acb->rqbuf_lastindex];
-		*pQbuffer = *iop_data;
-		acb->rqbuf_lastindex++;
+		pQbuffer = &acb->rqbuffer[acb->rqbuf_lastindex++];
+
 		/* if last, index number set it to 0 */
 		acb->rqbuf_lastindex %= ARCMSR_MAX_QBUFFER;
+
+		*pQbuffer = *iop_data;
 		iop_data++;
 		iop_len--;
 	}

--- a/sys/dev/hptmv/entry.c
+++ b/sys/dev/hptmv/entry.c
@@ -2382,8 +2382,7 @@ static void hpt_worker_thread(void)
 		mtx_lock(&DpcQueue_Lock);
 		while (DpcQueue_First!=DpcQueue_Last) {
 			ST_HPT_DPC p;
-			p = DpcQueue[DpcQueue_First];
-			DpcQueue_First++;
+			p = DpcQueue[DpcQueue_First++];
 			DpcQueue_First %= MAX_DPC;
 			DPC_Request_Nums++;
 			mtx_unlock(&DpcQueue_Lock);

--- a/sys/dev/hptmv/ioctl.c
+++ b/sys/dev/hptmv/ioctl.c
@@ -87,7 +87,9 @@ static int
 event_queue_add(PHPT_EVENT pEvent)
 {
 	int p;
-	p = (event_queue_tail + 1) % MAX_EVENTS;
+	p = (event_queue_tail + 1);
+	if (p == MAX_EVENTS)
+		p = 0;
 	if (p==event_queue_head)
 	{
 		return -1;
@@ -102,9 +104,9 @@ event_queue_remove(PHPT_EVENT pEvent)
 {
 	if (event_queue_head != event_queue_tail)
 	{
-		*pEvent = hpt_event_queue[event_queue_head];
-		event_queue_head++;
-		event_queue_head %= MAX_EVENTS;
+		*pEvent = hpt_event_queue[event_queue_head++];
+		if (event_queue_head == MAX_EVENTS)
+			event_queue_head = 0;
 		return 0;
 	}
 	return -1;

--- a/sys/dev/sound/pci/maestro3.c
+++ b/sys/dev/sound/pci/maestro3.c
@@ -1160,7 +1160,7 @@ m3_handle_channel_intr:
 		pch = &sc->pch[i];
 		if (pch->active) {
 			pch->ptr = m3_pchan_getptr_internal(pch);
-			delta = pch->bufsize + pch->ptr - pch->prevptr;
+			delta = pch->ptr - pch->prevptr;
 			delta %= pch->bufsize;
 			if (delta < sndbuf_getblksz(pch->buffer))
 				continue;
@@ -1174,7 +1174,7 @@ m3_handle_channel_intr:
 		rch = &sc->rch[i];
 		if (rch->active) {
 			rch->ptr = m3_rchan_getptr_internal(rch);
-			delta = rch->bufsize + rch->ptr - rch->prevptr;
+			delta = rch->ptr - rch->prevptr;
 			delta %= rch->bufsize;
 			if (delta < sndbuf_getblksz(rch->buffer))
 				continue;

--- a/sys/dev/wpi/if_wpi.c
+++ b/sys/dev/wpi/if_wpi.c
@@ -2440,7 +2440,7 @@ wpi_debug_registers(struct wpi_softc *sc)
 		DPRINTF(sc, WPI_DEBUG_REGISTER, "  %-18s: 0x%08x ",
 		    wpi_get_csr_string(csr_tbl[i]), WPI_READ(sc, csr_tbl[i]));
 
-		if ((i + 1) % 2 == 0)
+		if ((i & 1) != 0)
 			DPRINTF(sc, WPI_DEBUG_REGISTER, "\n");
 	}
 	DPRINTF(sc, WPI_DEBUG_REGISTER, "\n\n");
@@ -2451,7 +2451,7 @@ wpi_debug_registers(struct wpi_softc *sc)
 			    wpi_get_prph_string(prph_tbl[i]),
 			    wpi_prph_read(sc, prph_tbl[i]));
 
-			if ((i + 1) % 2 == 0)
+			if ((i & 1) != 0)
 				DPRINTF(sc, WPI_DEBUG_REGISTER, "\n");
 		}
 		DPRINTF(sc, WPI_DEBUG_REGISTER, "\n");

--- a/tools/tools/vt/mkkfont/mkkfont.c
+++ b/tools/tools/vt/mkkfont/mkkfont.c
@@ -96,7 +96,7 @@ print_mappings(struct font_header *fh, int map_index)
 		printf("{ 0x%04x, 0x%04x, 0x%02x },",
 		    be32toh(fm.vfm_src), be16toh(fm.vfm_dst),
 		    be16toh(fm.vfm_len));
-		col = (col + 1) % 2;
+		col ^= 1;
 	}
 
 	printf("\n};\n");


### PR DESCRIPTION
These are all in ring buffers. The most common optimization is knowing that an index only increases by 1, and is modulus by some non-power of 2 number, we can check if it gets there before resetting the number to 0, this is better for platforms like ARM where there is no builtin modulus or division.