### PR TITLE
exec(3) manpage: corect typo on 'ellipses'

### DIFF
--- a/lib/libc/gen/exec.3
+++ b/lib/libc/gen/exec.3
@@ -76,7 +76,7 @@ is to be executed.
 .Pp
 The
 .Fa "const char *arg"
-and subsequent ellipses in the
+and subsequent ellipsis in the
 .Fn execl ,
 .Fn execlp ,
 and


### PR DESCRIPTION
This is from the Advanced UNIX Programming Course (Fall'23) at NTHU.