### PR TITLE
Cirrus CI: Update pkg by standard means

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -93,10 +93,8 @@ task:
   install_script:
   - sh .cirrus-ci/pkg-install.sh ${TOOLCHAIN_PKG} git-lite
 
-  xxx_upgrade_pkg_script:
-  - fetch https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/pkg-1.20.9.pkg
-  - pkg install -y ./pkg-1.20.9.pkg
-  - rm -f pkg-1.20.9.pkg
+  upgrade_pkg_script:
+  - pkg upgrade -y pkg
 
   setup_script:
   - uname -a


### PR DESCRIPTION
pkg version 1.20.9 has been MFHd.

---

cc/ @markjdb @brooksdavis @bapt @emaste 

Granted, we are now back to using HTTP ;-)