### PR TITLE
awk(1): Fix typo

### DIFF
--- a/usr.bin/awk/awk.1
+++ b/usr.bin/awk/awk.1
@@ -811,7 +811,7 @@ to it.
 The scope rules for variables in functions are a botch;
 the syntax is worse.
 .Sh DEPRECATED BEHAVIOR
-One True Awk has accpeted
+One True Awk has accepted
 .Fl F Ar t
 to mean the same as
 .Fl F Ar <TAB>


### PR DESCRIPTION
This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.