### PR TITLE
fstat(1): Fix typo

### DIFF
--- a/usr.bin/fstat/fstat.1
+++ b/usr.bin/fstat/fstat.1
@@ -310,7 +310,7 @@ $ fstat . | awk 'NR > 1 {printf "%d%s(%s) ", $3, $4, $1;}'
 2133wd(alice) 2132wd(alice) 1991wd(alice)
 .Ed
 .Pp
-Create a list of processes sorted by number of opened files in desdencing order:
+Create a list of processes sorted by number of opened files in descending order:
 .Bd -literal -offset indent
 $ fstat | awk 'NR > 1 {print $2;}' | sort | uniq -c | sort -r
  728 firefox


### PR DESCRIPTION
This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.