### PR TITLE
mt(1): Fix typo

### DIFF
--- a/usr.bin/mt/mt.1
+++ b/usr.bin/mt/mt.1
@@ -339,7 +339,7 @@ For example, specifying
 .Fl w Ar 0
 will enable all settings except for LBP_W.
 .It Fl l
-List available protection parmeters and their current settings.
+List available protection parameters and their current settings.
 .It Fl L Ar len
 Set the length of the protection information in bytes.
 For Reed-Solomon CRC, the protection information length should be 4 bytes.


### PR DESCRIPTION
This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.