### PR TITLE
cat(1): Fix typo

### DIFF
--- a/bin/cat/Makefile
+++ b/bin/cat/Makefile
@@ -20,7 +20,7 @@ SUBDIR.${MK_TESTS}+= tests
 #LIBADD+=        cap_net
 #CFLAGS+=-DWITH_CASPER
 #.endif
-# Depend on Makefile to rebiuld when WITH_CASPER changes
+# Depend on Makefile to rebuild when WITH_CASPER changes
 cat.o:	Makefile
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.