### PR TITLE
sh(1): Fix typo

### DIFF
--- a/bin/sh/eval.c
+++ b/bin/sh/eval.c
@@ -899,7 +899,7 @@ evalcommand(union node *cmd, int flags, struct backcmd *backcmd)
 				 * so we just delete the hash before and after
 				 * the command runs. Partly deleting like
 				 * changepatch() does doesn't seem worth the
-				 * bookinging effort, since most such runs add
+				 * booking effort, since most such runs add
 				 * directories in front of the new PATH.
 				 */
 				clearcmdentry();


### PR DESCRIPTION
This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.