### PR TITLE
sh(1): Fix typo

### DIFF
--- a/bin/sh/mail.c
+++ b/bin/sh/mail.c
@@ -55,7 +55,7 @@ static time_t mailtime[MAXMBOXES];	/* times of mailboxes */
 
 /*
  * Print appropriate message(s) if mail has arrived.  If the argument is
- * nozero, then the value of MAIL has changed, so we just update the
+ * non-zero, then the value of MAIL has changed, so we just update the
  * values.
  */
 


### PR DESCRIPTION
This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.