### PR TITLE
bin/pax/pax.c: typo

### DIFF
--- a/bin/pax/pax.c
+++ b/bin/pax/pax.c
@@ -69,7 +69,7 @@ int	nflag;			/* select first archive member match */
 int	tflag;			/* restore access time after read */
 int	uflag;			/* ignore older modification time files */
 int	vflag;			/* produce verbose output */
-int	Dflag;			/* same as uflag except inode change time */
+int	Dflag;			/* same as uflag except for inode change time */
 int	Hflag;			/* follow command line symlinks (write only) */
 int	Lflag;			/* follow symlinks when writing */
 int	Oflag;			/* limit to single volume */


### PR DESCRIPTION
Name: Zhan Wei Wu
Email: david5061@gapp.nthu.edu.tw
Line72: same as uflag except inode -> same as uflag except for inode
This is from the Advanced UNIX Programming Course (Fall23) at NTHU.