### PR TITLE
diff(1): fix a typo

### DIFF
--- a/usr.bin/diff/diff.1
+++ b/usr.bin/diff/diff.1
@@ -440,7 +440,7 @@ lines from FILE2
 .It Fl -ignore-file-name-case
 ignore case when comparing file names
 .It Fl -no-ignore-file-name-case
-do not ignore case wen comparing file names (default)
+do not ignore case when comparing file names (default)
 .It Fl -normal
 default diff output
 .It Fl -speed-large-files


### PR DESCRIPTION
On the manpage of diff(1), "when" is mistyped to "wen".

This is from the Advanced UNIX Programming Course (Fall'23) at NTHU.