### PR TITLE
df(1): fix a typo

### DIFF
--- a/bin/df/df.1
+++ b/bin/df/df.1
@@ -120,7 +120,7 @@ specification from the environment.
 Select locally-mounted file system for display.
 If used in combination with the
 .Fl t Ar type
-option, file system types will be added or excluded acccording to the
+option, file system types will be added or excluded according to the
 parameters of that option.
 .It Fl m
 Use 1048576 byte (1 Mebibyte) blocks rather than the default.


### PR DESCRIPTION
On the manpage of df(1), "according" is mistyped into "acccording"

This is from the Advanced UNIX Programming Course (Fall'23) at NTHU.