### PR TITLE
camcontrol(8): Fix typos

### DIFF
--- a/sbin/camcontrol/camcontrol.8
+++ b/sbin/camcontrol/camcontrol.8
@@ -745,7 +745,7 @@ Disable block descriptors for mode sense.
 Display/edit block descriptors instead of mode page.
 .It Fl L
 Use long LBA block descriptors.
-Allows number of LBAs bigger then 2^^32.
+Allows number of LBAs bigger than 2^^32.
 .It Fl b
 Displays mode page data in binary format.
 .It Fl e
@@ -762,7 +762,7 @@ The editor will be invoked if
 detects that standard input is terminal.
 .It Fl l
 Lists all available mode pages.
-If specified more then once, also lists subpages.
+If specified more than once, also lists subpages.
 .It Fl m Ar page[,subpage]
 This specifies the number of the mode page and optionally subpage the user
 would like to view and/or edit.


### PR DESCRIPTION
On line 748, "bigger than" is mistyped as "bigger then", and on line 765, "more than" is mistyped as "more then".

This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.