### PR TITLE
gvinum(8): Fix a typo

### DIFF
--- a/sbin/gvinum/gvinum.8
+++ b/sbin/gvinum/gvinum.8
@@ -351,7 +351,7 @@ Then, initiate the rebuild:
 .Pp
 .Dl "gvinum start myraid5vol.p0"
 .Pp
-The plex will go up form degraded mode after the rebuild is finished.
+The plex will go up from degraded mode after the rebuild is finished.
 The plex can still be used while the rebuild is in progress, although requests
 might be delayed.
 .Pp


### PR DESCRIPTION
In the manual page of gvinum(8), "go up from" is mistyped as "go up form" on line 354.

This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.