### PR TITLE
typo in contrib/bearssl/src/hash/ghash_pclmul.c

### DIFF
--- a/contrib/bearssl/src/hash/ghash_pclmul.c
+++ b/contrib/bearssl/src/hash/ghash_pclmul.c
@@ -76,7 +76,7 @@ BR_TARGETS_X86_UP
  * inexpensive, and it can be mutualised.
  *
  *
- * Since SSE2 opcodes do not have facilities for shitfting full 128-bit
+ * Since SSE2 opcodes do not have facilities for shifting full 128-bit
  * values with bit precision, we have to break down values into 64-bit
  * chunks. We number chunks from 0 to 3 in left to right order.
  */


### PR DESCRIPTION
Name: Po-Yu, Wu
Email: poyuwu17@gapp.nthu.edu.tw
[At contrib/bearssl/src/hash/ghash_pclmul.c line79](https://github.com/freebsd/freebsd-src/blob/dbca442414191a43f334435b7910b63cb2777d53/contrib/bearssl/src/hash/ghash_pclmul.c#L79
): shitfting -> shifting

This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.