### PR TITLE
libkrb5: avoid crash if MD4 is not available

### DIFF
--- a/crypto/heimdal/lib/krb5/salt-arcfour.c
+++ b/crypto/heimdal/lib/krb5/salt-arcfour.c
@@ -53,7 +53,11 @@ ARCFOUR_string_to_key(krb5_context context,
 	goto out;
     }
 
-    EVP_DigestInit_ex(m, EVP_md4(), NULL);
+    if (EVP_DigestInit_ex(m, EVP_md4(), NULL) == 0) {
+	ret = EOPNOTSUPP;
+	krb5_set_error_message (context, ret, N_("Cannot create digest", ""));
+	goto out;
+    }
 
     ret = wind_utf8ucs2_length(password.data, &len);
     if (ret) {


### PR DESCRIPTION
ARCFOUR_string_to_key uses MD4 to create a digest of the provided password.  It does not check for an error return from EVP_DigestInit_ex, so if MD4 is not available in libcrypto, it will crash when attempting to use the invalid EVP object.

This manifests as a crash in kadmind (or kadmin -l) when adding a new key if the "default_keys" setting includes arcfour-hmac-md5 (which it does by default) and MD4 is not available.

It now returns an error instead of crashing.

PR:	275915