### PR TITLE
nfsstat: update option strings in docs

### DIFF
--- a/usr.bin/nfsstat/nfsstat.1
+++ b/usr.bin/nfsstat/nfsstat.1
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 5, 2023
+.Dd December 27, 2023
 .Dt NFSSTAT 1
 .Os
 .Sh NAME
@@ -36,7 +36,7 @@ statistics
 .Sh SYNOPSIS
 .Nm
 .Op Fl -libxo
-.Op Fl cdEemszW
+.Op Fl cdEemqszW
 .Op Fl w Ar wait
 .Sh DESCRIPTION
 The

--- a/usr.bin/nfsstat/nfsstat.c
+++ b/usr.bin/nfsstat/nfsstat.c
@@ -500,7 +500,7 @@ static void
 usage(void)
 {
 	(void)fprintf(stderr,
-	    "usage: nfsstat [-cdemszW] [-w wait]\n");
+	    "usage: nfsstat [-cdEemqszW] [-w wait]\n");
 	exit(1);
 }
 


### PR DESCRIPTION
Add the missing -q option to the nfsstat(1) manpage SYNOPSIS (it is already documented in DESCRIPTION), and add the missing -E and -q options to the built-in usage output.

PR: 275912