### PR TITLE
nanobsd: Bump default target media size

### DIFF
--- a/tools/tools/nanobsd/defaults.sh
+++ b/tools/tools/nanobsd/defaults.sh
@@ -105,7 +105,7 @@ NANO_NEWFS="-b 4096 -f 512 -i 8192 -U"
 NANO_DRIVE=ada0
 
 # Target media size in 512 bytes sectors
-NANO_MEDIASIZE=2000000
+NANO_MEDIASIZE=16000000
 
 # Number of code images on media (1 or 2)
 NANO_IMAGES=2


### PR DESCRIPTION
Otherwise the instructions in the article [^1] will fail due to a lack of space.

[^1]: https://docs.freebsd.org/en/articles/nanobsd/

Related to:	998abf5a1274 ("nanobsd: Bump rescue size to 8GB")