### PR TITLE
procfs: Add self & exe symlinks like NetBSD does

### DIFF
--- a/share/man/man5/procfs.5
+++ b/share/man/man5/procfs.5
@@ -253,10 +253,14 @@ directory containing process information for process
 .Pa pid .
 .It Pa /proc/curproc
 directory containing process information for the current process
+.It Pa /proc/self
+directory containing process information for the current process
 .It Pa /proc/curproc/cmdline
 the process executable name
 .It Pa /proc/curproc/etype
 executable type
+.It Pa /proc/curproc/exe
+executable image
 .It Pa /proc/curproc/file
 executable image
 .It Pa /proc/curproc/fpregs

--- a/sys/fs/procfs/procfs.c
+++ b/sys/fs/procfs/procfs.c
@@ -158,6 +158,8 @@ procfs_init(PFS_INIT_ARGS)
 
 	pfs_create_link(root, "curproc", procfs_docurproc,
 	    NULL, NULL, NULL, 0);
+	pfs_create_link(root, "self", procfs_docurproc,
+	    NULL, NULL, NULL, 0);
 
 	dir = pfs_create_dir(root, "pid",
 	    procfs_attr_all_rx, NULL, NULL, PFS_PROCDEP);
@@ -187,6 +189,8 @@ procfs_init(PFS_INIT_ARGS)
 	    procfs_attr_rw, procfs_candebug, NULL, PFS_RDWR);
 
 	pfs_create_link(dir, "file", procfs_doprocfile,
+	    NULL, procfs_notsystem, NULL, 0);
+	pfs_create_link(dir, "exe", procfs_doprocfile,
 	    NULL, procfs_notsystem, NULL, 0);
 
 	return (0);


### PR DESCRIPTION
This simple patch adds `self` and `exe` symlinks to /proc like NetBSD does.  It would simplify a lot of patches in ports.