### PR TITLE
Prefer atomic_compare_exchange_weak_explicit in at_quick_exit

### DIFF
--- a/lib/libc/stdlib/quick_exit.c
+++ b/lib/libc/stdlib/quick_exit.c
@@ -54,7 +54,7 @@ at_quick_exit(void (*func)(void))
 		return (-1);
 	}
 	h->cleanup = func;
-	while (!atomic_compare_exchange_strong(&handlers, &h->next, h)) {
+	while (!atomic_compare_exchange_weak_explicit(&handlers, &h->next, h, memory_order_release, memory_order_acquire)) {
 		/* nothing */ ;
 	}
 	return (0);


### PR DESCRIPTION
It's often more efficient on some architectures, and the worst case scenario is that h-next is assigned the same value it has before, which is rare, and doesn't change anything. In addition, release/acquire is fine here too.