### PR TITLE
chio.c : typo fix

### DIFF
--- a/bin/chio/chio.c
+++ b/bin/chio/chio.c
@@ -32,7 +32,7 @@
  */
 /*
  * Additional Copyright (c) 1997, by Matthew Jacob, for NASA/Ames Research Ctr.
- * Addidional Copyright (c) 2000, by C. Stephen Gunn, Waterspout Communications
+ * Additional Copyright (c) 2000, by C. Stephen Gunn, Waterspout Communications
  */
 
 #include <sys/param.h>


### PR DESCRIPTION
In the copyright section of the file chio.c, there is a typo on line 35 : "Addidional" which should be "Additional"
Event: This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.