### PR TITLE
Fmake CI test run

### DIFF
--- a/share/mk/bsd.own.mk
+++ b/share/mk/bsd.own.mk
@@ -154,10 +154,8 @@ __<bsd.own.mk>__:
 
 .if ${MK_CTF} != "no"
 CTFCONVERT_CMD=	${CTFCONVERT} ${CTFFLAGS} ${.TARGET}
-.elif defined(.PARSEDIR) || (defined(MAKE_VERSION) && ${MAKE_VERSION} >= 5201111300)
-CTFCONVERT_CMD=
 .else
-CTFCONVERT_CMD=	@:
+CTFCONVERT_CMD=
 .endif 
 
 .endif # !_WITHOUT_SRCCONF

--- a/share/mk/bsd.port.mk
+++ b/share/mk/bsd.port.mk
@@ -9,11 +9,7 @@ _PORTSDIR=	${.CURDIR}/${RELPATH}
 .endif
 .endfor
 _PORTSDIR?=	/usr/ports
-.if defined(.PARSEDIR)
 PORTSDIR=	${_PORTSDIR:tA}
-.else # fmake doesn't have :tA
-PORTSDIR!=	realpath ${_PORTSDIR}
-.endif
 .endif
 
 BSDPORTMK?=	${PORTSDIR}/Mk/bsd.port.mk

--- a/share/mk/bsd.port.subdir.mk
+++ b/share/mk/bsd.port.subdir.mk
@@ -9,11 +9,7 @@ _PORTSDIR=	${.CURDIR}/${RELPATH}
 .endif
 .endfor
 _PORTSDIR?=	/usr/ports
-.if defined(.PARSEDIR)
 PORTSDIR=	${_PORTSDIR:tA}
-.else # fmake doesn't have :tA
-PORTSDIR!=	realpath ${_PORTSDIR}
-.endif
 .endif
 
 BSDPORTSUBDIRMK?=	${PORTSDIR}/Mk/bsd.port.subdir.mk

--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -43,9 +43,6 @@ __ENV_ONLY_OPTIONS:= \
 
 # early include for customization
 # see local.sys.mk below
-# Not included when building in fmake compatibility mode (still needed
-# for older system support)
-.if defined(.PARSEDIR)
 .sinclude <local.sys.env.mk>
 
 .include <bsd.mkopt.mk>
@@ -108,9 +105,6 @@ NO_META_IGNORE_HOST_HEADERS=	1
 .sinclude <auto.obj.mk>
 .endif
 .endif	# ${MK_AUTO_OBJ} == "yes"
-.else # bmake
-.include <bsd.mkopt.mk>
-.endif
 
 # If the special target .POSIX appears (without prerequisites or
 # commands) before the first noncomment line in the makefile, make shall

--- a/tools/build/make_check/Makefile
+++ b/tools/build/make_check/Makefile
@@ -58,10 +58,6 @@ all:
 	@echo "ok 14 shell # Test shell detected no regression."
 	@${SMAKE} shell_1 || ${SMAKE} failure
 	@echo "ok 15 shell_1 # Test shell_1 detected no regression."
-.if !defined(.PARSEDIR)
-	@${SMAKE} shell_2 || ${SMAKE} failure
-	@echo "ok 16 shell_2 # Test shell_2 detected no regression."
-.endif
 
 .if make(C_check)
 C_check:
@@ -101,28 +97,12 @@ notdef:
 .endif
 
 .if make(modifiers)
-.if defined(.PARSEDIR)
 # check if bmake can expand plain variables
 .MAKE.EXPAND_VARIABLES= yes
 x!= ${SMAKE} -V .CURDIR:H
 modifiers:
 .if ${.CURDIR:H} != "$x"
 	@false
-.endif
-.else
-# See if make(1) supports the C modifier.
-modifiers: dollarV
-	@if ${SMAKE} -V .CURDIR:C/.// 2>&1 >/dev/null | \
-	    grep -q "Unknown modifier 'C'"; then \
-		false; \
-	fi
-
-# check that make -V '${VAR}' works
-V_expn != V_OK=ok ${SMAKE} -r -f /dev/null -V '$${V_OK}'
-dollarV:
-.if ${V_expn} == ""
-	@false
-.endif
 .endif
 .endif
 


### PR DESCRIPTION
Bootstrapping from fmake hasn't been relevant since FreeBSD 9 when we switched to bmake. We can safely delete the workarounds we put into the tree for that transition now. We haven't supported building -current from FreeBSD 8.x (or 9.x with fmake as the default make) since FreeBSD 11ish. It's well past time to remove it.

I opened up this commit to run github's CI stuff, though it works on MacOS already...