### PR TITLE
release: Add missing /var/crash ZFS dataset

### DIFF
--- a/release/tools/vmimage.subr
+++ b/release/tools/vmimage.subr
@@ -197,6 +197,7 @@ buildfs() {
 			-o fs=zroot/usr/obj \
 			-o fs=zroot/var\;mountpoint=/var\;canmount=off \
 			-o fs=zroot/var/audit\;setuid=off\;exec=off \
+			-o fs=zroot/var/crash\;setuid=off\;exec=off \
 			-o fs=zroot/var/log\;setuid=off\;exec=off \
 			-o fs=zroot/var/mail\;atime=on \
 			-o fs=zroot/var/tmp\;setuid=off \


### PR DESCRIPTION
This matches the layout from bsdinstall.

Fixes:	89585511cc05 ("release: Add support for creating ZFS-based VM images")