### PR TITLE
cd9660: Add support for mask,dirmask,uid,gid options

### DIFF
--- a/sbin/mount_cd9660/mount_cd9660.8
+++ b/sbin/mount_cd9660/mount_cd9660.8
@@ -29,7 +29,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 11, 2018
+.Dd January 2, 2024
 .Dt MOUNT_CD9660 8
 .Os
 .Sh NAME
@@ -39,8 +39,12 @@
 .Nm
 .Op Fl begjrv
 .Op Fl C Ar charset
+.Op Fl G Ar gid
+.Op Fl m Ar mask
+.Op Fl M Ar mask
 .Op Fl o Ar options
 .Op Fl s Ar startsector
+.Op Fl U Ar uid
 .Ar special node
 .Sh DESCRIPTION
 The
@@ -66,6 +70,37 @@ Do not strip version numbers on files.
 only the last one will be listed.)
 In either case, files may be opened without explicitly stating a
 version number.
+.It Fl G Ar group
+Set the group of the files in the file system to
+.Ar group .
+The default gid on non-Rockridge volumes is zero.
+.It Fl U Ar user
+Set the owner of the files in the file system to
+.Ar user .
+The default uid on non-Rockridge volumes is zero.
+.It Fl m Ar mask
+Specify the maximum file permissions for files
+in the file system.
+(For example, a
+.Ar mask
+of
+.Li 755
+specifies that, by default, the owner should have
+read, write, and execute permissions for files, but
+others should only have read and execute permissions).
+See
+.Xr chmod 1
+for more information about octal file modes.
+Only the nine low-order bits of
+.Ar mask
+are used.
+The default
+.Ar mask
+on non-Rockridge volumes is 755.
+.It Fl M Ar mask
+Specify the maximum file permissions for directories
+in the file system.
+See the previous option's description for details.
 .It Fl j
 Do not use any Joliet extensions included in the file system.
 .It Fl o

--- a/sbin/mount_cd9660/mount_cd9660.c
+++ b/sbin/mount_cd9660/mount_cd9660.c
@@ -44,8 +44,11 @@
 
 #include <arpa/inet.h>
 
+#include <ctype.h>
 #include <err.h>
 #include <errno.h>
+#include <grp.h>
+#include <pwd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -60,6 +63,9 @@ static struct mntopt mopts[] = {
 	MOPT_END
 };
 
+static gid_t	a_gid(const char *);
+static uid_t	a_uid(const char *);
+static mode_t	a_mask(const char *);
 static int	get_ssector(const char *dev);
 static int	set_charset(struct iovec **, int *iovlen, const char *);
 void	usage(void);
@@ -80,7 +86,7 @@ main(int argc, char **argv)
 	mntflags = verbose = 0;
 	ssector = -1;
 
-	while ((ch = getopt(argc, argv, "begjo:rs:vC:")) != -1)
+	while ((ch = getopt(argc, argv, "begG:jm:M:o:rs:U:vC:")) != -1)
 		switch (ch) {
 		case 'b':
 			build_iovec(&iov, &iovlen, "brokenjoliet", NULL, (size_t)-1);
@@ -90,6 +96,15 @@ main(int argc, char **argv)
 			break;
 		case 'g':
 			build_iovec(&iov, &iovlen, "gens", NULL, (size_t)-1);
+			break;
+		case 'G':
+		        build_iovec_argf(&iov, &iovlen, "gid", "%d", a_gid(optarg));
+			break;
+		case 'm':
+			build_iovec_argf(&iov, &iovlen, "mask", "%u", a_mask(optarg));
+			break;
+		case 'M':
+			build_iovec_argf(&iov, &iovlen, "dirmask", "%u", a_mask(optarg));
 			break;
 		case 'j':
 			build_iovec(&iov, &iovlen, "nojoliet", NULL, (size_t)-1);
@@ -109,6 +124,9 @@ main(int argc, char **argv)
 			break;
 		case 's':
 			ssector = atoi(optarg);
+			break;
+		case 'U':
+		        build_iovec_argf(&iov, &iovlen, "uid", "%d", a_uid(optarg));
 			break;
 		case 'v':
 			verbose++;
@@ -173,8 +191,8 @@ void
 usage(void)
 {
 	(void)fprintf(stderr,
-"usage: mount_cd9660 [-begjrv] [-C charset] [-o options] [-s startsector]\n"
-"                    special node\n");
+"usage: mount_cd9660 [-begjrv] [-C charset] [-G gid] [-m mask] [-M mask]\n"
+"                    [-o options] [-U uid] [-s startsector] special node\n");
 	exit(EX_USAGE);
 }
 
@@ -253,4 +271,59 @@ set_charset(struct iovec **iov, int *iovlen, const char *localcs)
 	build_iovec(iov, iovlen, "cs_local", cs_local, (size_t)-1);
 
 	return (0);
+}
+
+static gid_t
+a_gid(const char *s)
+{
+	struct group *gr;
+	const char *gname;
+	gid_t gid;
+
+	if ((gr = getgrnam(s)) != NULL)
+		gid = gr->gr_gid;
+	else {
+		for (gname = s; *s && isdigit(*s); ++s);
+		if (!*s)
+			gid = atoi(gname);
+		else
+			errx(EX_NOUSER, "unknown group id: %s", gname);
+	}
+	return (gid);
+}
+
+static uid_t
+a_uid(const char *s)
+{
+	struct passwd *pw;
+	const char *uname;
+	uid_t uid;
+
+	if ((pw = getpwnam(s)) != NULL)
+		uid = pw->pw_uid;
+	else {
+		for (uname = s; *s && isdigit(*s); ++s);
+		if (!*s)
+			uid = atoi(uname);
+		else
+			errx(EX_NOUSER, "unknown user id: %s", uname);
+	}
+	return (uid);
+}
+
+static mode_t
+a_mask(const char *s)
+{
+	int done, rv;
+	char *ep;
+
+	done = 0;
+	rv = -1;
+	if (*s >= '0' && *s <= '7') {
+		done = 1;
+		rv = strtol(optarg, &ep, 8);
+	}
+	if (!done || rv < 0 || *ep)
+		errx(EX_USAGE, "invalid file mode: %s", s);
+	return (rv);
 }

--- a/sys/fs/cd9660/cd9660_mount.h
+++ b/sys/fs/cd9660/cd9660_mount.h
@@ -40,6 +40,10 @@
 struct iso_args {
 	char	*fspec;			/* block special device to mount */
 	struct	oexport_args export;	/* network export info */
+	uid_t   uid;		    	/* uid that owns ISO-9660 files */
+	gid_t   gid;		    	/* gid that owns ISO-9660 files */
+	mode_t  fmask;		  	/* file mask to be applied for files */
+	mode_t  dmask;		  	/* file mask to be applied for directories */
 	int	flags;			/* mounting flags, see below */
 	int	ssector;		/* starting sector, 0 for 1st session */
 	char	*cs_disk;		/* disk charset for Joliet cs conversion */
@@ -51,3 +55,6 @@ struct iso_args {
 #define ISOFSMNT_NOJOLIET 0x00000008	/* disable Joliet Ext.*/
 #define ISOFSMNT_BROKENJOLIET 0x00000010/* allow broken Joliet disks */
 #define	ISOFSMNT_KICONV 0x00000020	/* Use libiconv to convert chars */
+
+#define ISOFSMNT_UID	0x00000100	/* override uid */
+#define ISOFSMNT_GID	0x00000200	/* override gid */

--- a/sys/fs/cd9660/cd9660_vfsops.c
+++ b/sys/fs/cd9660/cd9660_vfsops.c
@@ -104,6 +104,12 @@ cd9660_cmount(struct mntarg *ma, void *data, uint64_t flags)
 
 	ma = mount_argsu(ma, "from", args.fspec, MAXPATHLEN);
 	ma = mount_arg(ma, "export", &args.export, sizeof(args.export));
+	if (args.flags & ISOFSMNT_UID)
+		ma = mount_argf(ma, "uid", "%d", args.uid);
+	if (args.flags & ISOFSMNT_GID)
+		ma = mount_argf(ma, "gid", "%d", args.gid);
+	ma = mount_argf(ma, "mask", "%d", args.fmask);
+	ma = mount_argf(ma, "dirmask", "%d", args.dmask);
 	ma = mount_argsu(ma, "cs_disk", args.cs_disk, 64);
 	ma = mount_argsu(ma, "cs_local", args.cs_local, 64);
 	ma = mount_argf(ma, "ssector", "%u", args.ssector);
@@ -218,6 +224,7 @@ iso_mountfs(struct vnode *devvp, struct mount *mp)
 	struct g_consumer *cp;
 	struct bufobj *bo;
 	char *cs_local, *cs_disk;
+	int v;
 
 	dev = devvp->v_rdev;
 	dev_ref(dev);
@@ -387,12 +394,28 @@ iso_mountfs(struct vnode *devvp, struct mount *mp)
 	isomp->im_mountp = mp;
 	isomp->im_dev = dev;
 	isomp->im_devvp = devvp;
+	isomp->im_fmask = isomp->im_dmask = ACCESSPERMS;
 
 	vfs_flagopt(mp->mnt_optnew, "norrip", &isomp->im_flags, ISOFSMNT_NORRIP);
 	vfs_flagopt(mp->mnt_optnew, "gens", &isomp->im_flags, ISOFSMNT_GENS);
 	vfs_flagopt(mp->mnt_optnew, "extatt", &isomp->im_flags, ISOFSMNT_EXTATT);
 	vfs_flagopt(mp->mnt_optnew, "nojoliet", &isomp->im_flags, ISOFSMNT_NOJOLIET);
 	vfs_flagopt(mp->mnt_optnew, "kiconv", &isomp->im_flags, ISOFSMNT_KICONV);
+
+	if (vfs_scanopt(mp->mnt_optnew, "uid", "%d", &v) == 1) {
+		isomp->im_flags |= ISOFSMNT_UID;
+		isomp->im_uid = v;
+	}
+	if (vfs_scanopt(mp->mnt_optnew, "gid", "%d", &v) == 1) {
+		isomp->im_flags |= ISOFSMNT_GID;
+		isomp->im_gid = v;
+	}
+	if (vfs_scanopt(mp->mnt_optnew, "mask", "%d", &v) == 1) {
+		isomp->im_fmask &= v;
+	}
+	if (vfs_scanopt(mp->mnt_optnew, "dirmask", "%d", &v) == 1) {
+		isomp->im_dmask &= v;
+	}
 
 	/* Check the Rock Ridge Extension support */
 	if (!(isomp->im_flags & ISOFSMNT_NORRIP)) {

--- a/sys/fs/cd9660/iso.h
+++ b/sys/fs/cd9660/iso.h
@@ -237,6 +237,11 @@ struct iso_mnt {
 	struct g_consumer *im_cp;
 	struct bufobj *im_bo;
 
+	uid_t	im_uid;
+	gid_t	im_gid;
+	mode_t	im_fmask;
+	mode_t	im_dmask;
+
 	int logical_block_size;
 	int im_bshift;
 	int im_bmask;


### PR DESCRIPTION
This patch adds arbitrary mask, dirmask, uid & gid support to ISO9660 ala MSDOSFS.

To test:

```
cd /usr/src/sbin/mount_cd9660
make clean obj depend
make
sudo make install
cd /usr/src/sys/modules/cd9660
make clean obj depend
make
sudo make install
sudo kldunload cd9660
sudo mdconfig -a -t vnode -f /path/to/iso.iso
sudo mount_cd9660 -m640 -M750 -Uricardo -Goperator /dev/md0 /mnt
```
