### PR TITLE
wc: Do not use st_size if it equals zero

### DIFF
--- a/usr.bin/wc/wc.c
+++ b/usr.bin/wc/wc.c
@@ -230,7 +230,8 @@ cnt(const char *file)
 			(void)close(fd);
 			return (1);
 		}
-		if (S_ISREG(sb.st_mode)) {
+		/* Don't do it on pseudo-filesystems that advertize a zero size */
+		if (S_ISREG(sb.st_mode) && sb.st_size > 0) {
 			reset_siginfo();
 			charct = sb.st_size;
 			show_cnt(file, linect, wordct, charct, llct);


### PR DESCRIPTION
Fix for wc(1) not being able to `wc -c` a file in pseudo-filesystems that advertize a zero size value.