### PR TITLE
bin/ed/ed(1): typo fix

### DIFF
--- a/bin/ed/ed.1
+++ b/bin/ed/ed.1
@@ -720,7 +720,7 @@ with
 By default, only the first match in each line is replaced.
 If the
 .Em g
-(global) suffix is given, then every match to be replaced.
+(global) suffix is given, then every match is to be replaced.
 The
 .Em n
 suffix, where
@@ -832,7 +832,7 @@ Write the addressed lines to
 .Ar file .
 Any previous contents of
 .Ar file
-is lost without warning.
+are lost without warning.
 If there is no default filename, then the default filename is set to
 .Ar file ,
 otherwise it is unchanged.


### PR DESCRIPTION
Adding a missing verb "is" on line 723 :
"If the g (global) suffix is given, then every match to be replaced." should be "If the g (global) suffix is given, then every match is to be replaced."

Changing is to are on line 835 :
"Any previous contents of file is lost without warning." changed to "Any previous contents of file are lost without warning."

Event: This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.