### PR TITLE
hexdump: Do not trust st_size if it equals zero

### DIFF
--- a/usr.bin/hexdump/display.c
+++ b/usr.bin/hexdump/display.c
@@ -391,13 +391,14 @@ doskip(const char *fname, int statok)
 	if (statok) {
 		if (fstat(fileno(stdin), &sb))
 			err(1, "%s", fname);
-		if (S_ISREG(sb.st_mode) && skip > sb.st_size) {
+		if (S_ISREG(sb.st_mode) && skip > sb.st_size && sb.st_size > 0) {
 			address += sb.st_size;
 			skip -= sb.st_size;
 			return;
 		}
 	}
-	if (!statok || S_ISFIFO(sb.st_mode) || S_ISSOCK(sb.st_mode)) {
+	if (!statok || S_ISFIFO(sb.st_mode) || S_ISSOCK(sb.st_mode) || \
+	    (S_ISREG(sb.st_mode) && sb.st_size == 0)) {
 		noseek();
 		return;
 	}


### PR DESCRIPTION
Fix for `hexdump -s` not being able to skip on a file residing in pseudo-filesystems that advertize a zero size value.

To reproduce: `hexdump -s1 /compat/linux/proc/mounts`

Bug https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276106