### PR TITLE
tail: Do not trust st_size if it equals zero

### DIFF
--- a/usr.bin/tail/forward.c
+++ b/usr.bin/tail/forward.c
@@ -102,7 +102,7 @@ forward(FILE *fp, const char *fn, enum STYLE style, off_t off, struct stat *sbp)
 	case FBYTES:
 		if (off == 0)
 			break;
-		if (S_ISREG(sbp->st_mode)) {
+		if (S_ISREG(sbp->st_mode) && sbp->st_size > 0) {
 			if (sbp->st_size < off)
 				off = sbp->st_size;
 			if (fseeko(fp, off, SEEK_SET) == -1) {
@@ -134,7 +134,7 @@ forward(FILE *fp, const char *fn, enum STYLE style, off_t off, struct stat *sbp)
 		}
 		break;
 	case RBYTES:
-		if (S_ISREG(sbp->st_mode)) {
+		if (S_ISREG(sbp->st_mode) && sbp->st_size > 0) {
 			if (sbp->st_size >= off &&
 			    fseeko(fp, -off, SEEK_END) == -1) {
 				ierr(fn);
@@ -151,7 +151,7 @@ forward(FILE *fp, const char *fn, enum STYLE style, off_t off, struct stat *sbp)
 				return;
 		break;
 	case RLINES:
-		if (S_ISREG(sbp->st_mode))
+		if (S_ISREG(sbp->st_mode) && sbp->st_size > 0)
 			if (!off) {
 				if (fseeko(fp, (off_t)0, SEEK_END) == -1) {
 					ierr(fn);


### PR DESCRIPTION
Fix for `tail` not being able to operate on files residing in pseudo-filesystems that advertize a zero size value.

To reproduce: `tail -1 /compat/linux/proc/mounts`

Bug: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276107