### PR TITLE
mail: add volatile in grabh()

### DIFF
--- a/usr.bin/mail/tty.c
+++ b/usr.bin/mail/tty.c
@@ -54,7 +54,7 @@ int
 grabh(struct header *hp, int gflags)
 {
 	struct termios ttybuf;
-	sig_t saveint;
+	volatile sig_t saveint;
 	sig_t savetstp;
 	sig_t savettou;
 	sig_t savettin;


### PR DESCRIPTION
```
    mail: add volatile in grabh()

    setjmp() requires that any stack variables modified between the setjmp
    call and the longjmp() must be volatile.  This means that 'saveint' in
    grabh() must be volatile, since it's modified after the setjmp().
    Otherwise, the signal handler is not properly restored, resulting in a
    crash (SIGBUS) if ^C if typed twice while composing.

    PR:             276119
    Reported by:    Christopher Davidson <christopher.davidson@gmail.com>
    MFC after:      2 weeks
```