### PR TITLE
share/examples/sound/midi.c, share/examples/sound/ossmidi.h typo

### DIFF
--- a/share/examples/sound/midi.c
+++ b/share/examples/sound/midi.c
@@ -49,7 +49,7 @@ main()
 		switch (event.type) {
 		case NOTE_ON:
 		case NOTE_OFF:
-		case CONTROLER_ON:
+		case CONTROLLER_ON:
 			if ((l = read(midi_config.fd, &(event.note), sizeof(event.note))) == -1) {
 				perror("Error reading MIDI note");
 				exit(1);
@@ -65,7 +65,7 @@ main()
 		case NOTE_OFF:
 			printf("Channel %d, note %d, velocity %d\n", event.channel, event.note, event.velocity);
 			break;
-		case CONTROLER_ON:
+		case CONTROLLER_ON:
 			printf("Channel %d, controller %d, value %d\n", event.channel, event.controller, event.value);
 			break;
 		default:

--- a/share/examples/sound/ossmidi.h
+++ b/share/examples/sound/ossmidi.h
@@ -33,7 +33,7 @@
 #define NOTE_ON 0x90
 #define NOTE_OFF 0x80
 #define CHANNEL_MASK 0xF
-#define CONTROLER_ON 0xB0
+#define CONTROLLER_ON 0xB0
 
 typedef struct midi_event {
 	unsigned char type;


### PR DESCRIPTION
- Name: Assume-Zhan
- Email: [assume0701@gapp.nthu.edu.tw](mailto:assume0701@gapp.nthu.edu.tw)

Typo in line 52 of share/examples/sound/midi.c: CONTROLER_ON -> CONTROLLER_ON
Typo in line 68 of share/examples/sound/midi.c: CONTROLER_ON -> CONTROLLER_ON
Typo in line 36 of share/examples/sound/ossmidi.h: CONTROLER_ON -> CONTROLLER_ON

Event: This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.