### PR TITLE
pkg-stage.sh: add x11/sddm

### DIFF
--- a/release/scripts/pkg-stage.sh
+++ b/release/scripts/pkg-stage.sh
@@ -32,6 +32,7 @@ www/links
 x11-drivers/xf86-video-vmware
 x11/gnome
 x11/kde5
+x11/sddm
 x11/xorg"
 
 # If NOPORTS is set for the release, do not attempt to build pkg(8).


### PR DESCRIPTION
Given the incubation of SDDM in KDE: it will make sense to include SDDM
alongside KDE.

Merge to stable, then ideally releng/13.3 before the first release
candidate of 13.3.