### PR TITLE
nvmecontrol: Fix typo in ns.c

### DIFF
--- a/sbin/nvmecontrol/ns.c
+++ b/sbin/nvmecontrol/ns.c
@@ -534,7 +534,7 @@ nscontrollers(const struct cmd *f, int argc, char *argv[])
 /*
  * NS MGMT Command specific status values:
  * 0xa = Invalid Format
- * 0x15 = Namespace Insuffience capacity
+ * 0x15 = Namespace Insufficient capacity
  * 0x16 = Namespace ID  unavailable (number namespaces exceeded)
  * 0xb = Thin Provisioning Not supported
  */


### PR DESCRIPTION
Name: Yu-Sheng Ma
Email: s110062131@m110.nthu.edu.tw

`Insufficient` was spelled wrongly on line 537.

This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.