### PR TITLE
typo fixed in sigfastblock.2

### DIFF
--- a/lib/libc/sys/sigfastblock.2
+++ b/lib/libc/sys/sigfastblock.2
@@ -129,7 +129,7 @@ The variable address passed to
 is not aligned naturally.
 The
 .Dv SIGFASTBLOCK_UNSETPTR
-operation was attempted without prior successfull call to
+operation was attempted without prior successful call to
 .Dv SIGFASTBLOCK_SETPTR .
 .It Bq Er EFAULT
 Attempt to read or write to the sigblock variable failed.


### PR DESCRIPTION
In line 132: `successfull`-> `successful`

This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.