### PR TITLE
fix typo in ipf.8

### DIFF
--- a/sbin/ipf/ipf/ipf.8
+++ b/sbin/ipf/ipf/ipf.8
@@ -48,7 +48,7 @@ supports \fBlanguage\fI.  At present, the only target language supported is
 \fBC\fB (-cc) for which two files - \fBip_rules.c\fP
 and \fBip_rules.h\fP are generated in the \fBCURRENT DIRECTORY\fP when
 \fBipf\fP is being run.  These files can be used with the
-\fBIPFILTER_COMPILED\fP kernel option to build filter rules staticlly into
+\fBIPFILTER_COMPILED\fP kernel option to build filter rules statically into
 the kernel.
 .TP
 .B \-d


### PR DESCRIPTION
In line 51: `staticlly`-> `statically`

This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.