### PR TITLE
exit.3: add the comma after an empty space

### DIFF
--- a/lib/libc/stdlib/exit.3
+++ b/lib/libc/stdlib/exit.3
@@ -78,7 +78,7 @@ The
 implementation of the
 .Fn _Exit
 function does not call destructors registered with
-.Xr __cxa_atexit 3,
+.Xr __cxa_atexit 3 ,
 does not flush buffers, and does not close streams.
 .Pp
 Both functions make the low-order eight bits of the


### PR DESCRIPTION
exit(3) man page shows __cxa_atexit(3,) instead of __cxa_atexit(3), in a particular section. It seems the comma gets inside the parenthesis and with an extra space, it can be viewed as expected.