### PR TITLE
Fix grammar error in usr.bin/xinstall/xinstall.c

### DIFF
--- a/usr.bin/xinstall/xinstall.c
+++ b/usr.bin/xinstall/xinstall.c
@@ -65,7 +65,7 @@
 #include "mtree.h"
 
 /*
- * Memory strategy threshold, in pages: if physmem is larger then this, use a
+ * Memory strategy threshold, in pages: if physmem is larger than this, use a
  * large buffer.
  */
 #define PHYSPAGES_THRESHOLD (32*1024)


### PR DESCRIPTION
Line 68: larger then this -> larger than this

Event: Advanced UNIX Programming Course (Fall’23) at NTHU