### PR TITLE
Fix grammar error in usr.bin/stat/stat.c

### DIFF
--- a/usr.bin/stat/stat.c
+++ b/usr.bin/stat/stat.c
@@ -1022,7 +1022,7 @@ format1(const struct stat *st,
 		(void)strcat(lfmt, tmp);
 
 		/*
-		 * For precision of less that nine digits, trim off the
+		 * For precision of less than nine digits, trim off the
 		 * less significant figures.
 		 */
 		for (; prec < 9; prec++)


### PR DESCRIPTION
Line 1025: less that nine -> less than nine

Event: Advanced UNIX Programming Course (Fall’23) at NTHU