### PR TITLE
bhyve/acpi.c: return ENOMEM instead of EFAULT and call free() after being used

### DIFF
--- a/usr.sbin/bhyve/acpi.c
+++ b/usr.sbin/bhyve/acpi.c
@@ -326,7 +326,7 @@ basl_load(struct vmctx *ctx, int fd)
 
 	addr = calloc(1, sb.st_size);
 	if (addr == NULL)
-		return (EFAULT);
+		return (ENOMEM);
 
 	if (read(fd, addr, sb.st_size) < 0)
 		return (errno);
@@ -338,6 +338,7 @@ basl_load(struct vmctx *ctx, int fd)
 	BASL_EXEC(basl_table_create(&table, ctx, name, BASL_TABLE_ALIGNMENT));
 	BASL_EXEC(basl_table_append_bytes(table, addr, sb.st_size));
 
+	free(addr);
 	return (0);
 }
 


### PR DESCRIPTION
1. In basl_load() function, when allocation fails, it returns an EFAULT instead of ENOMEM. An EFAULT can mislead in some scenarios, whereas an ENOMEM for an allocation function makes much more sense.

2. Call free() on addr, as it's not being used anymore after the basl_table_append_bytes() function.
