### PR TITLE
amd64 MINIMAL config: Add back FFS

### DIFF
--- a/sys/amd64/conf/MINIMAL
+++ b/sys/amd64/conf/MINIMAL
@@ -40,6 +40,7 @@ options 	INET			# InterNETworking
 options 	INET6			# IPv6 communications protocols
 options 	TCP_OFFLOAD		# TCP offload
 options 	SCTP_SUPPORT		# Allow kldload of SCTP
+options 	FFS			# Berkeley Fast Filesystem
 options 	SOFTUPDATES		# Enable FFS soft updates support
 options 	UFS_ACL			# Support for access control lists
 options 	UFS_DIRHASH		# Improve performance on big directories


### PR DESCRIPTION
Without this option (that is present in i386 MINIMAL), the kernel cannot boot into UFS.

Fixes https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276240