### PR TITLE
setkey(8): fix typo a FQDN -> an FQDN

### DIFF
--- a/sbin/setkey/setkey.8
+++ b/sbin/setkey/setkey.8
@@ -230,7 +230,7 @@ IPv4/v6 address.
 The
 .Nm
 utility
-can resolve a FQDN into numeric addresses.
+can resolve an FQDN into numeric addresses.
 If the FQDN resolves into multiple addresses,
 .Nm
 will install multiple SAD/SPD entries into the kernel


### PR DESCRIPTION
Event: Advanced UNIX Programming Course (Fall'23) at NTHU.