### PR TITLE
fix - fix typo strip_escapes

### DIFF
--- a/bin/ed/main.c
+++ b/bin/ed/main.c
@@ -1289,7 +1289,7 @@ has_trailing_escape(char *s, char *t)
 }
 
 
-/* strip_escapes: return copy of escaped string of at most length PATH_MAX */
+/* strip_escapes: return a copy of escaped string of at most length PATH_MAX */
 char *
 strip_escapes(char *s)
 {


### PR DESCRIPTION
In bin/ed/main.c, "return copy" should be "return a copy" at line 1292
- Event: Advanced UNIX programming course (Fall'23) at NTHU