### PR TITLE
fix - fix typo echo.1

### DIFF
--- a/bin/echo/echo.1
+++ b/bin/echo/echo.1
@@ -42,7 +42,7 @@
 .Sh DESCRIPTION
 The
 .Nm
-utility writes any specified operands, separated by single blank
+utility writes any specified operands, separated by a single blank
 .Pq Ql "\ "
 characters and followed by a newline
 .Pq Ql \en

--- a/bin/ed/main.c
+++ b/bin/ed/main.c
@@ -1289,7 +1289,7 @@ has_trailing_escape(char *s, char *t)
 }
 
 
-/* strip_escapes: return copy of escaped string of at most length PATH_MAX */
+/* strip_escapes: return a copy of escaped string of at most length PATH_MAX */
 char *
 strip_escapes(char *s)
 {


### PR DESCRIPTION
In man page echo(1), "separated by single blank" should be "separated by a single blank"
- Event: Advanced UNIX programming course (Fall'23) at NTHU