### PR TITLE
fix - fix typo in df.1

### DIFF
--- a/bin/df/df.1
+++ b/bin/df/df.1
@@ -117,7 +117,7 @@ option and any
 .Ev BLOCKSIZE
 specification from the environment.
 .It Fl l
-Select locally-mounted file system for display.
+Select a locally-mounted file system for display.
 If used in combination with the
 .Fl t Ar type
 option, file system types will be added or excluded according to the


### PR DESCRIPTION
In man page df(1), "select locally-mounted file system" should be "select a locally-mounted file system" at line 120
- Event: Advanced UNIX programming course (Fall'23) at NTHU