### PR TITLE
fix - fix typo in cpuset.1

### DIFF
--- a/bin/cpuset/cpuset.1
+++ b/bin/cpuset/cpuset.1
@@ -144,14 +144,14 @@ A special list of
 .Dq all
 may be specified in which case the list includes all CPUs from the root set.
 .It Fl n Ar policy:domain-list
-Specifies a list of domains and allocation policy to apply to a target.
+Specifies a list of domains and allocation policies to apply to a target.
 Ranges may be specified as in
 .Fl l .
 Valid policies include first-touch (ft), round-robin (rr), prefer and
 interleave (il).
 First-touch allocates on the local domain when memory is available.
 Round-robin alternates between every possible domain page at a time.
-The prefer policy accepts only a single domain in the set.
+The preferred policy accepts only a single domain in the set.
 The parent of the set is consulted if the preferred domain is unavailable.
 Interleave operates like round-robin with an implementation defined stripe
 width.


### PR DESCRIPTION
In man page cpuset(1), policy should be policies at line 147 and "prefer policy" should be "preferred policy" at line 154
- Event: Advanced UNIX programming course (Fall'23) at NTHU