### PR TITLE
ccdconfig(8): fix typo uses a 64 sector interleave -> uses a 64-sector interleave

### DIFF
--- a/sbin/camcontrol/camcontrol.8
+++ b/sbin/camcontrol/camcontrol.8
@@ -524,7 +524,7 @@ This is to aid in script writing.
 Print out transfer rate information.
 .El
 .It Ic identify
-Send a ATA identify command (0xec) to a device.
+Send an ATA identify command (0xec) to a device.
 .It Ic reportluns
 Send the SCSI REPORT LUNS (0xA0) command to the given device.
 By default,

--- a/sbin/ccdconfig/ccdconfig.8
+++ b/sbin/ccdconfig/ccdconfig.8
@@ -152,7 +152,7 @@ are exactly the same as you might place in the
 configuration file.
 The first example creates a 4-disk stripe out of
 four scsi disk partitions.
-The stripe uses a 64 sector interleave.
+The stripe uses a 64-sector interleave.
 The second example is an example of a complex stripe/mirror combination.
 It reads as a two disk stripe of da4 and da5 which is mirrored
 to a two disk stripe of da6 and da7.

--- a/sbin/rcorder/rcorder.8
+++ b/sbin/rcorder/rcorder.8
@@ -224,7 +224,7 @@ If a file has an item in
 or in
 .Ql BEFORE
 that could not be provided,
-this missing provider and the requirement will be drawn bold red as well.
+this missing provider and the requirement will be drawn in bold red as well.
 .Sh SEE ALSO
 .Xr acpiconf 8 ,
 .Xr rc 8 ,

--- a/sbin/setkey/setkey.8
+++ b/sbin/setkey/setkey.8
@@ -230,7 +230,7 @@ IPv4/v6 address.
 The
 .Nm
 utility
-can resolve a FQDN into numeric addresses.
+can resolve an FQDN into numeric addresses.
 If the FQDN resolves into multiple addresses,
 .Nm
 will install multiple SAD/SPD entries into the kernel


### PR DESCRIPTION
Event: Advanced UNIX Programming Course (Fall'23) at NTHU.Event: Advanced UNIX Programming Course (Fall'23) at NTHU.