### PR TITLE
dmesg(8): fix typo timetamps -> timestamps

### DIFF
--- a/sbin/camcontrol/camcontrol.8
+++ b/sbin/camcontrol/camcontrol.8
@@ -524,7 +524,7 @@ This is to aid in script writing.
 Print out transfer rate information.
 .El
 .It Ic identify
-Send a ATA identify command (0xec) to a device.
+Send an ATA identify command (0xec) to a device.
 .It Ic reportluns
 Send the SCSI REPORT LUNS (0xA0) command to the given device.
 By default,

--- a/sbin/ccdconfig/ccdconfig.8
+++ b/sbin/ccdconfig/ccdconfig.8
@@ -152,7 +152,7 @@ are exactly the same as you might place in the
 configuration file.
 The first example creates a 4-disk stripe out of
 four scsi disk partitions.
-The stripe uses a 64 sector interleave.
+The stripe uses a 64-sector interleave.
 The second example is an example of a complex stripe/mirror combination.
 It reads as a two disk stripe of da4 and da5 which is mirrored
 to a two disk stripe of da6 and da7.

--- a/sbin/comcontrol/comcontrol.8
+++ b/sbin/comcontrol/comcontrol.8
@@ -35,7 +35,7 @@ to the given number.
 The units are seconds.
 The default is 5 minutes, 0 means
 waiting forever.
-This option needed mainly to specify upper limit of minutes
+This option is needed mainly to specify an upper limit of minutes
 to prevent modem hanging.
 .El
 .Pp

--- a/sbin/devmatch/devmatch.8
+++ b/sbin/devmatch/devmatch.8
@@ -97,7 +97,7 @@ The term PNP is overloaded in
 .Fx .
 It means, generically, the identifying data the bus provides about a
 device.
-While this include old ISA PNP identifiers, it also includes the
+While this includes old ISA PNP identifiers, it also includes the
 logical equivalent in USB, PCI, and others.
 .Pp
 Many drivers currently lack proper PNP table decorations and need to

--- a/sbin/dmesg/dmesg.8
+++ b/sbin/dmesg/dmesg.8
@@ -74,7 +74,7 @@ variables control how the kernel timestamps entries in the message buffer:
 The default value is shown next to each variable.
 .Bl -tag -width indent
 .It  kern.msgbuf_show_timestamp : No 0
-If set to 0, no timetamps are added.
+If set to 0, no timestamps are added.
 If set to 1, then a 1-second granularity timestamp will be added to most lines
 in the message buffer.
 If set to 2, then a microsecond granularity timestamp will be added.

--- a/sbin/rcorder/rcorder.8
+++ b/sbin/rcorder/rcorder.8
@@ -224,7 +224,7 @@ If a file has an item in
 or in
 .Ql BEFORE
 that could not be provided,
-this missing provider and the requirement will be drawn bold red as well.
+this missing provider and the requirement will be drawn in bold red as well.
 .Sh SEE ALSO
 .Xr acpiconf 8 ,
 .Xr rc 8 ,

--- a/sbin/setkey/setkey.8
+++ b/sbin/setkey/setkey.8
@@ -230,7 +230,7 @@ IPv4/v6 address.
 The
 .Nm
 utility
-can resolve a FQDN into numeric addresses.
+can resolve an FQDN into numeric addresses.
 If the FQDN resolves into multiple addresses,
 .Nm
 will install multiple SAD/SPD entries into the kernel


### PR DESCRIPTION
Event: Advanced UNIX Programming Course (Fall'23) at NTHU.Event: Advanced UNIX Programming Course (Fall'23) at NTHU.