### PR TITLE
domainname(1): fix typo "run" -> "runs"

### DIFF
--- a/bin/domainname/domainname.1
+++ b/bin/domainname/domainname.1
@@ -44,7 +44,7 @@ set the domain name by supplying an argument; this is usually done with the
 .Va nisdomainname
 variable in the
 .Pa /etc/rc.conf
-file, normally run at boot
+file, normally runs at boot
 time.
 .Sh NOTES
 The YP/NIS (formerly ``Yellow Pages'' but renamed for legal reasons)


### PR DESCRIPTION
- line 47: "normally run at boot" -> "normally runs at boot"
- Event: Advanced UNIX programming course (Fall'23) at NTHU