### PR TITLE
lib/libbe/libbe.3: Fix typo

### DIFF
--- a/lib/libbe/libbe.3
+++ b/lib/libbe/libbe.3
@@ -147,8 +147,8 @@
 .Sh DESCRIPTION
 .Nm
 interfaces with libzfs to provide a set of functions for various operations
-regarding ZFS boot environments including "deep" boot environments in which
-a boot environments has child datasets.
+regarding ZFS boot environments, including "deep" boot environments in which
+a boot environment has child datasets.
 .Pp
 A context structure is passed to each function, allowing for a small amount
 of state to be retained, such as errors from previous operations.


### PR DESCRIPTION
name: Cheng-Yuan Wu
email: nthu112062583@gapp.nthu.edu.tw
line `149~151`: Fixing grammar and typo by adding `,` in front of `including` at line `150` and removing `s` from `environments` at line `151`.

Event: from the Advanced UNIX Programming Course (Fall’23) at NTHU.