### PR TITLE
newfs_msdos.8: example for specific cluster size

### DIFF
--- a/sbin/newfs_msdos/newfs_msdos.8
+++ b/sbin/newfs_msdos/newfs_msdos.8
@@ -23,7 +23,7 @@
 .\" OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 .\" IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd June 14, 2018
+.Dd January 12, 2024
 .Dt NEWFS_MSDOS 8
 .Os
 .Sh NAME
@@ -134,7 +134,7 @@ File system block size (bytes per cluster).
 This should resolve to an
 acceptable number of sectors per cluster (see below).
 .It Fl c Ar cluster-size
-Sectors per cluster.
+Sectors per cluster, also called allocation size.
 Acceptable values are powers of 2 in the range
 1 through 128.
 If the block or cluster size are not specified, the code
@@ -222,6 +222,12 @@ Create a file system, using default parameters, on
 .Pa /dev/ada0s1 :
 .Bd -literal -offset indent
 newfs_msdos /dev/ada0s1
+.Ed
+.Pp
+Create a FAT32 filesystem with a 32K allocation size on
+.Pa /dev/mmcsd0s1 :
+.Bd -literal -offset indent
+newfs_msdos -F 32 -A -c 64 /dev/mmcsd0s1
 .Ed
 .Pp
 Create a standard 1.44M file system, with volume label


### PR DESCRIPTION
The usual use case in 2024 for newfs_msdosfs is creating filesystems on SD cards for older hardware. In most tutorials, they call the cluster size "allocation size". Therefore, add a small note next to cluster size that it is also called allocation size, and add an example for how to do this.

Fun fact, you can't do this on Windows without downloading suspicious programs.