### PR TITLE
wcsstr does not take restricted pointers

### DIFF
--- a/include/wchar.h
+++ b/include/wchar.h
@@ -156,8 +156,7 @@ wchar_t	*wcsrchr(const wchar_t *, wchar_t) __pure;
 size_t	wcsrtombs(char * __restrict, const wchar_t ** __restrict, size_t,
 	    mbstate_t * __restrict);
 size_t	wcsspn(const wchar_t *, const wchar_t *) __pure;
-wchar_t	*wcsstr(const wchar_t * __restrict, const wchar_t * __restrict)
-	    __pure;
+wchar_t *wcsstr(const wchar_t *, const wchar_t *) __pure;
 size_t	wcsxfrm(wchar_t * __restrict, const wchar_t * __restrict, size_t);
 int	wctob(wint_t);
 double	wcstod(const wchar_t * __restrict, wchar_t ** __restrict);

--- a/lib/libc/string/wcsstr.c
+++ b/lib/libc/string/wcsstr.c
@@ -38,7 +38,7 @@
  * Find the first occurrence of find in s.
  */
 wchar_t *
-wcsstr(const wchar_t * __restrict s, const wchar_t * __restrict find)
+wcsstr(const wchar_t *s, const wchar_t *find)
 {
 	wchar_t c, sc;
 	size_t len;

--- a/lib/libc/string/wmemchr.3
+++ b/lib/libc/string/wmemchr.3
@@ -120,7 +120,7 @@
 .Ft size_t
 .Fn wcsspn "const wchar_t *s1" "const wchar_t *s2"
 .Ft wchar_t *
-.Fn wcsstr "const wchar_t * restrict s1" "const wchar_t * restrict s2"
+.Fn wcsstr "const wchar_t *s1" "const wchar_t *s2"
 .Sh DESCRIPTION
 The functions implement string manipulation operations over wide character
 strings.


### PR DESCRIPTION
wcsstr is not supposed to have restrict qualifiers. No other library has it, and the C standard says it does not have them either.