### PR TITLE
fdwrite.c: initialize pointers to NULL and a few other cleanups

### DIFF
--- a/usr.sbin/fdwrite/fdwrite.c
+++ b/usr.sbin/fdwrite/fdwrite.c
@@ -10,7 +10,6 @@
  *
  */
 
-#include <ctype.h>
 #include <err.h>
 #include <fcntl.h>
 #include <paths.h>
@@ -26,7 +25,7 @@ format_track(int fd, int cyl, int secs, int head, int rate,
      int gaplen, int secsize, int fill, int interleave)
 {
     struct fd_formb f;
-    register int i,j;
+    int i,j;
     int il[100];
 
     memset(il,0,sizeof il);
@@ -68,7 +67,7 @@ main(int argc, char **argv)
     int bpt, verbose=1, nbytes=0, track;
     int interactive = 1;
     const char *device= "/dev/fd0";
-    char *trackbuf = 0,*vrfybuf = 0;
+    char *trackbuf = NULL,*vrfybuf = NULL;
     struct fd_type fdt;
     FILE *tty;
 
@@ -192,5 +191,8 @@ main(int argc, char **argv)
     }
     if(verbose)
 	printf("%d bytes on %d flopp%s\n",nbytes,fdn,fdn==1?"y":"ies");
+
+    free(trackbuf);
+    free(vrfybuf);
     exit(0);
 }

--- a/usr.sbin/fdwrite/fdwrite.c
+++ b/usr.sbin/fdwrite/fdwrite.c
@@ -25,7 +25,7 @@ format_track(int fd, int cyl, int secs, int head, int rate,
      int gaplen, int secsize, int fill, int interleave)
 {
     struct fd_formb f;
-    int i,j;
+    int i, j;
     int il[100];
 
     memset(il,0,sizeof il);
@@ -67,7 +67,7 @@ main(int argc, char **argv)
     int bpt, verbose=1, nbytes=0, track;
     int interactive = 1;
     const char *device= "/dev/fd0";
-    char *trackbuf = NULL,*vrfybuf = NULL;
+    char *trackbuf = NULL, *vrfybuf = NULL;
     struct fd_type fdt;
     FILE *tty;
 


### PR DESCRIPTION
1. Both trackbuf and vrfybuf are initialized to zero (NULL). While it's okay to initialize pointers to zero, to keep consistency, as they're explicitly pointers, it's better to just use NULL ((void *)0) instead of 0 (both are equivalent to the compilers).
2. Call free() for both trackbuf and vrfybuf after their job has been done.
3. Remove the register keyword. Compilers generally ignore this keyword (except for very very old compilers and CPUs).
4. Remove the ctype.h header. It's not being used anywhere in the file.