### PR TITLE
find: Allow '/' to be used with -perm for GNU compatibility

### DIFF
--- a/usr.bin/find/find.1
+++ b/usr.bin/find/find.1
@@ -28,7 +28,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 22, 2023
+.Dd January 15, 2024
 .Dt FIND 1
 .Os
 .Sh NAME
@@ -757,7 +757,7 @@ Slashes
 .Pq Dq Li /
 are treated as normal characters and do not have to be
 matched explicitly.
-.It Ic -perm Oo Cm - Ns | Ns Cm + Oc Ns Ar mode
+.It Ic -perm Oo Cm - Ns | Ns Cm + Ns | Ns Cm / Oc Ns Ar mode
 The
 .Ar mode
 may be either symbolic (see
@@ -786,7 +786,10 @@ are set in the file's mode bits.
 If the
 .Ar mode
 is preceded by a plus
-.Pq Dq Li + ,
+.Pq Dq Li +
+or a slash
+.Pq Dq Li /
+(for GNU compatibility),
 this primary evaluates to true
 if any of the bits in the
 .Ar mode

--- a/usr.bin/find/function.c
+++ b/usr.bin/find/function.c
@@ -1338,7 +1338,7 @@ c_perm(OPTION *option, char ***argvp)
 	if (*perm == '-') {
 		new->flags |= F_ATLEAST;
 		++perm;
-	} else if (*perm == '+') {
+	} else if (*perm == '+' || *perm == '/') {
 		new->flags |= F_ANY;
 		++perm;
 	}


### PR DESCRIPTION
Since 2005 GNU find(1) no longer allows '+' to be used with `-perm`, forcing the use of a `/` instead.

This PR adds support for this character as synonym for '+'.

Fixes https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276326