### PR TITLE
GitHub: style: Add the synchronize activity type

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -9,7 +9,7 @@ name: Style Checker
 on:
   pull_request: # maybe pull_request_target
     branches: [ main ]
-    types: [ opened, reopened, edited ]
+    types: [ opened, reopened, edited, synchronize ]
 
 permissions:
   contents: read


### PR DESCRIPTION
@bsdimp Here is what I believe is the missing piece for the style check to re-run upon `git push --force-with-lease` et al.