### PR TITLE
bsdinstall/distfetch.c: check environment variables before downloading and handle memory allocation errors

### DIFF
--- a/usr.sbin/bsdinstall/distfetch/distfetch.c
+++ b/usr.sbin/bsdinstall/distfetch/distfetch.c
@@ -79,14 +79,14 @@ main(void)
 	if (bsddialog_init() == BSDDIALOG_ERROR) {
 		free(diststring);
 		errx(EXIT_FAILURE, "Error libbsddialog: %s\n",
-		     bsddialog_geterror());
+		    bsddialog_geterror());
 	}
 	bsddialog_initconf(&conf);
 	bsddialog_backtitle(&conf, OSNAME " Installer");
 
 	for (i = 0; i < ndists; i++) {
-	        if ((urls[i] = malloc(PATH_MAX)) == NULL) {
-		        free(urls);
+		if ((urls[i] = malloc(PATH_MAX)) == NULL) {
+			free(urls);
 			free(diststring);
 			bsddialog_end();
 			errx(EXIT_FAILURE, "Error: distfetch URLs out of memory!");


### PR DESCRIPTION
1. Currently, distfetch checks environment variables existence when it will use them or in a case (in chdir()) it doesn't check at all. As they are necessary to set before doing anything with it, check them, if they set or not, before proceeding any further. This also avoids extra cleaning when that environment variable isn't set.
2. Handle memory allocation error in malloc(PATH_MAX) and replace (sizeof const char *) with (sizeof char *). Both are similar and const doesn't have a size.
3. Indent the error message a bit in chdir().