### PR TITLE
bsdiff: Use mmap instead of malloc

### DIFF
--- a/usr.bin/bsdiff/bsdiff/bsdiff.c
+++ b/usr.bin/bsdiff/bsdiff/bsdiff.c
@@ -38,6 +38,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/mman.h>
 
 #ifndef O_BINARY
 #define O_BINARY 0
@@ -115,7 +116,7 @@ int main(int argc,char *argv[])
 {
 	int fd;
 	u_char *old,*new;
-	off_t oldsize,newsize;
+	off_t oldsize,newsize,xnewsize;
 	saidx_t *I;
 	off_t scan,pos,len;
 	off_t lastscan,lastpos,lastoffset;
@@ -147,10 +148,9 @@ int main(int argc,char *argv[])
 		err(1, "%s", argv[1]);
 	}
 
-	if (((old=malloc(oldsize+1))==NULL) ||
-		(lseek(fd,0,SEEK_SET)!=0) ||
-		(read(fd,old,oldsize)!=oldsize) ||
-		(close(fd)==-1)) err(1,"%s",argv[1]);
+	old = mmap(NULL, oldsize+1, PROT_READ, MAP_SHARED, fd, 0);
+	if (old == MAP_FAILED || close(fd) == -1)
+		err(1, "%s", argv[1]);
 
 	if(((I=malloc((oldsize+1)*sizeof(saidx_t)))==NULL)) err(1,NULL);
 
@@ -168,10 +168,9 @@ int main(int argc,char *argv[])
 		err(1, "%s", argv[2]);
 	}
 
-	if (((new=malloc(newsize+1))==NULL) ||
-		(lseek(fd,0,SEEK_SET)!=0) ||
-		(read(fd,new,newsize)!=newsize) ||
-		(close(fd)==-1)) err(1,"%s",argv[2]);
+	new = mmap(NULL, newsize+1, PROT_READ, MAP_SHARED, fd, 0);
+	if (new == MAP_FAILED || close(fd) == -1)
+		err(1, "%s", argv[2]);
 
 	if(((db=malloc(newsize+1))==NULL) ||
 		((eb=malloc(newsize+1))==NULL)) err(1,NULL);
@@ -304,9 +303,9 @@ int main(int argc,char *argv[])
 		errx(1, "BZ2_bzWriteClose, bz2err = %d", bz2err);
 
 	/* Compute size of compressed diff data */
-	if ((newsize = ftello(pf)) == -1)
+	if ((xnewsize = ftello(pf)) == -1)
 		err(1, "ftello");
-	offtout(newsize - len, header + 16);
+	offtout(xnewsize - len, header + 16);
 
 	/* Write compressed extra data */
 	if ((pfbz2 = BZ2_bzWriteOpen(&bz2err, pf, 9, 0, 0)) == NULL)
@@ -330,8 +329,8 @@ int main(int argc,char *argv[])
 	free(db);
 	free(eb);
 	free(I);
-	free(old);
-	free(new);
+	munmap(old, oldsize+1);
+	munmap(new, newsize+1);
 
 	return 0;
 }

--- a/usr.bin/bsdiff/bspatch/bspatch.c
+++ b/usr.bin/bsdiff/bspatch/bspatch.c
@@ -42,6 +42,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/mman.h>
 
 #ifndef O_BINARY
 #define O_BINARY 0
@@ -151,7 +152,7 @@ int main(int argc, char *argv[])
 	if (cap_enter() < 0)
 		err(1, "failed to enter security sandbox");
 
-	cap_rights_init(&rights_ro, CAP_READ, CAP_FSTAT, CAP_SEEK);
+	cap_rights_init(&rights_ro, CAP_READ, CAP_FSTAT, CAP_SEEK, CAP_MMAP_R);
 	cap_rights_init(&rights_wr, CAP_WRITE);
 	cap_rights_init(&rights_dir, CAP_UNLINKAT);
 
@@ -220,12 +221,13 @@ int main(int argc, char *argv[])
 		errx(1, "BZ2_bzReadOpen, bz2err = %d", ebz2err);
 
 	if ((oldsize = lseek(oldfd, 0, SEEK_END)) == -1 ||
-	    oldsize > SSIZE_MAX ||
-	    (old = malloc(oldsize)) == NULL ||
-	    lseek(oldfd, 0, SEEK_SET) != 0 ||
-	    read(oldfd, old, oldsize) != oldsize ||
-	    close(oldfd) == -1)
+	    oldsize > SSIZE_MAX)
 		err(1, "%s", argv[1]);
+
+	old = mmap(NULL, oldsize+1, PROT_READ, MAP_SHARED, oldfd, 0);
+	if (old == MAP_FAILED || close(oldfd) != 0)
+		err(1, "%s", argv[1]);
+
 	if ((new = malloc(newsize)) == NULL)
 		err(1, NULL);
 
@@ -294,7 +296,7 @@ int main(int argc, char *argv[])
 	newfile = NULL;
 
 	free(new);
-	free(old);
+	munmap(old, oldsize+1);
 
 	return (0);
 }


### PR DESCRIPTION
Use mmap instead of malloc in bsdiff/bspatch.

Debian adds a [patch](https://sources.debian.org/patches/bsdiff/4.3-23/) only to bsdiff to use mmap.  Also [Chromium's fork](https://github.com/cgmb/bsdiff-chromium) uses mmap.

I tested it and it works.  Haven't done any regression or performance tests though.

