### PR TITLE
sysctl.8: fix format typo

### DIFF
--- a/sbin/sysctl/sysctl.8
+++ b/sbin/sysctl/sysctl.8
@@ -322,7 +322,7 @@ option has been deprecated and is silently ignored.
 .Xr sysctl 3 ,
 .Xr loader.conf 5 ,
 .Xr sysctl.conf 5 ,
-.Xr security 7,
+.Xr security 7 ,
 .Xr loader 8
 .Sh HISTORY
 A


### PR DESCRIPTION
Before:
<img width="435" alt="before" src="https://github.com/freebsd/freebsd-src/assets/9573190/4e690162-7eac-4ab0-adff-5e73c8a1bf37">

After:
<img width="437" alt="after" src="https://github.com/freebsd/freebsd-src/assets/9573190/4032a7d6-0313-4a17-b8df-c85df59ec30a">
