### PR TITLE
glabel: Add support for detecting Linux swap

### DIFF
--- a/lib/geom/label/glabel.8
+++ b/lib/geom/label/glabel.8
@@ -118,6 +118,9 @@ REISERFS (directory
 .It
 NTFS (directory
 .Pa /dev/ntfs/ ) .
+.It
+Swap Linux (directory
+.Pa /dev/swaplinux/ ) .
 .El
 .Pp
 Support for partition metadata is implemented for:

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -3633,6 +3633,7 @@ geom/label/g_label_reiserfs.c	optional geom_label
 geom/label/g_label_ufs.c	optional geom_label
 geom/label/g_label_gpt.c	optional geom_label | geom_label_gpt
 geom/label/g_label_disk_ident.c	optional geom_label
+geom/label/g_label_swaplinux.c	optional geom_label
 geom/linux_lvm/g_linux_lvm.c	optional geom_linux_lvm
 geom/mirror/g_mirror.c		optional geom_mirror
 geom/mirror/g_mirror_ctl.c	optional geom_mirror

--- a/sys/geom/label/g_label.c
+++ b/sys/geom/label/g_label.c
@@ -105,6 +105,7 @@ const struct g_label_desc *g_labels[] = {
 	&g_label_ntfs,
 	&g_label_disk_ident,
 	&g_label_flashmap,
+	&g_label_swaplinux,
 #endif
 	&g_label_generic,
 	NULL

--- a/sys/geom/label/g_label.h
+++ b/sys/geom/label/g_label.h
@@ -79,6 +79,7 @@ extern struct g_label_desc g_label_gpt;
 extern struct g_label_desc g_label_gpt_uuid;
 extern struct g_label_desc g_label_disk_ident;
 extern struct g_label_desc g_label_flashmap;
+extern struct g_label_desc g_label_swaplinux;
 
 extern void g_label_rtrim(char *label, size_t size);
 #endif	/* _KERNEL */

--- a/sys/geom/label/g_label_swaplinux.c
+++ b/sys/geom/label/g_label_swaplinux.c
@@ -1,0 +1,91 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/kernel.h>
+#include <sys/malloc.h>
+
+#include <geom/geom.h>
+#include <geom/geom_dbg.h>
+#include <geom/label/g_label.h>
+
+/*
+ * Taken from
+ * https://github.com/util-linux/util-linux/blob/master/include/swapheader.h
+ */
+
+#define SWAP_VERSION 1
+#define SWAP_UUID_LENGTH 16
+#define SWAP_LABEL_LENGTH 16
+#define SWAP_SIGNATURE "SWAPSPACE2"
+#define SWAP_SIGNATURE_SZ (sizeof(SWAP_SIGNATURE) - 1)
+
+struct swap_header_v1_2 {
+	char	      bootbits[1024];    /* Space for disklabel etc. */
+	uint32_t      version;
+	uint32_t      last_page;
+	uint32_t      nr_badpages;
+	unsigned char uuid[SWAP_UUID_LENGTH];
+	char	      volume_name[SWAP_LABEL_LENGTH];
+	uint32_t      padding[117];
+	uint32_t      badpages[1];
+};
+
+typedef union {
+	struct swap_header_v1_2	header;
+	struct {
+		uint8_t reserved[4096 - SWAP_SIGNATURE_SZ];
+		char	signature[SWAP_SIGNATURE_SZ];
+	} tail;
+} swhdr_t;
+
+#define sw_version	header.version
+#define sw_volume_name	header.volume_name
+#define sw_signature	tail.signature
+
+static void
+g_label_swaplinux_taste(struct g_consumer *cp, char *label, size_t size)
+{
+	struct g_provider *pp;
+	swhdr_t *hdr;
+
+	g_topology_assert_not();
+	pp = cp->provider;
+	label[0] = '\0';
+
+	KASSERT(pp->sectorsize != 0, ("Tasting a disk with 0 sectorsize"));
+	if ((4096 % pp->sectorsize) != 0)
+		return;
+
+	hdr = (swhdr_t *)g_read_data(cp, 0, 4096, NULL);
+	if (hdr == NULL)
+		return;
+
+	/* Check version and magic string */
+	if (hdr->sw_version == SWAP_VERSION &&
+	    !memcmp(hdr->sw_signature, SWAP_SIGNATURE, SWAP_SIGNATURE_SZ))
+		G_LABEL_DEBUG(1, "linux swap detected on %s.", pp->name);
+	else
+		goto exit_free;
+
+	/* Check for volume label */
+	if (hdr->sw_volume_name[0] == '\0')
+		goto exit_free;
+
+	/* Terminate label */
+	hdr->sw_volume_name[sizeof(hdr->sw_volume_name) - 1] = '\0';
+	strlcpy(label, hdr->sw_volume_name, size);
+
+exit_free:
+	g_free(hdr);
+}
+
+struct g_label_desc g_label_swaplinux = {
+	.ld_taste = g_label_swaplinux_taste,
+	.ld_dirprefix = "swaplinux/",
+	.ld_enabled = 1
+};
+
+G_LABEL_INIT(swaplinux, g_label_swaplinux, "Create device nodes for Linux swap");

--- a/sys/modules/geom/geom_label/Makefile
+++ b/sys/modules/geom/geom_label/Makefile
@@ -12,6 +12,7 @@ SRCS+=	g_label_msdosfs.c
 SRCS+=	g_label_ntfs.c
 SRCS+=	g_label_reiserfs.c
 SRCS+=	g_label_ufs.c
+SRCS+=	g_label_swaplinux.c
 SRCS+=	opt_geom.h
 SRCS+=	vnode_if.h
 


### PR DESCRIPTION
This will benefit dual-boot installations and also live-CD's.

How I tested it:

1. Compile kernel without GEOM_LABEL
1. `cd /sys/modules/geom/geom_label`
1. `make`
1. `sudo make install`
1. Reboot
1. Attach virtual disk to VM.
1. `echo -e 'n\np\n1\n\n\nt\n82\nw' | sudo chroot /compat/linux fdisk /dev/vtbd1` to create a Linux swap partition (type 82)
1. `sudo chroot /compat/linux mkswap -L MYSWAP /dev/vtbd1s1`
1. `sudo sh -c 'echo geom_label_load=\"YES\" >> /boot/loader.conf'`
1. Reboot
1. `sudo gnop create -v -o 4096 /dev/swaplinux/MYSWAP`
1. `sudo swapon /dev/swaplinux/MYSWAP.nop`
1. `swapinfo | grep MYSWAP`

Cleanup:
1. `sudo swapoff /dev/swaplinux/MYSWAP.nop`
1. `sudo gnop destroy /dev/swaplinux/MYSWAP.nop`

For testing the mount patch that does the gnop dance automatically:
1. `cd /usr/src/sbin/swapon`
1. `make`
1. `sudo make install`
1. `sudo swapon /dev/swaplinux/MYSWAP`
1. `swapinfo |grep MYSWAP`
1. `sudo swapoff /dev/swaplinux/MYSWAP`

The commands for using gnop can be automated with this patch to swapon: https://github.com/freebsd/freebsd-src/pull/1084