### PR TITLE
swapon: Do not overwrite Linux swap header

### DIFF
--- a/sbin/swapon/Makefile
+++ b/sbin/swapon/Makefile
@@ -6,6 +6,8 @@ LINKS=	${BINDIR}/swapon ${BINDIR}/swapoff
 LINKS+=	${BINDIR}/swapon ${BINDIR}/swapctl
 MLINKS=	swapon.8 swapoff.8
 MLINKS+=swapon.8 swapctl.8
+SRCS=	swapon.c swaplinux.c
+HDRS+=	extern.h
 
 LIBADD=	util
 

--- a/sbin/swapon/extern.h
+++ b/sbin/swapon/extern.h
@@ -1,0 +1,5 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+int is_linux_swap(const char *);

--- a/sbin/swapon/swaplinux.c
+++ b/sbin/swapon/swaplinux.c
@@ -1,0 +1,66 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fcntl.h>
+#include <err.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "extern.h"
+
+/*
+ * Definitions and structure taken from
+ * https://github.com/util-linux/util-linux/blob/master/include/swapheader.h
+ */
+
+#define SWAP_VERSION 1
+#define SWAP_UUID_LENGTH 16
+#define SWAP_LABEL_LENGTH 16
+#define SWAP_SIGNATURE "SWAPSPACE2"
+#define SWAP_SIGNATURE_SZ (sizeof(SWAP_SIGNATURE) - 1)
+
+struct swap_header_v1_2 {
+	char	      bootbits[1024];    /* Space for disklabel etc. */
+	uint32_t      version;
+	uint32_t      last_page;
+	uint32_t      nr_badpages;
+	unsigned char uuid[SWAP_UUID_LENGTH];
+	char	      volume_name[SWAP_LABEL_LENGTH];
+	uint32_t      padding[117];
+	uint32_t      badpages[1];
+};
+
+typedef union {
+	struct swap_header_v1_2 header;
+	struct {
+		uint8_t	reserved[4096 - SWAP_SIGNATURE_SZ];
+		char	signature[SWAP_SIGNATURE_SZ];
+	} tail;
+} swhdr_t;
+
+#define sw_version	header.version
+#define sw_volume_name	header.volume_name
+#define sw_signature	tail.signature
+
+int
+is_linux_swap(const char *name)
+{
+	uint8_t buf[4096];
+	swhdr_t *hdr = (swhdr_t *) buf;
+	int fd;
+
+	fd = open(name, O_RDONLY);
+	if (fd == -1)
+		return (-1);
+
+	if (read(fd, buf, 4096) != 4096) {
+		close(fd);
+		return (-1);
+	}
+	close(fd);
+
+	return (hdr->sw_version == SWAP_VERSION &&
+	    !memcmp(hdr->sw_signature, SWAP_SIGNATURE, SWAP_SIGNATURE_SZ));
+}


### PR DESCRIPTION
The Linux swap partition uses a 4096-byte header that holds the label & UUID. You can see the structure [here](https://github.com/util-linux/util-linux/blob/master/include/swapheader.h). 

The problem is thus how to prevent FreeBSD from overwriting the header. It turns out there's a neat way to do just that with GEOM using the [gnop](https://man.freebsd.org/cgi/man.cgi?query=gnop&apropos=0&sektion=0&manpath=FreeBSD+14.0-RELEASE+and+Ports&arch=default&format=html) system tool:

```
sudo gnop create -v -o 4096 /dev/vtbd1s1
sudo swapon /dev/vtbd1s1.nop
...
sudo swapoff /dev/vtbd1s1.nop
sudo gnop destroy /dev/vtbd1s1.nop
```

This PR modifies **swapon** to automate this process, which also works with /etc/fstab.  This will benefit dual-boot installations and also live-CD's.

For automated detection of swap label by GEOM see this PR: https://github.com/freebsd/freebsd-src/pull/1083

Fixes: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=221935