### PR TITLE
add noexcept to stdlib.h for C++11

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -84,9 +84,9 @@ extern int __mb_cur_max;
 extern int ___mb_cur_max(void);
 #define	MB_CUR_MAX	((size_t)___mb_cur_max())
 
-_Noreturn void	 abort(void);
+_Noreturn void	 abort(void) __noexcept;
 int	 abs(int) __pure2;
-int	 atexit(void (* _Nonnull)(void));
+int	 atexit(void (* _Nonnull)(void)) __noexcept;
 double	 atof(const char *);
 int	 atoi(const char *);
 long	 atol(const char *);
@@ -154,7 +154,7 @@ unsigned long long
 	 strtoull(const char * __restrict, char ** __restrict, int);
 #endif /* __LONG_LONG_SUPPORTED */
 
-_Noreturn void	 _Exit(int);
+_Noreturn void	 _Exit(int) __noexcept;
 #endif /* __ISO_C_VISIBLE >= 1999 */
 
 /*
@@ -163,9 +163,9 @@ _Noreturn void	 _Exit(int);
 #if __ISO_C_VISIBLE >= 2011 || __cplusplus >= 201103L
 void *	aligned_alloc(size_t, size_t) __malloc_like __alloc_align(1)
 	    __alloc_size(2);
-int	at_quick_exit(void (*)(void));
+int	at_quick_exit(void (*)(void)) __noexcept;
 _Noreturn void
-	quick_exit(int);
+	quick_exit(int) __noexcept;
 #endif /* __ISO_C_VISIBLE >= 2011 */
 /*
  * Extensions made by POSIX relative to C.

--- a/sys/sys/cdefs.h
+++ b/sys/sys/cdefs.h
@@ -359,6 +359,17 @@
 #endif
 
 /*
+ * noexcept keyword added in C++11.
+ */
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#define __noexcept noexcept
+#define __noexcept_if(__c) noexcept(__c)
+#else
+#define __noexcept
+#define __noexcept_if(__c)
+#endif
+
+/*
  * We use `__restrict' as a way to define the `restrict' type qualifier
  * without disturbing older software that is unaware of C99 keywords.
  * GCC also provides `__restrict' as an extension to support C99-style


### PR DESCRIPTION
C++11 requires that certain functions in `<stdlib.h>`/`<cstdlib>` be marked `noexcept`.  To support this, add a new macro `__NOEXCEPT` to `<sys/cdefs.h>` and apply it those functions.

I also added `__NOEXCEPT_IF` to `<sys/cdefs.h>` for completeness, but it's currently not used.

Tested with buildworld.