### PR TITLE
chflags: Fix -f option

### DIFF
--- a/bin/chflags/chflags.c
+++ b/bin/chflags/chflags.c
@@ -182,9 +182,11 @@ main(int argc, char *argv[])
 		if (newflags == p->fts_statp->st_flags)
 			continue;
 		if (chflagsat(AT_FDCWD, p->fts_accpath, newflags,
-		    atflag) == -1 && !fflag) {
-			warn("%s", p->fts_path);
-			rval = 1;
+		    atflag) == -1) {
+			if (!fflag) {
+				warn("%s", p->fts_path);
+				rval = 1;
+			}
 		} else if (vflag || siginfo) {
 			(void)printf("%s", p->fts_path);
 			if (vflag > 1 || siginfo)


### PR DESCRIPTION
There's a bug with the -f option when used with the -v option.

To reproduce:

```
$ chflags -vf uchg /etc/passwd
/etc/passwd
$ echo $?
0
```

Fixes https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276723
