### PR TITLE
libkern/strcpy.c: remove unnecessary parenthesis

### DIFF
--- a/sys/libkern/strcpy.c
+++ b/sys/libkern/strcpy.c
@@ -33,7 +33,7 @@
 #include <sys/libkern.h>
 
 char *
-(strcpy)(char * __restrict to, const char * __restrict from)
+strcpy(char * __restrict to, const char * __restrict from)
 {
 	char *save = to;
 


### PR DESCRIPTION
This is a trivial change, found this while I was looking for strcpy() implementation. Seems added a long time ago.
From
`(strcpy)(...)` 
to
`strcpy(...)` 