### PR TITLE
kldxref: fix maketempfile function's way of finding root dir

### DIFF
--- a/usr.sbin/kldxref/kldxref.c
+++ b/usr.sbin/kldxref/kldxref.c
@@ -717,12 +717,9 @@ read_kld(char *filename, char *kldname)
 static FILE *
 maketempfile(char *dest, const char *root)
 {
-	char *p;
-	int n, fd;
+	int fd;
 
-	p = strrchr(root, '/');
-	n = p != NULL ? p - root + 1 : 0;
-	if (snprintf(dest, MAXPATHLEN, "%.*slhint.XXXXXX", n, root) >=
+	if (snprintf(dest, MAXPATHLEN, "%s/lhint.XXXXXX", root) >=
 	    MAXPATHLEN) {
 		errno = ENAMETOOLONG;
 		return (NULL);


### PR DESCRIPTION

Rather than assuming that the "root" is passed as directory and will be
marked by a trailing slash, we just assume that the directory, which has
been checked previously to be a directory, is a directory.

This fixes an inconsistency between `kldxref /boot/modules`, which tries
to create the temp file in `/boot/`, and `kldxref /boot/modules/`, which
tries to create it in `/boot/modules/` itself.
