### PR TITLE
freebsd-tips: freebsd-update fetch, then install

### DIFF
--- a/usr.bin/fortune/datfiles/freebsd-tips
+++ b/usr.bin/fortune/datfiles/freebsd-tips
@@ -533,9 +533,10 @@ Run "etcupdate extract" once when your sources match your running system, then r
 Do you want to do a binary upgrade of your running FreeBSD installation? Use freebsd-update(8).
 
 To install updates and patches for the running branch use
-# freebsd-update fetch install
+# freebsd-update fetch
+# freebsd-update install
 
-To upgrade to a newer release use
+Then, to upgrade to a newer release use
 # freebsd-update upgrade -r ${name_of_release}
 
 		-- Lars Engels <lme@FreeBSD.org>


### PR DESCRIPTION
```text
In end of life (EOL) warning cases: freebsd-update fetch install (the
two commands, combined) may fetch and patch, but not install.

Instead: run the two consecutively. Consistent with installation
information in /releases/ areas and with accepted
https://reviews.freebsd.org/D42722
```