### PR TITLE
libipsec: make const-correct

### DIFF
--- a/lib/libipsec/ipsec_dump_policy.c
+++ b/lib/libipsec/ipsec_dump_policy.c
@@ -67,9 +67,9 @@ static char *set_address(char *, size_t, struct sockaddr *);
  * When delimiter == NULL, alternatively ' '(space) is applied.
  */
 char *
-ipsec_dump_policy(caddr_t policy, char *delimiter)
+ipsec_dump_policy(c_caddr_t policy, const char *delimiter)
 {
-	struct sadb_x_policy *xpl = (struct sadb_x_policy *)policy;
+	const struct sadb_x_policy *xpl = (const struct sadb_x_policy *)policy;
 	struct sadb_x_ipsecrequest *xisr;
 	size_t off, buflen;
 	char *buf;

--- a/lib/libipsec/ipsec_get_policylen.c
+++ b/lib/libipsec/ipsec_get_policylen.c
@@ -41,7 +41,7 @@
 #include "ipsec_strerror.h"
 
 int
-ipsec_get_policylen(caddr_t policy)
+ipsec_get_policylen(c_caddr_t policy)
 {
 	return policy ? PFKEY_EXTLEN(policy) : -1;
 }

--- a/lib/libipsec/ipsec_set_policy.3
+++ b/lib/libipsec/ipsec_set_policy.3
@@ -41,11 +41,11 @@
 .Sh SYNOPSIS
 .In netipsec/ipsec.h
 .Ft "char *"
-.Fn ipsec_set_policy "char *policy" "int len"
+.Fn ipsec_set_policy "const char *policy" "int len"
 .Ft int
-.Fn ipsec_get_policylen "char *buf"
+.Fn ipsec_get_policylen "const char *buf"
 .Ft "char *"
-.Fn ipsec_dump_policy "char *buf" "char *delim"
+.Fn ipsec_dump_policy "c_caddr_t *buf" "const char *delim"
 .Sh DESCRIPTION
 The
 .Fn ipsec_set_policy

--- a/lib/libipsec/policy_parse.y
+++ b/lib/libipsec/policy_parse.y
@@ -77,16 +77,16 @@ static struct sockaddr *p_src = NULL;
 static struct sockaddr *p_dst = NULL;
 
 struct _val;
-extern void yyerror(char *msg);
-static struct sockaddr *parse_sockaddr(struct _val *buf);
+extern void yyerror(const char *msg);
+static struct sockaddr *parse_sockaddr(const struct _val *buf);
 static int rule_check(void);
 static int init_x_policy(void);
 static int set_x_request(struct sockaddr *src, struct sockaddr *dst);
-static int set_sockaddr(struct sockaddr *addr);
+static int set_sockaddr(const struct sockaddr *addr);
 static void policy_parse_request_init(void);
-static caddr_t policy_parse(char *msg, int msglen);
+static caddr_t policy_parse(const char *msg, int msglen);
 
-extern void __policy__strbuffer__init__(char *msg);
+extern void __policy__strbuffer__init__(const char *msg);
 extern void __policy__strbuffer__free__(void);
 extern int yylex(void);
 
@@ -211,7 +211,7 @@ addresses
 %%
 
 void
-yyerror(char *msg)
+yyerror(const char *msg)
 {
 	fprintf(stderr, "libipsec: %s while parsing \"%s\"\n",
 		msg, __libipsecyytext);
@@ -220,7 +220,7 @@ yyerror(char *msg)
 }
 
 static struct sockaddr *
-parse_sockaddr(struct _val *buf)
+parse_sockaddr(const struct _val *buf)
 {
 	struct addrinfo hints, *res;
 	char *serv = NULL;
@@ -346,7 +346,7 @@ set_x_request(struct sockaddr *src, struct sockaddr *dst)
 }
 
 static int
-set_sockaddr(struct sockaddr *addr)
+set_sockaddr(const struct sockaddr *addr)
 {
 	if (addr == NULL) {
 		__ipsec_errcode = EIPSEC_NO_ERROR;
@@ -383,7 +383,7 @@ policy_parse_request_init(void)
 }
 
 static caddr_t
-policy_parse(char *msg, int msglen)
+policy_parse(const char *msg, int msglen)
 {
 	int error;
 	pbuf = NULL;
@@ -413,7 +413,7 @@ policy_parse(char *msg, int msglen)
 }
 
 caddr_t
-ipsec_set_policy(char *msg, int msglen)
+ipsec_set_policy(const char *msg, int msglen)
 {
 	caddr_t policy;
 

--- a/sys/net/pfkeyv2.h
+++ b/sys/net/pfkeyv2.h
@@ -444,13 +444,13 @@ _Static_assert(sizeof(struct sadb_x_sa_replay) == 8, "struct size mismatch");
 /* Utilities */
 #define PFKEY_ALIGN8(a) (1 + (((a) - 1) | (8 - 1)))
 #define	PFKEY_EXTLEN(msg) \
-	PFKEY_UNUNIT64(((struct sadb_ext *)(msg))->sadb_ext_len)
+	PFKEY_UNUNIT64(((const struct sadb_ext *)(msg))->sadb_ext_len)
 #define PFKEY_ADDR_PREFIX(ext) \
-	(((struct sadb_address *)(ext))->sadb_address_prefixlen)
+	(((const struct sadb_address *)(ext))->sadb_address_prefixlen)
 #define PFKEY_ADDR_PROTO(ext) \
-	(((struct sadb_address *)(ext))->sadb_address_proto)
+	(((const struct sadb_address *)(ext))->sadb_address_proto)
 #define PFKEY_ADDR_SADDR(ext) \
-	((struct sockaddr *)((caddr_t)(ext) + sizeof(struct sadb_address)))
+	((const struct sockaddr *)((c_caddr_t)(ext) + sizeof(struct sadb_address)))
 
 /* in 64bits */
 #define	PFKEY_UNUNIT64(a)	((a) << 3)

--- a/sys/netipsec/ipsec.h
+++ b/sys/netipsec/ipsec.h
@@ -350,9 +350,9 @@ extern	int m_striphdr(struct mbuf *m, int skip, int hlen);
 #endif /* _KERNEL */
 
 #ifndef _KERNEL
-extern caddr_t ipsec_set_policy(char *, int);
-extern int ipsec_get_policylen(caddr_t);
-extern char *ipsec_dump_policy(caddr_t, char *);
+extern caddr_t ipsec_set_policy(const char *, int);
+extern int ipsec_get_policylen(c_caddr_t);
+extern char *ipsec_dump_policy(c_caddr_t, const char *);
 extern const char *ipsec_strerror(void);
 
 #endif /* ! KERNEL */


### PR DESCRIPTION
- add const to the appropriate places in the libipsec public API and the relevant internal functions needed to support that.

- replace caddr_t with c_caddr_t in ipsec_dump_policy()

- update the ipsec_dump_policy manpage to use c_caddr_t (this manpage was already wrong as it had "char *" instead of caddr_t previously).

While here, update pfkeyv2.h to not cast away const in the PFKEY_*() macros.

This should not cause any ABI changes as the actual types have not changed.

---

this came up during my work on the traceroute merge (and will make that easier) but should fixed regardless of that.