### PR TITLE
axgbe: Various stability improvements

### DIFF
--- a/sys/dev/axgbe/if_axgbe_pci.c
+++ b/sys/dev/axgbe/if_axgbe_pci.c
@@ -59,10 +59,8 @@
 #include "opt_rss.h"
 
 #ifdef RSS
-
 #include <net/rss_config.h>
 #include <netinet/in_rss.h>
-
 #endif
 
 MALLOC_DEFINE(M_AXGBE, "axgbe", "axgbe data");
@@ -440,7 +438,14 @@ axgbe_if_attach_pre(if_ctx_t ctx)
         sc->pdata.xgmac_res = mac_res[0];
         sc->pdata.xpcs_res = mac_res[1];
 
-        /* Set the PCS indirect addressing definition registers*/
+	/*
+	 * Set the PCS indirect addressing definition registers.
+	 * A newer version of the hardware is using the same PCI ids
+	 * for the network device but has altered register definitions
+	 * for determining the window settings for the indirect PCS access.
+	 * This code checks hardware usage and uses the register values
+	 * accordingly.
+	 */
 	rdev = pci_find_dbsf(0, 0, 0, 0);
 	if (rdev && pci_get_device(rdev) == 0x15d0
 		&& pci_get_vendor(rdev) == 0x1022) {

--- a/sys/dev/axgbe/xgbe-common.h
+++ b/sys/dev/axgbe/xgbe-common.h
@@ -479,6 +479,8 @@
 #define MAC_PFR_VTFE_WIDTH		1
 #define MAC_PFR_VUCC_INDEX		22
 #define MAC_PFR_VUCC_WIDTH		1
+#define MAC_PFR_RA_INDEX		31
+#define MAC_PFR_RA_WIDTH		1
 #define MAC_PMTCSR_MGKPKTEN_INDEX	1
 #define MAC_PMTCSR_MGKPKTEN_WIDTH	1
 #define MAC_PMTCSR_PWRDWN_INDEX		0
@@ -1319,8 +1321,16 @@
 #define MDIO_PMA_10GBR_FECCTRL		0x00ab
 #endif
 
+#ifndef MDIO_PMA_RX_CTRL1
+#define MDIO_PMA_RX_CTRL1		0x8051
+#endif
+
 #ifndef MDIO_PCS_DIG_CTRL
 #define MDIO_PCS_DIG_CTRL		0x8000
+#endif
+
+#ifndef MDIO_PCS_DIGITAL_STAT
+#define MDIO_PCS_DIGITAL_STAT		0x8010
 #endif
 
 #ifndef MDIO_AN_XNP
@@ -1402,6 +1412,8 @@
 #define XGBE_KR_TRAINING_ENABLE		BIT(1)
 
 #define XGBE_PCS_CL37_BP		BIT(12)
+#define XGBE_PCS_PSEQ_STATE_MASK	0x1c
+#define XGBE_PCS_PSEQ_STATE_POWER_GOOD	0x10
 
 #define XGBE_AN_CL37_INT_CMPLT		BIT(0)
 #define XGBE_AN_CL37_INT_MASK		0x01
@@ -1422,6 +1434,10 @@
 #define XGBE_PMA_PLL_CTRL_MASK		BIT(15)
 #define XGBE_PMA_PLL_CTRL_ENABLE	BIT(15)
 #define XGBE_PMA_PLL_CTRL_DISABLE	0x0000
+
+#define XGBE_PMA_RX_RST_0_MASK		BIT(4)
+#define XGBE_PMA_RX_RST_0_RESET_ON	0x10
+#define XGBE_PMA_RX_RST_0_RESET_OFF	0x00
 
 /* Bit setting and getting macros
  *  The get macro will extract the current bit field value from within

--- a/sys/dev/axgbe/xgbe-dev.c
+++ b/sys/dev/axgbe/xgbe-dev.c
@@ -1452,7 +1452,7 @@ xgbe_dev_read(struct xgbe_channel *channel)
 	if (!err || !etlt) {
 		/* No error if err is 0 or etlt is 0 */
 		if (etlt == 0x09 &&
-			(if_getcapenable(pdata->netdev) & IFCAP_VLAN_HWTAGGING)) {
+		    (if_getcapenable(pdata->netdev) & IFCAP_VLAN_HWTAGGING)) {
 			XGMAC_SET_BITS(packet->attributes, RX_PACKET_ATTRIBUTES,
 			    VLAN_CTAG, 1);
 			packet->vlan_ctag = XGMAC_GET_BITS_LE(rdesc->desc0,

--- a/sys/dev/axgbe/xgbe-dev.c
+++ b/sys/dev/axgbe/xgbe-dev.c
@@ -1451,7 +1451,8 @@ xgbe_dev_read(struct xgbe_channel *channel)
 
 	if (!err || !etlt) {
 		/* No error if err is 0 or etlt is 0 */
-		if (etlt == 0x09) {
+		if (etlt == 0x09 &&
+			(if_getcapenable(pdata->netdev) & IFCAP_VLAN_HWTAGGING)) {
 			XGMAC_SET_BITS(packet->attributes, RX_PACKET_ATTRIBUTES,
 			    VLAN_CTAG, 1);
 			packet->vlan_ctag = XGMAC_GET_BITS_LE(rdesc->desc0,
@@ -2028,6 +2029,12 @@ static void
 xgbe_config_mac_address(struct xgbe_prv_data *pdata)
 {
 	xgbe_set_mac_address(pdata, if_getlladdr(pdata->netdev));
+
+	/*
+	 * Promisc mode does not work as intended. Multicast traffic
+	 * is triggering the filter, so enable Receive All.
+	 */
+	XGMAC_IOWRITE_BITS(pdata, MAC_PFR, RA, 1);
 
 	/* Filtering is done using perfect filtering and hash filtering */
 	if (pdata->hw_feat.hash_table_size) {

--- a/sys/dev/axgbe/xgbe-i2c.c
+++ b/sys/dev/axgbe/xgbe-i2c.c
@@ -327,8 +327,6 @@ out:
 	if (state->ret || XI2C_GET_BITS(isr, IC_RAW_INTR_STAT, STOP_DET))
 		pdata->i2c_complete = true;
 
-	return;
-
 reissue_check:
 	/* Reissue interrupt if status is not clear */
 	if (pdata->vdata->irq_reissue_support)

--- a/sys/dev/axgbe/xgbe-phy-v2.c
+++ b/sys/dev/axgbe/xgbe-phy-v2.c
@@ -2252,7 +2252,8 @@ xgbe_phy_rx_reset(struct xgbe_prv_data *pdata)
 			     XGBE_PCS_PSEQ_STATE_MASK);
 
 	if (reg == XGBE_PCS_PSEQ_STATE_POWER_GOOD) {
-		/* Mailbox command timed out, reset of RX block is required.
+		/*
+	         * Mailbox command timed out, reset of RX block is required.
 		 * This can be done by asserting the reset bit and waiting
 		 * for its completion.
 		 */

--- a/sys/dev/axgbe/xgbe-sysctl.c
+++ b/sys/dev/axgbe/xgbe-sysctl.c
@@ -1607,6 +1607,10 @@ axgbe_sysctl_init(struct xgbe_prv_data *pdata)
 	pdata->sysctl_xgmac_reg = 0;
 	pdata->sysctl_xpcs_mmd = 1;
 	pdata->sysctl_xpcs_reg = 0;
+	pdata->link_workaround = 1;
+	pdata->tx_pause = 1;
+	pdata->rx_pause = 1;
+	pdata->enable_rss = 1;
 
 	SYSCTL_ADD_UINT(clist, top, OID_AUTO, "axgbe_debug_level", CTLFLAG_RWTUN,
 	    &pdata->debug_level, 0, "axgbe log level -- higher is verbose");
@@ -1618,6 +1622,18 @@ axgbe_sysctl_init(struct xgbe_prv_data *pdata)
 	SYSCTL_ADD_UINT(clist, top, OID_AUTO, "link_workaround",
 	    CTLFLAG_RWTUN, &pdata->link_workaround, 0,
 	    "enable the workaround for link issue in coming up");
+
+	SYSCTL_ADD_UINT(clist, top, OID_AUTO, "rss_enabled",
+		CTLFLAG_RDTUN, &pdata->enable_rss, 1,
+		"shows the RSS feature state (1 - enable, 0 - disable)");
+
+	SYSCTL_ADD_UINT(clist, top, OID_AUTO, "tx_pause",
+		CTLFLAG_RDTUN, &pdata->tx_pause, 1,
+		"shows the Flow Control TX pause feature state (1 - enable, 0 - disable)");
+
+	SYSCTL_ADD_UINT(clist, top, OID_AUTO, "rx_pause",
+		CTLFLAG_RDTUN, &pdata->rx_pause, 1,
+		"shows the Flow Control RX pause feature state (1 - enable, 0 - disable)");
 
 	SYSCTL_ADD_PROC(clist, top, OID_AUTO, "xgmac_register",
 	    CTLTYPE_STRING | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,

--- a/sys/dev/axgbe/xgbe-txrx.c
+++ b/sys/dev/axgbe/xgbe-txrx.c
@@ -702,7 +702,7 @@ axgbe_isc_rxd_pkt_get(void *arg, if_rxd_info_t ri)
 	struct xgbe_packet_data *packet = &ring->packet_data;
 	struct xgbe_ring_data	*rdata;
 	unsigned int last, context_next, context;
-	unsigned int buf1_len, buf2_len, max_len, len = 0, prev_cur;
+	unsigned int buf1_len, buf2_len, len = 0, prev_cur;
 	int i = 0;
 
 	axgbe_printf(2, "%s: rxq %d cidx %d cur %d dirty %d\n", __func__,
@@ -767,11 +767,9 @@ read_again:
 		axgbe_printf(2, "%s: csum flags 0x%x\n", __func__, ri->iri_csum_flags);
 	}
 
-	max_len = if_getmtu(pdata->netdev) + ETH_HLEN;
 	if (XGMAC_GET_BITS(packet->attributes, RX_PACKET_ATTRIBUTES, VLAN_CTAG)) {
 		ri->iri_flags |= M_VLANTAG;
 		ri->iri_vtag = packet->vlan_ctag;
-		max_len += VLAN_HLEN;
 		axgbe_printf(2, "%s: iri_flags 0x%x vtag 0x%x\n", __func__,
 		    ri->iri_flags, ri->iri_vtag);
 	}
@@ -787,9 +785,6 @@ read_again:
 
 	if (__predict_false(len == 0))
 		axgbe_printf(1, "%s: Discarding Zero len packet\n", __func__);
-
-	if (__predict_false(len > max_len))
-		axgbe_error("%s: Big packet %d/%d\n", __func__, len, max_len);
 
 	if (__predict_false(packet->errors))
 		axgbe_printf(1, "<-- %s: rxq: %d len: %d frags: %d cidx %d cur: %d "

--- a/sys/dev/axgbe/xgbe.h
+++ b/sys/dev/axgbe/xgbe.h
@@ -180,9 +180,9 @@
 #define XGBE_DMA_SYS_AWCR	0x30303030
 
 /* DMA cache settings - PCI device */
-#define XGBE_DMA_PCI_ARCR	0x00000003
-#define XGBE_DMA_PCI_AWCR	0x13131313
-#define XGBE_DMA_PCI_AWARCR	0x00000313
+#define XGBE_DMA_PCI_ARCR	0x000f0f0f
+#define XGBE_DMA_PCI_AWCR	0x0f0f0f0f
+#define XGBE_DMA_PCI_AWARCR	0x00000f0f
 
 /* DMA channel interrupt modes */
 #define XGBE_IRQ_MODE_EDGE	0


### PR DESCRIPTION
Note: this is a continuation of https://reviews.freebsd.org/D40725. First half containing only link and module compatibility changes went in with https://github.com/freebsd/freebsd-src/commit/445bed5c4d859575951361e432024396b938f863

- Hook in RSS glue.
- Default to "off" for the split header feature to ensure netmap compatibility.
- Change the PCS indirection register values based on hardware type (ported from Linux).
- Move tunable settings to sysctl_init() and set the defaults there. Ensure it's called at the right time by moving it back.
- Reset PHY RX data path when mailbox command times out (Ported from Linux).
- Check if VLAN HW tagging is enabled before assuming a VLAN tag is present in a descriptor.
- Disable the hardware filter since multicast traffic is dropped in promisc mode.
- Remove unnecessary return statement.
- Missing sfp_get_mux, causing a race between ports to read SFP(+) sideband signals.
- Validate and fix incorrectly initialized polarity/configuration registers.
- Remove unnecessary SFP reset.
- axgbe_isc_rxd_pkt_get has no error state, remove unnecessary big packet check.
- Enable RSF to prevent zero-length packets while in Netmap mode.
- DMA cache coherency update (ported from Linux).