### PR TITLE
ctags: Use C99 bool instead of defining our own

### DIFF
--- a/usr.bin/ctags/ctags.c
+++ b/usr.bin/ctags/ctags.c
@@ -86,8 +86,8 @@ main(int argc, char **argv)
 
 	setlocale(LC_ALL, "");
 
-	aflag = uflag = NO;
-	tflag = YES;
+	aflag = uflag = false;
+	tflag = true;
 	while ((ch = getopt(argc, argv, "BFTadf:tuwvx")) != -1)
 		switch(ch) {
 		case 'B':
@@ -97,7 +97,7 @@ main(int argc, char **argv)
 			searchar = '/';
 			break;
 		case 'T':
-			tflag = NO;
+			tflag = false;
 			break;
 		case 'a':
 			aflag++;
@@ -109,7 +109,7 @@ main(int argc, char **argv)
 			outfile = optarg;
 			break;
 		case 't':
-			tflag = YES;
+			tflag = true;
 			break;
 		case 'u':
 			uflag++;
@@ -251,24 +251,24 @@ init(void)
 	const unsigned char	*sp;
 
 	for (i = 0; i < 256; i++) {
-		_wht[i] = _etk[i] = _itk[i] = _btk[i] = NO;
-		_gd[i] = YES;
+		_wht[i] = _etk[i] = _itk[i] = _btk[i] = false;
+		_gd[i] = true;
 	}
 #define	CWHITE	" \f\t\n"
 	for (sp = CWHITE; *sp; sp++)	/* white space chars */
-		_wht[*sp] = YES;
+		_wht[*sp] = true;
 #define	CTOKEN	" \t\n\"'#()[]{}=-+%*/&|^~!<>;,.:?"
 	for (sp = CTOKEN; *sp; sp++)	/* token ending chars */
-		_etk[*sp] = YES;
+		_etk[*sp] = true;
 #define	CINTOK	"ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz0123456789"
 	for (sp = CINTOK; *sp; sp++)	/* valid in-token chars */
-		_itk[*sp] = YES;
+		_itk[*sp] = true;
 #define	CBEGIN	"ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
 	for (sp = CBEGIN; *sp; sp++)	/* token starting chars */
-		_btk[*sp] = YES;
+		_btk[*sp] = true;
 #define	CNOTGD	",;"
 	for (sp = CNOTGD; *sp; sp++)	/* invalid after-function chars */
-		_gd[*sp] = NO;
+		_gd[*sp] = false;
 }
 
 /*

--- a/usr.bin/ctags/ctags.h
+++ b/usr.bin/ctags/ctags.h
@@ -30,10 +30,9 @@
  *
  */
 
-#define	bool	char
+/* This header requires bool for some externed symbols. */
+#include <stdbool.h>
 
-#define	YES		1
-#define	NO		0
 #define	EOS		'\0'
 
 #define	ENDLINE		50		/* max length of pattern */
@@ -81,14 +80,14 @@ extern char	lbuf[LINE_MAX];
 extern char    *lbp;
 extern char	searchar;		/* ex search character */
 
-extern int	cicmp(const char *);
+extern bool	cicmp(const char *);
 extern void	get_line(void);
 extern void	pfnote(const char *, int);
-extern int	skip_key(int);
+extern bool	skip_key(int);
 extern void	put_entries(NODE *);
 extern void	toss_yysec(void);
 extern void	l_entries(void);
 extern void	y_entries(void);
-extern int	PF_funcs(void);
+extern bool	PF_funcs(void);
 extern void	c_entries(void);
 extern void	skip_comment(int);

--- a/usr.bin/ctags/fortran.c
+++ b/usr.bin/ctags/fortran.c
@@ -41,14 +41,14 @@ static void takeprec(void);
 
 char *lbp;				/* line buffer pointer */
 
-int
+bool
 PF_funcs(void)
 {
 	bool	pfcnt;			/* pascal/fortran functions found */
 	char	*cp;
 	char	tok[MAXTOKEN];
 
-	for (pfcnt = NO;;) {
+	for (pfcnt = false;;) {
 		lineftell = ftell(inf);
 		if (!fgets(lbuf, sizeof(lbuf), inf))
 			return (pfcnt);
@@ -120,7 +120,7 @@ PF_funcs(void)
 		(void)strlcpy(tok, lbp, sizeof(tok));	/* possible trunc */
 		get_line();			/* process line for ex(1) */
 		pfnote(tok, lineno);
-		pfcnt = YES;
+		pfcnt = true;
 	}
 	/*NOTREACHED*/
 }
@@ -129,7 +129,7 @@ PF_funcs(void)
  * cicmp --
  *	do case-independent strcmp
  */
-int
+bool
 cicmp(const char *cp)
 {
 	int	len;
@@ -140,9 +140,9 @@ cicmp(const char *cp)
 		continue;
 	if (!*cp) {
 		lbp += len;
-		return (YES);
+		return (true);
 	}
-	return (NO);
+	return (false);
 }
 
 static void

--- a/usr.bin/ctags/lisp.c
+++ b/usr.bin/ctags/lisp.c
@@ -44,7 +44,7 @@
 void
 l_entries(void)
 {
-	int	special;
+	bool	special;
 	char	*cp;
 	char	savedc;
 	char	tok[MAXTOKEN];
@@ -57,15 +57,15 @@ l_entries(void)
 		lbp = lbuf;
 		if (!cicmp("(def"))
 			continue;
-		special = NO;
+		special = false;
 		switch(*lbp | ' ') {
 		case 'm':
 			if (cicmp("method"))
-				special = YES;
+				special = true;
 			break;
 		case 'w':
 			if (cicmp("wrapper") || cicmp("whopper"))
-				special = YES;
+				special = true;
 		}
 		for (; !isspace(*lbp); ++lbp)
 			continue;

--- a/usr.bin/ctags/tree.c
+++ b/usr.bin/ctags/tree.c
@@ -100,7 +100,7 @@ add_node(NODE *node, NODE *cur_node)
 		if (!cur_node->been_warned)
 			if (!wflag)
 				fprintf(stderr, "Duplicate entry in files %s and %s: %s (Warning only)\n", node->file, cur_node->file, node->entry);
-		cur_node->been_warned = YES;
+		cur_node->been_warned = true;
 	}
 	else if (dif < 0)
 		if (cur_node->left)

--- a/usr.bin/ctags/yacc.c
+++ b/usr.bin/ctags/yacc.c
@@ -48,7 +48,7 @@ y_entries(void)
 	bool	in_rule;
 	char	tok[MAXTOKEN];
 
-	in_rule = NO;
+	in_rule = false;
 
 	while (GETC(!=, EOF))
 		switch (c) {
@@ -62,12 +62,12 @@ y_entries(void)
 			break;
 		case '{':
 			if (skip_key('}'))
-				in_rule = NO;
+				in_rule = false;
 			break;
 		case '\'':
 		case '"':
 			if (skip_key(c))
-				in_rule = NO;
+				in_rule = false;
 			break;
 		case '%':
 			if (GETC(==, '%'))
@@ -82,7 +82,7 @@ y_entries(void)
 			break;
 		case '|':
 		case ';':
-			in_rule = NO;
+			in_rule = false;
 			break;
 		default:
 			if (in_rule || (!isalpha(c) && c != '.' && c != '_'))
@@ -101,7 +101,7 @@ y_entries(void)
 			}
 			if (c == ':') {
 				pfnote(tok, lineno);
-				in_rule = YES;
+				in_rule = true;
 			}
 			else
 				(void)ungetc(c, inf);


### PR DESCRIPTION
Use stdbool.h definitions instead of defining non-standard ones.