### PR TITLE
Lagg.4 - removed .Xr reference to /etc/rc.conf(5)

### DIFF
--- a/share/man/man4/lagg.4
+++ b/share/man/man4/lagg.4
@@ -214,7 +214,7 @@ The following example shows how to create an infiniband failover interface.
 .Ed
 .Pp
 Configure two ethernets for failover with static IP in
-.Xr /etc/rc.conf 5 :
+/etc/rc.conf:
 .Bd -literal -offset indent
 cloned_interfaces="lagg0"
 ifconfig_lagg0="laggproto failover laggport bge0 laggport bge1 \e

--- a/share/man/man4/lagg.4
+++ b/share/man/man4/lagg.4
@@ -214,7 +214,7 @@ The following example shows how to create an infiniband failover interface.
 .Ed
 .Pp
 Configure two ethernets for failover with static IP in
-/etc/rc.conf:
+.Pa /etc/rc.conf :
 .Bd -literal -offset indent
 cloned_interfaces="lagg0"
 ifconfig_lagg0="laggproto failover laggport bge0 laggport bge1 \e

--- a/sys/contrib/openzfs/man/man8/zpool-iostat.8
+++ b/sys/contrib/openzfs/man/man8/zpool-iostat.8
@@ -146,7 +146,11 @@ Specify
 .Sy u
 for a printed representation of the internal representation of time.
 See
+<<<<<<< HEAD
 .Xr time 1 .
+=======
+.Xr time 2 .
+>>>>>>> 99007677d048 (Revert "elftc_set_timestamps.3 modification to update from utime(2) -> utime(3)")
 Specify
 .Sy d
 for standard date format.

--- a/sys/contrib/openzfs/man/man8/zpool-list.8
+++ b/sys/contrib/openzfs/man/man8/zpool-list.8
@@ -95,7 +95,11 @@ Specify
 .Sy u
 for a printed representation of the internal representation of time.
 See
+<<<<<<< HEAD
 .Xr time 1 .
+=======
+.Xr time 2 .
+>>>>>>> 99007677d048 (Revert "elftc_set_timestamps.3 modification to update from utime(2) -> utime(3)")
 Specify
 .Sy d
 for standard date format.

--- a/sys/contrib/openzfs/man/man8/zpool-status.8
+++ b/sys/contrib/openzfs/man/man8/zpool-status.8
@@ -112,7 +112,11 @@ Specify
 .Sy u
 for a printed representation of the internal representation of time.
 See
+<<<<<<< HEAD
 .Xr time 1 .
+=======
+.Xr time 2 .
+>>>>>>> 99007677d048 (Revert "elftc_set_timestamps.3 modification to update from utime(2) -> utime(3)")
 Specify
 .Sy d
 for standard date format.

--- a/sys/contrib/openzfs/man/man8/zpool-wait.8
+++ b/sys/contrib/openzfs/man/man8/zpool-wait.8
@@ -99,7 +99,11 @@ Specify
 .Sy u
 for a printed representation of the internal representation of time.
 See
+<<<<<<< HEAD
 .Xr time 1 .
+=======
+.Xr time 2 .
+>>>>>>> 99007677d048 (Revert "elftc_set_timestamps.3 modification to update from utime(2) -> utime(3)")
 Specify
 .Sy d
 for standard date format.


### PR DESCRIPTION
lagg.4: manual page incorrectly .Xr to /etc/rc.conf(5) removed link and kept test of /etc/rc.conf