### PR TITLE
fusefs: only test for incoherency if FN_SIZECHANGE is set

### DIFF
--- a/sys/fs/fuse/fuse_internal.c
+++ b/sys/fs/fuse/fuse_internal.c
@@ -269,10 +269,10 @@ fuse_internal_cache_attrs(struct vnode *vp, struct fuse_attr *attr,
 
 	if (vnode_isreg(vp) &&
 	    fvdat->cached_attrs.va_size != VNOVAL &&
+	    fvdat->flag & FN_SIZECHANGE &&
 	    attr->size != fvdat->cached_attrs.va_size)
 	{
-		if ( data->cache_mode == FUSE_CACHE_WB &&
-		    fvdat->flag & FN_SIZECHANGE)
+		if (data->cache_mode == FUSE_CACHE_WB)
 		{
 			const char *msg;
 


### PR DESCRIPTION
FUSE emits spurious incoherency warnings in writethrough mode. The warnings are triggered by setattr calls generated by vnode truncation turning the cached va_size vattr stale, causing comparisons with the fresh version provided by the server to fail. Only validate the vnode's va_size vattr if the FN_SIZECHANGE flag is set.