### PR TITLE
which: Use size_t instead of ssize_t for pathlen

### DIFF
--- a/usr.bin/which/which.c
+++ b/usr.bin/which/which.c
@@ -45,7 +45,7 @@ int
 main(int argc, char **argv)
 {
 	char *p, *path;
-	ssize_t pathlen;
+	size_t pathlen;
 	int opt, status;
 
 	status = EXIT_SUCCESS;


### PR DESCRIPTION
The "pathlen" variable is the return value of strlen(3) and is then passed as an argument to malloc(3) and memcpy(3). The size_t type matches the prototype for these functions. The size_t type is unsigned so it can fit larger $PATH values than ssize_t. However, In practice ssize_t should be larger enough so this change is just for clarity.