### PR TITLE
Updates to 3 manual pages: lagg.4, xlocale.3, buf.9

### DIFF
--- a/lib/libc/locale/xlocale.3
+++ b/lib/libc/locale/xlocale.3
@@ -166,10 +166,10 @@ along with the headers that expose them, is provided here:
 .Xr vsprintf_l 3 ,
 .Xr vsscanf_l 3
 .It In stdlib.h
-.Xr atof_l 3 ,
-.Xr atoi_l 3 ,
-.Xr atol_l 3 ,
-.Xr atoll_l 3 ,
+.\".Xr atof_l 3 ,
+.\".Xr atoi_l 3 ,
+.\".Xr atol_l 3 ,
+.\".Xr atoll_l 3 ,
 .Xr mblen_l 3 ,
 .Xr mbstowcs_l 3 ,
 .Xr mbtowc_l 3 ,

--- a/share/man/man4/lagg.4
+++ b/share/man/man4/lagg.4
@@ -214,7 +214,7 @@ The following example shows how to create an infiniband failover interface.
 .Ed
 .Pp
 Configure two ethernets for failover with static IP in
-.Xr /etc/rc.conf 5 :
+.Pa /etc/rc.conf :
 .Bd -literal -offset indent
 cloned_interfaces="lagg0"
 ifconfig_lagg0="laggproto failover laggport bge0 laggport bge1 \e

--- a/share/man/man9/buf.9
+++ b/share/man/man9/buf.9
@@ -132,8 +132,6 @@ instantiated VM Buffers (struct buf's) prevent their underlying pages in the
 buffer cache from being freed.
 This can complicate the life of the paging
 system.
-.\" .Sh SEE ALSO
-.\" .Xr <fillmein> 9
 .Sh HISTORY
 The
 .Nm


### PR DESCRIPTION
Update manual page references and macros to align to mandoc syntax

xlocale.3: Comment out reference to atof_l(3), atoi_l(3), atol_l(3), atoll_l(3)
  These manual page references do not exist.
lagg.4: Change the reference for /etc/rc.conf from a reference link
  .Xr -> .Pa based on the context within the manual page it is used.
buf.9: Remove .Xr entries from the file
  The buf.9 manual page contains a commented out .Xr reference.
  The <filmmein> 9 entry is a placeholder and has been removed for
  clarity.