### PR TITLE
cp: Remove useless ssize_t cast

### DIFF
--- a/bin/cp/utils.c
+++ b/bin/cp/utils.c
@@ -91,7 +91,7 @@ copy_fallback(int from_fd, int to_fd)
 		wcount = write(to_fd, bufp, wresid);
 		if (wcount <= 0)
 			break;
-		if (wcount >= (ssize_t)wresid)
+		if (wcount >= wresid)
 			break;
 	}
 	return (wcount < 0 ? wcount : rcount);


### PR DESCRIPTION
Both wcount and wresid are ssize_t so this cast is not needed. Just remove it so the code is easier to read.