### PR TITLE
Perfer sys/cdefs.h __unreachable over the builtin

### DIFF
--- a/bin/nproc/nproc.c
+++ b/bin/nproc/nproc.c
@@ -94,7 +94,7 @@ main(int argc, char *argv[])
 			break;
 		case OPT_VERSION:
 			version();
-			__builtin_unreachable();
+			__unreachable();
 		case OPT_HELP:
 			help();
 			exit(EXIT_SUCCESS);

--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -275,7 +275,7 @@ main(int argc, char *argv[])
 			break;
 		case 'h':
 			usage(0);
-			__builtin_unreachable();
+			__unreachable();
 		default:
 			usage(1);
 		}

--- a/usr.sbin/kldxref/elf.c
+++ b/usr.sbin/kldxref/elf.c
@@ -514,7 +514,7 @@ elf_address_from_pointer(struct elf_file *efile, const void *p)
 		else
 			return (be64dec(p));
 	default:
-		__builtin_unreachable();
+		__unreachable();
 	}
 }
 


### PR DESCRIPTION
The __builtin_unreachable macro provided by Clang and GCC is a hint to the compiler used for optimization. The programs work fine even if the compiler doesn't support it. The sys/cdefs.h has had __unreachable for 9 years (commit 732b31de5d9244bd1cc98192e09ee1881e9f55e9). It expands to the builtin if it is available. In the rare case that it is unsupported it expands to a null statement so compilation does not fail.