### PR TITLE
Fix some spellings in various parts of libc

### DIFF
--- a/lib/libc/db/btree/bt_seq.c
+++ b/lib/libc/db/btree/bt_seq.c
@@ -83,7 +83,7 @@ __bt_seq(const DB *dbp, DBT *key, DBT *data, u_int flags)
 	}
 
 	/*
-	 * If scan unitialized as yet, or starting at a specific record, set
+	 * If scan uninitialized as yet, or starting at a specific record, set
 	 * the scan to a specific key.  Both __bt_seqset and __bt_seqadv pin
 	 * the page the cursor references if they're successful.
 	 */

--- a/lib/libc/db/btree/bt_utils.c
+++ b/lib/libc/db/btree/bt_utils.c
@@ -66,7 +66,7 @@ __bt_ret(BTREE *t, EPG *e, DBT *key, DBT *rkey, DBT *data, DBT *rdata, int copy)
 	bl = GETBLEAF(e->page, e->index);
 
 	/*
-	 * We must copy big keys/data to make them contigous.  Otherwise,
+	 * We must copy big keys/data to make them contiguous.  Otherwise,
 	 * leave the page pinned and don't copy unless the user specified
 	 * concurrent access.
 	 */

--- a/lib/libc/inet/inet_net_pton.c
+++ b/lib/libc/inet/inet_net_pton.c
@@ -138,7 +138,7 @@ inet_net_pton_ipv4(const char *src, u_char *dst, size_t size) {
 			goto enoent;
 	}
 
-	/* Firey death and destruction unless we prefetched EOS. */
+	/* Fiery death and destruction unless we prefetched EOS. */
 	if (ch != '\0')
 		goto enoent;
 

--- a/lib/libc/locale/localeconv.c
+++ b/lib/libc/locale/localeconv.c
@@ -45,7 +45,7 @@
  * monetary and numeric locales.
  *
  * Because localeconv() may be called many times (especially by library
- * routines like printf() & strtod()), the approprate members of the 
+ * routines like printf() & strtod()), the appropriate members of the
  * lconv structure are computed only when the monetary or numeric 
  * locale has been changed.
  */

--- a/lib/libc/stdlib/div.c
+++ b/lib/libc/stdlib/div.c
@@ -48,7 +48,7 @@ div(int num, int denom)
 	 * words, we should always truncate the quotient towards
 	 * 0, never -infinity.
 	 *
-	 * Machine division and remainer may work either way when
+	 * Machine division and remainder may work either way when
 	 * one or both of n or d is negative.  If only one is
 	 * negative and r.quot has been truncated towards -inf,
 	 * r.rem will have the same sign as denom and the opposite

--- a/lib/libc/xdr/xdr.c
+++ b/lib/libc/xdr/xdr.c
@@ -621,7 +621,7 @@ xdr_netobj(XDR *xdrs, struct netobj *np)
 }
 
 /*
- * XDR a descriminated union
+ * XDR a discriminated union
  * Support routine for discriminated unions.
  * You create an array of xdrdiscrim structures, terminated with
  * an entry with a null procedure pointer.  The routine gets

--- a/lib/libc/xdr/xdr_reference.c
+++ b/lib/libc/xdr/xdr_reference.c
@@ -56,7 +56,7 @@
  * referenced by a pointer inside the structure that is currently being
  * translated.  pp references a pointer to storage. If *pp is null
  * the  necessary storage is allocated.
- * size is the sizeof the referneced structure.
+ * size is the sizeof the referenced structure.
  * proc is the routine to handle the referenced structure.
  */
 bool_t


### PR DESCRIPTION
f0a666e914d718ebdcc27763d2870bb0da4fcbc2, 8aafb0560ac47442251b693bb0a79f25e52b8d94, and 8d40c6a559c7b2dd6529b1ec3a91b88cf02d52e8 are sorted from OpenBSD. Others are just diffs (from OpenBSD) (where I found these typos).
