### PR TITLE
wlan.4 - Removed the Aironet Communications kernel reference for 4500/4800 devices

### DIFF
--- a/share/man/man4/wlan.4
+++ b/share/man/man4/wlan.4
@@ -166,7 +166,6 @@ not ratified and subject to change.
 Be aware that this specification is incompatible with earlier drafts.
 Stations implementing earlier drafts (e.g., Linux) may be incompatible.
 .Sh SEE ALSO
-.Xr an 4 ,
 .Xr ath 4 ,
 .Xr bwi 4 ,
 .Xr bwn 4 ,


### PR DESCRIPTION
wlan.4 - This is also references wifi.4. The Aironet Communication module for 4500/4800 devices are no longer in FreeBSD. It was confirmed that the last time it was available is Release 13.2 - https://man.freebsd.org/cgi/man.cgi?query=an&apropos=0&sektion=4&manpath=FreeBSD+13.2-RELEASE&arch=default&format=html