### PR TITLE
sys/amd64/conf: unify MINIMAL and GENERIC debug

### DIFF
--- a/sys/amd64/conf/GENERIC
+++ b/sys/amd64/conf/GENERIC
@@ -94,25 +94,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-options 	BUF_TRACKING		# Track buffer history
-options 	DDB			# Support DDB.
-options 	FULL_BUF_TRACKING	# Track more buffer history
-options 	GDB			# Support remote GDB.
-options 	DEADLKRES		# Enable the deadlock resolver
-options 	INVARIANTS		# Enable calls of extra sanity checking
-options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-options 	QUEUE_MACRO_DEBUG_TRASH	# Trash queue(2) internal pointers on invalidation
-options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
-options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
-options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
-
-# Kernel Sanitizers
-#options 	COVERAGE		# Generic kernel coverage. Used by KCOV
-#options 	KCOV			# Kernel Coverage Sanitizer
-# Warning: KUBSAN can result in a kernel too large for loader to load
-#options 	KUBSAN			# Kernel Undefined Behavior Sanitizer
-#options 	KCSAN			# Kernel Concurrency Sanitizer
+include ../../conf/std.debug
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/amd64/conf/GENERIC
+++ b/sys/amd64/conf/GENERIC
@@ -94,7 +94,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/amd64/conf/GENERIC-NODEBUG
+++ b/sys/amd64/conf/GENERIC-NODEBUG
@@ -26,6 +26,6 @@
 #
 
 include GENERIC
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   GENERIC-NODEBUG

--- a/sys/amd64/conf/MINIMAL
+++ b/sys/amd64/conf/MINIMAL
@@ -79,7 +79,7 @@ options 	INCLUDE_CONFIG_FILE	# Include this file in kernel
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Make an SMP-capable kernel by default
 options 	SMP			# Symmetric MultiProcessor Kernel

--- a/sys/amd64/conf/MINIMAL
+++ b/sys/amd64/conf/MINIMAL
@@ -78,6 +78,8 @@ options 	INCLUDE_CONFIG_FILE	# Include this file in kernel
 # Debugging support.  Always need this:
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
+# For full debugger support use (turn off in stable branch):
+include ../../conf/std.debug
 
 # Make an SMP-capable kernel by default
 options 	SMP			# Symmetric MultiProcessor Kernel

--- a/sys/amd64/conf/MINIMAL-NODEBUG
+++ b/sys/amd64/conf/MINIMAL-NODEBUG
@@ -6,6 +6,6 @@
 #NO_UNIVERSE
 
 include MINIMAL
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   MINIMAL-NODEBUG

--- a/sys/amd64/conf/MINIMAL-NODEBUG
+++ b/sys/amd64/conf/MINIMAL-NODEBUG
@@ -1,0 +1,11 @@
+#
+# MINIMAL-NODEBUG -- Non-debug MINIMAL kernel.
+#
+# This is the MINIMAL equivalent to GENERIC-NODEBUG.
+
+#NO_UNIVERSE
+
+include MINIMAL
+include "../../conf/std.nodebug"
+
+ident   MINIMAL-NODEBUG

--- a/sys/amd64/conf/NOTES
+++ b/sys/amd64/conf/NOTES
@@ -159,3 +159,15 @@ options 	KSTACK_PAGES=5
 # Enable detailed accounting by the PV entry allocator.
 
 options 	PV_STATS
+
+#####################################################################
+# Kernel sanitizers
+
+#options	COVERAGE		# Generic kernel coverage. Used by KCOV
+#options	KCOV			# Kernel Coverage Sanitizer
+# Warning: KUBSAN can result in a kernel too large for loader to load
+#options	KUBSAN			# Kernel Undefined Behavior Sanitizer
+#options	KCSAN			# Kernel Concurrency Sanitizer
+#options	KASAN			# Kernel Address Sanitizer
+#options	KCSAN			# Kernel Concurrency Sanitizer
+#options	KMSAN			# Kernel Memory Sanitizer

--- a/sys/arm/conf/GENERIC-NODEBUG
+++ b/sys/arm/conf/GENERIC-NODEBUG
@@ -26,6 +26,6 @@
 #
 
 include GENERIC
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   GENERIC-NODEBUG

--- a/sys/arm/conf/std.armv6
+++ b/sys/arm/conf/std.armv6
@@ -63,18 +63,10 @@ makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 
+options		USB_DEBUG		# Enable usb debug support code
+
 # For full debugger support use (turn off in stable branch):
-options 	DDB			# Support DDB
-options 	GDB			# Support remote GDB
-#options 	DEADLKRES		# Enable the deadlock resolver
-options 	INVARIANTS		# Enable calls of extra sanity checking
-options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
-options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
-options 	ALT_BREAK_TO_DEBUGGER	# Enter debugger on keyboard escape sequence
-options 	USB_DEBUG		# Enable usb debug support code
-options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
+include ../../conf/std.debug
 
 # Optional extras, never enabled by default:
 #options 	BOOTVERBOSE

--- a/sys/arm/conf/std.armv6
+++ b/sys/arm/conf/std.armv6
@@ -66,7 +66,7 @@ options 	KDB_TRACE		# Print a stack trace for a panic.
 options		USB_DEBUG		# Enable usb debug support code
 
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Optional extras, never enabled by default:
 #options 	BOOTVERBOSE

--- a/sys/arm/conf/std.armv7
+++ b/sys/arm/conf/std.armv7
@@ -63,18 +63,10 @@ makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 
+options		USB_DEBUG		# Enable usb debug support code
+
 # For full debugger support use (turn off in stable branch):
-options 	DDB			# Support DDB
-options 	GDB			# Support remote GDB
-#options 	DEADLKRES		# Enable the deadlock resolver
-options 	INVARIANTS		# Enable calls of extra sanity checking
-options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
-options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
-options 	ALT_BREAK_TO_DEBUGGER	# Enter debugger on keyboard escape sequence
-options 	USB_DEBUG		# Enable usb debug support code
-options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
+include ../../conf/std.debug
 
 # Optional extras, never enabled by default:
 #options 	BOOTVERBOSE

--- a/sys/arm/conf/std.armv7
+++ b/sys/arm/conf/std.armv7
@@ -66,7 +66,7 @@ options 	KDB_TRACE		# Print a stack trace for a panic.
 options		USB_DEBUG		# Enable usb debug support code
 
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Optional extras, never enabled by default:
 #options 	BOOTVERBOSE

--- a/sys/arm64/conf/GENERIC-MMCCAM-NODEBUG
+++ b/sys/arm64/conf/GENERIC-MMCCAM-NODEBUG
@@ -9,6 +9,6 @@
 #NO_UNIVERSE
 
 include GENERIC-MMCCAM
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident GENERIC-MMCCAM-NODEBUG

--- a/sys/arm64/conf/GENERIC-NODEBUG
+++ b/sys/arm64/conf/GENERIC-NODEBUG
@@ -26,6 +26,6 @@
 #
 
 include GENERIC
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   GENERIC-NODEBUG

--- a/sys/arm64/conf/std.arm64
+++ b/sys/arm64/conf/std.arm64
@@ -73,7 +73,7 @@ options 	PERTHREAD_SSP		# Per-thread SSP canary
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Kernel Sanitizers
 #options 	COVERAGE		# Generic kernel coverage. Used by KCOV

--- a/sys/arm64/conf/std.arm64
+++ b/sys/arm64/conf/std.arm64
@@ -73,16 +73,7 @@ options 	PERTHREAD_SSP		# Per-thread SSP canary
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-options 	DDB			# Support DDB.
-options 	GDB			# Support remote GDB.
-options 	DEADLKRES		# Enable the deadlock resolver
-options 	INVARIANTS		# Enable calls of extra sanity checking
-options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
-options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
-options 	ALT_BREAK_TO_DEBUGGER	# Enter debugger on keyboard escape sequence
-options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
+include ../../conf/std.debug
 
 # Kernel Sanitizers
 #options 	COVERAGE		# Generic kernel coverage. Used by KCOV

--- a/sys/conf/std.debug
+++ b/sys/conf/std.debug
@@ -1,0 +1,17 @@
+#
+# std.debug -- Enable debug options for -CURRENT.
+#
+
+options 	BUF_TRACKING		# Track buffer history
+options 	DDB			# Support DDB.
+options 	FULL_BUF_TRACKING	# Track more buffer history
+options 	GDB			# Support remote GDB.
+options 	DEADLKRES		# Enable the deadlock resolver
+options 	INVARIANTS		# Enable calls of extra sanity checking
+options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
+options 	QUEUE_MACRO_DEBUG_TRASH	# Trash queue(2) internal pointers on invalidation
+options 	WITNESS			# Enable checks to detect deadlocks and cycles
+options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
+options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
+options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
+options		ALT_BREAK_TO_DEBUGGER	# Enter debugger on keyboard escape sequence

--- a/sys/i386/conf/GENERIC
+++ b/sys/i386/conf/GENERIC
@@ -88,15 +88,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-options 	DDB			# Support DDB.
-options 	GDB			# Support remote GDB.
-options 	DEADLKRES		# Enable the deadlock resolver
-options 	INVARIANTS		# Enable calls of extra sanity checking
-options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
-options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
-options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
+include ../../conf/std.debug
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/i386/conf/GENERIC
+++ b/sys/i386/conf/GENERIC
@@ -88,7 +88,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/i386/conf/GENERIC-NODEBUG
+++ b/sys/i386/conf/GENERIC-NODEBUG
@@ -26,6 +26,6 @@
 #
 
 include GENERIC
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   GENERIC-NODEBUG

--- a/sys/i386/conf/MINIMAL
+++ b/sys/i386/conf/MINIMAL
@@ -87,7 +87,7 @@ options 	INCLUDE_CONFIG_FILE	# Include this file in kernel
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Make an SMP-capable kernel by default
 options 	SMP			# Symmetric MultiProcessor Kernel

--- a/sys/i386/conf/MINIMAL
+++ b/sys/i386/conf/MINIMAL
@@ -86,6 +86,8 @@ options 	INCLUDE_CONFIG_FILE	# Include this file in kernel
 # Debugging support.  Always need this:
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
+# For full debugger support use (turn off in stable branch):
+include ../../conf/std.debug
 
 # Make an SMP-capable kernel by default
 options 	SMP			# Symmetric MultiProcessor Kernel

--- a/sys/i386/conf/MINIMAL-NODEBUG
+++ b/sys/i386/conf/MINIMAL-NODEBUG
@@ -6,6 +6,6 @@
 #NO_UNIVERSE
 
 include MINIMAL
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   MINIMAL-NODEBUG

--- a/sys/i386/conf/MINIMAL-NODEBUG
+++ b/sys/i386/conf/MINIMAL-NODEBUG
@@ -1,0 +1,11 @@
+#
+# MINIMAL-NODEBUG -- Non-debug MINIMAL kernel.
+#
+# This is the MINIMAL equivalent to GENERIC-NODEBUG.
+
+#NO_UNIVERSE
+
+include MINIMAL
+include "../../conf/std.nodebug"
+
+ident   MINIMAL-NODEBUG

--- a/sys/powerpc/conf/GENERIC
+++ b/sys/powerpc/conf/GENERIC
@@ -91,14 +91,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-options 	DDB			# Support DDB
-#options 	DEADLKRES		# Enable the deadlock resolver
-options 	INVARIANTS		# Enable calls of extra sanity checking
-options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
-options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
-options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
+include ../../conf/std.debug
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/powerpc/conf/GENERIC
+++ b/sys/powerpc/conf/GENERIC
@@ -91,7 +91,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/powerpc/conf/GENERIC-NODEBUG
+++ b/sys/powerpc/conf/GENERIC-NODEBUG
@@ -26,6 +26,6 @@
 #
 
 include GENERIC
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   GENERIC-NODEBUG

--- a/sys/powerpc/conf/GENERIC64
+++ b/sys/powerpc/conf/GENERIC64
@@ -101,14 +101,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-options 	DDB			# Support DDB
-#options 	DEADLKRES		# Enable the deadlock resolver
-options 	INVARIANTS		# Enable calls of extra sanity checking
-options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
-options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
-options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
+include ../../conf/std.debug
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/powerpc/conf/GENERIC64
+++ b/sys/powerpc/conf/GENERIC64
@@ -101,7 +101,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/powerpc/conf/GENERIC64-NODEBUG
+++ b/sys/powerpc/conf/GENERIC64-NODEBUG
@@ -26,6 +26,6 @@
 #
 
 include GENERIC64
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   GENERIC64-NODEBUG

--- a/sys/powerpc/conf/GENERIC64LE
+++ b/sys/powerpc/conf/GENERIC64LE
@@ -97,7 +97,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-include ../../conf/std.debug
+include "std.debug"
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/powerpc/conf/GENERIC64LE
+++ b/sys/powerpc/conf/GENERIC64LE
@@ -97,14 +97,7 @@ options 	RCTL			# Resource limits
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-options 	DDB			# Support DDB
-#options 	DEADLKRES		# Enable the deadlock resolver
-options 	INVARIANTS		# Enable calls of extra sanity checking
-options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
-options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
-options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
+include ../../conf/std.debug
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/powerpc/conf/GENERIC64LE-NODEBUG
+++ b/sys/powerpc/conf/GENERIC64LE-NODEBUG
@@ -26,6 +26,6 @@
 #
 
 include GENERIC64LE
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   GENERIC64LE-NODEBUG

--- a/sys/riscv/conf/GENERIC
+++ b/sys/riscv/conf/GENERIC
@@ -156,17 +156,8 @@ device		spigen
 options 	KDB			# Enable kernel debugger support.
 options 	KDB_TRACE		# Print a stack trace for a panic.
 # For full debugger support use (turn off in stable branch):
-options 	DDB			# Support DDB.
-options 	GDB			# Support remote GDB.
-options 	DEADLKRES		# Enable the deadlock resolver
-options 	INVARIANTS		# Enable calls of extra sanity checking
-options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
-options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
-options 	ALT_BREAK_TO_DEBUGGER	# Enter debugger on keyboard escape sequence
+include "std.debug"
 # options 	EARLY_PRINTF=sbi
-options 	VERBOSE_SYSINIT=0	# Support debug.verbose_sysinit, off by default
 
 # Kernel dump features.
 options 	EKCD			# Support for encrypted kernel dumps

--- a/sys/riscv/conf/GENERIC-NODEBUG
+++ b/sys/riscv/conf/GENERIC-NODEBUG
@@ -26,6 +26,6 @@
 #
 
 include GENERIC
-include "../../conf/std.nodebug"
+include "std.nodebug"
 
 ident   GENERIC-NODEBUG


### PR DESCRIPTION
Add debugging features (WITNESS, INVARIANTS, etc.) to MINIMAL to match the options enabled in GENERIC.

Add a new MINIMAL-NODEBUG kernel which turns these features off in the same way GENERIC-NODEBUG does.

This reduces the differences between GENERIC and MINIMAL in a way that should be less confusing to users.

---

this only addresses amd64 for now.  other archs can have the equivalent changes made afterwards if this causes no issues.