### PR TITLE
ACPI/IIC: Miscellaneous changes

### DIFF
--- a/sys/dev/acpica/acpi_cmbat.c
+++ b/sys/dev/acpica/acpi_cmbat.c
@@ -344,7 +344,7 @@ acpi_cmbat_get_bix(void *arg)
     bix_buffer.Pointer = NULL;
     bix_buffer.Length = ACPI_ALLOCATE_BUFFER;
 
-    for (n = 0; n < sizeof(bobjs); n++) {
+    for (n = 0; n < nitems(bobjs); n++) {
 	as = AcpiEvaluateObject(h, bobjs[n].name, NULL, &bix_buffer);
 	if (!ACPI_FAILURE(as)) {
 	    res = (ACPI_OBJECT *)bix_buffer.Pointer;
@@ -355,7 +355,7 @@ acpi_cmbat_get_bix(void *arg)
         bix_buffer.Length = ACPI_ALLOCATE_BUFFER;
     }
     /* Both _BIF and _BIX were not found. */
-    if (n == sizeof(bobjs)) {
+    if (n == nitems(bobjs)) {
 	ACPI_VPRINT(dev, acpi_device_get_parent_softc(dev),
 	    "error fetching current battery info -- %s\n",
 	    AcpiFormatException(as));

--- a/sys/dev/ichiic/ig4_iic.c
+++ b/sys/dev/ichiic/ig4_iic.c
@@ -675,6 +675,10 @@ ig4iic_transfer(device_t dev, struct iic_msg *msgs, uint32_t nmsgs)
 		rpstart = !stop;
 	}
 
+	if (error == IIC_ENOACK && bootverbose)
+		device_printf(dev, "Warning: NACK for slave address 0x%x\n",
+		    msgs[i].slave >> 1);
+
 	if (!allocated)
 		sx_unlock(&sc->call_lock);
 	return (error);

--- a/sys/dev/ichiic/ig4_reg.h
+++ b/sys/dev/ichiic/ig4_reg.h
@@ -37,7 +37,7 @@
  *
  * Datasheet reference:  Section 22.
  *
- * http://www.intel.com/content/www/us/en/processors/core/4th-gen-core-family-mobile-i-o-datasheet.html?wapkw=datasheets+4th+generation
+ * https://www.intel.com/content/dam/www/public/us/en/documents/datasheets/4th-gen-core-family-mobile-i-o-datasheet.pdf
  *
  * This is a from-scratch driver under the BSD license using the Intel data
  * sheet and the linux driver for reference.  All code is freshly written

--- a/sys/dev/iicbus/acpi_iicbus.c
+++ b/sys/dev/iicbus/acpi_iicbus.c
@@ -254,6 +254,9 @@ acpi_iicbus_space_handler(UINT32 Function, ACPI_PHYSICAL_ADDRESS Address,
 	sc = __containerof(info, struct acpi_iicbus_softc, space_handler_info);
 	dev = sc->super_sc.dev;
 
+	/* the address is expected to need shifting */
+	sb->SlaveAddress <<= 1;
+
 	switch (Function) {
 	case AML_FIELD_ATTRIO(AML_FIELD_ATTRIB_SEND_RECEIVE, ACPI_READ):
 		val = acpi_iicbus_recvb(dev, sb->SlaveAddress, gsb->data);


### PR DESCRIPTION
Some changes that I feel are too small to split into multiple pull requests.

acpi_iicbus:
The underlying i2c driver expects the addresses it receives to need shifting, the opregion handler however receives the addresses already shifted, so shift the address to the left in the handler before sending it off.
See https://uefi.org/specs/ACPI/6.5/13_System_Mgmt_Bus_Interface_Specification.html#smbus-slave-addresses

ig4_iic:
Some DSDTs define non-existent devices, its a little disconnecting to have a device present on the DSDT then have it seemingly ignored by the system, so I added a warning for it (only prints if bootverbose is set).

The other two changes are fairly trivial, one updates an outdated link and the other replaces an incorrect use of sizeof with nitems.

Also, about the acpi_iicbus driver, what testing would be needed to get the address space handler enabled by default? It currently works just fine with my laptop's battery and i2c(8), will see if I can test it on other things.

Tested on the Acer one 10 s1002.