### PR TITLE
read.2 - resolved a self-reference link in manual page

### DIFF
--- a/lib/libsys/read.2
+++ b/lib/libsys/read.2
@@ -129,15 +129,23 @@ before the end-of-file, but in no other case.
 In accordance with
 .St -p1003.1-2004 ,
 both
+<<<<<<< HEAD
 .Xr read 2
+=======
+.Fn read
+>>>>>>> 29f97d973eec (read.2 - udpated both write / read references from .Xr to .Fn to align to function calls)
 and
-.Xr write 2
+.Fn write
 syscalls are atomic with respect to each other in the effects on file
 content, when they operate on regular files.
 If two threads each call one of the
+<<<<<<< HEAD
 .Xr read 2
+=======
+.Fn read
+>>>>>>> 29f97d973eec (read.2 - udpated both write / read references from .Xr to .Fn to align to function calls)
 or
-.Xr write 2 ,
+.Fn write ,
 syscalls, each call will see either all of the changes of the other call,
 or none of them.
 The


### PR DESCRIPTION
read.2 - Identified a self-reference in read(2) with .Xr and transitioned them to .Nm to resolve the mandoc -Tlint error message