### PR TITLE
assert.3 - Remove the .Rs and .Re macros to resolving WARNING from mandoc -Tlint

### DIFF
--- a/share/man/man3/assert.3
+++ b/share/man/man3/assert.3
@@ -120,19 +120,15 @@ If none is provided, it only points at the constraint.
 .Xr abort2 2 ,
 .Xr abort 3
 .Sh STANDARDS
-.Rs
 The
 .Fn assert
 macro conforms to
 .St -isoC-99 .
-.Re
 .Pp
-.Rs
 The
 .Fn static_assert
 macro conforms to
 .St -isoC-2011 .
-.Re
 .Sh HISTORY
 An
 .Nm


### PR DESCRIPTION
assert.3 - Remove the .Rs and .Re macros to align with the mandoc -Tlint output. 

Removal of the .Rs and .Re macros resolves the warning output (from mandoc) of: WARNING: invalid content in Rs block. 

The resulting output does not visually change (confirmed with mantra utility and man utility).