### PR TITLE
.github: Switch to v4 of actions/checkout

### DIFF
--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -38,7 +38,7 @@ jobs:
           - target_arch: aarch64
             target: arm64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install packages (Ubuntu)
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
GitHub is emitting a warning that v3 is deprecated due to using Node.js 16.