### PR TITLE
Address self reference links: open.2 mdmfs.8 cfumass.4 bhnd_erom.9 device_add_child.9

### DIFF
--- a/lib/libsys/open.2
+++ b/lib/libsys/open.2
@@ -323,7 +323,7 @@ by the descriptor at the time of the call.
 .Pp
 .Dv O_PATH
 returns a file descriptor that can be used as a directory file descriptor for
-.Xr openat 2
+.Fn openat
 and other system calls taking a file descriptor argument, like
 .Xr fstatat 2
 and others.

--- a/sbin/mdmfs/mdmfs.8
+++ b/sbin/mdmfs/mdmfs.8
@@ -61,7 +61,7 @@ filesystem
 The
 .Nm
 utility is designed to be a work-alike and look-alike of the deprecated
-.Xr mount_mfs 8 .
+.Nm mount_mfs .
 The end result is essentially the same,
 but is accomplished in a completely different way.
 Based on
@@ -149,7 +149,7 @@ it uses the default arguments to all the helper programs.
 The following options are available.
 Where possible,
 the option letter matches the one used by
-.Xr mount_mfs 8
+.Nm mount_mfs
 for the same thing.
 .Bl -tag -width indent
 .It Fl a Ar maxcontig
@@ -404,10 +404,10 @@ Mount a vnode-backed cd9660 file system using automatic device numbering:
 The
 .Nm
 utility, while designed to be compatible with
-.Xr mount_mfs 8 ,
+.Nm mount_mfs ,
 can be useful by itself.
 Since
-.Xr mount_mfs 8
+.Nm mount_mfs
 had some silly defaults, a
 .Dq compatibility
 mode is provided for the case where bug-to-bug compatibility is desired.
@@ -421,7 +421,7 @@ or
 (as returned by
 .Xr getprogname 3 ) .
 In this mode, the following behavior, as done by
-.Xr mount_mfs 8 ,
+.Nm mount_mfs ,
 is duplicated:
 .Bl -bullet -offset indent
 .It

--- a/share/man/man4/cfumass.4
+++ b/share/man/man4/cfumass.4
@@ -57,7 +57,7 @@ To use
 .Nm :
 .Bl -bullet
 .It
-.Xr cfumass 4
+.Nm cfumass
 must be loaded as a module or compiled into the kernel.
 .It
 The USB Mass Storage template must be chosen by setting the

--- a/share/man/man9/bhnd_erom.9
+++ b/share/man/man9/bhnd_erom.9
@@ -204,7 +204,7 @@ hardware core must be provided using the
 .Fa eio
 argument.
 The registers can be mapped using
-.Xr bhnd_erom_io_map 9 .
+.Fn bhnd_erom_io_map .
 .Pp
 On devices that do not provide standard
 .Xr bhnd_chipc 4

--- a/share/man/man9/device_add_child.9
+++ b/share/man/man9/device_add_child.9
@@ -111,10 +111,10 @@ When adding a child to another device node, such as in an identify
 routine, use
 .Xr BUS_ADD_CHILD 9
 instead of
-.Xr device_add_child 9 .
+.Fn device_add_child .
 .Xr BUS_ADD_CHILD 9
 will call
-.Xr device_add_child 9
+.Fn device_add_child
 and add the proper bus-specific data to the new child.
 .Fn device_add_child
 does not call


### PR DESCRIPTION
open.2 - Changed openat .Xr reference to .Nm
mdmfs.8 - Updates to .Xr references
cfumass.4 - Updates to .Xr references
bhnd_erom.9 - Updates to .Xr references
device_add_child.9 - Updates to .Xr references
