### PR TITLE
mv: Set file flags after setting file times

### DIFF
--- a/bin/mv/mv.c
+++ b/bin/mv/mv.c
@@ -319,6 +319,12 @@ err:		if (unlink(to))
 	 */
 	preserve_fd_acls(from_fd, to_fd, from, to);
 	(void)close(from_fd);
+
+	ts[0] = sbp->st_atim;
+	ts[1] = sbp->st_mtim;
+	if (futimens(to_fd, ts))
+		warn("%s: set times", to);
+
 	/*
 	 * XXX
 	 * NFS doesn't support chflags; ignore errors unless there's reason
@@ -338,11 +344,6 @@ err:		if (unlink(to))
 		}
 	} else
 		warn("%s: cannot stat", to);
-
-	ts[0] = sbp->st_atim;
-	ts[1] = sbp->st_mtim;
-	if (futimens(to_fd, ts))
-		warn("%s: set times", to);
 
 	if (close(to_fd)) {
 		warn("%s", to);


### PR DESCRIPTION
Certain file flags prevent the setting of the file times, thus we should set the file times first.

This is done right in NetBSD: https://github.com/NetBSD/src/blob/trunk/bin/mv/mv.c#L327

In cp we also do the right thing: https://github.com/freebsd/freebsd-src/blob/main/bin/cp/utils.c#L300