### PR TITLE
genet: add module (if_genet.ko)

### DIFF
--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -154,6 +154,7 @@ SUBDIR=	\
 	if_edsc \
 	${_if_enc} \
 	if_epair \
+	${_genet} \
 	${_if_gif} \
 	${_if_gre} \
 	${_if_me} \
@@ -638,6 +639,11 @@ _cxgbe=		cxgbe
 # This has only been tested on amd64 and arm64
 .if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "aarch64"
 _mpi3mr=mpi3mr
+.endif
+
+# Specific to the Raspberry Pi.
+.if ${MACHINE_CPUARCH} == "aarch64"
+_genet=		genet
 .endif
 
 .if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "aarch64" || \

--- a/sys/modules/genet/Makefile
+++ b/sys/modules/genet/Makefile
@@ -1,0 +1,7 @@
+
+.PATH: ${SRCTOP}/sys/arm64/broadcom/genet
+
+KMOD=	if_genet
+SRCS=	if_genet.c miibus_if.h gpio_if.h syscon_if.h opt_device_polling.h
+
+.include <bsd.kmod.mk>


### PR DESCRIPTION
The driver already had the appropriate module macros, it just wasn't hooked into the build system.

Since this device is specific to the Raspberry Pi 4, only build it for AArch64.

---

tested with monolithic (GENERIC) kernel and modular kernel without miibus (using miibus.ko) on an RPi4.
