### PR TITLE
bcm2838_xhci: add module

### DIFF
--- a/sys/arm/broadcom/bcm2835/bcm2838_xhci.c
+++ b/sys/arm/broadcom/bcm2835/bcm2838_xhci.c
@@ -212,3 +212,5 @@ DEFINE_CLASS_1(bcm_xhci, bcm_xhci_driver, bcm_xhci_methods,
 
 DRIVER_MODULE(bcm_xhci, pci, bcm_xhci_driver, 0, 0);
 MODULE_DEPEND(bcm_xhci, usb, 1, 1, 1);
+MODULE_DEPEND(bcm_xhci, pci, 1, 1, 1);
+MODULE_DEPEND(bcm_xhci, xhci, 1, 1, 1);

--- a/sys/dev/usb/controller/xhci.c
+++ b/sys/dev/usb/controller/xhci.c
@@ -4406,3 +4406,5 @@ static const struct usb_bus_methods xhci_bus_methods = {
 	.set_hw_power_sleep = xhci_set_hw_power_sleep,
 	.set_endpoint_mode = xhci_set_endpoint_mode,
 };
+
+MODULE_VERSION(xhci, 1);

--- a/sys/modules/usb/Makefile
+++ b/sys/modules/usb/Makefile
@@ -44,7 +44,7 @@ MAKE+=" DEBUG_FLAGS+=-DUSB_REQ_DEBUG"
 
 SUBDIR = usb
 SUBDIR += ${_dwc_otg} ehci ${_musb} ohci uhci xhci ${_uss820dci} \
-	  ${_atmegadci} ${_avr32dci} ${_rsu} ${_rsufw}
+	  ${_atmegadci} ${_avr32dci} ${_rsu} ${_rsufw} ${_bcm2838_xhci}
 SUBDIR += ${_rum} ${_run} ${_runfw} ${_uath} upgt usie ural ${_zyd} ${_urtw} 
 SUBDIR += atp cfumass uhid uhid_snes ukbd ums udbp uep wmt wsp ugold uled \
 	  usbhid
@@ -96,6 +96,11 @@ _urtw=		urtw
 
 .if ${MACHINE_CPUARCH} == "avr32"
 _avr32dci=	avr32dci
+.endif
+
+.if ${MACHINE_CPUARCH} == "aarch64"
+# The bcm2838_xhci shim is specific to the Raspberry Pi 4 SoC.
+_bcm2838_xhci=	bcm2838_xhci
 .endif
 
 .if ${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_CPUARCH} == "amd64" || \

--- a/sys/modules/usb/bcm2838_xhci/Makefile
+++ b/sys/modules/usb/bcm2838_xhci/Makefile
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Lexi Winter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+S=	${SRCTOP}/sys
+
+.PATH: $S/arm/broadcom/bcm2835
+
+KMOD=	bcm2838_xhci
+SRCS=	bcm2838_xhci.c
+
+.include <bsd.kmod.mk>


### PR DESCRIPTION
bcm2838_xhci(4) is a shim for the XHCI controller on the Raspberry Pi 4B SoC.  It loads the controller's firmware before passing control to the normal xhci(4) driver.

When xhci(4) is built as a module (and not in the kernel), bcm2838_xhci is not built at all and the RPi4's XHCI controller won't attach due to missing firmware.

To fix this, build a new module, bcm2838_xhci.ko, which depends on xhci.ko.  For the dependency to work correctly, also modify xhci to provide the 'xhci' module in addition to the 'xhci_pci' module it already provided.

Since bcm2838_xhci is specific to a quirk of the RPi4 SoC, only build the module for AArch64.