### PR TITLE
nvme(4), nvd(4): build modules on aarch64

### DIFF
--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -704,6 +704,12 @@ _e6000sw=	e6000sw
 _neta=		neta
 .endif
 
+.if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64" \
+	|| ${MACHINE_CPUARCH} == "aarch64"
+_nvme=		nvme
+_nvd=		nvd
+.endif
+
 .if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"
 _agp=		agp
 .if ${MACHINE_CPUARCH} == "i386" || !empty(COMPAT_FREEBSD32_ENABLED)
@@ -793,8 +799,6 @@ _iwmfw=		iwmfw
 _iwnfw=		iwnfw
 .endif
 _nfe=		nfe
-_nvd=		nvd
-_nvme=		nvme
 _nvram=		nvram
 .if ${MK_CRYPT} != "no" || defined(ALL_MODULES)
 _padlock=	padlock


### PR DESCRIPTION
tested with a modular kernel (no 'nvme' or 'nvd' devices), with a QEMU emulated NVMe disk on a macOS host; with nvd.ko and nvme.ko loaded in loader.conf, the system is able to boot from an NVMe root device.