### PR TITLE
sys/arm64: add CPU part identifiers for Apple M1 and M2

### DIFF
--- a/sys/arm64/arm64/identcpu.c
+++ b/sys/arm64/arm64/identcpu.c
@@ -250,6 +250,23 @@ static const struct cpu_parts cpu_parts_qcom[] = {
 	CPU_PART_NONE,
 };
 
+/* Apple */
+static const struct cpu_parts cpu_parts_apple[] = {
+	{ CPU_PART_M1_ICESTORM, "M1 Icestorm" },
+	{ CPU_PART_M1_FIRESTORM, "M1 Firestorm" },
+	{ CPU_PART_M1_ICESTORM_PRO, "M1 Pro Icestorm" },
+	{ CPU_PART_M1_FIRESTORM_PRO, "M1 Pro Firestorm" },
+	{ CPU_PART_M1_ICESTORM_MAX, "M1 Max Icestorm" },
+	{ CPU_PART_M1_FIRESTORM_MAX, "M1 Max Firestorm" },
+	{ CPU_PART_M2_BLIZZARD, "M2 Blizzard" },
+	{ CPU_PART_M2_AVALANCHE, "M2 Avalanche" },
+	{ CPU_PART_M2_BLIZZARD_PRO, "M2 Pro Blizzard" },
+	{ CPU_PART_M2_AVALANCHE_PRO, "M2 Pro Avalanche" },
+	{ CPU_PART_M2_BLIZZARD_MAX, "M2 Max Blizzard" },
+	{ CPU_PART_M2_AVALANCHE_MAX, "M2 Max Avalanche" },
+	CPU_PART_NONE,
+};
+
 /* Unknown */
 static const struct cpu_parts cpu_parts_none[] = {
 	CPU_PART_NONE,
@@ -260,7 +277,7 @@ static const struct cpu_parts cpu_parts_none[] = {
  */
 const struct cpu_implementers cpu_implementers[] = {
 	{ CPU_IMPL_AMPERE,	"Ampere",	cpu_parts_none },
-	{ CPU_IMPL_APPLE,	"Apple",	cpu_parts_none },
+	{ CPU_IMPL_APPLE,	"Apple",	cpu_parts_apple },
 	{ CPU_IMPL_APM,		"APM",		cpu_parts_apm },
 	{ CPU_IMPL_ARM,		"ARM",		cpu_parts_arm },
 	{ CPU_IMPL_BROADCOM,	"Broadcom",	cpu_parts_none },

--- a/sys/arm64/include/cpu.h
+++ b/sys/arm64/include/cpu.h
@@ -132,6 +132,20 @@
 #define	CPU_PART_KRYO400_GOLD	0x804
 #define	CPU_PART_KRYO400_SILVER	0x805
 
+/* Apple part numbers */
+#define CPU_PART_M1_ICESTORM      0x022
+#define CPU_PART_M1_FIRESTORM     0x023
+#define CPU_PART_M1_ICESTORM_PRO  0x024
+#define CPU_PART_M1_FIRESTORM_PRO 0x025
+#define CPU_PART_M1_ICESTORM_MAX  0x028
+#define CPU_PART_M1_FIRESTORM_MAX 0x029
+#define CPU_PART_M2_BLIZZARD      0x032
+#define CPU_PART_M2_AVALANCHE     0x033
+#define CPU_PART_M2_BLIZZARD_PRO  0x034
+#define CPU_PART_M2_AVALANCHE_PRO 0x035
+#define CPU_PART_M2_BLIZZARD_MAX  0x038
+#define CPU_PART_M2_AVALANCHE_MAX 0x039
+
 #define	CPU_IMPL(midr)	(((midr) >> 24) & 0xff)
 #define	CPU_PART(midr)	(((midr) >> 4) & 0xfff)
 #define	CPU_VAR(midr)	(((midr) >> 20) & 0xf)


### PR DESCRIPTION
Obtained from:	Linux