### PR TITLE
Instrument kernel boot time with capped DELAY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.so
 *.sw[nop]
 *~
-.vscode
 _.tinderbox.*
 _.universe-toolchain
 _.amd64.*

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.sw[nop]
 *~
+.vscode
 _.tinderbox.*
 _.universe-toolchain
 _.amd64.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "tslog.h": "c"
+    }
+}

--- a/sys/contrib/openzfs/module/zfs/zfs_chksum.c
+++ b/sys/contrib/openzfs/module/zfs/zfs_chksum.c
@@ -30,6 +30,7 @@
 
 #include <sys/blake3.h>
 #include <sys/sha2.h>
+#include <sys/tslog.h>
 
 /* limit benchmarking to max 256KiB, when EdonR is slower then this: */
 #define	LIMIT_PERF_MBS	300
@@ -140,6 +141,7 @@ static void
 chksum_run(chksum_stat_t *cs, abd_t *abd, void *ctx, int round,
     uint64_t *result)
 {
+	TSENTER();
 	hrtime_t start;
 	uint64_t run_bw, run_time_ns, run_count = 0, size = 0;
 	uint32_t l, loops = 0;
@@ -177,6 +179,7 @@ chksum_run(chksum_stat_t *cs, abd_t *abd, void *ctx, int round,
 	run_bw = size * run_count * NANOSEC;
 	run_bw /= run_time_ns;	/* B/s */
 	*result = run_bw/1024/1024; /* MiB/s */
+	TSEXIT();
 }
 
 #define	LIMIT_INIT	0

--- a/sys/contrib/openzfs/module/zfs/zfs_chksum.c
+++ b/sys/contrib/openzfs/module/zfs/zfs_chksum.c
@@ -245,7 +245,7 @@ chksum_benchmark(void)
 	/* we need the benchmark only for the kernel module */
 	return;
 #endif
-
+	TSENTER();
 	chksum_stat_t *cs;
 	uint64_t max;
 	uint32_t id, cbid = 0, id_save;
@@ -264,6 +264,7 @@ chksum_benchmark(void)
 	/* edonr - needs to be the first one here (slow CPU check) */
 	cs = &chksum_stat_data[cbid++];
 
+	TSENTER2("edonr");
 	/* edonr */
 	cs->init = abd_checksum_edonr_tmpl_init;
 	cs->func = abd_checksum_edonr_native;
@@ -271,7 +272,9 @@ chksum_benchmark(void)
 	cs->name = "edonr";
 	cs->impl = "generic";
 	chksum_benchit(cs);
+	TSEXIT2("edonr");
 
+	TSENTER2("skein");
 	/* skein */
 	cs = &chksum_stat_data[cbid++];
 	cs->init = abd_checksum_skein_tmpl_init;
@@ -280,7 +283,9 @@ chksum_benchmark(void)
 	cs->name = "skein";
 	cs->impl = "generic";
 	chksum_benchit(cs);
+	TSEXIT2("skein");
 
+	TSENTER2("sha256");
 	/* sha256 */
 	id_save = sha256->getid();
 	for (max = 0, id = 0; id < sha256->getcnt(); id++) {
@@ -298,7 +303,9 @@ chksum_benchmark(void)
 		}
 	}
 	sha256->setid(id_save);
+	TSEXIT2("sha256");
 
+	TSENTER2("sha512");
 	/* sha512 */
 	id_save = sha512->getid();
 	for (max = 0, id = 0; id < sha512->getcnt(); id++) {
@@ -316,7 +323,9 @@ chksum_benchmark(void)
 		}
 	}
 	sha512->setid(id_save);
+	TSEXIT2("sha512");
 
+	TSENTER2("blake3");
 	/* blake3 */
 	id_save = blake3->getid();
 	for (max = 0, id = 0; id < blake3->getcnt(); id++) {
@@ -334,6 +343,8 @@ chksum_benchmark(void)
 		}
 	}
 	blake3->setid(id_save);
+	TSEXIT2("blake3");
+	TSEXIT();
 }
 
 void

--- a/sys/kern/kern_cons.c
+++ b/sys/kern/kern_cons.c
@@ -144,7 +144,6 @@ cninit(void)
 	struct consdev *best_cn, *cn, **list;
 
 	TSENTER();
-	TSENTER2("first");
 	/*
 	 * Check if we should mute the console (for security reasons perhaps)
 	 * It can be changes dynamically using sysctl kern.consmute
@@ -163,7 +162,6 @@ cninit(void)
 	 * here.
 	 */
 	kbdinit();
-	TSEXIT2("first");
 
 	TSENTER2("foreach");
 	/*
@@ -191,8 +189,6 @@ cninit(void)
 	}
 	TSEXIT2("foreach");
 
-	TSENTER2("rest");
-
 	if (best_cn == NULL)
 		return;
 	if ((boothowto & RB_MULTIPLE) == 0) {
@@ -205,8 +201,6 @@ cninit(void)
 	 * Make the best console the preferred console.
 	 */
 	cnselect(best_cn);
-	TSEXIT2("rest");
-
 #ifdef EARLY_PRINTF
 	/*
 	 * Release early console.
@@ -226,6 +220,7 @@ cninit_finish(void)
 int
 cnadd(struct consdev *cn)
 {
+	TSENTER();
 	struct cn_device *cnd;
 	int i;
 
@@ -250,6 +245,7 @@ cnadd(struct consdev *cn)
 
 	/* Add device to the active mask. */
 	cnavailable(cn, (cn->cn_flags & CN_FLAG_NOAVAIL) == 0);
+	TSEXIT();
 	return (0);
 }
 

--- a/sys/kern/kern_cons.c
+++ b/sys/kern/kern_cons.c
@@ -172,14 +172,15 @@ cninit(void)
 		TSENTER2("foreach1");
 		cn = *list;
 		cnremove(cn);
+		TSEXIT2("foreach1");
+		TSENTER2("foreach2");
 		/* Skip cons_consdev. */
 		if (cn->cn_ops == NULL)
 			continue;
 		cn->cn_ops->cn_probe(cn);
 		if (cn->cn_pri == CN_DEAD)
 			continue;
-		TSEXIT2("foreach1");
-		TSENTER2("foreach2");
+		TSEXIT2("foreach2");
 		if (best_cn == NULL || cn->cn_pri > best_cn->cn_pri)
 			best_cn = cn;
 		if (boothowto & RB_MULTIPLE) {
@@ -189,7 +190,6 @@ cninit(void)
 			cn->cn_ops->cn_init(cn);
 			cnadd(cn);
 		}
-		TSEXIT2("foreach2");
 	}
 	TSEXIT2("foreach");
 

--- a/sys/kern/kern_cons.c
+++ b/sys/kern/kern_cons.c
@@ -144,6 +144,7 @@ cninit(void)
 	struct consdev *best_cn, *cn, **list;
 
 	TSENTER();
+	TSENTER2("first");
 	/*
 	 * Check if we should mute the console (for security reasons perhaps)
 	 * It can be changes dynamically using sysctl kern.consmute
@@ -162,7 +163,9 @@ cninit(void)
 	 * here.
 	 */
 	kbdinit();
+	TSEXIT2("first");
 
+	TSENTER2("foreach");
 	/*
 	 * Find the first console with the highest priority.
 	 */
@@ -186,6 +189,10 @@ cninit(void)
 			cnadd(cn);
 		}
 	}
+	TSEXIT2("foreach");
+
+	TSENTER2("rest");
+
 	if (best_cn == NULL)
 		return;
 	if ((boothowto & RB_MULTIPLE) == 0) {
@@ -198,6 +205,7 @@ cninit(void)
 	 * Make the best console the preferred console.
 	 */
 	cnselect(best_cn);
+	TSEXIT2("rest");
 
 #ifdef EARLY_PRINTF
 	/*
@@ -242,7 +250,6 @@ cnadd(struct consdev *cn)
 
 	/* Add device to the active mask. */
 	cnavailable(cn, (cn->cn_flags & CN_FLAG_NOAVAIL) == 0);
-
 	return (0);
 }
 

--- a/sys/kern/kern_cons.c
+++ b/sys/kern/kern_cons.c
@@ -169,6 +169,7 @@ cninit(void)
 	 */
 	best_cn = NULL;
 	SET_FOREACH(list, cons_set) {
+		TSENTER2("foreach1");
 		cn = *list;
 		cnremove(cn);
 		/* Skip cons_consdev. */
@@ -177,6 +178,8 @@ cninit(void)
 		cn->cn_ops->cn_probe(cn);
 		if (cn->cn_pri == CN_DEAD)
 			continue;
+		TSEXIT2("foreach1");
+		TSENTER2("foreach2");
 		if (best_cn == NULL || cn->cn_pri > best_cn->cn_pri)
 			best_cn = cn;
 		if (boothowto & RB_MULTIPLE) {
@@ -186,6 +189,7 @@ cninit(void)
 			cn->cn_ops->cn_init(cn);
 			cnadd(cn);
 		}
+		TSEXIT2("foreach2");
 	}
 	TSEXIT2("foreach");
 

--- a/sys/x86/x86/delay.c
+++ b/sys/x86/x86/delay.c
@@ -69,6 +69,9 @@ delay_tsc(int n)
 static int
 delay_tc(int n)
 {
+	if (n > 50) {
+		n = 10;
+	}
 	struct timecounter *tc;
 	timecounter_get_t *func;
 	uint64_t end, freq, now;


### PR DESCRIPTION
In order to compute the potential headroom of FreeBSD kernel boot time optimisation by tuning the DELAY calls, cap the max delay to 50ms and profile the boot time.