### PR TITLE
Update printf(3) based on latest OpenBSD structure and format

### DIFF
--- a/lib/libc/stdio/printf.3
+++ b/lib/libc/stdio/printf.3
@@ -29,7 +29,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd September 5, 2023
+.Dd March 24, 2024
 .Dt PRINTF 3
 .Os
 .Sh NAME
@@ -81,14 +81,19 @@ The
 family of functions produces output according to a
 .Fa format
 as described below.
+This format may contain
+.Dq conversion specifiers ;
+the results of such conversions, if any, depend on the arguments
+following theg
+.Fa format
+string.
+.Pp
 The
 .Fn printf
 and
 .Fn vprintf
-functions
-write output to
-.Dv stdout ,
-the standard output stream;
+functions write output to the standard output stream,
+.Em stdout ;
 .Fn fprintf
 and
 .Fn vfprintf
@@ -105,12 +110,13 @@ and
 .Fn vsnprintf
 write to the character string
 .Fa str ;
-and
 .Fn asprintf
 and
 .Fn vasprintf
 dynamically allocate a new string with
-.Xr malloc 3 .
+.Xr malloc 3g
+that is stored ing
+.Fa ret .
 .Pp
 These functions write the output under the control of a
 .Fa format
@@ -119,7 +125,6 @@ string that specifies how subsequent arguments
 .Xr stdarg 3 )
 are converted for output.
 .Pp
-The
 .Fn asprintf
 and
 .Fn vasprintf
@@ -140,14 +145,14 @@ to be a
 .Dv NULL
 pointer.
 .Pp
-The
 .Fn snprintf
 and
 .Fn vsnprintf
 functions
 will write at most
 .Fa size Ns \-1
-of the characters printed into the output string
+of the characters tog
+.Fa strg
 (the
 .Fa size Ns 'th
 character then gets the terminating
@@ -156,11 +161,10 @@ if the return value is greater than or equal to the
 .Fa size
 argument, the string was too short
 and some of the printed characters were discarded.
-The output is always null-terminated, unless
+The output is null-terminated, unless
 .Fa size
 is 0.
 .Pp
-The
 .Fn sprintf
 and
 .Fn vsprintf
@@ -168,7 +172,10 @@ functions
 effectively assume a
 .Fa size
 of
-.Dv INT_MAX + 1.
+.Dv INT_MAX + 1 ;
+results in an infinite
+.Fa size ;
+their use is not recommended.
 .Pp
 The format string is composed of zero or more directives:
 ordinary
@@ -187,8 +194,30 @@ with the conversion specifier.
 After the
 .Cm % ,
 the following appear in sequence:
-.Bl -bullet
-.It
+.Pp
+The overall syntax of a conversion specification is:
+.Bd -filled -offset indent
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Ar flags
+.Op Ar width
+.Op . Ar precision
+.Op Ar size
+.Ar conversion
+.Sm on
+.Ed
+.Pp
+Not all combinations of these parts are meaningful;
+see the description of the individual
+.Ar conversion
+specifiers for details.
+.Pp
+The parts of a conversion specification are as follows:
+.Bl -tag -wdith Ds
+.It Cm %
+A literal percent character begins a conversion specification.
+.It Ar argno Ns Cm $
 An optional field, consisting of a decimal digit string followed by a
 .Cm $ ,
 specifying the next argument to access.
@@ -198,12 +227,13 @@ Arguments are numbered starting at
 .Cm 1 .
 If unaccessed arguments in the format string are interspersed with ones that
 are accessed the results will be indeterminate.
-.It
+.It Ar flags
 Zero or more of the following flags:
-.Bl -tag -width ".So \  Sc (space)"
-.It Sq Cm #
-The value should be converted to an
-.Dq alternate form .
+.Bl -tag -width 11n
+.It Cm # Pq hash
+Use an
+.Dq alternate form
+for the output.
 For
 .Cm c , d , i , n , p , s ,
 and
@@ -222,7 +252,9 @@ for
 conversions) prepended to it.
 For
 .Cm o
-conversions, the precision of the number is increased to force the first
+conversions, the
+.Ar precision
+of the number is increased to force the first
 character of the output string to a zero.
 For
 .Cm x
@@ -248,24 +280,28 @@ and
 .Cm G
 conversions, trailing zeros are not removed from the result as they
 would otherwise be.
-.It So Cm 0 Sc (zero)
+.It Cm 0 (zero)
 Zero padding.
 For all conversions except
 .Cm n ,
 the converted value is padded on the left with zeros rather than blanks.
-If a precision is given with a numeric conversion
+If a
+.Ar precision
+is given with a numeric
+.Ar conversion
 .Cm ( b , B , d , i , o , u , i , x ,
 and
 .Cm X ) ,
 the
 .Cm 0
 flag is ignored.
-.It Sq Cm \-
+.It Cm \- Pq minus
 A negative field width flag;
 the converted value is to be left adjusted on the field boundary.
 Except for
 .Cm n
-conversions, the converted value is padded on the right with blanks,
+.Ar conversion ,
+the converted value is padded on the right with blanks,
 rather than on the left with blanks or zeros.
 A
 .Cm \-
@@ -273,17 +309,19 @@ overrides a
 .Cm 0
 if both are given.
 .It So "\ " Sc (space)
-A blank should be left before a positive number
-produced by a signed conversion
+For signed conversions, print a space character before a positive number
+associated with theseg
+.Ar conversiong
+optionsg
 .Cm ( a , A , d , e , E , f , F , g , G ,
 or
 .Cm i ) .
-.It Sq Cm +
+.It Cm + Pq plus
 A sign must always be placed before a
-number produced by a signed conversion.
-A
+number produced by a signedg
+.Ar conversion .
 .Cm +
-overrides a space if both are used.
+overrides a space if both are specified.
 .It So "'" Sc (apostrophe)
 Decimal conversions
 .Cm ( d , u ,
@@ -297,13 +335,14 @@ should be grouped and separated by thousands using
 the non-monetary separator returned by
 .Xr localeconv 3 .
 .El
-.It
+.Itg
+.It Ar width
 An optional decimal digit string specifying a minimum field width.
 If the converted value has fewer characters than the field width, it will
 be padded with spaces on the left (or right, if the left-adjustment
 flag has been given) to fill out
 the field width.
-.It
+.It Pf . Ar precision
 An optional precision, in the form of a period
 .Cm \&.
 followed by an
@@ -325,7 +364,7 @@ conversions, or the maximum number of characters to be printed from a
 string for
 .Cm s
 conversions.
-.It
+.It Ar size
 An optional length modifier, that specifies the size of the argument.
 The following length modifiers are valid for the
 .Cm b , B , d , i , n , o , u , x ,
@@ -396,177 +435,94 @@ conversion:
 A character that specifies the type of conversion to be applied.
 .El
 .Pp
-A field width or precision, or both, may be indicated by
-an asterisk
-.Ql *
-or an asterisk followed by one or more decimal digits and a
-.Ql $
-instead of a
-digit string.
+A fieldg
+.Ar width
+org
+.Ar precision ,
+or both, may be indicated as
+.Cm * Ns Op Ar argno Ns Cm $ ,
+i.e. as an aterisk optionally followed
+by an unsigned decimal digit string and a dollar sign.
 In this case, an
 .Vt int
-argument supplies the field width or precision.
-A negative field width is treated as a left adjustment flag followed by a
-positive field width; a negative precision is treated as though it were
+argument supplies the fieldg
+.Ar width
+org
+.Ar precision .
+A negative fieldg
+.Ar widthg
+is treated as a left adjustment flag followed by a
+positive fieldg
+.Ar width ;
+a negativeg
+.Ar precision
+is treated as though it were
 missing.
 If a single format directive mixes positional
-.Pq Li nn$
-and non-positional arguments, the results are undefined.
+.Ar argno Ns Cm $
+and modifiers, the result is undefined.
 .Pp
-The conversion specifiers and their meanings are:
-.Bl -tag -width ".Cm bBdiouxX"
-.It Cm bBdiouxX
-The
-.Vt int
-(or appropriate variant) argument is converted to
-unsigned binary
-.Cm ( b
-and
-.Cm B ) ,
-signed decimal
-.Cm ( d
-and
-.Cm i ) ,
-unsigned octal
-.Pq Cm o ,
-unsigned decimal
-.Pq Cm u ,
-or unsigned hexadecimal
-.Cm ( x
-and
-.Cm X )
-notation.
-The letters
-.Dq Li abcdef
-are used for
-.Cm x
-conversions; the letters
+The conversion specifiers are:
+.Pp
+.Bl -tag -width ".Cm %"
+.It Cm %
+No argument is converted.
+The completeg
+.Ar conversion
+specification
+is
+.Ql %% .
+.El
+.Bl -tag -width ".Cm A"
+.It Cm A
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm #
+.Op CM \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar hexadecimals
+.Op Cm L | l
+.Cm A
+.Sm On
+.Pp
+.Cm A
+conversion uses the prefix
+.Dq Li 0X ,
+the letters
 .Dq Li ABCDEF
-are used for
-.Cm X
-conversions.
-The precision, if any, gives the minimum number of digits that must
-appear; if the converted value requires fewer digits, it is padded on
-the left with zeros.
-.It Cm DOU
-The
-.Vt "long int"
-argument is converted to signed decimal, unsigned octal, or unsigned
-decimal, as if the format had been
-.Cm ld , lo ,
-or
-.Cm lu
-respectively.
-These conversion characters are deprecated, and will eventually disappear.
-.It Cm eE
-The
-.Vt double
-argument is rounded and converted in the style
-.Sm off
-.Oo \- Oc Ar d Li \&. Ar ddd Li e \(+- Ar dd
-.Sm on
-where there is one digit before the
-decimal-point character
-and the number of digits after it is equal to the precision;
-if the precision is missing,
-it is taken as 6; if the precision is
-zero, no decimal-point character appears.
-An
-.Cm E
-conversion uses the letter
-.Ql E
-(rather than
-.Ql e )
-to introduce the exponent.
-The exponent always contains at least two digits; if the value is zero,
-the exponent is 00.
+to represent theg
+.Ar hexadecimal
+characters, and the letter
+.Ql P
+to separate the mantissa and exponent.
 .Pp
-For
-.Cm a , A , e , E , f , F , g ,
-and
-.Cm G
-conversions, positive and negative infinity are represented as
-.Li inf
-and
-.Li -inf
-respectively when using the lowercase conversion character, and
-.Li INF
-and
-.Li -INF
-respectively when using the uppercase conversion character.
-Similarly, NaN is represented as
-.Li nan
-when using the lowercase conversion, and
-.Li NAN
-when using the uppercase conversion.
-.It Cm fF
 The
 .Vt double
-argument is rounded and converted to decimal notation in the style
-.Sm off
-.Oo \- Oc Ar ddd Li \&. Ar ddd ,
-.Sm on
-where the number of digits after the decimal-point character
-is equal to the precision specification.
-If the precision is missing, it is taken as 6; if the precision is
-explicitly zero, no decimal-point character appears.
-If a decimal point appears, at least one digit appears before it.
-.It Cm gG
-The
-.Vt double
-argument is converted in style
-.Cm f
-or
-.Cm e
-(or
-.Cm F
-or
-.Cm E
-for
-.Cm G
-conversions).
-The precision specifies the number of significant digits.
-If the precision is missing, 6 digits are given; if the precision is zero,
-it is treated as 1.
-Style
-.Cm e
-is used if the exponent from its conversion is less than \-4 or greater than
-or equal to the precision.
-Trailing zeros are removed from the fractional part of the result; a
-decimal point appears only if it is followed by at least one digit.
-.It Cm aA
-The
-.Vt double
-argument is rounded and converted to hexadecimal notation in the style
+argument is rounded and converted tog
+.Ar hexadecimal
+notation in the style
 .Sm off
 .Oo \- Oc Li 0x Ar h Li \&. Ar hhhp Oo \(+- Oc Ar d ,
 .Sm on
 where the number of digits after the hexadecimal-point character
-is equal to the precision specification.
-If the precision is missing, it is taken as enough to represent
+is equal to theg
+.Ar precision
+specification.
+If theg
+.Ar precision
+is missing, it is taken as enough to represent
 the floating-point number exactly, and no rounding occurs.
-If the precision is zero, no hexadecimal-point character appears.
+If theg
+.Ar precision
+is zero, no hexadecimal-point character appears.
 The
 .Cm p
 is a literal character
 .Ql p ,
 and the exponent consists of a positive or negative sign
 followed by a decimal number representing an exponent of 2.
-The
-.Cm A
-conversion uses the prefix
-.Dq Li 0X
-(rather than
-.Dq Li 0x ) ,
-the letters
-.Dq Li ABCDEF
-(rather than
-.Dq Li abcdef )
-to represent the hex digits, and the letter
-.Ql P
-(rather than
-.Ql p )
-to separate the mantissa and exponent.
 .Pp
 Note that there may be multiple valid ways to represent floating-point
 numbers in this hexadecimal format.
@@ -583,6 +539,86 @@ Zeroes are always represented with a mantissa of 0 (preceded by a
 .Ql -
 if appropriate) and an exponent of
 .Li +0 .
+.Pp
+.It Cm a
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm #
+.Op CM \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar hexadecimals
+.Op Cm L | l
+.Cm a
+.Sm On
+.Pp
+.Cm a
+conversion uses the prefix
+.Dq Li 0x ,
+the letters
+.Dq Li abcdef
+to represent theg
+.Ar hexadecimal
+charcters, and the letter 'p' to separate the mantissa and exponent.
+.Pp
+The
+.Vt double
+argument is rounded and converted tog
+.Ar hexadecimal
+notation in the style
+.Sm off
+.Oo \- Oc Li 0x Ar h Li \&. Ar hhhp Oo \(+- Oc Ar d ,
+.Sm on
+where the number of digits after the hexadecimal-point character
+is equal to theg
+.Ar precision
+specification.
+If theg
+.Ar precision
+is missing, it is taken as enough to represent
+the floating-point number exactly, and no rounding occurs.
+If theg
+.Ar precision
+is zero, no hexadecimal-point character appears.
+The
+.Cm p
+is a literal character
+.Ql p ,
+and the exponent consists of a positive or negative sign
+followed by a decimal number representing an exponent of 2.
+.Pp
+Note that there may be multiple valid ways to represent floating-point
+numbers in this hexadecimal format.
+For example,
+.Li 0x1.92p+1 , 0x3.24p+0 , 0x6.48p-1 ,
+and
+.Li 0xc.9p-2
+are all equivalent.
+.Fx 8.0
+and later always prints finite non-zero numbers using
+.Ql 1
+as the digit before the hexadecimal point.
+Zeroes are always represented with a mantissa of 0 (preceded by a
+.Ql -
+if appropriate) and an exponent of
+.Li +0 .
+.Pp
+.It Cm b
+The
+.Vt unsigned int
+(or appropriate variant) argument is converted to unsigned binary.
+This is used for
+.Cm x
+conversions.
+.Pp
+.It Cm B
+The
+.Vt unsigned int
+(or apporiate variant) argument is converted to unsigned binary.
+This is used for
+.Cm X
+conversions.
 .It Cm C
 Treated as
 .Cm c
@@ -606,28 +642,300 @@ and the (potentially multi-byte) sequence representing the
 single wide character is written, including any shift sequences.
 If a shift sequence is used, the shift state is also restored
 to the original state after the character.
+.It Cm D
+A deprecated alias for
+.Cm %ld .
+.It Cm d
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar mindigits
+.Op Ar size
+.Cm d
+.Sm on
+.Pp
+The
+.Vt int
+argument is converted to signed decimal notation.
+If specified, at least
+.Ar mindigits
+are printed, padding with leading zeros if needed.
+.It Cm E
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm #
+.Op Cm \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar decimals
+.Op Cm L | l
+.Cm E
+.Sm on
+.Pp
+The
+.Vt double
+argument is rounded and converted in the style
+.Sm off
+.Oo \- Oc Ar d Li \&. Ar ddd Li E \(+- Ar dd
+.Sm on
+where there is one digit before the
+decimal-point character
+and the number of digits after it is equal to theg
+.Ar precision ;
+if theg
+.Ar precision
+is missing,
+it is taken as 6; if theg
+.Ar precision
+is
+zero, no decimal-point character appears.
+An
+.Cm E
+conversion uses the letter
+.Ql E
+to introduce the exponent.
+The exponent always contains at least two digits; if the value is zero,
+the exponent is 00.
+.Pp
+If the argument is infinity, it is converted tog
+.Li INFg
+org
+.Li -INF .
+If the argument is not-a-number (NaN), it is converted tog
+.Li NANg
+or
+.Li -NAN .
+.It Cm e
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm #
+.Op Cm \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar decimals
+.Op Cm L | l
+.Cm e
+.Sm on
+.Pp
+The
+.Vt double
+argument is rounded and converted in the style
+.Sm off
+.Oo \- Oc Ar d Li \&. Ar ddd Li e \(+- Ar dd
+.Sm on
+where there is one digit before the
+decimal-point character
+and the number of digits after it is equal to theg
+.Ar precision ;
+if theg
+.Ar precision
+is missing,
+it is taken as 6; if theg
+.Ar precision
+is
+zero, no decimal-point character appears.
+An
+.Cm e
+conversion uses the letter
+.Ql e
+to introduce the exponent.
+The exponent always contains at least two digits; if the value is zero,
+the exponent is 00.
+.Pp
+If the argument is infinity, it is converted to
+.Li INF
+or
+.Li -INF .
+If the argument is not-a-number (NaN), it is converted to
+.Li NAN
+or
+.Li -NAN .
+.It Cm F
+.Sm off
+.Cm %
+.Op ar argno Cm $
+.Op Cm #
+.Op Cm \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar decimals
+.Op Cm L | l
+.Cm F
+.Sm on
+.Pp
+The
+.Vt double
+argument is rounded and converted to decimal notation [\-]ddd.dddddd with
+.Ar decimals ,
+or six digits by default, after the decimal point.
+If
+.Ar decimals
+is zero and the
+.Sq Cm #
+flag is not given, the decimal point is omitted.
+If a decimal point appears, at least one digit appears before it.
+If the argument is infinity, it is converted to
+.Ql INF or
+.Ql -INF .
+If the argument is not-anumber (NaN), it is converted to
+.Ql NAN or
+.Ql -NAN .
+.It Cm f
+.Sm off
+.Cm %
+.Op ar argno Cm $
+.Op Cm #
+.Op Cm \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar decimals
+.Op Cm L | l
+.Cm f
+.Sm on
+.Pp
+The
+.Vt double
+argument is rounded and converted to decimal notation [\-]ddd.dddddd with
+.Ar decimals ,
+or six digits by default, after the decimal point.
+If
+.Ar decimals
+is zero and the
+.Sq Cm #
+flag is not given, the decimal point is omitted.
+If a decimal point appears, at least one digit appears before it.
+If the argument is infinity, it is converted to
+.Ql inf or
+.Ql -inf .
+If the argument is not-anumber (NaN), it is converted to
+.Ql nan or
+.Ql -nan .
+.It Cm i
+An alias for
+.Cm d ,
+supporting the same modifiers.
+The
+.Vt int
+argument is converted to a signed decimal notation.
+.It Cm G
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm #
+.Op Cm \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar significant
+.Op Cm L | l
+.Cm G
+.Sm on
+.Pp
+The
+.Vt double
+argument is converted in style
+.Cm F
+or
+.Cm E
+.Pq general gloating point notation
+with
+.Ar significant
+digits, or six significant digits by default.
+If
+.Ar significant
+is zero, one is used instead.
+Style
+.Cm e
+is used if the exponent from its conversion is less than \-4
+or greater than or equal to
+.Ar significant .
+Unless the
+.Sq Cm #
+flag is given, trailing zeros are removed from the fractional
+part of the result, and the decimal point only appears if it is
+followed by a least one digit.
+.It Cm g
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm #
+.Op Cm \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar significant
+.Op Cm L | l
+.Cm g
+.Sm on
+.Pp
+The
+.Vt double
+argument is converted in style
+.Cm f
+or
+.Cm e
+.Pq general gloating point notation
+with
+.Ar significant
+digits, or six significant digits by default.
+If
+.Ar significant
+is zero, one is used instead.
+Style
+.Cm e
+is used if the exponent from its conversion is less than \-4
+or greater than or equal to
+.Ar significant .
+Unless the
+.Sq Cm #
+flag is given, trailing zeros are removed from the fractional
+part of the result, and the decimal point only appears if it is
+followed by a least one digit.
+.Pp
+.It Cm m
+Print the string representation of the error code stored in the
+.Dv errno
+variable at the beginning of the call, as returned by
+.Xr strerror 3 .
+No argument is taken.
+.It Cm n
+The number of characters written so far is stored into the
+integer indicated by the
+.Vt "int *"
+(or variant) pointer argument.
+No argument is converted.
+.It Cm O
+A deprecate alias forg
+.Ar lo .
+.It Cm p
+The
+.Vt "void *"
+pointer argument is printed ing
+.Ar hexadecimal
+(as if by
+.Ql %#x
+or
+.Ql %#lx ) .
+.Pp
+.Pp
 .It Cm S
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm \-
+.Op Ar width
+.Op . Ar maxbytes
+.Cm ls
+.Sm on
+.Pp
 Treated as
 .Cm s
 with the
 .Cm l
 (ell) modifier.
-.It Cm s
-The
-.Vt "char *"
-argument is expected to be a pointer to an array of character type (pointer
-to a string).
-Characters from the array are written up to (but not including)
-a terminating
-.Dv NUL
-character;
-if a precision is specified, no more than the number specified are
-written.
-If a precision is given, no null character
-need be present; if the precision is not specified, or is greater than
-the size of the array, the array must contain a terminating
-.Dv NUL
-character.
 .Pp
 If the
 .Cm l
@@ -653,43 +961,130 @@ the number of bytes required to render the multibyte representation of
 the string, the array must contain a terminating wide
 .Dv NUL
 character.
-.It Cm p
+.It Cm s
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm \-
+.Op Ar width
+.Op . Ar maxbytes
+.Cm s
+.Sm on
+.Pp
 The
-.Vt "void *"
-pointer argument is printed in hexadecimal (as if by
-.Ql %#x
-or
-.Ql %#lx ) .
-.It Cm n
-The number of characters written so far is stored into the
-integer indicated by the
-.Vt "int *"
-(or variant) pointer argument.
-No argument is converted.
-.It Cm m
-Print the string representation of the error code stored in the
-.Dv errno
-variable at the beginning of the call, as returned by
-.Xr strerror 3 .
-No argument is taken.
-.It Cm %
-A
-.Ql %
-is written.
-No argument is converted.
-The complete conversion specification
-is
-.Ql %% .
+.Vt "char *"
+argument is expected to be a pointer to an array of character type (pointer
+to a string).
+Characters from the array are written up to (but not including)
+a terminating
+.Dv NUL
+character;
+if a precision is specified, no more than the number specified are
+written.
+If a precision is given, no null character
+need be present; if theg
+.Ar precision
+is not specified, or is greater than
+the size of the array, the array must contain a terminating
+.Dv NUL
+character.
+.It Cm U
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm \~ | 0
+.Op .Ar mindigits
+.Op .Ar size
+.Cm U
+.Sm on
+.Pp
+A deprecated alias forg
+.Cm lu .
+.It Cm u
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm \~ | 0
+.Op .Ar mindigits
+.Op .Ar size
+.Cm u
+.Sm on
+.Pp
+The
+.Vt unsigned int
+argument is converted to unsigned decimal notation.
+If specified, at least
+.Ar mindigits
+are printed, padding with leading zeros if needed.
+The following are similar to
+.Cm u
+except that they take an argument of a different size:
+.Bl -column %hhu
+.It Cm hhu Ta Vt unsigned char
+.It Cm hu  Ta Vt unsigned short
+.It Cm u   Ta Vt unsigned int
+.It Cm lu  Ta Vt unsigned long Pq percent ell u
+.It Cm llu Ta Vt unsigned long long Pq percent ell ell u
+.It Cm ju  Ta Vt uintmax_t
+.It Cm tu  Ta unsigned type of same size as Vt ptrdiff_t
+.It Cm zu  Ta Vt size_t
+.It Cm qu  Ta Vt u_quad_t Pq deprecated
 .El
 .Pp
+.It Cm X
+.Sm off
+.Cm %
+.Op ar argno Cm $
+.Op Cm #
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar mindigits
+.Op Ar size
+.Cm X
+.Sm on
+.Pp
+Identical to
+.Vt x
+except that upper case is used, i.e. '0X' for the
+optional prefix and
+.Ql 0123456789ABCDEF
+for the digits.
+.Pp
+.It Cm x
+.Sm off
+.Cm %
+.Op ar argno Cm $
+.Op Cm #
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar mindigits
+.Op Ar size
+.Cm x
+.Sm on
+.Pp
+Similar to
+.Vt u
+except that theg
+.Vt unsigned int
+argument is converted to unsigned hexadecimal notation using the digits
+.Ql 0123456789abcdef .
+If the
+.Sq CM #
+flag is given, the string
+.Ql 0x
+is prepended unless the value is zero.
 The decimal point
 character is defined in the program's locale (category
 .Dv LC_NUMERIC ) .
 .Pp
 In no case does a non-existent or small field width cause truncation of
-a numeric field; if the result of a conversion is wider than the field
+a numeric field; if the result of ag
+.Ar conversion
+is wider than the field
 width, the
-field is expanded to contain the conversion result.
+field is expanded to contain the
+.Ar conversion
+result.
 .Sh RETURN VALUES
 These functions return the number of characters printed
 (not including the trailing
@@ -746,9 +1141,9 @@ char *newfmt(const char *fmt, ...)
 .Ed
 .Sh COMPATIBILITY
 The conversion formats
-.Cm \&%D , \&%O ,
+.Cm D , O ,
 and
-.Cm \&%U
+.Cm U
 are not standard and
 are provided only for backward compatibility.
 The conversion format
@@ -758,7 +1153,7 @@ is also not standard and provides the popular extension from the
 library.
 .Pp
 The effect of padding the
-.Cm %p
+.Cm p
 format with zeros (either by the
 .Cm 0
 flag or by specifying a precision), and the benign effect (i.e., none)
@@ -767,10 +1162,10 @@ of the
 flag on
 .Cm %n
 and
-.Cm %p
+.Cm p
 conversions, as well as other
 nonsensical combinations such as
-.Cm %Ld ,
+.Cm Ld ,
 are not standard; such combinations
 should be avoided.
 .Sh ERRORS

--- a/lib/libc/stdio/printf.3
+++ b/lib/libc/stdio/printf.3
@@ -116,7 +116,6 @@ and
 dynamically allocate a new string with
 .Xr malloc 3
 that is stored in
->>>>>>> 5affdd06c021 (Update order of parameters alphabetically)
 .Fa ret .
 .Pp
 These functions write the output under the control of a
@@ -904,18 +903,52 @@ variable at the beginning of the call, as returned by
 .Xr strerror 3 .
 No argument is taken.
 .It Cm n
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Ar size 
+.Cm n
+.Sm on
+.Pp
 The number of characters written so far is stored into the
 integer indicated by the
 .Vt "int *"
 (or variant) pointer argument.
 No argument is converted.
 .It Cm O
-A deprecate alias forg
+A deprecated alias for
 .Ar lo .
+.It Cm o
+.Sm off
+.Cm %
+.Op Ar argno Cm $
+.Op Cm #
+.Op Cm \~ | +
+.Op Cm \- | 0
+.Op Ar width
+.Op . Ar significant
+.Op Cm L | l
+.Cm o
+.Sm on
+.Pp
+Similar to
+.Ar u
+except that the
+.Ar unsigned int
+argument is converted to unsigned octal notation.
+If the 
+.Ql # 
+flag is given,
+.Ar minidigits
+is increased such that the first digit printed is a zero, except
+if a zero value is printed with an explicit
+.Ar minidigts
+of zero.
+.Pp
 .It Cm p
 The
 .Vt "void *"
-pointer argument is printed ing
+pointer argument is printed in
 .Ar hexadecimal
 (as if by
 .Ql %#x

--- a/lib/libc/stdio/printf.3
+++ b/lib/libc/stdio/printf.3
@@ -84,7 +84,7 @@ as described below.
 This format may contain
 .Dq conversion specifiers ;
 the results of such conversions, if any, depend on the arguments
-following theg
+following the
 .Fa format
 string.
 .Pp
@@ -114,8 +114,9 @@ write to the character string
 and
 .Fn vasprintf
 dynamically allocate a new string with
-.Xr malloc 3g
-that is stored ing
+.Xr malloc 3
+that is stored in
+>>>>>>> 5affdd06c021 (Update order of parameters alphabetically)
 .Fa ret .
 .Pp
 These functions write the output under the control of a
@@ -151,8 +152,9 @@ and
 functions
 will write at most
 .Fa size Ns \-1
-of the characters tog
-.Fa strg
+of the characters to
+.Fa str
+of the characters printed into the output string
 (the
 .Fa size Ns 'th
 character then gets the terminating
@@ -160,7 +162,7 @@ character then gets the terminating
 if the return value is greater than or equal to the
 .Fa size
 argument, the string was too short
-and some of the printed characters were discarded.
+and some of the print characters are discarded.
 The output is null-terminated, unless
 .Fa size
 is 0.
@@ -310,15 +312,15 @@ overrides a
 if both are given.
 .It So "\ " Sc (space)
 For signed conversions, print a space character before a positive number
-associated with theseg
-.Ar conversiong
-optionsg
+associated with these
+.Ar conversion
+options
 .Cm ( a , A , d , e , E , f , F , g , G ,
 or
 .Cm i ) .
 .It Cm + Pq plus
 A sign must always be placed before a
-number produced by a signedg
+number produced by a signed
 .Ar conversion .
 .Cm +
 overrides a space if both are specified.
@@ -435,9 +437,9 @@ conversion:
 A character that specifies the type of conversion to be applied.
 .El
 .Pp
-A fieldg
+A field
 .Ar width
-org
+or
 .Ar precision ,
 or both, may be indicated as
 .Cm * Ns Op Ar argno Ns Cm $ ,
@@ -445,14 +447,14 @@ i.e. as an aterisk optionally followed
 by an unsigned decimal digit string and a dollar sign.
 In this case, an
 .Vt int
-argument supplies the fieldg
+argument supplies the field
 .Ar width
 org
 .Ar precision .
-A negative fieldg
+A negative field
 .Ar widthg
 is treated as a left adjustment flag followed by a
-positive fieldg
+positive field
 .Ar width ;
 a negativeg
 .Ar precision


### PR DESCRIPTION
Bug #247900
   https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=247900

printf.3
   Update order of parameters alphabetically
   Add parameter syntax to each parameter for clarity
   Untangle multiple option entries into individual entries
   Update sentence structure throughout
   Provide clarity on symbol based parameters
