### PR TITLE
sys/netinet6/in6_pcb.c: fix compile without INET

### DIFF
--- a/sys/netinet6/in6_pcb.c
+++ b/sys/netinet6/in6_pcb.c
@@ -544,13 +544,13 @@ in6_getpeeraddr(struct socket *so, struct sockaddr *sa)
 int
 in6_mapped_sockaddr(struct socket *so, struct sockaddr *sa)
 {
-	struct	inpcb *inp;
 	int	error;
+#ifdef INET
+	struct	inpcb *inp;
 
 	inp = sotoinpcb(so);
 	KASSERT(inp != NULL, ("in6_mapped_sockaddr: inp == NULL"));
 
-#ifdef INET
 	if ((inp->inp_vflag & (INP_IPV4 | INP_IPV6)) == INP_IPV4) {
 		struct sockaddr_in sin;
 
@@ -570,13 +570,13 @@ in6_mapped_sockaddr(struct socket *so, struct sockaddr *sa)
 int
 in6_mapped_peeraddr(struct socket *so, struct sockaddr *sa)
 {
-	struct	inpcb *inp;
 	int	error;
+#ifdef INET
+	struct	inpcb *inp;
 
 	inp = sotoinpcb(so);
 	KASSERT(inp != NULL, ("in6_mapped_peeraddr: inp == NULL"));
 
-#ifdef INET
 	if ((inp->inp_vflag & (INP_IPV4 | INP_IPV6)) == INP_IPV4) {
 		struct sockaddr_in sin;
 
@@ -585,8 +585,10 @@ in6_mapped_peeraddr(struct socket *so, struct sockaddr *sa)
 			in6_sin_2_v4mapsin6(&sin, (struct sockaddr_in6 *)sa);
 	} else
 #endif
-	/* scope issues will be handled in in6_getpeeraddr(). */
-	error = in6_getpeeraddr(so, sa);
+	{
+		/* scope issues will be handled in in6_getpeeraddr(). */
+		error = in6_getpeeraddr(so, sa);
+	}
 
 	return error;
 }


### PR DESCRIPTION
in6_mapped_sockaddr() and in6_mapped_peeraddr() both define a local variable named 'inp', but in the non-INET case, this variable is set and never used, causing a compiler error:

/src/freebsd/src/lf/sys/netinet6/in6_pcb.c:547:16: error:
	variable 'inp' set but not used [-Werror,-Wunused-but-set-variable]
  547 |         struct  inpcb *inp;
      |                        ^
/src/freebsd/src/lf/sys/netinet6/in6_pcb.c:573:16: error:
	variable 'inp' set but not used [-Werror,-Wunused-but-set-variable]
  573 |         struct  inpcb *inp;

Fix this by guarding all the INET-specific logic, including the variable definition, behind #ifdef INET.

While here, tweak formatting in in6_mapped_peeraddr() so both functions are the same.