### PR TITLE
sys/netpfil/pf: fix non-INET module build

### DIFF
--- a/sys/netpfil/pf/pf.c
+++ b/sys/netpfil/pf/pf.c
@@ -7956,7 +7956,10 @@ pf_dummynet_route(struct pf_pdesc *pd, struct pf_kstate *s,
 
 		if (s != NULL && s->nat_rule.ptr != NULL &&
 		    s->nat_rule.ptr->action == PF_RDR &&
-		    ((pd->af == AF_INET && IN_LOOPBACK(ntohl(pd->dst->v4.s_addr))) ||
+		    (
+#ifdef INET
+		    (pd->af == AF_INET && IN_LOOPBACK(ntohl(pd->dst->v4.s_addr))) ||
+#endif
 		    (pd->af == AF_INET6 && IN6_IS_ADDR_LOOPBACK(&pd->dst->v6)))) {
 			/*
 			 * If we're redirecting to loopback mark this packet


### PR DESCRIPTION
pf.ko, when built as a module without 'options INET' but with 'options VIMAGE', won't load:

link_elf_obj: symbol vnet_entry_in_loopback_mask undefined

This is because it uses IN_LOOPBACK(), which in the VIMAGE case uses INET-specific symbols.

Fix by making this check conditional on #ifdef INET.

---

i'm not entirely sure this is the right fix, because i don't understand why it builds fine as part of the kernel (with 'device pf') but won't load as a module.  however, this patch does make pf work here.