### PR TITLE
Fix ahc(4) in target mode

### DIFF
--- a/sys/dev/aic7xxx/aic7xxx.c
+++ b/sys/dev/aic7xxx/aic7xxx.c
@@ -7794,9 +7794,9 @@ ahc_handle_target_cmd(struct ahc_softc *ahc, struct target_cmd *cmd)
 		/* Tag was included */
 		atio->tag_action = *byte++;
 		atio->tag_id = *byte++;
-		atio->ccb_h.flags |= CAM_TAG_ACTION_VALID;
+		atio->ccb_h.flags = CAM_TAG_ACTION_VALID;
 	} else {
-		atio->ccb_h.flags &= ~CAM_TAG_ACTION_VALID;
+		atio->ccb_h.flags = 0;
 	}
 	byte++;
 


### PR DESCRIPTION
This reverts part of 5e63cdb45, as I could only test with AIC-7890 and AIC-7892 cards (AHA-2940U2W and ASC-29160N) I only reverted the changes in the aic7xxx.c driver and left aic79xx.c and the other cards touched by the change alone.

With this change when trying to use ctl(4) the following error occurs when trying to do anything but a trivially small I/O:

ahc0: Connection stuck awaiting busfree or Identify Msg.

This then crashes the card and will eventually lead to a panic():

panic: Timed-out target SCB but bus idle

I have tested this change on the aforementioned cards as targets on x86_64 and aarch64 (through qemu) and I get wire-speeds with both Linux and FreeBSD as the initiator through both an AHA-2940U2W and an LSI 53c1030.