### PR TITLE
/bin/rmdir: Exit with status 2 for invalid arguments

### DIFF
--- a/bin/rmdir/rmdir.1
+++ b/bin/rmdir/rmdir.1
@@ -74,14 +74,14 @@ The
 .Nm
 utility exits with one of the following values:
 .Bl -tag -width indent
-.It Li 0
-Each directory entry specified by a
+.It Er 0
+Each
 .Ar directory
-operand
-referred to an empty directory and was removed
-successfully.
-.It Li >0
-An error occurred.
+referred to an empty directory and was removed successfully.
+.It Er 1
+An error occurred while attempting to remove one or more directories.
+.It Er 2
+Invalid arguments.
 .El
 .Sh EXAMPLES
 Remove the directory
@@ -97,6 +97,7 @@ stopping at the first non-empty directory (if any):
 .Dl $ rmdir -p cow/horse/monkey
 .Sh SEE ALSO
 .Xr rm 1
+.Xr rmdir 2
 .Sh STANDARDS
 The
 .Nm

--- a/bin/rmdir/rmdir.c
+++ b/bin/rmdir/rmdir.c
@@ -112,5 +112,5 @@ usage(void)
 {
 
 	(void)fprintf(stderr, "usage: rmdir [-pv] directory ...\n");
-	exit(1);
+	exit(2);
 }

--- a/bin/rmdir/tests/rmdir_test.sh
+++ b/bin/rmdir/tests/rmdir_test.sh
@@ -35,8 +35,8 @@ invalid_usage_head()
 
 invalid_usage_body()
 {
-	atf_check -s not-exit:0 -e match:"$usage_output" rmdir -p
-	atf_check -s not-exit:0 -e match:"$usage_output" rmdir -v
+	atf_check -s exit:2 -e match:"$usage_output" rmdir -p
+	atf_check -s exit:2 -e match:"$usage_output" rmdir -v
 }
 
 atf_test_case no_arguments
@@ -47,7 +47,7 @@ no_arguments_head()
 
 no_arguments_body()
 {
-	atf_check -s not-exit:0 -e match:"$usage_output" rmdir
+	atf_check -s exit:2 -e match:"$usage_output" rmdir
 }
 
 atf_init_test_cases()


### PR DESCRIPTION
PR: [277677](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=277677)

Signed-off-by: henrichhartzer@tuta.io