### PR TITLE
sys/netinet/cc: Switch from deprecated random() to prng32()

### DIFF
--- a/sys/netinet/cc/cc_cdg.c
+++ b/sys/netinet/cc/cc_cdg.c
@@ -57,6 +57,7 @@
 #include <sys/malloc.h>
 #include <sys/module.h>
 #include <sys/queue.h>
+#include <sys/prng.h>
 #include <sys/socket.h>
 #include <sys/socketvar.h>
 #include <sys/sysctl.h>
@@ -507,7 +508,8 @@ cdg_cong_signal(struct cc_var *ccv, ccsignal_t signal_type)
 static inline int
 prob_backoff(long qtrend)
 {
-	int backoff, idx, p;
+	int backoff, idx;
+	uint32_t p;
 
 	backoff = (qtrend > ((MAXGRAD * V_cdg_exp_backoff_scale) << D_P_E));
 
@@ -519,8 +521,8 @@ prob_backoff(long qtrend)
 			idx = qtrend;
 
 		/* Backoff probability proportional to rate of queue growth. */
-		p = (INT_MAX / (1 << EXP_PREC)) * probexp[idx];
-		backoff = (random() < p);
+		p = (UINT32_MAX / (1 << EXP_PREC)) * probexp[idx];
+		backoff = (prng32() < p);
 	}
 
 	return (backoff);

--- a/sys/netinet/cc/cc_chd.c
+++ b/sys/netinet/cc/cc_chd.c
@@ -58,6 +58,7 @@
 #include <sys/limits.h>
 #include <sys/malloc.h>
 #include <sys/module.h>
+#include <sys/prng.h>
 #include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/socketvar.h>
@@ -85,8 +86,8 @@
  */
 #define	CC_CHD_DELAY	0x02000000
 
-/* Largest possible number returned by random(). */
-#define	RANDOM_MAX	INT_MAX
+/* Largest possible number returned by prng32(). */
+#define	RANDOM_MAX	UINT32_MAX
 
 static void	chd_ack_received(struct cc_var *ccv, ccsignal_t ack_type);
 static void	chd_cb_destroy(struct cc_var *ccv);
@@ -159,9 +160,9 @@ chd_window_decrease(struct cc_var *ccv)
 static __inline int
 should_backoff(int qdly, int maxqdly, struct chd *chd_data)
 {
-	unsigned long p, rand;
+	uint32_t rand, p;
 
-	rand = random();
+	rand = prng32();
 
 	if (qdly < V_chd_qthresh) {
 		chd_data->loss_compete = 0;

--- a/sys/netinet/cc/cc_hd.c
+++ b/sys/netinet/cc/cc_hd.c
@@ -59,6 +59,7 @@
 #include <sys/limits.h>
 #include <sys/malloc.h>
 #include <sys/module.h>
+#include <sys/prng.h>
 #include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/socketvar.h>
@@ -77,8 +78,8 @@
 
 #include <netinet/khelp/h_ertt.h>
 
-/* Largest possible number returned by random(). */
-#define	RANDOM_MAX	INT_MAX
+/* Largest possible number returned by prng32(). */
+#define	RANDOM_MAX	UINT32_MAX
 
 static void	hd_ack_received(struct cc_var *ccv, ccsignal_t ack_type);
 static int	hd_mod_init(void);
@@ -128,7 +129,7 @@ should_backoff(int qdly, int maxqdly)
 			p = (RANDOM_MAX / 100) * V_hd_pmax;
 	}
 
-	return (random() < p);
+	return (prng32() < p);
 }
 
 /*

--- a/sys/netinet/icmp6.h
+++ b/sys/netinet/icmp6.h
@@ -63,7 +63,7 @@
 #ifndef _NETINET_ICMP6_H_
 #define _NETINET_ICMP6_H_
 
-#include <stdint.h>
+#include <sys/stdint.h>
 
 #define ICMPV6_PLD_MAXLEN	1232	/* IPV6_MMTU - sizeof(struct ip6_hdr)
 					   - sizeof(struct icmp6_hdr) */


### PR DESCRIPTION
Related: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=277655

Signed-off-by: henrichhartzer@tuta.io