### PR TITLE
ec2: homedir bug fixed in cloud-init 24.1.4

### DIFF
--- a/release/tools/ec2-cloud-init.conf
+++ b/release/tools/ec2-cloud-init.conf
@@ -23,8 +23,9 @@ vm_extra_pre_umount() {
 		    lock_passwd: True
 		    groups: [wheel]
 		    shell: /bin/sh
-		    # Currently broken, cloud-init hard-codes to /usr/home/*
 		    homedir: /home/ec2-user
+		    doas:
+		    - permit nopass ec2-user
 	EOF
 
 	return 0


### PR DESCRIPTION
This bug fix is due to be released in Quarterly:

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=275896

While here, overwrite the `doas` stanza, which needs to correspond to the user that we are creating.

Sponsored by:	The FreeBSD Foundation