### PR TITLE
usr.bin/units: use else..if to avoid calling the next branch

### DIFF
--- a/usr.bin/units/units.c
+++ b/usr.bin/units/units.c
@@ -497,8 +497,7 @@ lookupunit(const char *unit)
 			}
 		}
 		free(copy);
-	}
-	if (unit[strlen(unit) - 1] == 's') {
+	} else if (unit[strlen(unit) - 1] == 's') {
 		copy = dupstr(unit);
 		copy[strlen(copy) - 1] = 0;
 		for (i = 0; i < unitcount; i++) {


### PR DESCRIPTION
Even if the first branch succeeds, next time it will still check for the second branch (which will be false) as the first one was true. Add an else..if statement to address this.

Copy of https://github.com/freebsd/freebsd-src/pull/1005 (without the first one).