### PR TITLE
Support ARP for 802 networks.

### DIFF
--- a/sys/net/if_arp.h
+++ b/sys/net/if_arp.h
@@ -45,7 +45,7 @@
 struct	arphdr {
 	u_short	ar_hrd;		/* format of hardware address */
 #define ARPHRD_ETHER 	1	/* ethernet hardware format */
-#define ARPHRD_IEEE802	6	/* token-ring hardware format */
+#define ARPHRD_IEEE802	6	/* 802.2 networks (ethernet/tb/tr) */
 #define ARPHRD_FRELAY 	15	/* frame relay hardware format */
 #define ARPHRD_IEEE1394	24	/* firewire hardware format */
 #define ARPHRD_INFINIBAND 32	/* infiniband hardware format */

--- a/sys/netinet/if_ether.c
+++ b/sys/netinet/if_ether.c
@@ -682,6 +682,10 @@ arpintr(struct mbuf *m)
 		hlen = ETHER_ADDR_LEN; /* RFC 826 */
 		layer = "ethernet";
 		break;
+	case ARPHRD_IEEE802:
+		hlen = ETHER_ADDR_LEN;
+		layer = "ieee802";
+		break;
 	case ARPHRD_INFINIBAND:
 		hlen = 20;	/* RFC 4391, INFINIBAND_ALEN */
 		layer = "infiniband";


### PR DESCRIPTION
Enable ARP support for hardware type 6, 802 networks, which includes 802.3 Ethernet, 802.4 Token Bus and 802.5 token Ring.

802 network types are processed the same as the original 10Mb Ethernet (hardware type 1).

References:
* The 802 networks, and their interoperability, are described in [RFC-1042](https://www.rfc-editor.org/rfc/rfc1042).
* ARP assigned numbers are listed in [IANA Address Resolution Protocol (ARP) Parameters](https://www.iana.org/assignments/arp-parameters/arp-parameters.xhtml).


