### PR TITLE
src.libnames.mk: fix LIBPFCTL definition

### DIFF
--- a/share/mk/src.libnames.mk
+++ b/share/mk/src.libnames.mk
@@ -617,7 +617,7 @@ LIBOPTS?=	${LIBOPTSDIR}/libopts${PIE_SUFFIX}.a
 LIBPARSEDIR=	${_LIB_OBJTOP}/usr.sbin/ntp/libparse
 LIBPARSE?=	${LIBPARSEDIR}/libparse${PIE_SUFFIX}.a
 
-LIBPFCTL=	${_LIB_OBJTOP}/lib/libpfctl
+LIBPFCTLDIR=	${_LIB_OBJTOP}/lib/libpfctl
 LIBPFCTL?=	${LIBPFCTLDIR}/libpfctl${PIE_SUFFIX}.a
 
 LIBLPRDIR=	${_LIB_OBJTOP}/usr.sbin/lpr/common_source


### PR DESCRIPTION
Following the convention used in the rest of this file, ${LIBPFCTLDIR} should refer to the directory, and ${LIBPFCTL} to the library itself.

Instead, both values were assigned to ${LIBPFCTL}, and ${LIBPFCTLDIR} was not set at all.

This appears to be a simple typo and not a deliberate choice, so fix it by assigning the directory name to ${LIBPFCTLDIR} instead.