### PR TITLE
rescue: remove routed, rtquery

### DIFF
--- a/rescue/rescue/Makefile
+++ b/rescue/rescue/Makefile
@@ -119,10 +119,6 @@ CRUNCH_PROGS_sbin+= ipf
 CRUNCH_LIBS_ipf+=	${LIBIPF}
 .endif
 
-.if ${MK_ROUTED} != "no"
-CRUNCH_PROGS_sbin+= routed rtquery
-.endif
-
 .if ${MK_ZFS} != "no"
 CRUNCH_PROGS_sbin+= bectl
 CRUNCH_PROGS_sbin+= zfs
@@ -177,7 +173,6 @@ CRUNCH_PROGS_sbin+= bsdlabel fdisk
 CRUNCH_ALIAS_bsdlabel= disklabel
 .endif
 
-CRUNCH_SRCDIR_rtquery= ${SRCTOP}/sbin/routed/rtquery
 CRUNCH_SRCDIR_ipf= ${SRCTOP}/sbin/ipf/ipf
 .if ${MK_ZFS} != "no"
 CRUNCH_SRCDIR_zfs= ${SRCTOP}/cddl/sbin/zfs


### PR DESCRIPTION
These binaries are used to implement RIP/RIPng.  While it used to be fairly common for hosts to run RIP for routing, nowadays this is a very niche protocol and is not commonly used.

This reduces the size of rescue by 99072 bytes.