### PR TITLE
rescue: add ipfw, pfctl

### DIFF
--- a/rescue/rescue/Makefile
+++ b/rescue/rescue/Makefile
@@ -119,6 +119,15 @@ CRUNCH_PROGS_sbin+= ipf
 CRUNCH_LIBS_ipf+=	${LIBIPF}
 .endif
 
+.if ${MK_IPFW} != "no"
+CRUNCH_PROGS_sbin+= ipfw
+.endif
+
+.if ${MK_PF} != "no"
+CRUNCH_PROGS_sbin+= pfctl
+CRUNCH_LIBS_pfctl+= ${LIBPFCTL} ${LIBNV}
+.endif
+
 .if ${MK_ROUTED} != "no"
 CRUNCH_PROGS_sbin+= routed rtquery
 .endif


### PR DESCRIPTION
Rationale for this change:

- ipf is already there

- if the kernel is configured with a packet filter which drops packets by default, pfctl or ipfw will be required in the rescue environment to make the network functional.

- rescue's stated purpose is to be useful for small/embedded systems (and is also quite useful for small jails); a rescue-based router would want these binaries.

On amd64, this increases the size of rescue from 17346200 to 17907248, or 561048 bytes (3.2%).