### PR TITLE
package: move bsdconfig to its own package

### DIFF
--- a/usr.sbin/bsdconfig/Makefile
+++ b/usr.sbin/bsdconfig/Makefile
@@ -22,6 +22,7 @@ SUBDIR=	console \
 SUBDIR+= examples
 .endif
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig
 FILES=		USAGE
 

--- a/usr.sbin/bsdconfig/console/Makefile
+++ b/usr.sbin/bsdconfig/console/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/080.console
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/console/include/Makefile
+++ b/usr.sbin/bsdconfig/console/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/080.console/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/diskmgmt/Makefile
+++ b/usr.sbin/bsdconfig/diskmgmt/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/050.diskmgmt
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/diskmgmt/include/Makefile
+++ b/usr.sbin/bsdconfig/diskmgmt/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/050.diskmgmt/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/docsinstall/Makefile
+++ b/usr.sbin/bsdconfig/docsinstall/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/020.docsinstall
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/docsinstall/include/Makefile
+++ b/usr.sbin/bsdconfig/docsinstall/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/020.docsinstall/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/dot/Makefile
+++ b/usr.sbin/bsdconfig/dot/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/dot
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/dot/include/Makefile
+++ b/usr.sbin/bsdconfig/dot/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/dot/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/examples/Makefile
+++ b/usr.sbin/bsdconfig/examples/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${SHAREDIR}/examples/bsdconfig
 FILES=		add_some_packages.sh browse_packages_http.sh bsdconfigrc
 

--- a/usr.sbin/bsdconfig/include/Makefile
+++ b/usr.sbin/bsdconfig/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/include
 FILES=		bsdconfig.hlp media.hlp messages.subr network_device.hlp \
 		options.hlp tcp.hlp usage.hlp

--- a/usr.sbin/bsdconfig/includes/Makefile
+++ b/usr.sbin/bsdconfig/includes/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/includes
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/includes/include/Makefile
+++ b/usr.sbin/bsdconfig/includes/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/includes/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/mouse/Makefile
+++ b/usr.sbin/bsdconfig/mouse/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/110.mouse
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/mouse/include/Makefile
+++ b/usr.sbin/bsdconfig/mouse/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/110.mouse/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/networking/Makefile
+++ b/usr.sbin/bsdconfig/networking/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include share
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/120.networking
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/networking/include/Makefile
+++ b/usr.sbin/bsdconfig/networking/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/120.networking/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/networking/share/Makefile
+++ b/usr.sbin/bsdconfig/networking/share/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${SHAREDIR}/bsdconfig/networking
 FILES=		common.subr device.subr hostname.subr ipaddr.subr media.subr \
 		netmask.subr resolv.subr routing.subr services.subr

--- a/usr.sbin/bsdconfig/packages/Makefile
+++ b/usr.sbin/bsdconfig/packages/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/030.packages
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/packages/include/Makefile
+++ b/usr.sbin/bsdconfig/packages/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/030.packages/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/password/Makefile
+++ b/usr.sbin/bsdconfig/password/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include share
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/040.password
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/password/include/Makefile
+++ b/usr.sbin/bsdconfig/password/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/040.password/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/password/share/Makefile
+++ b/usr.sbin/bsdconfig/password/share/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${SHAREDIR}/bsdconfig/password
 FILES=		password.subr
 

--- a/usr.sbin/bsdconfig/security/Makefile
+++ b/usr.sbin/bsdconfig/security/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/130.security
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/security/include/Makefile
+++ b/usr.sbin/bsdconfig/security/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/130.security/include
 FILES=		messages.subr securelevel.hlp
 

--- a/usr.sbin/bsdconfig/share/Makefile
+++ b/usr.sbin/bsdconfig/share/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR=	media packages
 
+PACKAGE=	bsdconfig
 FILESDIR=	${SHAREDIR}/bsdconfig
 FILES=		common.subr device.subr dialog.subr geom.subr keymap.subr \
 		mustberoot.subr script.subr strings.subr struct.subr \

--- a/usr.sbin/bsdconfig/share/media/Makefile
+++ b/usr.sbin/bsdconfig/share/media/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${SHAREDIR}/bsdconfig/media
 FILES=		any.subr cdrom.subr common.subr directory.subr dos.subr \
 		http.subr httpproxy.subr network.subr \

--- a/usr.sbin/bsdconfig/share/packages/Makefile
+++ b/usr.sbin/bsdconfig/share/packages/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${SHAREDIR}/bsdconfig/packages
 FILES=		categories.subr index.awk index.subr musthavepkg.subr packages.subr
 

--- a/usr.sbin/bsdconfig/startup/Makefile
+++ b/usr.sbin/bsdconfig/startup/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include share
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/140.startup
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/startup/include/Makefile
+++ b/usr.sbin/bsdconfig/startup/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/140.startup/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/startup/share/Makefile
+++ b/usr.sbin/bsdconfig/startup/share/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${SHAREDIR}/bsdconfig/startup
 FILES=		rcconf.subr rcedit.subr rcvar.subr
 

--- a/usr.sbin/bsdconfig/timezone/Makefile
+++ b/usr.sbin/bsdconfig/timezone/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include share
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/090.timezone
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/timezone/include/Makefile
+++ b/usr.sbin/bsdconfig/timezone/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/090.timezone/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/timezone/share/Makefile
+++ b/usr.sbin/bsdconfig/timezone/share/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${SHAREDIR}/bsdconfig/timezone
 FILES=		continents.subr countries.subr iso3166.subr menus.subr \
 		zones.subr

--- a/usr.sbin/bsdconfig/ttys/Makefile
+++ b/usr.sbin/bsdconfig/ttys/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/150.ttys
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/ttys/include/Makefile
+++ b/usr.sbin/bsdconfig/ttys/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/150.ttys/include
 FILES=		messages.subr
 

--- a/usr.sbin/bsdconfig/usermgmt/Makefile
+++ b/usr.sbin/bsdconfig/usermgmt/Makefile
@@ -1,6 +1,7 @@
 
 SUBDIR= include share
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/070.usermgmt
 FILES=		INDEX USAGE
 

--- a/usr.sbin/bsdconfig/usermgmt/include/Makefile
+++ b/usr.sbin/bsdconfig/usermgmt/include/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${LIBEXECDIR}/bsdconfig/070.usermgmt/include
 FILES=		messages.subr usermgmt.hlp
 

--- a/usr.sbin/bsdconfig/usermgmt/share/Makefile
+++ b/usr.sbin/bsdconfig/usermgmt/share/Makefile
@@ -1,4 +1,5 @@
 
+PACKAGE=	bsdconfig
 FILESDIR=	${SHAREDIR}/bsdconfig/usermgmt
 FILES=		group.subr group_input.subr user.subr user_input.subr
 


### PR DESCRIPTION
this moves around 1MB of files out of FreeBSD-utilities, including a lot of files in /usr/share/bsdconfig.