### PR TITLE
tests: move atf_python/sys/ into the tests package

### DIFF
--- a/tests/atf_python/sys/Makefile
+++ b/tests/atf_python/sys/Makefile
@@ -2,6 +2,7 @@
 
 .PATH:	${.CURDIR}
 
+PACKAGE=tests
 FILES=	__init__.py
 SUBDIR=	net netlink netpfil
 

--- a/tests/atf_python/sys/net/Makefile
+++ b/tests/atf_python/sys/net/Makefile
@@ -2,6 +2,7 @@
 
 .PATH:	${.CURDIR}
 
+PACKAGE=tests
 FILES=	__init__.py rtsock.py tools.py vnet.py
 
 .include <bsd.own.mk>

--- a/tests/atf_python/sys/netlink/Makefile
+++ b/tests/atf_python/sys/netlink/Makefile
@@ -2,6 +2,7 @@
 
 .PATH:	${.CURDIR}
 
+PACKAGE=tests
 FILES=	__init__.py attrs.py base_headers.py message.py netlink.py \
 	netlink_generic.py netlink_route.py utils.py
 

--- a/tests/atf_python/sys/netpfil/Makefile
+++ b/tests/atf_python/sys/netpfil/Makefile
@@ -2,6 +2,7 @@
 
 .PATH:	${.CURDIR}
 
+PACKAGE=tests
 FILES=	__init__.py
 SUBDIR=	ipfw
 

--- a/tests/atf_python/sys/netpfil/ipfw/Makefile
+++ b/tests/atf_python/sys/netpfil/ipfw/Makefile
@@ -2,6 +2,7 @@
 
 .PATH:	${.CURDIR}
 
+PACKAGE=tests
 FILES=	__init__.py insns.py insn_headers.py ioctl.py ioctl_headers.py \
 	ipfw.py utils.py
 


### PR DESCRIPTION
these were already certainly meant to be in the existing tests package and were just missed by accident (since `PACKAGE=` isn't inherited by subdirs).