### PR TITLE
zfsbootcfg(8), zpool_influxdb(8): move to the zfs package

### DIFF
--- a/cddl/usr.libexec/zpool_influxdb/Makefile
+++ b/cddl/usr.libexec/zpool_influxdb/Makefile
@@ -4,6 +4,7 @@ ZFSTOP=	${SRCTOP}/sys/contrib/openzfs
 .PATH: ${ZFSTOP}/cmd/zpool_influxdb
 .PATH: ${ZFSTOP}/man/man8
 
+PACKAGE=zfs
 PROG=	zpool_influxdb
 MAN=	zpool_influxdb.8
 BINDIR?=	/usr/libexec/zfs

--- a/sbin/zfsbootcfg/Makefile
+++ b/sbin/zfsbootcfg/Makefile
@@ -1,3 +1,4 @@
+PACKAGE=zfs
 PROG=	zfsbootcfg
 MAN=	zfsbootcfg.8
 


### PR DESCRIPTION
These tools are only useful on a system running ZFS.