### PR TITLE
dumpon: fix set but not used variable

### DIFF
--- a/sbin/dumpon/dumpon.c
+++ b/sbin/dumpon/dumpon.c
@@ -463,20 +463,23 @@ main(int argc, char *argv[])
 	struct diocskerneldump_arg ndconf, *kdap;
 	struct addrinfo hints, *res;
 	const char *dev, *pubkeyfile, *server, *client, *gateway;
-	int ch, error, fd, cipher;
+	int ch, error, fd;
 	bool gzip, list, netdump, zstd, insert, rflag;
 	uint8_t ins_idx;
+#ifdef HAVE_CRYPTO
+	int cipher = KERNELDUMP_ENC_NONE;
+#endif
 
 	gzip = list = netdump = zstd = insert = rflag = false;
 	kdap = NULL;
 	pubkeyfile = NULL;
 	server = client = gateway = NULL;
 	ins_idx = KDA_APPEND;
-	cipher = KERNELDUMP_ENC_NONE;
 
 	while ((ch = getopt(argc, argv, "C:c:g:i:k:lrs:vZz")) != -1)
 		switch ((char)ch) {
 		case 'C':
+#ifdef HAVE_CRYPTO
 			if (strcasecmp(optarg, "chacha") == 0 ||
 			    strcasecmp(optarg, "chacha20") == 0)
 				cipher = KERNELDUMP_ENC_CHACHA20;
@@ -487,6 +490,11 @@ main(int argc, char *argv[])
 				errx(EX_USAGE, "Unrecognized cipher algorithm "
 				    "'%s'", optarg);
 			break;
+#else
+			errx(EX_USAGE, "Built without crypto support, "
+			    "-C is unhandled.");
+			break;
+#endif
 		case 'c':
 			client = optarg;
 			break;


### PR DESCRIPTION
That is my attempt to fix one issue, when compiling with WITHOUT_OPENSSL or WITHOUT_CRYPTO:

```
/usr/home/x/freebsd/sbin/dumpon/dumpon.c:478:21: error: variable 'cipher' set but not used [-Werror,-Wunused-but-set-variable]
        int ch, error, fd, cipher
```

I'm not sure if that is the proper way to fix that.