### PR TITLE
ng_pipe: Various improvements

### DIFF
--- a/sys/netgraph/ng_pipe.c
+++ b/sys/netgraph/ng_pipe.c
@@ -34,7 +34,7 @@
  * This node permits simple traffic shaping by emulating bandwidth
  * and delay, as well as random packet losses.
  * The node has two hooks, upper and lower. Traffic flowing from upper to
- * lower hook is referenced as downstream, and vice versa. Parameters for 
+ * lower hook is referenced as downstream, and vice versa. Parameters for
  * both directions can be set separately, except for delay.
  */
 
@@ -195,8 +195,8 @@ static const struct ng_cmdlist ngp_cmds[] = {
 	{
 		.cookie =	NGM_PIPE_COOKIE,
 		.cmd =		NGM_PIPE_GET_STATS,
-		.name = 	"getstats",
-		.respType =	 &ng_pipe_stats_type
+		.name =		"getstats",
+		.respType =	&ng_pipe_stats_type
 	},
 	{
 		.cookie =	NGM_PIPE_COOKIE,
@@ -494,7 +494,7 @@ parse_cfg(struct ng_pipe_hookcfg *current, struct ng_pipe_hookcfg *new,
 
 	if (new->qin_size_limit == -1)
 		current->qin_size_limit = 0;
-	else if (new->qin_size_limit >= 5) 
+	else if (new->qin_size_limit >= 5)
 		current->qin_size_limit = new->qin_size_limit;
 
 	if (new->qout_size_limit == -1)
@@ -547,7 +547,7 @@ parse_cfg(struct ng_pipe_hookcfg *current, struct ng_pipe_hookcfg *new,
 	} else if (new->bandwidth >= 100 && new->bandwidth <= 1000000000)
 		current->bandwidth = new->bandwidth;
 
-	if (current->bandwidth | priv->delay | 
+	if (current->bandwidth | priv->delay |
 	    current->duplicate | current->ber)
 		hinfo->noqueue = 0;
 	else
@@ -686,9 +686,9 @@ ngp_rcvdata(hook_p hook, item_p item)
 			}
 
 		/* Drop a frame from the queue head/tail, depending on cfg */
-		if (hinfo->cfg.drophead) 
+		if (hinfo->cfg.drophead)
 			ngp_h = TAILQ_FIRST(&ngp_f->packet_head);
-		else 
+		else
 			ngp_h = TAILQ_LAST(&ngp_f->packet_head, p_head);
 		TAILQ_REMOVE(&ngp_f->packet_head, ngp_h, ngp_link);
 		m1 = ngp_h->m;
@@ -783,7 +783,7 @@ pipe_dequeue(struct hookinfo *hinfo, struct timeval *now) {
 			hinfo->run.qin_octets -= m->m_pkthdr.len;
 			ngp_f->packets--;
 		}
-		
+
 		/* Calculate the serialization delay */
 		if (hinfo->cfg.bandwidth) {
 			hinfo->qin_utime.tv_usec +=

--- a/sys/netgraph/ng_pipe.c
+++ b/sys/netgraph/ng_pipe.c
@@ -44,6 +44,7 @@
 #include <sys/kernel.h>
 #include <sys/malloc.h>
 #include <sys/mbuf.h>
+#include <sys/prng.h>
 #include <sys/time.h>
 
 #include <vm/uma.h>
@@ -771,7 +772,7 @@ pipe_dequeue(struct hookinfo *hinfo, struct timeval *now) {
 		 * the original packet...
 		 */
 		if (hinfo->cfg.duplicate &&
-		    random() % 100 <= hinfo->cfg.duplicate) {
+		    prng32_bounded(100) <= hinfo->cfg.duplicate) {
 			ngp_h = uma_zalloc(ngp_zone, M_NOWAIT);
 			KASSERT(ngp_h != NULL, ("ngp_h zalloc failed (3)"));
 			m = m_dup(m, M_NOWAIT);
@@ -814,7 +815,7 @@ pipe_dequeue(struct hookinfo *hinfo, struct timeval *now) {
 		/* Randomly discard the frame, according to BER setting */
 		if (hinfo->cfg.ber) {
 			oldrand = rand;
-			rand = random();
+			rand = prng32_bounded(1U << 31);
 			if (((oldrand ^ rand) << 17) >=
 			    hinfo->ber_p[priv->overhead + m->m_pkthdr.len]) {
 				hinfo->stats.out_disc_frames++;

--- a/sys/netgraph/ng_pipe.c
+++ b/sys/netgraph/ng_pipe.c
@@ -936,6 +936,7 @@ ngp_disconnect(hook_p hook)
 	struct hookinfo *const hinfo = NG_HOOK_PRIVATE(hook);
 	struct ngp_fifo *ngp_f;
 	struct ngp_hdr *ngp_h;
+	priv_p priv;
 
 	KASSERT(hinfo != NULL, ("%s: null info", __FUNCTION__));
 	hinfo->hook = NULL;
@@ -961,6 +962,13 @@ ngp_disconnect(hook_p hook)
 	/* Release the packet loss probability table (BER) */
 	if (hinfo->ber_p)
 		free(hinfo->ber_p, M_NG_PIPE);
+
+
+	/* Destroy the node if all hooks are disconnected */
+	priv = NG_NODE_PRIVATE(NG_HOOK_NODE(hook));
+
+	if (priv->upper.hook == NULL && priv->lower.hook == NULL)
+		ng_rmnode_self(NG_HOOK_NODE(hook));
 
 	return (0);
 }


### PR DESCRIPTION
Various small improvements to `ng_pipe(4)`:

 - Fix various whitespace issues
 - Replace deprecated `random(9)` with `arc4random(9)`
 - Remove the node when all hooks are disconnected.  This is the behavior described in the man page
 - Do not panic when memory allocations fail