### PR TITLE
add dtb support for RPI CM4, CM4s, CM4_ioBoard

### DIFF
--- a/release/arm64/RPI.conf
+++ b/release/arm64/RPI.conf
@@ -3,7 +3,8 @@
 #
 
 DTB_DIR="/usr/local/share/rpi-firmware"
-DTB="bcm2710-rpi-2-b.dtb bcm2710-rpi-3-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-cm3.dtb bcm2711-rpi-4-b.dtb"
+DTB="bcm2710-rpi-2-b.dtb bcm2710-rpi-3-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-cm3.dtb \
+	bcm2711-rpi-4-b.dtb bcm2711-rpi-cm4-io.dtb bcm2711-rpi-cm4.dtb bcm2711-rpi-cm4s.dtb"
 EMBEDDED_TARGET_ARCH="aarch64"
 EMBEDDED_TARGET="arm64"
 EMBEDDEDBUILD=1


### PR DESCRIPTION
Since the test of PR #1179 was successful 
it should make sense to support these models.
That wasn't possible before because cm4-models crashed by pcie devmatch .

While in my tests I had manually added only bcm2711-rpi-cm4.dtb to config.txt 
without the corresponding bcm2711-rpi-cm4-io.dtb for the io-board,
I presume there normally should be no caveats with bcm2711-rpi-cm4-io.dtb .
 