### PR TITLE
alc(4): disable MSI-X by default on Killer cards

### DIFF
--- a/share/man/man4/alc.4
+++ b/share/man/man4/alc.4
@@ -136,7 +136,11 @@ This tunable disables MSI support on the Ethernet hardware.
 The default value is 0.
 .It Va hw.alc.msix_disable
 This tunable disables MSI-X support on the Ethernet hardware.
-The default value is 0.
+The default value is 2, which means to enable or disable MSI-X based on the
+card type; for "Killer" cards (E2x00) MSI-X will be disabled, while on other
+cards it will be enabled.
+Set this to 0 to force MSI-X to be enabled, or 1 to force it to be disabled
+regardless of card type.
 .El
 .Sh SYSCTL VARIABLES
 The following variables are available as both


### PR DESCRIPTION
Several users with alc(4)-based "Killer" Ethernet cards have reported issues with this driver not passing traffic, which are solved by disabling MSI-X using the provided tunable.

To work around this issue, disable MSI-X by default on this card.

This is done by having msix_disable default to 2, which means "auto-detect".  The user can still override this to either 0 or 1 as desired.

Since these are slow (1Gbps) Ethernet ICs used in low-end systems, it's unlikely this will cause any practical performance issues; on the other hand, the card not working by default likely causes issues for many new FreeBSD users who find their network port doesn't work and have no idea why.

PR:		230807
MFC after:	1 week

---

cc @emaste as you seem interested in user onboarding issues 