### PR TITLE
ifconfig tunnelfib is implemented in wg(4)

### DIFF
--- a/sbin/ifconfig/ifconfig.8
+++ b/sbin/ifconfig/ifconfig.8
@@ -549,9 +549,10 @@ A FIB
 .Ar fib_number
 is assigned to all packets encapsulated by tunnel interface, e.g.,
 .Xr gif 4 ,
-.Xr gre 4
+.Xr gre 4 ,
+.Xr vxlan 4 ,
 and
-.Xr vxlan 4 .
+.Xr wg 4 .
 .It Cm maclabel Ar label
 If Mandatory Access Control support is enabled in the kernel,
 set the MAC label to


### PR DESCRIPTION
It appears from the wg(4) source code that ifconfig's tunnelfib parameter is available so adding it to the man page.