### PR TITLE
ahc(4) clean up old Linux defines

### DIFF
--- a/sys/dev/aic7xxx/ahc_isa.c
+++ b/sys/dev/aic7xxx/ahc_isa.c
@@ -37,7 +37,6 @@
  * $Id$
  */
 
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic7xxx_osm.h>
 
 #include <sys/limits.h>		/* For CHAR_BIT*/

--- a/sys/dev/aic7xxx/ahc_pci.c
+++ b/sys/dev/aic7xxx/ahc_pci.c
@@ -31,7 +31,6 @@
  * $Id: //depot/aic7xxx/freebsd/dev/aic7xxx/ahc_pci.c#19 $
  */
 
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic7xxx_osm.h>
 
 static int ahc_pci_probe(device_t dev);

--- a/sys/dev/aic7xxx/ahd_pci.c
+++ b/sys/dev/aic7xxx/ahd_pci.c
@@ -31,7 +31,6 @@
  * $Id: //depot/aic7xxx/freebsd/dev/aic7xxx/ahd_pci.c#17 $
  */
 
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic79xx_osm.h>
 
 static int ahd_pci_probe(device_t dev);

--- a/sys/dev/aic7xxx/aic7770.c
+++ b/sys/dev/aic7xxx/aic7770.c
@@ -42,16 +42,9 @@
  * $Id: //depot/aic7xxx/aic7xxx/aic7770.c#34 $
  */
 
-#ifdef __linux__
-#include "aic7xxx_osm.h"
-#include "aic7xxx_inline.h"
-#include "aic7xxx_93cx6.h"
-#else
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic7xxx_osm.h>
 #include <dev/aic7xxx/aic7xxx_inline.h>
 #include <dev/aic7xxx/aic7xxx_93cx6.h>
-#endif
 
 #define ID_AIC7770	0x04907770
 #define ID_AHA_274x	0x04907771

--- a/sys/dev/aic7xxx/aic79xx.h
+++ b/sys/dev/aic7xxx/aic79xx.h
@@ -625,9 +625,7 @@ struct scb {
 	aic_io_ctx_t		  io_ctx;
 	struct ahd_softc	 *ahd_softc;
 	scb_flag		  flags;
-#ifndef __linux__
 	bus_dmamap_t		  dmamap;
-#endif
 	struct scb_platform_data *platform_data;
 	struct map_node	 	 *hscb_map;
 	struct map_node	 	 *sg_map;
@@ -1098,9 +1096,7 @@ struct ahd_completion
 struct ahd_softc {
 	bus_space_tag_t           tags[2];
 	bus_space_handle_t        bshs[2];
-#ifndef __linux__
 	bus_dma_tag_t		  buffer_dmat;   /* dmat for buffer I/O */
-#endif
 	struct scb_data		  scb_data;
 
 	struct hardware_scb	 *next_queued_hscb;

--- a/sys/dev/aic7xxx/aic79xx_osm.c
+++ b/sys/dev/aic7xxx/aic79xx_osm.c
@@ -32,7 +32,6 @@
  * $Id: //depot/aic7xxx/freebsd/dev/aic7xxx/aic79xx_osm.c#35 $
  */
 
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic79xx_osm.h>
 #include <dev/aic7xxx/aic79xx_inline.h>
 

--- a/sys/dev/aic7xxx/aic79xx_pci.c
+++ b/sys/dev/aic7xxx/aic79xx_pci.c
@@ -43,14 +43,8 @@
  * $Id: //depot/aic7xxx/aic7xxx/aic79xx_pci.c#88 $
  */
 
-#ifdef __linux__
-#include "aic79xx_osm.h"
-#include "aic79xx_inline.h"
-#else
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic79xx_osm.h>
 #include <dev/aic7xxx/aic79xx_inline.h>
-#endif
 
 static __inline uint64_t
 ahd_compose_id(u_int device, u_int vendor, u_int subdevice, u_int subvendor)

--- a/sys/dev/aic7xxx/aic79xx_reg_print.c
+++ b/sys/dev/aic7xxx/aic79xx_reg_print.c
@@ -6,7 +6,6 @@
  * $Id: //depot/aic7xxx/aic7xxx/aic79xx.reg#76 $
  */
 
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic79xx_osm.h>
 
 static ahd_reg_parse_entry_t MODE_PTR_parse_table[] = {

--- a/sys/dev/aic7xxx/aic7xxx.c
+++ b/sys/dev/aic7xxx/aic7xxx.c
@@ -42,16 +42,9 @@
  * $Id: //depot/aic7xxx/aic7xxx/aic7xxx.c#155 $
  */
 
-#ifdef __linux__
-#include "aic7xxx_osm.h"
-#include "aic7xxx_inline.h"
-#include "aicasm/aicasm_insformat.h"
-#else
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic7xxx_osm.h>
 #include <dev/aic7xxx/aic7xxx_inline.h>
 #include <dev/aic7xxx/aicasm/aicasm_insformat.h>
-#endif
 
 /****************************** Softc Data ************************************/
 struct ahc_softc_tailq ahc_tailq = TAILQ_HEAD_INITIALIZER(ahc_tailq);
@@ -1277,7 +1270,6 @@ ahc_handle_scsiint(struct ahc_softc *ahc, u_int intstat)
 				printerror = 0;
 			} else if (ahc_sent_msg(ahc, AHCMSG_1B,
 						MSG_BUS_DEV_RESET, TRUE)) {
-#ifdef __FreeBSD__
 				/*
 				 * Don't mark the user's request for this BDR
 				 * as completing with CAM_BDR_SENT.  CAM3
@@ -1291,7 +1283,6 @@ ahc_handle_scsiint(struct ahc_softc *ahc, u_int intstat)
 						  ROLE_INITIATOR)) {
 					aic_set_transaction_status(scb, CAM_REQ_CMP);
 				}
-#endif
 				ahc_compile_devinfo(&devinfo,
 						    initiator_role_id,
 						    target,
@@ -3878,23 +3869,11 @@ ahc_alloc(void *platform_arg, char *name)
 	struct  ahc_softc *ahc;
 	int	i;
 
-#ifndef	__FreeBSD__
-	ahc = malloc(sizeof(*ahc), M_DEVBUF, M_NOWAIT);
-	if (!ahc) {
-		printf("aic7xxx: cannot malloc softc!\n");
-		free(name, M_DEVBUF);
-		return NULL;
-	}
-#else
 	ahc = device_get_softc((device_t)platform_arg);
-#endif
 	memset(ahc, 0, sizeof(*ahc));
 	ahc->seep_config = malloc(sizeof(*ahc->seep_config),
 				  M_DEVBUF, M_NOWAIT);
 	if (ahc->seep_config == NULL) {
-#ifndef	__FreeBSD__
-		free(ahc, M_DEVBUF);
-#endif
 		free(name, M_DEVBUF);
 		return (NULL);
 	}
@@ -4041,17 +4020,13 @@ ahc_free(struct ahc_softc *ahc)
 	case 2:
 		aic_dma_tag_destroy(ahc, ahc->shared_data_dmat);
 	case 1:
-#ifndef __linux__
 		aic_dma_tag_destroy(ahc, ahc->buffer_dmat);
-#endif
 		break;
 	case 0:
 		break;
 	}
 
-#ifndef __linux__
 	aic_dma_tag_destroy(ahc, ahc->parent_dmat);
-#endif
 	ahc_platform_free(ahc);
 	ahc_fini_scbdata(ahc);
 	for (i = 0; i < AHC_NUM_TARGETS; i++) {
@@ -4085,9 +4060,6 @@ ahc_free(struct ahc_softc *ahc)
 		free(ahc->name, M_DEVBUF);
 	if (ahc->seep_config != NULL)
 		free(ahc->seep_config, M_DEVBUF);
-#ifndef __FreeBSD__
-	free(ahc, M_DEVBUF);
-#endif
 	return;
 }
 
@@ -4537,9 +4509,7 @@ ahc_alloc_scbs(struct ahc_softc *ahc)
 	newcount = MIN(newcount, (AHC_SCB_MAX_ALLOC - scb_data->numscbs));
 	for (i = 0; i < newcount; i++) {
 		struct scb_platform_data *pdata;
-#ifndef __linux__
 		int error;
-#endif
 		pdata = (struct scb_platform_data *)malloc(sizeof(*pdata),
 							   M_DEVBUF, M_NOWAIT);
 		if (pdata == NULL)
@@ -4554,12 +4524,11 @@ ahc_alloc_scbs(struct ahc_softc *ahc)
 		next_scb->sg_list_phys = physaddr + sizeof(struct ahc_dma_seg);
 		next_scb->ahc_softc = ahc;
 		next_scb->flags = SCB_FLAG_NONE;
-#ifndef __linux__
 		error = aic_dmamap_create(ahc, ahc->buffer_dmat, /*flags*/0,
 					  &next_scb->dmamap);
 		if (error != 0)
 			break;
-#endif
+
 		next_scb->hscb = &scb_data->hscbs[scb_data->numscbs];
 		next_scb->hscb->tag = ahc->scb_data->numscbs;
 		aic_timer_init(&next_scb->io_timer);
@@ -4860,7 +4829,6 @@ ahc_init(struct ahc_softc *ahc)
 	if ((AHC_TMODE_ENABLE & (0x1 << ahc->unit)) == 0)
 		ahc->features &= ~AHC_TARGETMODE;
 
-#ifndef __linux__
 	/* DMA tag for mapping buffers into device visible space. */
 	if (aic_dma_tag_create(ahc, ahc->parent_dmat, /*alignment*/1,
 			       /*boundary*/BUS_SPACE_MAXADDR_32BIT + 1,
@@ -4876,7 +4844,6 @@ ahc_init(struct ahc_softc *ahc)
 			       &ahc->buffer_dmat) != 0) {
 		return (ENOMEM);
 	}
-#endif
 
 	ahc->init_level++;
 

--- a/sys/dev/aic7xxx/aic7xxx.h
+++ b/sys/dev/aic7xxx/aic7xxx.h
@@ -589,9 +589,7 @@ struct scb {
 	aic_io_ctx_t		  io_ctx;
 	struct ahc_softc	 *ahc_softc;
 	scb_flag		  flags;
-#ifndef __linux__
 	bus_dmamap_t		  dmamap;
-#endif
 	struct scb_platform_data *platform_data;
 	struct sg_map_node	 *sg_map;
 	struct ahc_dma_seg 	 *sg_list;
@@ -932,9 +930,7 @@ typedef void ahc_callback_t (void *);
 struct ahc_softc {
 	bus_space_tag_t           tag;
 	bus_space_handle_t        bsh;
-#ifndef __linux__
 	bus_dma_tag_t		  buffer_dmat;   /* dmat for buffer I/O */
-#endif
 	struct scb_data		 *scb_data;
 
 	struct scb		 *next_queued_scb;

--- a/sys/dev/aic7xxx/aic7xxx_93cx6.c
+++ b/sys/dev/aic7xxx/aic7xxx_93cx6.c
@@ -64,16 +64,9 @@
  *   bit to be sent from the chip.
  */
 
-#ifdef __linux__
-#include "aic7xxx_osm.h"
-#include "aic7xxx_inline.h"
-#include "aic7xxx_93cx6.h"
-#else
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic7xxx_osm.h>
 #include <dev/aic7xxx/aic7xxx_inline.h>
 #include <dev/aic7xxx/aic7xxx_93cx6.h>
-#endif
 
 /*
  * Right now, we only have to read the SEEPROM.  But we make it easier to

--- a/sys/dev/aic7xxx/aic7xxx_osm.c
+++ b/sys/dev/aic7xxx/aic7xxx_osm.c
@@ -31,7 +31,6 @@
  * $Id: //depot/aic7xxx/freebsd/dev/aic7xxx/aic7xxx_osm.c#20 $
  */
 
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic7xxx_osm.h>
 #include <dev/aic7xxx/aic7xxx_inline.h>
 

--- a/sys/dev/aic7xxx/aic7xxx_pci.c
+++ b/sys/dev/aic7xxx/aic7xxx_pci.c
@@ -44,16 +44,9 @@
  * $Id: //depot/aic7xxx/aic7xxx/aic7xxx_pci.c#78 $
  */
 
-#ifdef __linux__
-#include "aic7xxx_osm.h"
-#include "aic7xxx_inline.h"
-#include "aic7xxx_93cx6.h"
-#else
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic7xxx_osm.h>
 #include <dev/aic7xxx/aic7xxx_inline.h>
 #include <dev/aic7xxx/aic7xxx_93cx6.h>
-#endif
 
 static __inline uint64_t
 ahc_compose_id(u_int device, u_int vendor, u_int subdevice, u_int subvendor)

--- a/sys/dev/aic7xxx/aic7xxx_reg_print.c
+++ b/sys/dev/aic7xxx/aic7xxx_reg_print.c
@@ -6,7 +6,6 @@
  * $Id: //depot/aic7xxx/aic7xxx/aic7xxx.reg#40 $
  */
 
-#include <sys/cdefs.h>
 #include <dev/aic7xxx/aic7xxx_osm.h>
 
 static ahc_reg_parse_entry_t SCSISEQ_parse_table[] = {


### PR DESCRIPTION
Linux removed theirs starting in 2018 in commit:
"scsi: aic7xxx: Fix build using bare-metal toolchain"

these now serve only to confuse.