### PR TITLE
ahc(4)/ahd(4): target mode: cancel outstanding AIOs and INOTs

### DIFF
--- a/sys/dev/aic7xxx/aic79xx.c
+++ b/sys/dev/aic7xxx/aic79xx.c
@@ -9836,6 +9836,7 @@ ahd_handle_en_lun(struct ahd_softc *ahd, struct cam_sim *sim, union ccb *ccb)
 	struct	   ahd_tmode_tstate *tstate;
 	struct	   ahd_tmode_lstate *lstate;
 	struct	   ccb_en_lun *cel;
+	union      ccb* cancel_ccb;
 	cam_status status;
 	u_int	   target;
 	u_int	   lun;
@@ -10054,12 +10055,20 @@ ahd_handle_en_lun(struct ahd_softc *ahd, struct cam_sim *sim, union ccb *ccb)
 
 		if (SLIST_FIRST(&lstate->accept_tios) != NULL) {
 			printf("ATIOs pending\n");
-			ccb->ccb_h.status = CAM_REQ_INVALID;
+			while ((cancel_ccb = (union ccb *)SLIST_FIRST(&lstate->accept_tios)) != NULL) {
+			       SLIST_REMOVE_HEAD(&lstate->accept_tios, sim_links.sle);
+			       cancel_ccb->ccb_h.status = CAM_REQ_ABORTED;
+			       xpt_done(cancel_ccb);
+			};
 		}
 
 		if (SLIST_FIRST(&lstate->immed_notifies) != NULL) {
 			printf("INOTs pending\n");
-			ccb->ccb_h.status = CAM_REQ_INVALID;
+			while ((cancel_ccb = (union ccb *)SLIST_FIRST(&lstate->immed_notifies)) != NULL) {
+			       SLIST_REMOVE_HEAD(&lstate->immed_notifies, sim_links.sle);
+			       cancel_ccb->ccb_h.status = CAM_REQ_ABORTED;
+			       xpt_done(cancel_ccb);
+			};
 		}
 
 		if (ccb->ccb_h.status != CAM_REQ_CMP) {

--- a/sys/dev/aic7xxx/aic7xxx.c
+++ b/sys/dev/aic7xxx/aic7xxx.c
@@ -7286,6 +7286,7 @@ ahc_handle_en_lun(struct ahc_softc *ahc, struct cam_sim *sim, union ccb *ccb)
 	struct	   ahc_tmode_tstate *tstate;
 	struct	   ahc_tmode_lstate *lstate;
 	struct	   ccb_en_lun *cel;
+	union      ccb* cancel_ccb;
 	cam_status status;
 	u_int	   target;
 	u_int	   lun;
@@ -7553,12 +7554,20 @@ ahc_handle_en_lun(struct ahc_softc *ahc, struct cam_sim *sim, union ccb *ccb)
 
 		if (SLIST_FIRST(&lstate->accept_tios) != NULL) {
 			printf("ATIOs pending\n");
-			ccb->ccb_h.status = CAM_REQ_INVALID;
+			while ((cancel_ccb = (union ccb *)SLIST_FIRST(&lstate->accept_tios)) != NULL) {
+			       SLIST_REMOVE_HEAD(&lstate->accept_tios, sim_links.sle);
+			       cancel_ccb->ccb_h.status = CAM_REQ_ABORTED;
+			       xpt_done(cancel_ccb);
+			};
 		}
 
 		if (SLIST_FIRST(&lstate->immed_notifies) != NULL) {
 			printf("INOTs pending\n");
-			ccb->ccb_h.status = CAM_REQ_INVALID;
+			while ((cancel_ccb = (union ccb *)SLIST_FIRST(&lstate->immed_notifies)) != NULL) {
+			       SLIST_REMOVE_HEAD(&lstate->immed_notifies, sim_links.sle);
+			       cancel_ccb->ccb_h.status = CAM_REQ_ABORTED;
+			       xpt_done(cancel_ccb);
+			};
 		}
 
 		if (ccb->ccb_h.status != CAM_REQ_CMP) {


### PR DESCRIPTION
When disabling a lun there can still be outstanding AIOs and INOTs, when this happens previously the lun would just fail to disable and trying to re-use the lun would break the card.

isp(4) in target mode does the same thing when disabling a lun, in testing this allows re-starting of ctld(8) with connected initiators and allows initiators to gracefully resume afterwards.

~I currently don't have any ahd(4) compatible hardware, but I purchased some. Once I have those, I will see if the equivalent changes can and should be made there too.~

I just applied to ahd(4) as well, the code is pretty much identical.