### PR TITLE
intro.2: add syscall.h to synopsis & mention emfile vars

### DIFF
--- a/lib/libsys/intro.2
+++ b/lib/libsys/intro.2
@@ -32,8 +32,9 @@
 .Dt INTRO 2
 .Os
 .Sh NAME
-.Nm intro
-.Nd introduction to system calls and error numbers
+.Nm intro ,
+.Nm errno
+.Nd introduction to system calls and their error numbers
 .Sh LIBRARY
 .Lb libc
 .Sh SYNOPSIS
@@ -333,7 +334,7 @@ Table of currently available system calls.
 .Sh ERRORS
 Nearly all of the system calls provide an error number referenced via
 the external identifier
-.Va errno .
+.Nm errno .
 This identifier is defined in
 .In sys/errno.h
 as:
@@ -349,7 +350,7 @@ For the initial thread and
 non-threaded processes,
 .Va __error()
 returns a pointer to a global
-.Va errno
+.Nm errno
 variable that is compatible with the previous definition.
 .Pp
 When a system call detects an error,
@@ -357,12 +358,12 @@ it returns an integer value
 indicating failure
 .Pq usually -1
 and sets the variable
-.Va errno
+.Nm errno
 accordingly.
 This allows interpretation of the failure on receiving
 -1 and to take action accordingly.
 Successful calls never set
-.Va errno ;
+.Nm errno ;
 once set, it remains until another error occurs.
 It should only be examined after an error.
 Note that a number of system calls overload the meanings of these

--- a/lib/libsys/intro.2
+++ b/lib/libsys/intro.2
@@ -37,6 +37,7 @@
 .Sh LIBRARY
 .Lb libc
 .Sh SYNOPSIS
+.In sys/syscall.h
 .In errno.h
 .Sh DESCRIPTION
 This section contains the system calls which comprise the

--- a/lib/libsys/intro.2
+++ b/lib/libsys/intro.2
@@ -511,8 +511,13 @@ system call was issued on a socket, pipe or FIFO.
 An attempt was made to modify a file or directory
 on a file system that was read-only at the time.
 .It Er 31 EMLINK Em "Too many links" .
-Maximum allowable hard links to a single file has been exceeded
-.Pq limit of 32767 hard links per file .
+Maximum allowable hard links to a single file has been exceeded.
+This limit is a filesystem dependent variable
+.Po
+.Va UFS_LINK_MAX No on Xr ufs 4 ,
+.Va FUSE_LINK_MAX No on Xr fusefs 4 , and
+.Va TMPFS_MAX No on Xr tmpfs 4
+.Pc .
 .It Er 32 EPIPE Em "Broken pipe" .
 A write on a pipe, socket or FIFO for which there is no process to read
 the data.


### PR DESCRIPTION
This patch is currently incorrect until filesystems are moved to section 4.

Does this make the creation of the files section in previous pr redundant?

Is it correct for me here to use "reported by"?

Thanks!