### PR TITLE
package: move authpf into the FreeBSD-pf package

### DIFF
--- a/usr.sbin/authpf/Makefile
+++ b/usr.sbin/authpf/Makefile
@@ -1,6 +1,7 @@
 
 .PATH:	${SRCTOP}/contrib/pf/authpf
 
+PACKAGE=pf
 PROG=	authpf
 MAN=	authpf.8
 BINOWN=	root


### PR DESCRIPTION
no UPDATING entry for this since authpf is only useful for pf(4) users, who must already have FreeBSD-pf installed. 