### PR TITLE
sys/amd64/conf/MINIMAL: remove virtio

### DIFF
--- a/sys/amd64/conf/MINIMAL
+++ b/sys/amd64/conf/MINIMAL
@@ -127,13 +127,6 @@ device		ether			# Ethernet support
 # Note that 'bpf' is required for DHCP.
 device		bpf			# Berkeley packet filter
 
-# VirtIO support
-device		virtio			# Generic VirtIO bus (required)
-device		virtio_pci		# VirtIO PCI device
-device		vtnet			# VirtIO Ethernet device
-device		virtio_blk		# VirtIO Block device
-device		virtio_balloon		# VirtIO Memory Balloon device
-
 # Linux KVM paravirtualization support
 device		kvm_clock		# KVM paravirtual clock driver
 


### PR DESCRIPTION
There is no reason for virtio support to be in minimal since it's all built as modules.  Remove it from the kernel config.

---

cc @igalic 