### PR TITLE
Fix CTL GET EVENT STATUS NOTIFICATION valid bits

### DIFF
--- a/sys/cam/ctl/ctl_cmd_table.c
+++ b/sys/cam/ctl/ctl_cmd_table.c
@@ -1227,7 +1227,7 @@ const struct ctl_cmd_entry ctl_cmd_table[256] =
 					  CTL_CMD_FLAG_ALLOW_ON_PR_RESV |
 					  CTL_FLAG_DATA_IN,
  CTL_LUN_PAT_NONE,
- 10, {0x02, 0x01, 0, 0, 0, 0xff, 0xff, 0xff, 0x07}},
+ 10, {0xe1, 0, 0, 0x7e, 0, 0, 0xff, 0xff, 0x07}},
 
 /* 4B PAUSE/RESUME */
 {NULL, CTL_SERIDX_INVLD, CTL_CMD_FLAG_NONE, CTL_LUN_PAT_NONE},


### PR DESCRIPTION
Linux as an initiator periodically sends the following to SCSI cdrom devices: 4a 01 00 00 10 00 00 00 08 00

According to the ctl_cmd_entry for this command this is invalid which leads to a lot of failed SCSI commands.

The mask in this commit is based off of the t10 spec available here: https://www.t10.org/ftp/t10/document.97/97-108r0.pdf

And @bsdimp's research.

This solves the issue with Linux initiators.