### PR TITLE
package: fix dependency generation

### DIFF
--- a/release/packages/generate-ucl.sh
+++ b/release/packages/generate-ucl.sh
@@ -153,7 +153,7 @@ EOF
 		PKG_WWW "${PKG_WWW}" \
 		PKG_MAINTAINER "${PKG_MAINTAINER}" \
 		UCLFILES "${srctree}/release/packages/" \
-		${uclsource} ${uclfile}
+		${uclfile} ${uclfile}
 
 	return 0
 }


### PR DESCRIPTION
A bug in release/packages/generate-ucl.sh causes package dependencies (other than shlib depends) to not be generated correctly, meaning packages are missing their dependencies.

generate-ucl.sh creates the UCL file by:

1. copying ${uclsource} (template.ucl) to ${uclfile}
2. appending dependencies to ${uclfile}
3. calling generate-ucl.lua on ${uclsource} to create ${uclfile}

This breaks because the dependencies added in step 2 are overwritten in step 3.

Fix this by calling generate-ucl.lua with ${uclfile} as both the input and output file, so anything we added to ${uclfile} is preserved.