### PR TITLE
package: FreeBSD-periodic should depend on FreeBSD-cron

### DIFF
--- a/release/packages/generate-ucl.sh
+++ b/release/packages/generate-ucl.sh
@@ -40,6 +40,9 @@ main() {
 		clang)
 			pkgdeps="lld libcompiler_rt-dev"
 			;;
+		periodic)
+			pkgdeps="cron"
+			;;
 
 		# -dev packages that have no corresponding non-dev package
 		# as a dependency.


### PR DESCRIPTION
Reported by: des

---

#1203 should be merged along with this otherwise the new dependency won't work.