### PR TITLE
rtadvd(8): support PREF64 (RFC 8781)

### DIFF
--- a/sys/netinet/icmp6.h
+++ b/sys/netinet/icmp6.h
@@ -63,6 +63,8 @@
 #ifndef _NETINET_ICMP6_H_
 #define _NETINET_ICMP6_H_
 
+#include <stdint.h>
+
 #define ICMPV6_PLD_MAXLEN	1232	/* IPV6_MMTU - sizeof(struct ip6_hdr)
 					   - sizeof(struct icmp6_hdr) */
 
@@ -375,10 +377,10 @@ struct nd_opt_dnssl {		/* DNSSL option (RFC 6106) */
 } __packed;
 
 struct nd_opt_pref64 {		/* PREF64 option (RFC 8781) */
-	u_int8_t	nd_opt_pref64_type;
-	u_int8_t	nd_opt_pref64_len;
+	uint8_t		nd_opt_pref64_type;
+	uint8_t		nd_opt_pref64_len;
 	/* bits 0-12 are the SL, bits 13-15 are the PLC */
-	u_int16_t	nd_opt_pref64_sl_plc;
+	uint16_t	nd_opt_pref64_sl_plc;
 	char		nd_opt_prefix[12];
 } __packed;
 

--- a/sys/netinet/icmp6.h
+++ b/sys/netinet/icmp6.h
@@ -307,7 +307,8 @@ struct nd_opt_hdr {		/* Neighbor discovery option header */
 #define ND_OPT_ROUTE_INFO		24	/* RFC 4191 */
 #define ND_OPT_RDNSS			25	/* RFC 6106 */
 #define ND_OPT_DNSSL			31	/* RFC 6106 */
-#define ND_OPT_MAX			31
+#define ND_OPT_PREF64			38	/* RFC 8781 */
+#define ND_OPT_MAX			38
 
 struct nd_opt_prefix_info {	/* prefix information */
 	u_int8_t	nd_opt_pi_type;
@@ -371,6 +372,14 @@ struct nd_opt_dnssl {		/* DNSSL option (RFC 6106) */
 	u_int16_t	nd_opt_dnssl_reserved;
 	u_int32_t	nd_opt_dnssl_lifetime;
 	/* followed by list of DNS search domains */
+} __packed;
+
+struct nd_opt_pref64 {		/* PREF64 option (RFC 8781) */
+	u_int8_t	nd_opt_pref64_type;
+	u_int8_t	nd_opt_pref64_len;
+	/* bits 0-12 are the SL, bits 13-15 are the PLC */
+	u_int16_t	nd_opt_pref64_sl_plc;
+	char		nd_opt_prefix[12];
 } __packed;
 
 /*

--- a/usr.sbin/rtadvd/rtadvd.conf.5
+++ b/usr.sbin/rtadvd/rtadvd.conf.5
@@ -428,6 +428,24 @@ DNS search list entries.
 The default value is 3/2 of the interval time.
 .El
 .Pp
+The following items are for PREF64 discovery
+.Pq RFC 8781 ,
+which will advertise the network's NAT64 prefix to clients.
+These items are optional.
+.Bl -tag -width indent
+.It Cm \&pref64
+(str) The prefix to advertise in the PREF64 option.
+.It Cm \&pref64len
+(num) The length of the PREF64 prefix.
+This must be 96, 64, 56, 48, 40, or 32.
+If not specified, the default is 96.
+.It Cm \&pref64lifetime
+(num) The prefix lifetime to advertise in the PREF64 option.
+This should be at least as long as the RA lifetime, but cannot be greater
+than 65528.
+If not specified, the default is the RA lifetime, or 65528, whichever is lower.
+.El
+.Pp
 You can also refer one line from another by using
 .Cm tc
 capability.

--- a/usr.sbin/rtadvd/rtadvd.h
+++ b/usr.sbin/rtadvd/rtadvd.h
@@ -32,6 +32,8 @@
  * SUCH DAMAGE.
  */
 
+#include <stdbool.h>
+
 #define	ELM_MALLOC(p,error_action)					\
 	do {								\
 		p = malloc(sizeof(*p));					\
@@ -148,6 +150,14 @@ struct rdnss {
 	uint32_t rd_ltime;	/* number of seconds valid */
 };
 
+struct pref64 {
+	TAILQ_ENTRY(pref64) p64_next;
+	bool		p64_enabled;
+	uint16_t	p64_plc;	/* prefix length code */
+	uint16_t	p64_sl;		/* scaled lifetime */
+	struct in6_addr	p64_prefix;
+};
+
 /*
  * The maximum length of a domain name in a DNS search list is calculated
  * by a domain name + length fields per 63 octets + a zero octet at
@@ -217,6 +227,7 @@ struct	rainfo {
 	/* actual RA packet data and its length */
 	size_t	rai_ra_datalen;
 	char	*rai_ra_data;
+	struct pref64 rai_pref64;	/* PREF64 option */
 
 	/* info about soliciter */
 	TAILQ_HEAD(, soliciter) rai_soliciter;	/* recent solication source */


### PR DESCRIPTION
the first commit adds the necessary icmp6.h bits, the second is the implementation in rtadvd.