### PR TITLE
Address module reproducibility issues

### DIFF
--- a/sys/modules/ice_ddp/Makefile
+++ b/sys/modules/ice_ddp/Makefile
@@ -1,5 +1,7 @@
 
+.PATH: ${SRCTOP}/sys/contrib/dev/ice
+
 KMOD=	ice_ddp
-FIRMWS=	${SRCTOP}/sys/contrib/dev/ice/ice-1.3.36.0.pkg:ice_ddp:0x01032400
+FIRMWS=	ice-1.3.36.0.pkg:ice_ddp:0x01032400
 
 .include <bsd.kmod.mk>

--- a/sys/modules/qatfw/qat_200xx/Makefile
+++ b/sys/modules/qatfw/qat_200xx/Makefile
@@ -4,6 +4,6 @@
 
 KMOD= qat_200xx_fw
 
-FIRMWS= ${SRCTOP}/sys/contrib/dev/qat/qat_200xx.bin:qat_200xx_fw:111 ${SRCTOP}/sys/contrib/dev/qat/qat_200xx_mmp.bin:qat_200xx_mmp_fw:111
+FIRMWS= qat_200xx.bin:qat_200xx_fw:111 qat_200xx_mmp.bin:qat_200xx_mmp_fw:111
 
 .include <bsd.kmod.mk>

--- a/sys/modules/qatfw/qat_4xxx/Makefile
+++ b/sys/modules/qatfw/qat_4xxx/Makefile
@@ -4,6 +4,6 @@
 
 KMOD= qat_4xxx_fw
 
-FIRMWS= ${SRCTOP}/sys/contrib/dev/qat/qat_4xxx.bin:qat_4xxx_fw:111 ${SRCTOP}/sys/contrib/dev/qat/qat_4xxx_mmp.bin:qat_4xxx_mmp_fw:111
+FIRMWS= qat_4xxx.bin:qat_4xxx_fw:111 qat_4xxx_mmp.bin:qat_4xxx_mmp_fw:111
 
 .include <bsd.kmod.mk>

--- a/sys/modules/qatfw/qat_c3xxx/Makefile
+++ b/sys/modules/qatfw/qat_c3xxx/Makefile
@@ -4,6 +4,6 @@
 
 KMOD= qat_c3xxx_fw
 
-FIRMWS= ${SRCTOP}/sys/contrib/dev/qat/qat_c3xxx.bin:qat_c3xxx_fw:111 ${SRCTOP}/sys/contrib/dev/qat/qat_c3xxx_mmp.bin:qat_c3xxx_mmp_fw:111
+FIRMWS= qat_c3xxx.bin:qat_c3xxx_fw:111 qat_c3xxx_mmp.bin:qat_c3xxx_mmp_fw:111
 
 .include <bsd.kmod.mk>

--- a/sys/modules/qatfw/qat_c4xxx/Makefile
+++ b/sys/modules/qatfw/qat_c4xxx/Makefile
@@ -4,6 +4,6 @@
 
 KMOD= qat_c4xxx_fw
 
-FIRMWS= ${SRCTOP}/sys/contrib/dev/qat/qat_c4xxx.bin:qat_c4xxx_fw:111 ${SRCTOP}/sys/contrib/dev/qat/qat_c4xxx_mmp.bin:qat_c4xxx_mmp_fw:111
+FIRMWS= qat_c4xxx.bin:qat_c4xxx_fw:111 qat_c4xxx_mmp.bin:qat_c4xxx_mmp_fw:111
 
 .include <bsd.kmod.mk>

--- a/sys/modules/qatfw/qat_c62x/Makefile
+++ b/sys/modules/qatfw/qat_c62x/Makefile
@@ -4,6 +4,6 @@
 
 KMOD= qat_c62x_fw
 
-FIRMWS= ${SRCTOP}/sys/contrib/dev/qat/qat_c62x.bin:qat_c62x_fw:111 ${SRCTOP}/sys/contrib/dev/qat/qat_c62x_mmp.bin:qat_c62x_mmp_fw:111
+FIRMWS= qat_c62x.bin:qat_c62x_fw:111 qat_c62x_mmp.bin:qat_c62x_mmp_fw:111
 
 .include <bsd.kmod.mk>

--- a/sys/modules/qatfw/qat_dh895xcc/Makefile
+++ b/sys/modules/qatfw/qat_dh895xcc/Makefile
@@ -4,6 +4,6 @@
 
 KMOD= qat_dh895xcc_fw
 
-FIRMWS= ${SRCTOP}/sys/contrib/dev/qat/qat_895xcc.bin:qat_dh895xcc_fw:111 ${SRCTOP}/sys/contrib/dev/qat/qat_895xcc_mmp.bin:qat_dh895xcc_mmp_fw:111
+FIRMWS= qat_895xcc.bin:qat_dh895xcc_fw:111 qat_895xcc_mmp.bin:qat_dh895xcc_mmp_fw:111
 
 .include <bsd.kmod.mk>


### PR DESCRIPTION
Use .PATH & bare filename. This prevents the real source path from being included in the built object, which improves reproducibility.