### PR TITLE
arp.8: don't document a syntax that doesn't exist

### DIFF
--- a/usr.sbin/arp/arp.8
+++ b/usr.sbin/arp/arp.8
@@ -44,7 +44,6 @@
 .Fl a
 .Nm
 .Fl d Ar hostname
-.Op Cm pub
 .Nm
 .Fl d
 .Op Fl i Ar interface
@@ -95,15 +94,8 @@ A super-user may delete an entry for the host called
 with the
 .Fl d
 flag.
-If the
-.Cm pub
-keyword is specified, only the
-.Dq published
-.Tn ARP
-entry
-for this host will be deleted.
 .Pp
-Alternatively, the
+The
 .Fl d
 flag may be combined with the
 .Fl a


### PR DESCRIPTION
The arp.8 manpage documents 'arp -d <addr> pub', but the 'pub' flag is not accepted by the arp command.  Remove this incorrect documentation.