### PR TITLE
ifconfig(8): change default IP address format to 'cidr'

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -27,6 +27,12 @@ NOTE TO PEOPLE WHO THINK THAT FreeBSD 15.x IS SLOW:
 	world, or to merely disable the most expensive debugging functionality
 	at runtime, run "ln -s 'abort:false,junk:false' /etc/malloc.conf".)
 
+20240504:
+	The default output format of ifconfig(8) has changed to use CIDR
+	notation for IPv4 and IPv6 addresses.  If you have shell scripts that
+	rely on parsing ifconfig(8) output, you may want to set
+	"IFCONFIG_FORMAT=inet:hex,inet6:numeric".
+
 20240428:
 	OpenBSM auditing runtime (auditd, etc.) has been moved into the new
 	package FreeBSD-audit.  If you use OpenBSM auditing and pkgbase, you

--- a/sbin/ifconfig/af_inet6.c
+++ b/sbin/ifconfig/af_inet6.c
@@ -85,7 +85,6 @@ static	int prefix(void *, int);
 #endif
 static	char *sec2str(time_t);
 static	int explicit_prefix = 0;
-extern	char *f_inet6, *f_addr;
 
 extern void setnd6flags(if_ctx *, const char *, int);
 extern void setnd6defif(if_ctx *,const char *, int);
@@ -246,10 +245,14 @@ print_p2p(struct sockaddr_in6 *sin)
 static void
 print_mask(int plen)
 {
-	if (f_inet6 != NULL && strcmp(f_inet6, "cidr") == 0)
+	switch (f_inet6) {
+	case INET6_CIDR:
 		printf("/%d", plen);
-	else
+		break;
+	case INET6_NUMERIC:
 		printf(" prefixlen %d", plen);
+		break;
+	}
 }
 
 static void

--- a/sbin/ifconfig/ifconfig.8
+++ b/sbin/ifconfig/ifconfig.8
@@ -173,15 +173,15 @@ Adjust the display of inet address subnet masks:
 .It Cm cidr
 CIDR notation, for example:
 .Ql 203.0.113.224/26
-.It Cm default
-Default format,
-.Cm hex
 .It Cm dotted
 Dotted quad notation, for example:
 .Ql 255.255.255.192
 .It Cm hex
 Hexadecimal format, for example:
 .Ql 0xffffffc0
+.It Cm default
+Default format,
+.Cm cidr
 .El
 .It Cm inet6
 Adjust the display of inet6 address prefixes (subnet masks):
@@ -192,12 +192,12 @@ CIDR notation, for example:
 .Ql ::1/128
 or
 .Ql fe80::1%lo0/64
-.It Cm default
-Default format,
-.Cm numeric
 .It Cm numeric
 Integer format, for example:
 .Ql prefixlen 64
+.It Cm default
+Default format,
+.Cm cidr
 .El
 .El
 .It Fl G Ar groupname

--- a/sbin/ifconfig/ifconfig.c
+++ b/sbin/ifconfig/ifconfig.c
@@ -90,7 +90,9 @@ int	exit_code = 0;
 static char ifname_to_print[IFNAMSIZ]; /* Helper for printifnamemaybe() */
 
 /* Formatter Strings */
-char	*f_inet, *f_inet6, *f_ether, *f_addr;
+inet_format_t f_inet;
+inet6_format_t f_inet6;
+char	*f_ether, *f_addr;
 
 #ifdef WITHOUT_NETLINK
 static void list_interfaces_ioctl(if_ctx *ctx);
@@ -313,10 +315,6 @@ cmpifaddrs(struct ifaddrs *a, struct ifaddrs *b, struct ifa_queue *q)
 static void freeformat(void)
 {
 
-	if (f_inet != NULL)
-		free(f_inet);
-	if (f_inet6 != NULL)
-		free(f_inet6);
 	if (f_ether != NULL)
 		free(f_ether);
 	if (f_addr != NULL)
@@ -344,10 +342,19 @@ static void setformat(char *input)
 			f_addr = strdup(modifier);
 		else if (strcmp(category, "ether") == 0)
 			f_ether = strdup(modifier);
-		else if (strcmp(category, "inet") == 0)
-			f_inet = strdup(modifier);
-		else if (strcmp(category, "inet6") == 0)
-			f_inet6 = strdup(modifier);
+		else if (strcmp(category, "inet") == 0) {
+			if (strcmp(modifier, "hex") == 0)
+				f_inet = INET_HEX;
+			else if (strcmp(modifier, "cidr") == 0)
+				f_inet = INET_CIDR;
+			else if (strcmp(modifier, "dotted") == 0)
+				f_inet = INET_DOTTED;
+		} else if (strcmp(category, "inet6") == 0) {
+			if (strcmp(modifier, "cidr") == 0)
+				f_inet6 = INET6_CIDR;
+			else if (strcmp(modifier, "numeric") == 0)
+				f_inet6 = INET6_NUMERIC;
+		}
 	}
 	free(formatstr);
 }
@@ -612,7 +619,7 @@ main(int ac, char *av[])
 		.io_s = -1,
 	};
 
-	f_inet = f_inet6 = f_ether = f_addr = NULL;
+	f_ether = f_addr = NULL;
 
 	lifh = ifconfig_open();
 	if (lifh == NULL)

--- a/sbin/ifconfig/ifconfig.h
+++ b/sbin/ifconfig/ifconfig.h
@@ -253,7 +253,21 @@ void	opt_register(struct option *);
 extern	ifconfig_handle_t *lifh;
 extern	int allmedia;
 extern	int exit_code;
-extern	char *f_inet, *f_inet6, *f_ether, *f_addr;
+
+typedef enum {
+	INET_CIDR = 0,
+	INET_HEX,
+	INET_DOTTED
+} inet_format_t;
+extern inet_format_t f_inet;
+
+typedef enum {
+	INET6_CIDR = 0,
+	INET6_NUMERIC
+} inet6_format_t;
+extern inet6_format_t f_inet6;
+
+extern	char *f_ether, *f_addr;
 
 void	clearifcap(if_ctx *ctx, const char *, int value);
 void	setifcap(if_ctx *ctx, const char *, int value);


### PR DESCRIPTION
'netmasks' haven't been used in IP networking for decades.  Change the default address format for both IPv4 and IPv6 addreses in ifconfig(8) to 'cidr', which prints addreses in the format most users will be more familiar with.

The previous format is still available using -finet:hex or -finet6:numeric.