### PR TITLE
ahc(4): Default to memory mapped IO

### DIFF
--- a/share/man/man4/ahc.4
+++ b/share/man/man4/ahc.4
@@ -131,7 +131,7 @@ target on multiple SCSI IDs.
 .Pp
 To allow PCI adapters to use memory mapped I/O if enabled:
 .Pp
-.Cd options AHC_ALLOW_MEMIO
+.Cd options AHC_ALLOW_MEMIO=(0 -- disabled, 1 -- enabled)
 .Bd -ragged -offset indent
 Memory mapped I/O is more efficient than the alternative, programmed I/O.
 Most PCI BIOSes will map devices so that either technique for communicating
@@ -141,12 +141,13 @@ the chip for memory mapped I/O. The typical symptom of this problem is a
 system hang if memory mapped I/O is attempted.
 .Pp
 Most modern motherboards perform the initialization correctly and work fine
-with this option enabled.
+with this option enabled and it is the default. This option can also be
+dynamically configued through a device hint documented below.
 .Ed
 .Pp
 To statically configure one or more controllers to assume the target role:
 .Pp
-.Cd options AHC_TMODE_ENABLE <bitmask of units>
+.Cd options AHC_TMODE_ENABLE=<bitmask of units>
 .Bd -ragged -offset indent
 The value assigned to this option should be a bitmap of all units where target
 mode is desired. For example, a value of 0x25, would enable target mode on
@@ -163,7 +164,11 @@ The following options are switchable by setting values in
 They are:
 .Bl -tag -width indent
 .It Va hint.ahc. Ns Ar N Ns Va .tmode_enable
-A hint to define whether the SCSI target mode is enabled (0 -- disabled, 1 -- enabled).
+A hint to define whether the SCSI target mode is enabled, defaults to disabled
+(0 -- disabled, 1 -- enabled).
+.It Va hint.ahc. Ns Ar N Ns Va .allow_memio
+A hint to define whether memory mapped io is enabled or disabled for this
+adapter, defaults to enabled (0 -- disabled, 1 -- enabled).
 .El
 .Ed
 .Sh HARDWARE

--- a/sys/dev/aic7xxx/ahc_pci.c
+++ b/sys/dev/aic7xxx/ahc_pci.c
@@ -138,7 +138,7 @@ ahc_pci_map_registers(struct ahc_softc *ahc)
 	struct	resource *regs;
 	int	regs_type;
 	int	regs_id;
-	int	allow_memio;
+	int	allow_memio = 1;
 
 	regs = NULL;
 	regs_type = 0;
@@ -150,14 +150,14 @@ ahc_pci_map_registers(struct ahc_softc *ahc)
 			       "allow_memio", &allow_memio) != 0) {
 		if (bootverbose)
 			device_printf(ahc->dev_softc, "Defaulting to MEMIO ");
-#ifdef AHC_ALLOW_MEMIO
-		if (bootverbose)
-			printf("on\n");
-		allow_memio = 1;
-#else
+#if defined(AHC_ALLOW_MEMIO) && (AHC_ALLOW_MEMIO == 0)
 		if (bootverbose)
 			printf("off\n");
 		allow_memio = 0;
+#else
+		if (bootverbose)
+			printf("on\n");
+		allow_memio = 1;
 #endif
 	}
 

--- a/sys/powerpc/conf/GENERIC
+++ b/sys/powerpc/conf/GENERIC
@@ -119,7 +119,6 @@ device		siis		# SiliconImage SiI3124/SiI3132/SiI3531 SATA
 
 # SCSI Controllers
 device		ahc		# AHA2940 and onboard AIC7xxx devices
-options 	AHC_ALLOW_MEMIO	# Attempt to use memory mapped I/O
 device		isp		# Qlogic family
 device		ispfw		# Firmware module for Qlogic host adapters
 device		mpt		# LSI-Logic MPT-Fusion

--- a/sys/powerpc/conf/GENERIC64
+++ b/sys/powerpc/conf/GENERIC64
@@ -137,7 +137,6 @@ device		nvd		# expose NVMe namespaces as disks, depends on nvme
 # SCSI Controllers
 device		aacraid		# Adaptec by PMC RAID
 device		ahc		# AHA2940 and onboard AIC7xxx devices
-options 	AHC_ALLOW_MEMIO	# Attempt to use memory mapped I/O
 device		isp		# Qlogic family
 device		ispfw		# Firmware module for Qlogic host adapters
 device		mrsas		# LSI/Avago MegaRAID SAS/SATA, 6Gb/s and 12Gb/s

--- a/sys/powerpc/conf/GENERIC64LE
+++ b/sys/powerpc/conf/GENERIC64LE
@@ -133,7 +133,6 @@ device		nvd		# expose NVMe namespaces as disks, depends on nvme
 # SCSI Controllers
 device		aacraid		# Adaptec by PMC RAID
 device		ahc		# AHA2940 and onboard AIC7xxx devices
-options 	AHC_ALLOW_MEMIO	# Attempt to use memory mapped I/O
 device		isp		# Qlogic family
 device		ispfw		# Firmware module for Qlogic host adapters
 device		mrsas		# LSI/Avago MegaRAID SAS/SATA, 6Gb/s and 12Gb/s


### PR DESCRIPTION
When this driver was written it made sense to make this default to off, but these days almost all BIOSses will do the right thing. Furthermore non-mmio communication only works on Intel architectures.

So lets default to allowing mmio, but not change the semantics of the `AHC_ALLOW_MEMIO` flag to not break existing installs. Also document the already existing `hint.ahc.<unit>.allow_memio`.