### PR TITLE
arp(8): allow -i with -s

### DIFF
--- a/usr.sbin/arp/arp.c
+++ b/usr.sbin/arp/arp.c
@@ -144,7 +144,7 @@ main(int argc, char *argv[])
 	if (!func)
 		func = F_GET;
 	if (opts.rifname) {
-		if (func != F_GET && !(func == F_DELETE && opts.aflag))
+		if (func != F_GET && func != F_SET && !(func == F_DELETE && opts.aflag))
 			xo_errx(1, "-i not applicable to this operation");
 		if ((opts.rifindex = if_nametoindex(opts.rifname)) == 0) {
 			if (errno == ENXIO)
@@ -375,7 +375,7 @@ set(int argc, char **argv)
 		}
 	}
 #ifndef WITHOUT_NETLINK
-	return (set_nl(0, dst, &sdl_m, host));
+	return (set_nl(opts.rifindex, dst, &sdl_m, host));
 #else
 	return (set_rtsock(dst, &sdl_m, host));
 #endif


### PR DESCRIPTION
arp(8) usually disallows adding a static ARP entry for an IP address which is not configured on a local interface.

Change this to allow such ARP entries to be added if '-i' is provided to specify the interface the ARP entry relates to.

Due to limitations in the kernel lltable, this still requires that a host route exists for the target address, but allows static ARP entries to be configured to proxy ARP for, e.g., local jails which use an IPv4 address with a /32 route.

---

cc @glebius 

this PR came about from my attempts to make proxy ARP work in FreeBSD -- i still couldn't get it to work for my purposes even with this PR, but i think this is useful even so. 