### PR TITLE
Fix memory corruption in C++ demangler

### DIFF
--- a/contrib/elftoolchain/libelftc/libelftc_dem_gnu3.c
+++ b/contrib/elftoolchain/libelftc/libelftc_dem_gnu3.c
@@ -2138,7 +2138,7 @@ cpp_demangle_read_sname(struct cpp_demangle_data *ddata)
 	assert(ddata->cur_output->size > 0);
 	if (vector_read_cmd_find(&ddata->cmd, READ_TMPL) == NULL)
 		ddata->last_sname =
-		    ddata->cur_output->container[ddata->output.size - 1];
+		    ddata->cur_output->container[ddata->cur_output->size - 1];
 
 	ddata->cur += len;
 

--- a/contrib/libcxxrt/libelftc_dem_gnu3.c
+++ b/contrib/libcxxrt/libelftc_dem_gnu3.c
@@ -2472,7 +2472,7 @@ cpp_demangle_read_sname(struct cpp_demangle_data *ddata)
 	assert(ddata->cur_output->size > 0);
 	if (vector_read_cmd_find(&ddata->cmd, READ_TMPL) == NULL)
 		ddata->last_sname =
-		    ddata->cur_output->container[ddata->output.size - 1];
+		    ddata->cur_output->container[ddata->cur_output->size - 1];
 
 	ddata->cur += len;
 


### PR DESCRIPTION
The __cxa_demangle_gnu3() and cpp_demangle_gnu3() functions segfault on various libcxxabi test cases due to a copy and paste error. This change fixes that.