### PR TITLE
netstat(1): increase width of Netif column

### DIFF
--- a/usr.bin/netstat/nhops.c
+++ b/usr.bin/netstat/nhops.c
@@ -64,7 +64,7 @@
 #include "common.h"
 
 /* column widths; each followed by one space */
-#define WID_IF_DEFAULT		12	/* width of netif column */
+#define WID_IF_DEFAULT		(Wflag ? IFNAMSIZ : 12)	/* width of netif column */
 #ifndef INET6
 #define	WID_DST_DEFAULT(af) 	18	/* width of destination column */
 #define	WID_GW_DEFAULT(af)	18	/* width of gateway column */

--- a/usr.bin/netstat/nhops.c
+++ b/usr.bin/netstat/nhops.c
@@ -64,16 +64,15 @@
 #include "common.h"
 
 /* column widths; each followed by one space */
+#define WID_IF_DEFAULT		12	/* width of netif column */
 #ifndef INET6
 #define	WID_DST_DEFAULT(af) 	18	/* width of destination column */
 #define	WID_GW_DEFAULT(af)	18	/* width of gateway column */
-#define	WID_IF_DEFAULT(af)	(Wflag ? 10 : 8) /* width of netif column */
 #else
 #define	WID_DST_DEFAULT(af) \
 	((af) == AF_INET6 ? (numeric_addr ? 33: 18) : 18)
 #define	WID_GW_DEFAULT(af) \
 	((af) == AF_INET6 ? (numeric_addr ? 29 : 18) : 18)
-#define	WID_IF_DEFAULT(af)	((af) == AF_INET6 ? 8 : (Wflag ? 10 : 8))
 #endif /*INET6*/
 static int wid_dst;
 static int wid_gw;
@@ -415,7 +414,7 @@ print_nhops_sysctl(int fibnum, int af)
 		wid_flags = 6;
 		wid_pksent = 8;
 		wid_mtu = 6;
-		wid_if = WID_IF_DEFAULT(fam);
+		wid_if = WID_IF_DEFAULT;
 		xo_open_instance("rt-family");
 		pr_family(fam);
 		xo_open_list("nh-entry");

--- a/usr.bin/netstat/route.c
+++ b/usr.bin/netstat/route.c
@@ -184,7 +184,7 @@ pr_family(int af1)
 }
 
 /* column widths; each followed by one space */
-#define WID_IF_DEFAULT		12	/* width of netif column */
+#define WID_IF_DEFAULT		(Wflag ? IFNAMSIZ : 12)	/* width of netif column */
 #ifndef INET6
 #define	WID_DST_DEFAULT(af) 	18	/* width of destination column */
 #define	WID_GW_DEFAULT(af)	18	/* width of gateway column */

--- a/usr.bin/netstat/route.c
+++ b/usr.bin/netstat/route.c
@@ -184,16 +184,15 @@ pr_family(int af1)
 }
 
 /* column widths; each followed by one space */
+#define WID_IF_DEFAULT		12	/* width of netif column */
 #ifndef INET6
 #define	WID_DST_DEFAULT(af) 	18	/* width of destination column */
 #define	WID_GW_DEFAULT(af)	18	/* width of gateway column */
-#define	WID_IF_DEFAULT(af)	(Wflag ? 10 : 8) /* width of netif column */
 #else
 #define	WID_DST_DEFAULT(af) \
 	((af) == AF_INET6 ? (numeric_addr ? 33: 18) : 18)
 #define	WID_GW_DEFAULT(af) \
 	((af) == AF_INET6 ? (numeric_addr ? 29 : 18) : 18)
-#define	WID_IF_DEFAULT(af)	((af) == AF_INET6 ? 8 : (Wflag ? 10 : 8))
 #endif /*INET6*/
 
 struct _wid wid;
@@ -234,7 +233,7 @@ set_wid(int fam)
 	wid.flags = 6;
 	wid.pksent = 8;
 	wid.mtu = 6;
-	wid.iface = WID_IF_DEFAULT(fam);
+	wid.iface = WID_IF_DEFAULT;
 	wid.expire = 6;
 }
 


### PR DESCRIPTION
The previous width of Netif (10 or 8) was too short for modern interface names; make it 12, which is long enough to display "epair0a.1000".

This came up in practice with genet(4) interfaces, since the base interface name is long enough that with the previous limit, VLAN identifiers would be truncated at 1 character in the IPv6 output: "genet0.100" becomes "genet0.1".

The width is now fixed, and doesn't depend on the address family, because there's no reason that length of the interface name would vary based on the AF.