### PR TITLE
kern/intr: remove support for passing trap frame as argument

### DIFF
--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -1346,8 +1346,8 @@ ithread_loop(void *arg)
  *
  * Input:
  * o ie:                        the event connected to this interrupt.
- * o frame:                     some archs (i.e. i386) pass a frame to some.
- *                              handlers as their main argument.
+ * o frame:                     the current trap frame.
+ *
  * Return value:
  * o 0:                         everything ok.
  * o EINVAL:                    stray interrupt.
@@ -1374,9 +1374,6 @@ intr_event_handle(struct intr_event *ie, struct trapframe *frame)
 
 	/*
 	 * Execute fast interrupt handlers directly.
-	 * To support clock handlers, if a handler registers
-	 * with a NULL argument, then we pass it a pointer to
-	 * a trapframe as its argument.
 	 */
 	td->td_intr_nesting_level++;
 	filter = false;
@@ -1405,12 +1402,8 @@ intr_event_handle(struct intr_event *ie, struct trapframe *frame)
 			continue;
 		}
 		CTR4(KTR_INTR, "%s: exec %p(%p) for %s", __func__,
-		    ih->ih_filter, ih->ih_argument == NULL ? frame :
-		    ih->ih_argument, ih->ih_name);
-		if (ih->ih_argument == NULL)
-			ret = ih->ih_filter(frame);
-		else
-			ret = ih->ih_filter(ih->ih_argument);
+		    ih->ih_filter, ih->ih_argument, ih->ih_name);
+		ret = ih->ih_filter(ih->ih_argument);
 #ifdef HWPMC_HOOKS
 		PMC_SOFT_CALL_TF( , , intr, all, frame);
 #endif


### PR DESCRIPTION
While otherwise a handy potential approach, getting the trap frame via the argument isn't documented and isn't supposed to be used.  With all uses removed, now remove support to end the mixed calling conventions.

Differential Revision: https://reviews.freebsd.org/D37688