### PR TITLE
Add MYKERNEL to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ tags
 .clangd
 .ccls-cache
 sys/*/compile
+MYKERNEL


### PR DESCRIPTION
This matches the handbook's suggestion to have custom kernels named `MYKERNEL`.