### PR TITLE
linprocfs: Add support for proc/sys/fs/mqueue/*

### DIFF
--- a/sys/compat/linprocfs/linprocfs.c
+++ b/sys/compat/linprocfs/linprocfs.c
@@ -2266,6 +2266,97 @@ again:
 }
 
 /*
+ * Filler function for proc/sys/fs/mqueue/msg_default
+ */
+static int
+linprocfs_domqueue_msg_default(PFS_FILL_ARGS)
+{
+	int res, error;
+	size_t size = sizeof(res);
+
+	error = kernel_sysctlbyname(curthread, "kern.mqueue.default_maxmsg",
+	    &res, &size, NULL, 0, 0, 0);
+	if (error != 0)
+		return (error);
+
+	sbuf_printf(sb, "%d\n", res);
+	return (0);
+}
+
+/*
+ * Filler function for proc/sys/fs/mqueue/msgsize_default
+ */
+static int
+linprocfs_domqueue_msgsize_default(PFS_FILL_ARGS)
+{
+	int res, error;
+	size_t size = sizeof(res);
+
+	error = kernel_sysctlbyname(curthread, "kern.mqueue.default_msgsize",
+	    &res, &size, NULL, 0, 0, 0);
+	if (error != 0)
+		return (error);
+
+	sbuf_printf(sb, "%d\n", res);
+	return (0);
+
+}
+
+/*
+ * Filler function for proc/sys/fs/mqueue/msg_max
+ */
+static int
+linprocfs_domqueue_msg_max(PFS_FILL_ARGS)
+{
+	int res, error;
+	size_t size = sizeof(res);
+
+	error = kernel_sysctlbyname(curthread, "kern.mqueue.maxmsg",
+	    &res, &size, NULL, 0, 0, 0);
+	if (error != 0)
+		return (error);
+
+	sbuf_printf(sb, "%d\n", res);
+	return (0);
+}
+
+/*
+ * Filler function for proc/sys/fs/mqueue/msgsize_max
+ */
+static int
+linprocfs_domqueue_msgsize_max(PFS_FILL_ARGS)
+{
+	int res, error;
+	size_t size = sizeof(res);
+
+	error = kernel_sysctlbyname(curthread, "kern.mqueue.maxmsgsize",
+	    &res, &size, NULL, 0, 0, 0);
+	if (error != 0)
+		return (error);
+
+	sbuf_printf(sb, "%d\n", res);
+	return (0);
+}
+
+/*
+ * Filler function for proc/sys/fs/mqueue/queues_max
+ */
+static int
+linprocfs_domqueue_queues_max(PFS_FILL_ARGS)
+{
+	int res, error;
+	size_t size = sizeof(res);
+
+	error = kernel_sysctlbyname(curthread, "kern.mqueue.maxmq",
+	    &res, &size, NULL, 0, 0, 0);
+	if (error != 0)
+		return (error);
+
+	sbuf_printf(sb, "%d\n", res);
+	return (0);
+}
+
+/*
  * Constructor
  */
 static int
@@ -2421,6 +2512,22 @@ linprocfs_init(PFS_INIT_ARGS)
 	pfs_create_file(dir, "sem", &linprocfs_dosysvipc_sem,
 	    NULL, NULL, NULL, PFS_RD);
 	pfs_create_file(dir, "shm", &linprocfs_dosysvipc_shm,
+	    NULL, NULL, NULL, PFS_RD);
+
+	/* /proc/sys/fs/... */
+	dir = pfs_create_dir(sys, "fs", NULL, NULL, NULL, 0);
+
+	/* /proc/sys/fs/mqueue/... */
+	dir = pfs_create_dir(dir, "mqueue", NULL, NULL, NULL, 0);
+	pfs_create_file(dir, "msg_default", &linprocfs_domqueue_msg_default,
+	    NULL, NULL, NULL, PFS_RD);
+	pfs_create_file(dir, "msgsize_default", &linprocfs_domqueue_msgsize_default,
+	    NULL, NULL, NULL, PFS_RD);
+	pfs_create_file(dir, "msg_max", &linprocfs_domqueue_msg_max,
+	    NULL, NULL, NULL, PFS_RD);
+	pfs_create_file(dir, "msgsize_max", &linprocfs_domqueue_msgsize_max,
+	    NULL, NULL, NULL, PFS_RD);
+	pfs_create_file(dir, "queues_max", &linprocfs_domqueue_queues_max,
 	    NULL, NULL, NULL, PFS_RD);
 
 	return (0);

--- a/sys/kern/uipc_mqueue.c
+++ b/sys/kern/uipc_mqueue.c
@@ -201,14 +201,18 @@ static SYSCTL_NODE(_kern, OID_AUTO, mqueue, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
 	"POSIX real time message queue");
 
 static int	default_maxmsg  = 10;
+SYSCTL_INT(_kern_mqueue, OID_AUTO, default_maxmsg, CTLFLAG_RD,
+    &default_maxmsg, 0, "Default maximum messages in queue");
 static int	default_msgsize = 1024;
+SYSCTL_INT(_kern_mqueue, OID_AUTO, default_msgsize, CTLFLAG_RD,
+    &default_msgsize, 0, "Default maximum message size");
 
 static int	maxmsg = 100;
 SYSCTL_INT(_kern_mqueue, OID_AUTO, maxmsg, CTLFLAG_RW,
-    &maxmsg, 0, "Default maximum messages in queue");
+    &maxmsg, 0, "maximum messages in queue");
 static int	maxmsgsize = 16384;
 SYSCTL_INT(_kern_mqueue, OID_AUTO, maxmsgsize, CTLFLAG_RW,
-    &maxmsgsize, 0, "Default maximum message size");
+    &maxmsgsize, 0, "maximum message size");
 static int	maxmq = 100;
 SYSCTL_INT(_kern_mqueue, OID_AUTO, maxmq, CTLFLAG_RW,
     &maxmq, 0, "maximum message queues");


### PR DESCRIPTION
TODO:
- Add support for mq_* syscalls
- Enhance documentation for linux(4) to include /dev/mqueue

```
$ grep . /compat/ubuntu/proc/sys/fs/mqueue/*
/compat/ubuntu/proc/sys/fs/mqueue/msg_default:10
/compat/ubuntu/proc/sys/fs/mqueue/msg_max:100
/compat/ubuntu/proc/sys/fs/mqueue/msgsize_default:1024
/compat/ubuntu/proc/sys/fs/mqueue/msgsize_max:16384
/compat/ubuntu/proc/sys/fs/mqueue/queues_max:100
```
