### PR TITLE
Avoid use after free in spa_export_common()

### DIFF
--- a/sys/contrib/openzfs/module/zfs/spa.c
+++ b/sys/contrib/openzfs/module/zfs/spa.c
@@ -7087,6 +7087,10 @@ export_spa:
 	if (new_state != POOL_STATE_UNINITIALIZED) {
 		if (!hardforce)
 			spa_write_cachefile(spa, B_TRUE, B_TRUE, B_FALSE);
+
+		if (new_state == POOL_STATE_EXPORTED)
+			zio_handle_export_delay(spa, gethrtime() - export_start);
+
 		spa_remove(spa);
 	} else {
 		/*
@@ -7096,9 +7100,6 @@ export_spa:
 		 */
 		spa->spa_is_exporting = B_FALSE;
 	}
-
-	if (new_state == POOL_STATE_EXPORTED)
-		zio_handle_export_delay(spa, gethrtime() - export_start);
 
 	mutex_exit(&spa_namespace_lock);
 	return (0);


### PR DESCRIPTION
Note that I am not familiar with this code; after a quick analysis this looks like what was initially intended.

This code is still found upstream at
https://github.com/openzfs/zfs/blob/master/module/zfs/spa.c#L7105.

Reported by:	Coverity
CID:		1545056
Sponsored by:	The FreeBSD Foundation