### PR TITLE
bhyve: avoid resource leak

### DIFF
--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -505,7 +505,7 @@ _ipfw_nptv6=	ipfw_nptv6
 _ipfilter=	ipfilter
 .endif
 
-.if ${MK_INET_SUPPORT} != "no" && ${KERN_OPTS:MFIB_ALGO}
+.if ${MK_INET_SUPPORT} != "no" && ${KERN_OPTS:MFIB_ALGO} && ${KERN_OPTS:MINET}
 _dpdk_lpm4=	dpdk_lpm4
 _fib_dxr=	fib_dxr
 .endif

--- a/usr.sbin/bhyve/bhyverun.c
+++ b/usr.sbin/bhyve/bhyverun.c
@@ -593,6 +593,7 @@ bhyve_parse_config_option(const char *option)
 	if (path == NULL)
 		err(4, "Failed to allocate memory");
 	set_config_value(path, value + 1);
+	free(path);
 	return (true);
 }
 


### PR DESCRIPTION
In bhyve_parse_config_option(), a string is allocated and passed to nvlist_add_string() but not free'd afterwards.

Reported by:	Coverity
CID:		1544049
Sponsored by:	The FreeBSD Foundation