### PR TITLE
ctladm: fix resource leak

### DIFF
--- a/usr.sbin/bhyve/bhyverun.c
+++ b/usr.sbin/bhyve/bhyverun.c
@@ -593,6 +593,7 @@ bhyve_parse_config_option(const char *option)
 	if (path == NULL)
 		err(4, "Failed to allocate memory");
 	set_config_value(path, value + 1);
+	free(path);
 	return (true);
 }
 

--- a/usr.sbin/ctladm/ctladm.c
+++ b/usr.sbin/ctladm/ctladm.c
@@ -3920,7 +3920,6 @@ cctl_nvlist_end_element(void *user_data, const char *name)
 		str = NULL;
 	} else if (strcmp(name, "trtype") == 0) {
 		cur_conn->trtype = atoi(str);
-		str = NULL;
 	} else if (strcmp(name, "connection") == 0) {
 		nvlist->cur_conn = NULL;
 	} else if (strcmp(name, "ctlnvmflist") == 0) {


### PR DESCRIPTION
The str variable in cctl_nvlist_end_element() does not get free()'d when converted to an integer value. (name is "trtype")

Reported by:	Coverity Scan
Coverity ID:	1545039
Sponsored by:	The FreeBSD Foundation