### PR TITLE
libnvmf: avoid resource leak

### DIFF
--- a/lib/libnvmf/nvmf_host.c
+++ b/lib/libnvmf/nvmf_host.c
@@ -653,19 +653,23 @@ nvmf_host_fetch_discovery_log_page(struct nvmf_qpair *qp,
 	log = NULL;
 	for (;;) {
 		error = nvmf_get_discovery_log_page(qp, 0, &hdr, sizeof(hdr));
-		if (error != 0)
+		if (error != 0) {
+			free(log);
 			return (error);
+		}
 		nvme_discovery_log_swapbytes(&hdr);
 
 		if (hdr.recfmt != 0) {
 			printf("NVMF: Unsupported discovery log format: %d\n",
 			    hdr.recfmt);
+			free(log);
 			return (EINVAL);
 		}
 
 		if (hdr.numrec > 1024) {
 			printf("NVMF: Too many discovery log entries: %ju\n",
 			    (uintmax_t)hdr.numrec);
+			free(log);
 			return (EFBIG);
 		}
 

--- a/share/man/man4/smb.4
+++ b/share/man/man4/smb.4
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifer: BSD-2-Clause
+.\"
 .\" Copyright (c) 1998, Nicolas Souchu
 .\" Copyright (c) 2004, Joerg Wunsch
 .\" Copyright (c) 2015, Michael Gmelin <freebsd@grem.de>
@@ -29,7 +32,7 @@
 .Os
 .Sh NAME
 .Nm smb
-.Nd SMB generic I/O device driver
+.Nd System Management Bus generic I/O device driver
 .Sh SYNOPSIS
 .Cd "device smb"
 .Sh DESCRIPTION

--- a/share/man/man4/smbfs.4
+++ b/share/man/man4/smbfs.4
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2020 Gordon Bergling
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -26,7 +29,7 @@
 .Os
 .Sh NAME
 .Nm smbfs
-.Nd "SMB FS"
+.Nd server message block (SMB1/CIFS) file system
 .Sh SYNOPSIS
 To compile this driver into the kernel,
 place the following lines in your

--- a/share/man/man4/unionfs.4
+++ b/share/man/man4/unionfs.4
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2020 Gordon Bergling
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -26,7 +29,7 @@
 .Os
 .Sh NAME
 .Nm unionfs
-.Nd "UNION FS"
+.Nd union mount file system
 .Sh SYNOPSIS
 To compile this driver into the kernel,
 place the following lines in your

--- a/usr.sbin/autofs/auto_master.5
+++ b/usr.sbin/autofs/auto_master.5
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2014 The FreeBSD Foundation
 .\"
 .\" This software was developed by Edward Tomasz Napierala under sponsorship
@@ -246,7 +249,7 @@ Special maps have names beginning with
 .Li - .
 Supported special maps are:
 .Pp
-.Bl -tag -width "-hosts" -compact
+.Bl -tag -width "-noauto" -compact
 .It Li -hosts
 Query the remote NFS server and map exported shares.
 This map is traditionally mounted on

--- a/usr.sbin/autofs/automount.8
+++ b/usr.sbin/autofs/automount.8
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2014 The FreeBSD Foundation
 .\"
 .\" This software was developed by Edward Tomasz Napierala under sponsorship
@@ -49,7 +52,7 @@ or unmounts
 .Xr autofs 4
 filesystems to match.
 These options are available:
-.Bl -tag -width ".Fl v"
+.Bl -tag -width "-D"
 .It Fl D
 Define a variable.
 It is only useful with

--- a/usr.sbin/autofs/automountd.8
+++ b/usr.sbin/autofs/automountd.8
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2014 The FreeBSD Foundation
 .\"
 .\" This software was developed by Edward Tomasz Napierala under sponsorship
@@ -54,7 +57,7 @@ forks a child process.
 The child process parses the appropriate map and mounts filesystems accordingly.
 Then it signals the kernel to release blocked processes that were waiting
 for the mount.
-.Bl -tag -width ".Fl v"
+.Bl -tag -width "-m maxproc"
 .It Fl D
 Define a variable.
 .It Fl i

--- a/usr.sbin/autofs/autounmountd.8
+++ b/usr.sbin/autofs/autounmountd.8
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2014 The FreeBSD Foundation
 .\"
 .\" This software was developed by Edward Tomasz Napierala under sponsorship
@@ -52,7 +55,7 @@ After a specified time passes,
 attempts to unmount a filesystem, retrying after some time if necessary.
 .Pp
 These options are available:
-.Bl -tag -width ".Fl v"
+.Bl -tag -width "-d"
 .It Fl d
 Debug mode: increase verbosity and do not daemonize.
 .It Fl r


### PR DESCRIPTION
In nvmf_host_fetch_discovery_log_page(), the log variable may have been allocated on the heap during a first loop cycle, and should be free()'d again before exiting upon errors.

Reported by:	Coverity
CID:		1545034
Sponsored by:	The FreeBSD Foundation