### PR TITLE
sound: avoid potential crash upon naming error

### DIFF
--- a/sys/dev/sound/pcm/channel.c
+++ b/sys/dev/sound/pcm/channel.c
@@ -1236,6 +1236,8 @@ chn_init(struct snddev_info *d, struct pcm_channel *parent, kobj_class_t cls,
 	}
 
 	PCM_UNLOCK(d);
+	b = NULL;
+	bs = NULL;
 	c = malloc(sizeof(*c), M_DEVBUF, M_WAITOK | M_ZERO);
 	c->methods = kobj_create(cls, M_DEVBUF, M_WAITOK | M_ZERO);
 	c->type = type;
@@ -1257,8 +1259,6 @@ chn_init(struct snddev_info *d, struct pcm_channel *parent, kobj_class_t cls,
 	snprintf(c->name, sizeof(c->name), "%s:%s:%s",
 	    device_get_nameunit(c->dev), dirs, devname);
 
-	b = NULL;
-	bs = NULL;
 	CHN_INIT(c, children);
 	CHN_INIT(c, children.busy);
 	c->devinfo = NULL;


### PR DESCRIPTION
In chn_init(), if dsp_unit2name() fails, the code sets ret to EINVAL and jumps to the out2 label, where the b and bs snd_dbuf variables may be destroyed without having been initialized in the first place.

Reported by:	Coverity Scan
CID:		1545029
CID:		1545025
Sponsored by:	The FreeBSD Foundation