### PR TITLE
bhyve: avoid side effect in assertion

### DIFF
--- a/usr.sbin/bhyve/tpm_ppi_qemu.c
+++ b/usr.sbin/bhyve/tpm_ppi_qemu.c
@@ -161,7 +161,7 @@ tpm_ppi_deinit(void *sc)
 	ppi = sc;
 
 	error = unregister_mem(&ppi_mmio);
-	assert(error = 0);
+	assert(error == 0);
 
 	free(ppi);
 }


### PR DESCRIPTION
An assert() was setting the error variable instead of checking it.

Reported by:	Coverity Scan
CID:		1521431
Sponsored by:	The FreeBSD Foundation