### PR TITLE
Fix "version introduced" in two manual pages

### DIFF
--- a/lib/libc/gen/exec.3
+++ b/lib/libc/gen/exec.3
@@ -344,7 +344,7 @@ function first appeared in
 The
 .Fn execvpe
 function first appeared in
-.Fx 15.0 .
+.Fx 14.1 .
 .Sh BUGS
 The type of the
 .Fa argv

--- a/usr.bin/posixmqcontrol/posixmqcontrol.1
+++ b/usr.bin/posixmqcontrol/posixmqcontrol.1
@@ -172,7 +172,7 @@ info reports a worst-case estimate for QSIZE.
 The
 .Nm
 command appeared in
-.Fx 15.0 .
+.Fx 14.1 .
 .Sh AUTHORS
 The
 .Nm


### PR DESCRIPTION
I discovered these mistakes by running `git grep -F '.Fx 15'` against the `releng/14.1` branch.

Please merge these changes to `stable/14` and `releng/14.1`.