### PR TITLE
cross: Move Solaris API64 defines to common

### DIFF
--- a/tools/build/cross-build/include/common/sys/_types.h
+++ b/tools/build/cross-build/include/common/sys/_types.h
@@ -45,3 +45,6 @@
  * Neither GLibc nor macOS define __va_list but many FreeBSD headers require it.
  */
 typedef __builtin_va_list __va_list;
+
+/* Needed for opensolaris compat. */
+typedef	__int64_t	off64_t;

--- a/tools/build/cross-build/include/mac/sys/_types.h
+++ b/tools/build/cross-build/include/mac/sys/_types.h
@@ -41,5 +41,3 @@
  * __darwin_ct_rune_t exists.
  */
 typedef __darwin_ct_rune_t __ct_rune_t;
-/* Needed for opensolaris compat. */
-typedef	__int64_t	off64_t;


### PR DESCRIPTION
off64_t is needed for both Linux and MacOS, so move them to the common area.

For testing purposes only...