### PR TITLE
improve LINT-NOINET{6,}

### DIFF
--- a/sys/amd64/conf/LINT-NOINET
+++ b/sys/amd64/conf/LINT-NOINET
@@ -1,7 +1,4 @@
 
 include LINT
 ident LINT-NOINET
-makeoptions MKMODULESENV+="WITHOUT_INET_SUPPORT="
 nooptions INET
-nodevice gre
-nodevice netmap

--- a/sys/amd64/conf/LINT-NOINET6
+++ b/sys/amd64/conf/LINT-NOINET6
@@ -1,5 +1,4 @@
 
 include LINT
 ident LINT-NOINET6
-makeoptions MKMODULESENV+="WITHOUT_INET6_SUPPORT="
 nooptions INET6

--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -490,7 +490,7 @@ _sctp=		sctp
 _if_stf=	if_stf
 .endif
 
-.if ${MK_INET_SUPPORT} != "no" || defined(ALL_MODULES)
+.if (${KERN_OPTS:MINET} && ${MK_INET_SUPPORT} != "no") || defined(ALL_MODULES)
 _if_me=		if_me
 _ipfw=		ipfw
 .if ${MK_INET6_SUPPORT} != "no" || defined(ALL_MODULES)


### PR DESCRIPTION
also includes a required fix for the ipfw module after this change.

tested both kernel configs with buildkernel on amd64.