### PR TITLE
dhclient: remove unused primary_address

### DIFF
--- a/sbin/dhclient/dhcpd.h
+++ b/sbin/dhclient/dhcpd.h
@@ -199,7 +199,6 @@ struct client_state {
 struct interface_info {
 	struct interface_info	*next;
 	struct hardware		 hw_address;
-	struct in_addr		 primary_address;
 	char			 name[IFNAMSIZ];
 	int			 rfdesc;
 	int			 wfdesc;


### PR DESCRIPTION
Its last use was removed in 396c7521364.

Also see: https://reviews.freebsd.org/D42717