### PR TITLE
rc: improve NAME_setup handling

### DIFF
--- a/libexec/rc/rc.subr
+++ b/libexec/rc/rc.subr
@@ -975,7 +975,8 @@ startmsg()
 #
 #	${name}_prepend	n	Command added before ${command}.
 #
-#	${name}_setup	n	Command executed before ${command}.
+#	${name}_setup	n	Command executed during start, restart and
+#				reload before ${rc_arg}_precmd is run.
 #
 #	${name}_login_class n	Login class to use, else "daemon".
 #
@@ -1287,9 +1288,9 @@ run_rc_command()
 			return 1
 		fi
 
-					# if there's a custom ${XXX_cmd},
-					# run that instead of the default
-					#
+		# if there's a custom ${XXX_cmd},
+		# run that instead of the default
+		#
 		eval _cmd=\$${rc_arg}_cmd \
 		     _precmd=\$${rc_arg}_precmd \
 		     _postcmd=\$${rc_arg}_postcmd
@@ -1301,6 +1302,14 @@ run_rc_command()
 			fi
 
 			if [ "${_rc_svcj}" != jailing ]; then
+				# service can redefine all so
+				# check for valid setup target
+				if [ "$rc_arg" = 'start' -o \
+				    "$rc_arg" = 'restart' -o \
+				    "$rc_arg" = 'reload' ]; then
+					_run_rc_setup || \
+					    warn "failed to setup ${name}"
+				fi
 				_run_rc_precmd || return 1
 			fi
 			if ! checkyesno ${name}_svcj; then
@@ -1400,6 +1409,8 @@ run_rc_command()
 			fi
 
 			if [ "${_rc_svcj}" != jailing ]; then
+				_run_rc_setup || warn "failed to setup ${name}"
+
 				if ! _run_rc_precmd; then
 					warn "failed precmd routine for ${name}"
 					return 1
@@ -1416,8 +1427,8 @@ run_rc_command()
 				fi
 			fi
 
-					# setup the full command to run
-					#
+			# setup the full command to run
+			#
 			startmsg "Starting ${name}."
 			if [ -n "$_chroot" ]; then
 				_cd=
@@ -1448,15 +1459,8 @@ $_cpusetcmd $command $rc_flags $command_args"
 				fi
 			fi
 
-			if [ -n "$_setup" ]; then
-				if ! _run_rc_doit "$_setup"; then
-					warn "failed to setup ${name}"
-				fi
-			fi
-
-					# Prepend default limits
+			# Prepend default limits
 			_doit="$_cd limits -C $_login_class $_limits $_doit"
-
 
 			local _really_run_it=true
 			if checkyesno ${name}_svcj; then
@@ -1466,8 +1470,8 @@ $_cpusetcmd $command $rc_flags $command_args"
 			fi
 
 			if [ "$_really_run_it" = true ]; then
-					# run the full command
-					#
+				# run the full command
+				#
 				if ! _run_rc_doit "$_doit"; then
 					warn "failed to start ${name}"
 					return 1
@@ -1475,8 +1479,8 @@ $_cpusetcmd $command $rc_flags $command_args"
 			fi
 
 			if [ "${_rc_svcj}" != jailing ]; then
-					# finally, run postcmd
-					#
+				# finally, run postcmd
+				#
 				_run_rc_postcmd
 			fi
 			;;
@@ -1490,14 +1494,14 @@ $_cpusetcmd $command $rc_flags $command_args"
 
 			_run_rc_precmd || return 1
 
-					# send the signal to stop
-					#
+			# send the signal to stop
+			#
 			echo "Stopping ${name}."
 			_doit=$(_run_rc_killcmd "${sig_stop:-TERM}")
 			_run_rc_doit "$_doit" || return 1
 
-					# wait for the command to exit,
-					# and run postcmd.
+			# wait for the command to exit,
+			# and run postcmd.
 			wait_for_pids $rc_pid
 
 			if checkyesno ${name}_svcj; then
@@ -1514,6 +1518,8 @@ $_cpusetcmd $command $rc_flags $command_args"
 				return 1
 			fi
 
+			_run_rc_setup || warn "failed to setup ${name}"
+
 			_run_rc_precmd || return 1
 
 			_doit=$(_run_rc_killcmd "${sig_reload:-HUP}")
@@ -1523,9 +1529,11 @@ $_cpusetcmd $command $rc_flags $command_args"
 			;;
 
 		restart)
-					# prevent restart being called more
-					# than once by any given script
-					#
+			_run_rc_setup || warn "failed to setup ${name}"
+
+			# prevent restart being called more
+			# than once by any given script
+			#
 			if ${_rc_restart_done:-false}; then
 				return 0
 			fi
@@ -1638,6 +1646,7 @@ $_cpusetcmd $command $rc_flags $command_args"
 #	_precmd		R
 #	_postcmd	R
 #	_return		W
+#	_setup		R
 #
 _run_rc_precmd()
 {
@@ -1665,6 +1674,20 @@ _run_rc_postcmd()
 		debug "run_rc_command: ${rc_arg}_postcmd: $_postcmd $rc_extra_args"
 		eval "$_postcmd $rc_extra_args"
 		_return=$?
+	fi
+	return 0
+}
+
+_run_rc_setup()
+{
+	# prevent multiple execution on restart => stop/start split
+	if ! ${_rc_restart_done:-false} && [ -n "$_setup" ]; then
+		debug "run_rc_command: ${rc_arg}_setup: $_setup"
+		eval "$_setup"
+		_return=$?
+		if [ $_return -ne 0 ]; then
+			return 1
+		fi
 	fi
 	return 0
 }

--- a/share/man/man8/rc.subr.8
+++ b/share/man/man8/rc.subr.8
@@ -27,7 +27,7 @@
 .\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd February 10, 2024
+.Dd May 28, 2024
 .Dt RC.SUBR 8
 .Os
 .Sh NAME
@@ -826,8 +826,15 @@ This is a generic version of
 or
 .Va ${name}_nice .
 .It Va ${name}_setup
-Command to be run prior to
-.Va command .
+Optional command to be run during
+.Cm start ,
+.Cm restart ,
+and
+.Cm reload
+prior to the respective
+.Ar argument Ns Va _precmd .
+If the command fails for any reason it will output a warning,
+but execution will continue.
 .It Ar argument Ns Va _cmd
 Shell commands which override the default method for
 .Ar argument .


### PR DESCRIPTION
Reload is used for service reconfiguration as well and lacks a NAME_prepend-like mechanism so it makes sense to extend the NAME_reload hook into this
action.

precmd may use configuration checks and blocks setup from doing its designated work (e.g. nginx).  In moving the invoke of the setup script in front allows us to provide custom scripts for config file generation and fixing prior to precmd checking configuration integrity.

Also introduce _run_rc_setup to separate the launcher from the main one.  Let it run correctly in the case of restart_precmd and block further execution as
would be the case in start due to the internal plumbing of restart being split into calling stop and start afterwards.

Also see: https://reviews.freebsd.org/D36259