### PR TITLE
export $autoboot var when running from $boottrace_cmd to fix root check root check if boottrace is enabled

### DIFF
--- a/libexec/rc/rc.subr
+++ b/libexec/rc/rc.subr
@@ -1856,7 +1856,8 @@ boottrace_fn()
 		set $_arg; . $_file
 		boottrace_sysctl "$_file done"
 	else
-		$boottrace_cmd "$_file" "$_arg"
+		_boot="${_boot}" rc_fast="${rc_fast}" autoboot="${autoboot}" \
+		    $boottrace_cmd "$_file" "$_arg"
 	fi
 }
 


### PR DESCRIPTION
At the moment, if bootrace profiling is enabled, autoboot is not exported to the rc scripts. This causes fsck to not check the root filesystem.  See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=278993