### PR TITLE
bhyve: correctly remove a memory mapping

### DIFF
--- a/usr.sbin/bhyve/amd64/pci_gvt-d.c
+++ b/usr.sbin/bhyve/amd64/pci_gvt-d.c
@@ -220,7 +220,7 @@ gvt_d_setup_opregion(struct pci_devinst *const pi)
 
 	opregion->hpa = asls;
 	opregion->len = header->size * KB;
-	munmap(header, sizeof(header));
+	munmap(header, sizeof(*header));
 
 	opregion->hva = mmap(NULL, opregion->len * KB, PROT_READ, MAP_SHARED,
 	    memfd, opregion->hpa);


### PR DESCRIPTION
In a normal code path while setting up GPU passthrough, the size parameter to munmap() is wrong and its operation not checked for errors, therefore leaking resources.

Reported by:	Coverity Scan
CID:		1519830
Sponsored by:	The FreeBSD Foundation