### PR TITLE
smbfs manuals: describe consistently

### DIFF
--- a/contrib/smbfs/mount_smbfs/mount_smbfs.8
+++ b/contrib/smbfs/mount_smbfs/mount_smbfs.8
@@ -1,11 +1,10 @@
 .\" $Id: mount_smbfs.8,v 1.10 2002/04/16 02:47:41 bp Exp $
-.\" $FreeBSD$
 .Dd November 1, 2018
 .Dt MOUNT_SMBFS 8
 .Os
 .Sh NAME
 .Nm mount_smbfs
-.Nd "mount a shared resource from an SMB file server"
+.Nd mount a server message block (SMB1/CIFS) file system
 .Sh SYNOPSIS
 .Nm
 .Op Fl E Ar cs1 Ns Cm \&: Ns Ar cs2

--- a/contrib/smbfs/smbutil/smbutil.1
+++ b/contrib/smbfs/smbutil/smbutil.1
@@ -4,7 +4,7 @@
 .Os
 .Sh NAME
 .Nm smbutil
-.Nd "interface to the SMB requester"
+.Nd interface to the server message block (SMB1/CIFS) requester
 .Sh SYNOPSIS
 .Nm
 .Op Fl hv

--- a/share/man/man5/nsmb.conf.5
+++ b/share/man/man5/nsmb.conf.5
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003
 .\" Originally written by Sergey A. Osokin
 .\" Rewritten by Tom Rhodes
@@ -28,9 +31,7 @@
 .Os
 .Sh NAME
 .Nm nsmb.conf
-.Nd configuration file for
-.Tn SMB
-requests
+.Nd configuration file for server message block (SMB1/CIFS) requests
 .Sh DESCRIPTION
 The
 .Nm


### PR DESCRIPTION
Not sure if it's sane to remove the "resource" keyword from mount_smbfs,
but with this change mount_smbfs will look more like the other mount tools.
Also all of our SMB1 stuff will have consistent descriptions and respond intelligently to "apropos {server message block, CIFS, SMB}".

Tested on our beautiful standard console, nothing wraps.

I trimmed one /$FreeBSD$ and added one SPDX, that's all I could do with that.
Lately I'm wondering if it's appropriate for me to make noise about that in commit log?

Rationale: I like our SMB1/CIFS driver, and tooling previously hard to distinguish from SMBus
MFC after: 3 days