### PR TITLE
smbus manuals: include term SMBus in description

### DIFF
--- a/contrib/smbfs/mount_smbfs/mount_smbfs.8
+++ b/contrib/smbfs/mount_smbfs/mount_smbfs.8
@@ -1,11 +1,10 @@
 .\" $Id: mount_smbfs.8,v 1.10 2002/04/16 02:47:41 bp Exp $
-.\" $FreeBSD$
 .Dd November 1, 2018
 .Dt MOUNT_SMBFS 8
 .Os
 .Sh NAME
 .Nm mount_smbfs
-.Nd "mount a shared resource from an SMB file server"
+.Nd mount a server message block (SMB1/CIFS) file system
 .Sh SYNOPSIS
 .Nm
 .Op Fl E Ar cs1 Ns Cm \&: Ns Ar cs2

--- a/contrib/smbfs/smbutil/smbutil.1
+++ b/contrib/smbfs/smbutil/smbutil.1
@@ -4,7 +4,7 @@
 .Os
 .Sh NAME
 .Nm smbutil
-.Nd "interface to the SMB requester"
+.Nd interface to the server message block (SMB1/CIFS) requester
 .Sh SYNOPSIS
 .Nm
 .Op Fl hv

--- a/share/man/man4/iicsmb.4
+++ b/share/man/man4/iicsmb.4
@@ -1,5 +1,7 @@
-.\" Copyright (c) 1998, Nicolas Souchu
-.\" All rights reserved.
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
+.\" Copyright (c) 1998, Nicolas Souchu. All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions
@@ -27,7 +29,7 @@
 .Os
 .Sh NAME
 .Nm iicsmb
-.Nd I2C to SMB bridge
+.Nd I2C to SMBus bridge
 .Sh SYNOPSIS
 .Cd "device iicsmb"
 .Pp

--- a/share/man/man4/smb.4
+++ b/share/man/man4/smb.4
@@ -32,7 +32,7 @@
 .Os
 .Sh NAME
 .Nm smb
-.Nd System Management Bus generic I/O device driver
+.Nd System Management Bus (SMBus) generic I/O device driver
 .Sh SYNOPSIS
 .Cd "device smb"
 .Sh DESCRIPTION

--- a/share/man/man5/nsmb.conf.5
+++ b/share/man/man5/nsmb.conf.5
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003
 .\" Originally written by Sergey A. Osokin
 .\" Rewritten by Tom Rhodes
@@ -28,9 +31,7 @@
 .Os
 .Sh NAME
 .Nm nsmb.conf
-.Nd configuration file for
-.Tn SMB
-requests
+.Nd configuration file for server message block (SMB1/CIFS) requests
 .Sh DESCRIPTION
 The
 .Nm


### PR DESCRIPTION
I'm sorry I didn't realize this last round.
This and the other PR finishes the description differentiation for "apropos smb"

Fixes: 5ad3b09f2fe9 (smb: distinguishable descriptions)
MFC after: 3 days

Related: https://www.reddit.com/r/ProgrammerHumor/comments/1ci0me1/welp/