### PR TITLE
iwl-devtrace.c: remove leftover FBSDID

### DIFF
--- a/sys/contrib/dev/iwlwifi/iwl-devtrace.c
+++ b/sys/contrib/dev/iwlwifi/iwl-devtrace.c
@@ -27,7 +27,6 @@
  */
 
 #include <sys/cdefs.h>
-__FBSDID("$FreeBSD$");
 
 #include "iwl-devtrace.h"
 


### PR DESCRIPTION
I found it when browsing the iwlwifi source code.