### PR TITLE
mdconfig: don't print NUL in the options list

### DIFF
--- a/sbin/mdconfig/mdconfig.c
+++ b/sbin/mdconfig/mdconfig.c
@@ -409,7 +409,7 @@ print_options(const char *dev, const char *file)
 {
 	struct md_ioctl mdiox;
 	int unit;
-	char sep = '\0';
+	const char *sep = "";
 
 	if (sscanf(dev, "md%d", &unit) != 1)
 		err(1, "invalid device: %s", dev);
@@ -427,40 +427,40 @@ print_options(const char *dev, const char *file)
 
 	printf("\t");
 	if (mdiox.md_options & MD_ASYNC) {
-		printf("%casync", sep);
-		sep = ',';
+		printf("%sasync", sep);
+		sep = ",";
 	}
 	if (mdiox.md_options & MD_CACHE) {
-		printf("%ccache", sep);
-		sep = ',';
+		printf("%scache", sep);
+		sep = ",";
 	}
 	if (mdiox.md_options & MD_CLUSTER) {
-		printf("%ccluster", sep);
-		sep = ',';
+		printf("%scluster", sep);
+		sep = ",";
 	}
 	if (mdiox.md_options & MD_COMPRESS) {
-		printf("%ccompress", sep);
-		sep = ',';
+		printf("%scompress", sep);
+		sep = ",";
 	}
 	if (mdiox.md_options & MD_FORCE) {
-		printf("%cforce", sep);
-		sep = ',';
+		printf("%sforce", sep);
+		sep = ",";
 	}
 	if (mdiox.md_options & MD_READONLY) {
-		printf("%creadonly", sep);
-		sep = ',';
+		printf("%sreadonly", sep);
+		sep = ",";
 	}
 	if (mdiox.md_options & MD_RESERVE) {
-		printf("%creserve", sep);
-		sep = ',';
+		printf("%sreserve", sep);
+		sep = ",";
 	}
 	if (mdiox.md_options & MD_VERIFY) {
-		printf("%cverify", sep);
-		sep = ',';
+		printf("%sverify", sep);
+		sep = ",";
 	}
 	if (mdiox.md_options & MD_MUSTDEALLOC) {
-		printf("%cmustdealloc", sep);
-		sep = ',';
+		printf("%smustdealloc", sep);
+		sep = ",";
 	}
 }
 

--- a/sbin/mdconfig/tests/mdconfig_test.sh
+++ b/sbin/mdconfig/tests/mdconfig_test.sh
@@ -296,6 +296,25 @@ attach_size_rounddown_cleanup()
 	cleanup_common
 }
 
+atf_test_case query_verbose cleanup
+query_verbose()
+{
+	atf_set "descr" "mdconfig -lv should print device details"
+}
+query_verbose_body()
+{
+	atf_check -s exit:0 -o save:mdconfig.out \
+	    -x 'mdconfig -a -t swap -s 1m -o reserve -o force'
+	md=$(cat mdconfig.out)
+	atf_check -s exit:0 \
+		-o match:"$md[[:space:]]+swap[[:space:]]+1024K[[:space:]]+[-][[:space:]]+[-][[:space:]]+force,reserve" \
+	-x "mdconfig -lv -u $md"
+}
+query_verbose_cleanup()
+{
+	cleanup_common
+}
+
 atf_init_test_cases()
 {
 	atf_add_test_case attach_vnode_non_explicit_type
@@ -307,4 +326,5 @@ atf_init_test_cases()
 	atf_add_test_case attach_swap
 	atf_add_test_case attach_with_specific_unit_number
 	atf_add_test_case attach_size_rounddown
+	atf_add_test_case query_verbose
 }


### PR DESCRIPTION
MFC with:	b01988d5e570158534110ca309fe93112c5c62f1
Sponsored by:	Axcient