### PR TITLE
mdconfig: remove the "cluster" option.

### DIFF
--- a/sbin/mdconfig/mdconfig.8
+++ b/sbin/mdconfig/mdconfig.8
@@ -33,7 +33,7 @@
 .\" SUCH DAMAGE.
 .\" from: src/usr.sbin/vnconfig/vnconfig.8,v 1.19 2000/12/27 15:30:29
 .\"
-.Dd August 27, 2021
+.Dd June 1, 2024
 .Dt MDCONFIG 8
 .Os
 .Sh NAME
@@ -230,8 +230,6 @@ option tends to waste memory by giving unwanted double caching,
 but it saves time if there is memory to spare.
 .It Oo Cm no Oc Ns Cm reserve
 Allocate and reserve all needed storage from the start, rather than as needed.
-.It Oo Cm no Oc Ns Cm cluster
-Enable clustering on this disk.
 .It Oo Cm no Oc Ns Cm compress
 Enable/disable compression features to reduce memory usage.
 .It Oo Cm no Oc Ns Cm force

--- a/sbin/mdconfig/mdconfig.c
+++ b/sbin/mdconfig/mdconfig.c
@@ -87,7 +87,7 @@ usage(void)
 "       mdconfig -l [-v] [-n] [-f file] [-u unit]\n"
 "       mdconfig file\n");
 	fprintf(stderr, "\t\ttype = {malloc, vnode, swap}\n");
-	fprintf(stderr, "\t\toption = {async, cache, cluster, compress,\n");
+	fprintf(stderr, "\t\toption = {async, cache, compress,\n");
 	fprintf(stderr, "\t\t          force, mustdealloc, readonly, ro,\n");
 	fprintf(stderr, "\t\t          reserve, verify}\n");
 	fprintf(stderr, "\t\tsize = %%d (512 byte blocks), %%db (B),\n");
@@ -156,13 +156,13 @@ main(int argc, char **argv)
 				mdio.md_options |= MD_AUTOUNIT | MD_COMPRESS;
 			} else if (!strcmp(optarg, "vnode")) {
 				mdio.md_type = MD_VNODE;
-				mdio.md_options |= MD_CLUSTER | MD_AUTOUNIT | MD_COMPRESS;
+				mdio.md_options |= MD_AUTOUNIT | MD_COMPRESS;
 			} else if (!strcmp(optarg, "swap")) {
 				mdio.md_type = MD_SWAP;
-				mdio.md_options |= MD_CLUSTER | MD_AUTOUNIT | MD_COMPRESS;
+				mdio.md_options |= MD_AUTOUNIT | MD_COMPRESS;
 			} else if (!strcmp(optarg, "null")) {
 				mdio.md_type = MD_NULL;
-				mdio.md_options |= MD_CLUSTER | MD_AUTOUNIT | MD_COMPRESS;
+				mdio.md_options |= MD_AUTOUNIT | MD_COMPRESS;
 			} else
 				errx(1, "unknown type: %s", optarg);
 			break;
@@ -182,6 +182,10 @@ main(int argc, char **argv)
 				mdio.md_options |= MD_CACHE;
 			else if (!strcmp(optarg, "nocache"))
 				mdio.md_options &= ~MD_CACHE;
+			/* 
+			 * For backwards-compatibility, continue to recognize
+			 * "cluster"
+			 */
 			else if (!strcmp(optarg, "cluster"))
 				mdio.md_options |= MD_CLUSTER;
 			else if (!strcmp(optarg, "nocluster"))
@@ -282,13 +286,11 @@ main(int argc, char **argv)
 			if (fflag != NULL || argc > 0) {
 				/* Imply ``-t vnode'' */
 				mdio.md_type = MD_VNODE;
-				mdio.md_options |= MD_CLUSTER | MD_AUTOUNIT |
-				    MD_COMPRESS;
+				mdio.md_options |= MD_AUTOUNIT | MD_COMPRESS;
 			} else if (sflag != NULL) {
 				/* Imply ``-t swap'' */
 				mdio.md_type = MD_SWAP;
-				mdio.md_options |= MD_CLUSTER | MD_AUTOUNIT |
-				    MD_COMPRESS;
+				mdio.md_options |= MD_AUTOUNIT | MD_COMPRESS;
 			} else
 				errx(1, "unable to determine type");
 		}
@@ -432,10 +434,6 @@ print_options(const char *dev, const char *file)
 	}
 	if (mdiox.md_options & MD_CACHE) {
 		printf("%scache", sep);
-		sep = ",";
-	}
-	if (mdiox.md_options & MD_CLUSTER) {
-		printf("%scluster", sep);
 		sep = ",";
 	}
 	if (mdiox.md_options & MD_COMPRESS) {


### PR DESCRIPTION
It's never had any effect.  The kernel ignores it.  Remove it from the documentation.  But continue to parse it on the command line, for backwards-compatibility.