### PR TITLE
build(7): increase visibility

### DIFF
--- a/share/man/man7/build.7
+++ b/share/man/man7/build.7
@@ -30,7 +30,9 @@
 .Os
 .Sh NAME
 .Nm build
-.Nd General instructions on how to build the system
+.Nd general instructions on how to build the
+.Fx
+system
 .Sh DESCRIPTION
 The sources for the
 .Fx
@@ -901,6 +903,7 @@ make TARGET_ARCH=armv6 DESTDIR=/clients/arm installworld installkernel
 .Xr make.conf 5 ,
 .Xr src.conf 5 ,
 .Xr arch 7 ,
+.Xr development 7 ,
 .Xr pkg 7 ,
 .Xr ports 7 ,
 .Xr release 7 ,

--- a/share/man/man7/build.7
+++ b/share/man/man7/build.7
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2000
 .\"	Mike W. Meyer
 .\"
@@ -891,11 +894,6 @@ cd /usr/src
 make TARGET_ARCH=armv6 buildworld buildkernel
 make TARGET_ARCH=armv6 DESTDIR=/clients/arm installworld installkernel
 .Ed
-.Sh HISTORY
-The
-.Nm
-manpage first appeared in
-.Fx 4.3 .
 .Sh SEE ALSO
 .Xr cc 1 ,
 .Xr install 1 ,
@@ -911,5 +909,10 @@ manpage first appeared in
 .Xr etcupdate 8 ,
 .Xr reboot 8 ,
 .Xr shutdown 8
+.Sh HISTORY
+The
+.Nm
+manpage first appeared in
+.Fx 4.3 .
 .Sh AUTHORS
 .An Mike W. Meyer Aq Mt mwm@mired.org


### PR DESCRIPTION
I figured correcting section order and tagging spdx is the commit prequel, then adding freebsd to the description and linking development is supposed to be it's own commit?

If these can be squashed, sorry I didn't do so.