### PR TITLE
manuals: improve apropos {console, keyboard}

### DIFF
--- a/sbin/conscontrol/conscontrol.8
+++ b/sbin/conscontrol/conscontrol.8
@@ -1,3 +1,5 @@
+.\"-
+.\" SPDX-License-Identifer: BSD-2-Clause
 .\"
 .\" Copyright (c) 2001 Jonathan Lemon <jlemon@FreeBSD.org>
 .\" All rights reserved.
@@ -23,12 +25,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 14, 2011
+.Dd July 7, 2024
 .Dt CONSCONTROL 8
 .Os
 .Sh NAME
 .Nm conscontrol
-.Nd control physical console devices
+.Nd control physical system video console devices
 .Sh SYNOPSIS
 .Nm
 .Op Cm list

--- a/share/man/man4/vt.4
+++ b/share/man/man4/vt.4
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2014 Warren Block
 .\" All rights reserved.
 .\"
@@ -22,12 +25,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd May 24, 2024
+.Dd July 7, 2024
 .Dt "VT" 4
 .Os
 .Sh NAME
 .Nm vt
-.Nd virtual terminal console driver
+.Nd virtual terminal system video console driver
 .Sh SYNOPSIS
 .Cd "options TERMINAL_KERN_ATTR=_attribute_"
 .Cd "options TERMINAL_NORM_ATTR=_attribute_"

--- a/usr.sbin/kbdcontrol/kbdcontrol.1
+++ b/usr.sbin/kbdcontrol/kbdcontrol.1
@@ -1,5 +1,7 @@
+.\"-
+.\" SPDX-License-Identifer: BSD-2-Clause
 .\"
-.\" kbdcontrol - a utility for manipulating the syscons or vt keyboard driver section
+.\" kbdcontrol - syscons or vt keyboard driver configuration utility
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions
@@ -10,12 +12,12 @@
 .\"    notice, this list of conditions and the following disclaimer in the
 .\"    documentation and/or other materials provided with the distribution.
 .\"
-.Dd March 16, 2016
+.Dd July 7, 2024
 .Dt KBDCONTROL 1
 .Os
 .Sh NAME
 .Nm kbdcontrol
-.Nd keyboard control and configuration utility
+.Nd system video console keyboard control/configuration utility
 .Sh SYNOPSIS
 .Nm
 .Op Fl dFKix

--- a/usr.sbin/kbdmap/kbdmap.1
+++ b/usr.sbin/kbdmap/kbdmap.1
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) March 1995 Wolfram Schneider <wosch@FreeBSD.org>. Berlin.
 .\" All rights reserved.
 .\"
@@ -21,13 +24,13 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.Dd July 3, 2002
+.Dd July 7, 2024
 .Dt KBDMAP 1
 .Os
 .Sh NAME
 .Nm kbdmap ,
 .Nm vidfont
-.Nd front end for syscons and vt
+.Nd system video console keyboard map/font dialog utilities
 .Sh SYNOPSIS
 .Nm
 .Op Fl K

--- a/usr.sbin/moused/moused.8
+++ b/usr.sbin/moused/moused.8
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-4-Clause
+.\"
 .\" Copyright (c) 1996
 .\"	Mike Pritchard <mpp@FreeBSD.org>.  All rights reserved.
 .\"
@@ -28,12 +31,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd May 15, 2008
+.Dd July 7, 2024
 .Dt MOUSED 8
 .Os
 .Sh NAME
 .Nm moused
-.Nd pass mouse data to the console driver
+.Nd pass mouse data to the system video console driver
 .Sh SYNOPSIS
 .Nm
 .Op Fl DPRacdfs

--- a/usr.sbin/vidcontrol/vidcontrol.1
+++ b/usr.sbin/vidcontrol/vidcontrol.1
@@ -1,3 +1,5 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
 .\"
 .\" vidcontrol - a utility for manipulating the syscons or vt video driver
 .\"
@@ -10,12 +12,12 @@
 .\"    notice, this list of conditions and the following disclaimer in the
 .\"    documentation and/or other materials provided with the distribution.
 .\"
-.Dd April 6, 2022
+.Dd July 7, 2024
 .Dt VIDCONTROL 1
 .Os
 .Sh NAME
 .Nm vidcontrol
-.Nd system console control and configuration utility
+.Nd system video console control and configuration utility
 .Sh SYNOPSIS
 .Nm
 .Op Fl CdHLPpx


### PR DESCRIPTION
I'm trying to make "apropos -s 1 keyboard" and "console" look nice and tell the console user what they're probably looking for, while distinguishing what they're not looking for (graphical environment tooling, serial console tooling, I dont know). Patches sent to freedesktop and libxkbcommon for that effect too. EDIT: all patches upstream accepted.

~~But, pointy hat to me: my proposed vidfont description is 81 characters. This wraps in man, which I think looks fine, but wraps in apropos, which looks horrible, on 80 char "standard console" including stock xterm; seems unacceptable regression. Ideas?~~

I don't know how it is on other people's boxen but in my house terminus bsd console (vt) is 85 char wide and is unaffected by this proposed regression.