### PR TITLE
bsdconfig manual: add "console dialog" to description

### DIFF
--- a/usr.sbin/bsdconfig/bsdconfig.8
+++ b/usr.sbin/bsdconfig/bsdconfig.8
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2012 Ron McDowell
 .\" Copyright (c) 2012-2013 Devin Teske
 .\" All rights reserved.
@@ -28,7 +31,7 @@
 .Os
 .Sh NAME
 .Nm bsdconfig
-.Nd system configuration utility
+.Nd system configuration console dialog utility
 .Sh SYNOPSIS
 .Nm
 .Op Fl h


### PR DESCRIPTION
This matches what is commonly done where curses utilities usually say curses in the description. Line utilities are very different from screen based utilities. ~~Also, many users will be searching for graphical utilities, which isn't here.~~

MFC after:	3 days