### PR TITLE
loader: Increase buffer size to accommodate longer commands

### DIFF
--- a/stand/common/commands.c
+++ b/stand/common/commands.c
@@ -229,7 +229,7 @@ command_commandlist(int argc __unused, char *argv[] __unused)
 {
 	struct bootblk_command	**cmdp;
 	int	res;
-	char	name[20];
+	char	name[23];
 
 	res = 0;
 	pager_open();
@@ -238,9 +238,10 @@ command_commandlist(int argc __unused, char *argv[] __unused)
 		if (res)
 			break;
 		if ((*cmdp)->c_name != NULL && (*cmdp)->c_desc != NULL) {
-			snprintf(name, sizeof(name), "  %-15s  ",
+			snprintf(name, sizeof(name), "  %-20s",
 			    (*cmdp)->c_name);
 			pager_output(name);
+			pager_output("  ");
 			pager_output((*cmdp)->c_desc);
 			res = pager_output("\n");
 		}


### PR DESCRIPTION
The longest command we have is "efi-autoresizecons". That combined with the two spaces before and after the command gives us a total of 23 characters including the null-terminator.

Increasing this caused alignment issues since `efi-autoresizecons` is > 15 chars ("%-15s"). So I also increased that to 20 and removed the two spaces at the end since they aren't really needed.

Before:
```
Available commands:
  copy_staging     copy staging
  staging_slop     set staging slop
  efi-autoresizeconEFI Auto-resize Console <-- Cuts off
  gop              graphics output protocol
  uga              universal graphics adapter
  efi-seed-entropy try to get entropy from the EFI RNG
  poweroff         power off the system
  ...
```

After:
```
Available commands:
  copy_staging        copy staging
  staging_slop        set staging slop
  efi-autoresizecons  EFI Auto-resize Console
  gop                 graphics output protocol
  uga                 universal graphics adapter
  efi-seed-entropy    try to get entropy from the EFI RNG
  poweroff            power off the system
  ...
```