### PR TITLE
Ctladm: misc fixes regarding port creation and deletion

### DIFF
--- a/etc/mtree/BSD.tests.dist
+++ b/etc/mtree/BSD.tests.dist
@@ -90,6 +90,8 @@
             ..
         ..
         usr.sbin
+            ctladm
+            ..
             dtrace
                 common
                     aggs

--- a/sys/cam/ctl/ctl_frontend_ioctl.c
+++ b/sys/cam/ctl/ctl_frontend_ioctl.c
@@ -267,7 +267,7 @@ cfi_ioctl_port_remove(struct ctl_req *req)
 	if (port_id == -1) {
 		req->status = CTL_LUN_ERROR;
 		snprintf(req->error_str, sizeof(req->error_str),
-		    "port_id not provided");
+		    "Missing required argument: port_id");
 		return;
 	}
 

--- a/sys/cam/ctl/ctl_frontend_iscsi.c
+++ b/sys/cam/ctl/ctl_frontend_iscsi.c
@@ -2149,16 +2149,23 @@ cfiscsi_ioctl_port_create(struct ctl_req *req)
 	uint16_t tag;
 
 	target = dnvlist_get_string(req->args_nvl, "cfiscsi_target", NULL);
-	alias = dnvlist_get_string(req->args_nvl, "cfiscsi_target_alias", NULL);
-	val = dnvlist_get_string(req->args_nvl, "cfiscsi_portal_group_tag",
-	    NULL);
-
-	if (target == NULL || val == NULL) {
+	if (target == NULL) {
 		req->status = CTL_LUN_ERROR;
 		snprintf(req->error_str, sizeof(req->error_str),
-		    "Missing required argument");
+		    "Missing required argument: cfiscsi_target");
 		return;
 	}
+
+	val = dnvlist_get_string(req->args_nvl, "cfiscsi_portal_group_tag",
+	    NULL);
+	if (val == NULL) {
+		req->status = CTL_LUN_ERROR;
+		snprintf(req->error_str, sizeof(req->error_str),
+		    "Missing required argument: cfiscsi_portal_group_tag");
+		return;
+	}
+
+	alias = dnvlist_get_string(req->args_nvl, "cfiscsi_target_alias", NULL);
 
 	tag = strtoul(val, NULL, 0);
 	ct = cfiscsi_target_find_or_create(&cfiscsi_softc, target, alias, tag);
@@ -2250,13 +2257,19 @@ cfiscsi_ioctl_port_remove(struct ctl_req *req)
 	uint16_t tag;
 
 	target = dnvlist_get_string(req->args_nvl, "cfiscsi_target", NULL);
-	val = dnvlist_get_string(req->args_nvl, "cfiscsi_portal_group_tag",
-	    NULL);
-
-	if (target == NULL || val == NULL) {
+	if (target == NULL) {
 		req->status = CTL_LUN_ERROR;
 		snprintf(req->error_str, sizeof(req->error_str),
-		    "Missing required argument");
+		    "Missing required argument: cfiscsi_target");
+		return;
+	}
+
+	val = dnvlist_get_string(req->args_nvl, "cfiscsi_portal_group_tag",
+	    NULL);
+	if (val == NULL) {
+		req->status = CTL_LUN_ERROR;
+		snprintf(req->error_str, sizeof(req->error_str),
+		    "Missing required argument: cfiscsi_portal_group_tag");
 		return;
 	}
 

--- a/usr.sbin/ctladm/Makefile
+++ b/usr.sbin/ctladm/Makefile
@@ -23,4 +23,7 @@ MAN=		ctladm.8
 CFLAGS+=	-DWANT_ISCSI
 .endif
 
+HAS_TESTS=
+SUBDIR.${MK_TESTS}+=	tests
+
 .include <bsd.prog.mk>

--- a/usr.sbin/ctladm/ctladm.8
+++ b/usr.sbin/ctladm/ctladm.8
@@ -673,8 +673,7 @@ and
 Specify the frontend port number.
 The port numbers can be found in the frontend port list.
 .It Fl r
-Remove port specified with
-.Pq Fl p Ar targ_port .
+Remove a port.
 .It Fl t Ar fe_type
 Specify the frontend type used by the
 .Pq Fl o ,

--- a/usr.sbin/ctladm/ctladm.8
+++ b/usr.sbin/ctladm/ctladm.8
@@ -35,7 +35,7 @@
 .\"
 .\" $Id: //depot/users/kenm/FreeBSD-test2/usr.sbin/ctladm/ctladm.8#3 $
 .\"
-.Dd June 5, 2024
+.Dd June 6, 2024
 .Dt CTLADM 8
 .Os
 .Sh NAME
@@ -166,7 +166,7 @@
 .Op Fl o Ar on|off
 .Op Fl w Ar wwpn
 .Op Fl W Ar wwnn
-.Op Fl O Ar pp|vp
+.Op Fl O Ar name=value
 .Op Fl p Ar targ_port
 .Op Fl r
 .Op Fl t Ar fe_type
@@ -625,7 +625,7 @@ The WWNN and WWPN may both be specified at the same time, but cannot be
 combined with enabling/disabling or listing ports.
 .Bl -tag -width 12n
 .It Fl c
-Create new frontend port using free pp and vp=0.
+Create new frontend port.
 .It Fl d Ar driver
 Specify the name of the frontend driver used by the
 .Pq Fl c
@@ -644,7 +644,31 @@ If no port number or port type is specified, all ports are turned on or
 off.
 .It Fl O Ar pp|vp
 Specify generic options on the ioctl frontend port.
-At present, only pp and vp port numbers can be set.
+The list of recognized options is driver-dependent.
+The
+.Dq ioctl
+driver recognizes
+.Dq pp
+and
+.Dq vp .
+The
+.Dq iscsi
+driver recongizes
+.Dq cfiscsi_portal_group_tag ,
+.Dq cfiscsi_target ,
+and
+.Dq cfiscsi_target_alias .
+The
+.Dq nvmf
+driver recognizes
+.Dq subnqn ,
+.Dq portid ,
+.Dq max_io_qsize ,
+.Dq enable_timeout ,
+.Dq ioccsz ,
+.Dq nn ,
+and
+.Dq serial .
 .It Fl p Ar targ_port
 Specify the frontend port number.
 The port numbers can be found in the frontend port list.

--- a/usr.sbin/ctladm/ctladm.c
+++ b/usr.sbin/ctladm/ctladm.c
@@ -580,11 +580,6 @@ cctl_port(int fd, int argc, char **argv, char *combinedopt)
 		break;
 	}
 	case CCTL_PORT_MODE_REMOVE:
-		if (targ_port == -1) {
-			warnx("%s: -r requires -p", __func__);
-			retval = 1;
-			goto bailout;
-		}
 		/* FALLTHROUGH */
 	case CCTL_PORT_MODE_CREATE: {
 		bzero(&req, sizeof(req));
@@ -594,8 +589,9 @@ cctl_port(int fd, int argc, char **argv, char *combinedopt)
 
 		if (port_mode == CCTL_PORT_MODE_REMOVE) {
 			req.reqtype = CTL_REQ_REMOVE;
-			nvlist_add_stringf(option_list, "port_id", "%d",
-			    targ_port);
+			if (targ_port != -1)
+				nvlist_add_stringf(option_list, "port_id", "%d",
+				    targ_port);
 		} else
 			req.reqtype = CTL_REQ_CREATE;
 

--- a/usr.sbin/ctladm/ctladm.c
+++ b/usr.sbin/ctladm/ctladm.c
@@ -397,7 +397,9 @@ static struct ctladm_opts cctl_fe_table[] = {
 static int
 cctl_port(int fd, int argc, char **argv, char *combinedopt)
 {
+	char result_buf[1024];
 	int c;
+	uint64_t created_port = -1;
 	int32_t targ_port = -1;
 	int retval = 0;
 	int wwnn_set = 0, wwpn_set = 0;
@@ -587,6 +589,8 @@ cctl_port(int fd, int argc, char **argv, char *combinedopt)
 	case CCTL_PORT_MODE_CREATE: {
 		bzero(&req, sizeof(req));
 		strlcpy(req.driver, driver, sizeof(req.driver));
+		req.result = result_buf;
+		req.result_len = sizeof(result_buf);
 
 		if (port_mode == CCTL_PORT_MODE_REMOVE) {
 			req.reqtype = CTL_REQ_REMOVE;
@@ -619,6 +623,20 @@ cctl_port(int fd, int argc, char **argv, char *combinedopt)
 			warnx("warning: %s", req.error_str);
 			break;
 		case CTL_LUN_OK:
+			if (port_mode == CCTL_PORT_MODE_CREATE) {
+				req.result_nvl = nvlist_unpack(result_buf, req.result_len, 0);
+				if (req.result_nvl == NULL) {
+					warnx("error unpacking result nvlist");
+					break;
+				}
+				created_port = nvlist_get_number(req.result_nvl, "port_id");
+				printf("Port created successfully\n");
+				printf("frontend: %s\n", driver);
+				printf("port:     %ju\n",
+				    (uintmax_t) created_port);
+				nvlist_destroy(req.result_nvl);
+			} else
+				printf("Port destroyed successfully\n");
 			break;
 		default:
 			warnx("unknown status: %d", req.status);

--- a/usr.sbin/ctladm/tests/Makefile
+++ b/usr.sbin/ctladm/tests/Makefile
@@ -1,0 +1,10 @@
+
+PACKAGE=	tests
+
+ATF_TESTS_SH=	port
+
+# "ctladm port" does not report the name of the port just created, so we can't
+# cleanup unless we assume that no other test created a port too.
+TEST_METADATA+= is_exclusive="true"
+
+.include <bsd.test.mk>

--- a/usr.sbin/ctladm/tests/Makefile
+++ b/usr.sbin/ctladm/tests/Makefile
@@ -3,8 +3,4 @@ PACKAGE=	tests
 
 ATF_TESTS_SH=	port
 
-# "ctladm port" does not report the name of the port just created, so we can't
-# cleanup unless we assume that no other test created a port too.
-TEST_METADATA+= is_exclusive="true"
-
 .include <bsd.test.mk>

--- a/usr.sbin/ctladm/tests/port.sh
+++ b/usr.sbin/ctladm/tests/port.sh
@@ -38,8 +38,6 @@ cleanup() {
 			;;
 		"iscsi")
 			TARGET=`awk '/target:/ {print $2}' port-create.txt`
-			# PORTNUM is ignored, but must be set
-			PORTNUM=9999
 			ctladm port -r -d $driver -p "$PORTNUM" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target=$TARGET
 			;;
 		esac
@@ -65,6 +63,25 @@ create_ioctl_body()
 	atf_check egrep -q "$portnum *YES *ioctl *ioctl" portlist.txt
 }
 create_ioctl_cleanup()
+{
+	cleanup ioctl
+}
+
+atf_test_case remove_ioctl_without_required_args cleanup
+remove_ioctl_without_required_args_head()
+{
+	atf_set "descr" "ctladm will gracefully fail to remove an ioctl target if required arguments are missing"
+	atf_set "require.user" "root"
+}
+remove_ioctl_without_required_args_body()
+{
+	skip_if_ctld
+
+	atf_check -o save:port-create.txt ctladm port -c -d "ioctl"
+	atf_check egrep -q "Port created successfully" port-create.txt
+	atf_check -s exit:1 -e match:"Missing required argument: port_id" ctladm port -r -d "ioctl"
+}
+remove_ioctl_without_required_args_cleanup()
 {
 	cleanup ioctl
 }
@@ -247,7 +264,7 @@ remove_iscsi_body()
 	atf_check -o save:port-create.txt ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
 	portnum=`awk '/port:/ {print $2}' port-create.txt`
 	atf_check -o save:portlist.txt ctladm portlist -qf iscsi
-	atf_check -o inline:"Port destroyed successfully\n" ctladm port -r -d iscsi -p 9999 -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
+	atf_check -o inline:"Port destroyed successfully\n" ctladm port -r -d iscsi -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
 	# Check that the port was removed.  A new port may have been added with
 	# the same ID, so match against the target and tag, too.
 	PGTAGHEX=0x7631	# PGTAG in hex
@@ -271,8 +288,8 @@ remove_iscsi_without_required_args_body()
 	TARGET=iqn.2018-10.myhost.remove_iscsi_without_required_args
 	atf_check -o save:port-create.txt ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
 	echo "target: $TARGET" >> port-create.txt
-	atf_check -s exit:1 -e match:"Missing required argument: cfiscsi_portal_group_tag" ctladm port -r -d iscsi -p 9999 -O cfiscsi_target="$TARGET"
-	atf_check -s exit:1 -e match:"Missing required argument: cfiscsi_target" ctladm port -r -d iscsi -p 9999 -O cfiscsi_portal_group_tag=$PGTAG
+	atf_check -s exit:1 -e match:"Missing required argument: cfiscsi_portal_group_tag" ctladm port -r -d iscsi -O cfiscsi_target="$TARGET"
+	atf_check -s exit:1 -e match:"Missing required argument: cfiscsi_target" ctladm port -r -d iscsi -O cfiscsi_portal_group_tag=$PGTAG
 }
 remove_iscsi_without_required_args_cleanup()
 {
@@ -289,6 +306,7 @@ atf_init_test_cases()
 	atf_add_test_case disable_ioctl
 	atf_add_test_case enable_ioctl
 	atf_add_test_case remove_ioctl
+	atf_add_test_case remove_ioctl_without_required_args
 	atf_add_test_case remove_iscsi
 	atf_add_test_case remove_iscsi_without_required_args
 }

--- a/usr.sbin/ctladm/tests/port.sh
+++ b/usr.sbin/ctladm/tests/port.sh
@@ -22,8 +22,9 @@ skip_if_ctld() {
 cleanup() {
 	driver=$1
 
-	if [ -e after-ports ]; then
-		diff before-ports after-ports | awk "/$driver/ {print \$2}" | xargs -n1 ctladm port -r -d ioctl -p
+	if [ -e port-create.txt ]; then
+		portnum=`awk '/port:/ {print $2}' port-create.txt`
+		ctladm port -r -d $driver -p $portnum
 	fi
 }
 
@@ -37,12 +38,13 @@ create_ioctl_body()
 {
 	skip_if_ctld
 
-	atf_check -o save:before-ports ctladm portlist -qf ioctl
-	atf_check ctladm port -c -d "ioctl"
-	atf_check -o save:after-ports ctladm portlist -qf ioctl
-	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
-		atf_fail "Did not create a new ioctl port"
-	fi
+	atf_check -o save:port-create.txt ctladm port -c -d "ioctl"
+	atf_check egrep -q "Port created successfully" port-create.txt
+	atf_check egrep -q "frontend: *ioctl" port-create.txt
+	atf_check egrep -q "port: *[0-9]+" port-create.txt
+	portnum=`awk '/port:/ {print $2}' port-create.txt`
+	atf_check -o save:portlist.txt ctladm portlist -qf ioctl
+	atf_check egrep -q "$portnum *YES *ioctl *ioctl" portlist.txt
 }
 create_ioctl_cleanup()
 {
@@ -59,13 +61,13 @@ create_ioctl_options_body()
 {
 	skip_if_ctld
 
-	atf_check -o save:before-ports ctladm portlist -qf ioctl
-	atf_check ctladm port -c -d "ioctl" -O pp=101 -O vp=102
-	atf_check -o save:after-ports ctladm portlist -qf ioctl
-	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
-		atf_fail "Did not create a new ioctl port"
-	fi
-	if ! egrep -q '101[[:space:]]+102' after-ports; then
+	atf_check -o save:port-create.txt ctladm port -c -d "ioctl" -O pp=101 -O vp=102
+	atf_check egrep -q "Port created successfully" port-create.txt
+	atf_check egrep -q "frontend: *ioctl" port-create.txt
+	atf_check egrep -q "port: *[0-9]+" port-create.txt
+	portnum=`awk '/port:/ {print $2}' port-create.txt`
+	atf_check -o save:portlist.txt ctladm portlist -qf ioctl
+	if ! egrep -q '101[[:space:]]+102' portlist.txt; then
 		ctladm portlist
 		atf_fail "Did not create the port with the specified options"
 	fi
@@ -86,13 +88,9 @@ disable_ioctl_body()
 {
 	skip_if_ctld
 
-	atf_check -o save:before-ports ctladm portlist -qf ioctl
-	atf_check ctladm port -c -d "ioctl"
-	atf_check -o save:after-ports ctladm portlist -qf ioctl
-	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
-		atf_fail "Did not create a new ioctl port"
-	fi
-	portnum=`diff before-ports after-ports | awk '/ioctl/ {print $2}'`;
+	atf_check -o save:port-create.txt ctladm port -c -d "ioctl"
+	portnum=`awk '/port:/ {print $2}' port-create.txt`
+	atf_check -o save:portlist.txt ctladm portlist -qf ioctl
 	atf_check -o ignore ctladm port -o off -p $portnum
 	atf_check -o match:"^$portnum *NO" ctladm portlist -qf ioctl
 }
@@ -111,13 +109,9 @@ enable_ioctl_body()
 {
 	skip_if_ctld
 
-	atf_check -o save:before-ports ctladm portlist -qf ioctl
-	atf_check ctladm port -c -d "ioctl"
-	atf_check -o save:after-ports ctladm portlist -qf ioctl
-	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
-		atf_fail "Did not create a new ioctl port"
-	fi
-	portnum=`diff before-ports after-ports | awk '/ioctl/ {print $2}'`;
+	atf_check -o save:port-create.txt ctladm port -c -d "ioctl"
+	portnum=`awk '/port:/ {print $2}' port-create.txt`
+	atf_check -o save:portlist.txt ctladm portlist -qf ioctl
 	atf_check -o ignore ctladm port -o off -p $portnum
 	atf_check -o ignore ctladm port -o on -p $portnum
 	atf_check -o match:"^$portnum *YES" ctladm portlist -qf ioctl
@@ -137,14 +131,18 @@ remove_ioctl_body()
 {
 	skip_if_ctld
 
-	atf_check -o save:before-ports ctladm portlist -qf ioctl
-	atf_check ctladm port -c -d "ioctl"
-	atf_check -o save:after-ports ctladm portlist -qf ioctl
-	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
-		atf_fail "Did not create a new ioctl port"
+	# Specify exact pp and vp to make the post-removal portlist check
+	# unambiguous
+	atf_check -o save:port-create.txt ctladm port -c -d "ioctl" -O pp=10001 -O vp=10002
+	portnum=`awk '/port:/ {print $2}' port-create.txt`
+	atf_check -o save:portlist.txt ctladm portlist -qf ioctl
+	atf_check -o inline:"Port destroyed successfully\n" ctladm port -r -d ioctl -p $portnum
+	# Check that the port was removed.  A new port may have been added with
+	# the same ID, so match against the pp and vp numbers, too.
+	if ctladm portlist -qf ioctl | egrep -q "^${portnum} .*10001 *10002"; then
+		ctladm portlist -qf ioctl
+		atf_fail "port was not removed"
 	fi
-	portnum=`diff before-ports after-ports | awk '/ioctl/ {print $2}'`;
-	atf_check ctladm port -r -d ioctl -p $portnum
 }
 
 atf_init_test_cases()

--- a/usr.sbin/ctladm/tests/port.sh
+++ b/usr.sbin/ctladm/tests/port.sh
@@ -1,5 +1,4 @@
 
-# * Creating camsim ports
 # Things that aren't tested due to lack of kernel support:
 # * Creating camsim ports
 # * Creating tpc ports
@@ -7,10 +6,19 @@
 # * Creating umass ports
 
 # TODO
-# * Creating iscsi ports
 # * Creating nvmf ports
 # * Creating ha ports
 # * Creating fc ports
+
+# The PGTAG can be any 16-bit number.  The only constraint is that each
+# PGTAG,TARGET pair must be globally unique.
+PGTAG=30257
+
+load_cfiscsi() {
+	if ! kldstat -q -m cfiscsi; then
+		kldload cfiscsi || atf_skip "could not load cfscsi kernel mod"
+	fi
+}
 
 skip_if_ctld() {
 	if service ctld onestatus > /dev/null; then
@@ -23,8 +31,18 @@ cleanup() {
 	driver=$1
 
 	if [ -e port-create.txt ]; then
-		portnum=`awk '/port:/ {print $2}' port-create.txt`
-		ctladm port -r -d $driver -p $portnum
+		case "$driver" in
+		"ioctl")
+			PORTNUM=`awk '/port:/ {print $2}' port-create.txt`
+			ctladm port -r -d $driver -p $PORTNUM
+			;;
+		"iscsi")
+			TARGET=`awk '/target:/ {print $2}' port-create.txt`
+			# PORTNUM is ignored, but must be set
+			PORTNUM=9999
+			ctladm port -r -d $driver -p "$PORTNUM" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target=$TARGET
+			;;
+		esac
 	fi
 }
 
@@ -49,6 +67,75 @@ create_ioctl_body()
 create_ioctl_cleanup()
 {
 	cleanup ioctl
+}
+
+atf_test_case create_iscsi cleanup
+create_iscsi_head()
+{
+	atf_set "descr" "ctladm can create a new iscsi port"
+	atf_set "require.user" "root"
+}
+create_iscsi_body()
+{
+	skip_if_ctld
+	load_cfiscsi
+
+	TARGET=iqn.2018-10.myhost.create_iscsi
+	atf_check -o save:port-create.txt ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
+	echo "target: $TARGET" >> port-create.txt
+	atf_check egrep -q "Port created successfully" port-create.txt
+	atf_check egrep -q "frontend: *iscsi" port-create.txt
+	atf_check egrep -q "port: *[0-9]+" port-create.txt
+	atf_check -o save:portlist.txt ctladm portlist -qf iscsi
+	# Unlike the ioctl driver, the iscsi driver creates ports in a disabled
+	# state, so the port's lunmap may be set before enabling it.
+	atf_check egrep -q "$portnum *NO *iscsi *iscsi.*$TARGET" portlist.txt
+}
+create_iscsi_cleanup()
+{
+	cleanup iscsi
+}
+
+atf_test_case create_iscsi_alias cleanup
+create_iscsi_alias_head()
+{
+	atf_set "descr" "ctladm can create a new iscsi port with a target alias"
+	atf_set "require.user" "root"
+}
+create_iscsi_alias_body()
+{
+	skip_if_ctld
+	load_cfiscsi
+
+	TARGET=iqn.2018-10.myhost.create_iscsi_alias
+	ALIAS="foobar"
+	atf_check -o save:port-create.txt ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET" -O cfiscsi_target_alias="$ALIAS"
+	echo "target: $TARGET" >> port-create.txt
+	atf_check egrep -q "Port created successfully" port-create.txt
+	atf_check egrep -q "frontend: *iscsi" port-create.txt
+	atf_check egrep -q "port: *[0-9]+" port-create.txt
+	atf_check -o save:portlist.txt ctladm portlist -qvf iscsi
+	atf_check egrep -q "cfiscsi_target_alias=$ALIAS" portlist.txt
+}
+create_iscsi_alias_cleanup()
+{
+	cleanup iscsi
+}
+
+atf_test_case create_iscsi_without_required_args
+create_iscsi_without_required_args_head()
+{
+	atf_set "descr" "ctladm will gracefully fail to create an iSCSI target if required arguments are missing"
+	atf_set "require.user" "root"
+}
+create_iscsi_without_required_args_body()
+{
+	skip_if_ctld
+	load_cfiscsi
+
+	TARGET=iqn.2018-10.myhost.create_iscsi
+	atf_check -s exit:1 -e match:"Missing required argument: cfiscsi_target" ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG
+	atf_check -s exit:1 -e match:"Missing required argument: cfiscsi_portal_group_tag" ctladm port -c -d "iscsi" -O cfiscsi_target=$TARGET
 }
 
 atf_test_case create_ioctl_options cleanup
@@ -145,11 +232,63 @@ remove_ioctl_body()
 	fi
 }
 
+atf_test_case remove_iscsi
+remove_iscsi_head()
+{
+	atf_set "descr" "ctladm can remove an iscsi port"
+	atf_set "require.user" "root"
+}
+remove_iscsi_body()
+{
+	skip_if_ctld
+	load_cfiscsi
+
+	TARGET=iqn.2018-10.myhost.remove_iscsi
+	atf_check -o save:port-create.txt ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
+	portnum=`awk '/port:/ {print $2}' port-create.txt`
+	atf_check -o save:portlist.txt ctladm portlist -qf iscsi
+	atf_check -o inline:"Port destroyed successfully\n" ctladm port -r -d iscsi -p 9999 -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
+	# Check that the port was removed.  A new port may have been added with
+	# the same ID, so match against the target and tag, too.
+	PGTAGHEX=0x7631	# PGTAG in hex
+	if ctladm portlist -qf iscsi | egrep -q "^${portnum} .*$PGTAG +[0-9]+ +$TARGET,t,$PGTAGHEX"; then
+		ctladm portlist -qf iscsi
+		atf_fail "port was not removed"
+	fi
+}
+
+atf_test_case remove_iscsi_without_required_args cleanup
+remove_iscsi_without_required_args_head()
+{
+	atf_set "descr" "ctladm will gracefully fail to remove an iSCSI target if required arguments are missing"
+	atf_set "require.user" "root"
+}
+remove_iscsi_without_required_args_body()
+{
+	skip_if_ctld
+	load_cfiscsi
+
+	TARGET=iqn.2018-10.myhost.remove_iscsi_without_required_args
+	atf_check -o save:port-create.txt ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
+	echo "target: $TARGET" >> port-create.txt
+	atf_check -s exit:1 -e match:"Missing required argument: cfiscsi_portal_group_tag" ctladm port -r -d iscsi -p 9999 -O cfiscsi_target="$TARGET"
+	atf_check -s exit:1 -e match:"Missing required argument: cfiscsi_target" ctladm port -r -d iscsi -p 9999 -O cfiscsi_portal_group_tag=$PGTAG
+}
+remove_iscsi_without_required_args_cleanup()
+{
+	cleanup iscsi
+}
+
 atf_init_test_cases()
 {
 	atf_add_test_case create_ioctl
+	atf_add_test_case create_iscsi
+	atf_add_test_case create_iscsi_without_required_args
+	atf_add_test_case create_iscsi_alias
 	atf_add_test_case create_ioctl_options
 	atf_add_test_case disable_ioctl
 	atf_add_test_case enable_ioctl
 	atf_add_test_case remove_ioctl
+	atf_add_test_case remove_iscsi
+	atf_add_test_case remove_iscsi_without_required_args
 }

--- a/usr.sbin/ctladm/tests/port.sh
+++ b/usr.sbin/ctladm/tests/port.sh
@@ -1,0 +1,157 @@
+
+# * Creating camsim ports
+# Things that aren't tested due to lack of kernel support:
+# * Creating camsim ports
+# * Creating tpc ports
+# * Creating camtgt ports
+# * Creating umass ports
+
+# TODO
+# * Creating iscsi ports
+# * Creating nvmf ports
+# * Creating ha ports
+# * Creating fc ports
+
+skip_if_ctld() {
+	if service ctld onestatus > /dev/null; then
+		# If ctld is running on this server, let's not interfere.
+		atf_skip "Cannot run this test while ctld is running"
+	fi
+}
+
+cleanup() {
+	driver=$1
+
+	if [ -e after-ports ]; then
+		diff before-ports after-ports | awk "/$driver/ {print \$2}" | xargs -n1 ctladm port -r -d ioctl -p
+	fi
+}
+
+atf_test_case create_ioctl cleanup
+create_ioctl_head()
+{
+	atf_set "descr" "ctladm can create a new ioctl port"
+	atf_set "require.user" "root"
+}
+create_ioctl_body()
+{
+	skip_if_ctld
+
+	atf_check -o save:before-ports ctladm portlist -qf ioctl
+	atf_check ctladm port -c -d "ioctl"
+	atf_check -o save:after-ports ctladm portlist -qf ioctl
+	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
+		atf_fail "Did not create a new ioctl port"
+	fi
+}
+create_ioctl_cleanup()
+{
+	cleanup ioctl
+}
+
+atf_test_case create_ioctl_options cleanup
+create_ioctl_options_head()
+{
+	atf_set "descr" "ctladm can set options when creating a new ioctl port"
+	atf_set "require.user" "root"
+}
+create_ioctl_options_body()
+{
+	skip_if_ctld
+
+	atf_check -o save:before-ports ctladm portlist -qf ioctl
+	atf_check ctladm port -c -d "ioctl" -O pp=101 -O vp=102
+	atf_check -o save:after-ports ctladm portlist -qf ioctl
+	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
+		atf_fail "Did not create a new ioctl port"
+	fi
+	if ! egrep -q '101[[:space:]]+102' after-ports; then
+		ctladm portlist
+		atf_fail "Did not create the port with the specified options"
+	fi
+}
+create_ioctl_options_cleanup()
+{
+	cleanup ioctl
+}
+
+
+atf_test_case disable_ioctl cleanup
+disable_ioctl_head()
+{
+	atf_set "descr" "ctladm can disable an ioctl port"
+	atf_set "require.user" "root"
+}
+disable_ioctl_body()
+{
+	skip_if_ctld
+
+	atf_check -o save:before-ports ctladm portlist -qf ioctl
+	atf_check ctladm port -c -d "ioctl"
+	atf_check -o save:after-ports ctladm portlist -qf ioctl
+	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
+		atf_fail "Did not create a new ioctl port"
+	fi
+	portnum=`diff before-ports after-ports | awk '/ioctl/ {print $2}'`;
+	atf_check -o ignore ctladm port -o off -p $portnum
+	atf_check -o match:"^$portnum *NO" ctladm portlist -qf ioctl
+}
+disable_ioctl_cleanup()
+{
+	cleanup ioctl
+}
+
+atf_test_case enable_ioctl cleanup
+enable_ioctl_head()
+{
+	atf_set "descr" "ctladm can enable an ioctl port"
+	atf_set "require.user" "root"
+}
+enable_ioctl_body()
+{
+	skip_if_ctld
+
+	atf_check -o save:before-ports ctladm portlist -qf ioctl
+	atf_check ctladm port -c -d "ioctl"
+	atf_check -o save:after-ports ctladm portlist -qf ioctl
+	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
+		atf_fail "Did not create a new ioctl port"
+	fi
+	portnum=`diff before-ports after-ports | awk '/ioctl/ {print $2}'`;
+	atf_check -o ignore ctladm port -o off -p $portnum
+	atf_check -o ignore ctladm port -o on -p $portnum
+	atf_check -o match:"^$portnum *YES" ctladm portlist -qf ioctl
+}
+enable_ioctl_cleanup()
+{
+	cleanup ioctl
+}
+
+atf_test_case remove_ioctl
+remove_ioctl_head()
+{
+	atf_set "descr" "ctladm can remove an ioctl port"
+	atf_set "require.user" "root"
+}
+remove_ioctl_body()
+{
+	skip_if_ctld
+
+	atf_check -o save:before-ports ctladm portlist -qf ioctl
+	atf_check ctladm port -c -d "ioctl"
+	atf_check -o save:after-ports ctladm portlist -qf ioctl
+	if test `wc -l before-ports | cut -w -f2` -ge `wc -l after-ports | cut -w -f2`; then
+		atf_fail "Did not create a new ioctl port"
+	fi
+	portnum=`diff before-ports after-ports | awk '/ioctl/ {print $2}'`;
+	atf_check ctladm port -r -d ioctl -p $portnum
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case create_ioctl
+	atf_add_test_case create_ioctl_options
+	atf_add_test_case disable_ioctl
+	atf_add_test_case enable_ioctl
+	atf_add_test_case remove_ioctl
+}


### PR DESCRIPTION
* Improve the man page regarding port creation and deletion
* Don't require "-p" when it isn't truly needed
* Print the port number of newly created frontend ports
* Print better error messages when a required argument is missing from a port creation or deletion request
* Add ATF tests

The motivation for these changes is https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271460 .  Basically, I've gotten into a situation where the only way to recover was a reboot.  But if I'd known how to manually remove iscsi ports with ctladm, I could've recovered without a reboot.  Between the man page changes and better error messages, I think that future users in my position will be able to figure it out.

I elected to review this on Github instead of Phabricator so I can split it into multiple commits.  But if you prefer, I can go back to Phabricator and create separate reviews in sequence.