### PR TITLE
Intrng: adjusting pic_init_secondary for further use cases

### DIFF
--- a/sys/arm/arm/gic.c
+++ b/sys/arm/arm/gic.c
@@ -205,6 +205,13 @@ arm_gic_init_secondary(device_t dev, uint32_t rootnum)
 	struct arm_gic_softc *sc = device_get_softc(dev);
 	u_int irq, cpu;
 
+	if (rootnum >= INTR_ROOT_COUNT) {
+		/*
+		 * Per-processor setup for devices with PPI interrupts?
+		 */
+		return;
+	}
+
 	/* Set the mask so we can find this CPU to send it IPIs */
 	cpu = PCPU_GET(cpuid);
 	MPASS(cpu < GIC_MAXCPU);

--- a/sys/arm/broadcom/bcm2835/bcm2836.c
+++ b/sys/arm/broadcom/bcm2835/bcm2836.c
@@ -543,6 +543,13 @@ bcm_lintc_init_secondary(device_t dev, uint32_t rootnum)
 	u_int cpu;
 	struct bcm_lintc_softc *sc;
 
+	if (rootnum >= INTR_ROOT_COUNT) {
+		/*
+		 * Per-processor setup for devices with PPI interrupts?
+		 */
+		return;
+	}
+
 	cpu = PCPU_GET(cpuid);
 	sc = device_get_softc(dev);
 

--- a/sys/arm64/arm64/gic_v3.c
+++ b/sys/arm64/arm64/gic_v3.c
@@ -1103,6 +1103,13 @@ gic_v3_init_secondary(device_t dev, uint32_t rootnum)
 	u_int cpu, irq;
 	int err, i;
 
+	if (rootnum >= INTR_ROOT_COUNT) {
+		/*
+		 * Per-processor setup for devices with PPI interrupts?
+		 */
+		return;
+	}
+
 	sc = device_get_softc(dev);
 	cpu = PCPU_GET(cpuid);
 

--- a/sys/arm64/arm64/gicv3_its.c
+++ b/sys/arm64/arm64/gicv3_its.c
@@ -1297,6 +1297,13 @@ gicv3_its_init_secondary(device_t dev, uint32_t rootnum)
 {
 	struct gicv3_its_softc *sc;
 
+	if (rootnum >= INTR_ROOT_COUNT) {
+		/*
+		 * Per-processor setup for devices with PPI interrupts?
+		 */
+		return;
+	}
+
 	sc = device_get_softc(dev);
 
 	/*

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -1570,12 +1570,10 @@ dosoftints(void)
 void
 intr_pic_init_secondary(void)
 {
+	struct intr_pic *pic;
 	device_t dev;
 	uint32_t rootnum;
 
-	/*
-	 * QQQ: Only root PICs are aware of other CPUs ???
-	 */
 	//mtx_lock(&isrc_table_lock);
 	for (rootnum = 0; rootnum < INTR_ROOT_COUNT; rootnum++) {
 		dev = intr_irq_roots[rootnum].dev;
@@ -1583,6 +1581,9 @@ intr_pic_init_secondary(void)
 			PIC_INIT_SECONDARY(dev, rootnum);
 		}
 	}
+
+	SLIST_FOREACH(pic, &pic_list, pic_next)
+		PIC_INIT_SECONDARY(pic->pic_dev, INTR_ROOT_COUNT);
 	//mtx_unlock(&isrc_table_lock);
 }
 #endif

--- a/sys/riscv/riscv/intc.c
+++ b/sys/riscv/riscv/intc.c
@@ -247,6 +247,13 @@ intc_init_secondary(device_t dev, uint32_t rootnum)
 	struct intr_irqsrc *isrc;
 	u_int cpu, irq;
 
+	if (rootnum >= INTR_ROOT_COUNT) {
+		/*
+		 * Per-processor setup for devices with PPI interrupts?
+		 */
+		return;
+	}
+
 	sc = device_get_softc(dev);
 	cpu = PCPU_GET(cpuid);
 


### PR DESCRIPTION
Issue is `pic_init_secondary()` was implemented for root PICs-only.  The author's theory appears to have been the root calls the function on child PICs.  At least one secondary PIC needs the function called, but the device-tree doesn't have it as a child of the root PIC.  As such instead simply calling the function on all registered PICs appears to make more sense.