### PR TITLE
fix INTRNG interrupt release

### DIFF
--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -530,8 +530,10 @@ int
 intr_event_destroy(struct intr_event *ie)
 {
 
-	if (ie == NULL)
-		return (EINVAL);
+	if (ie == NULL) {
+		printf("ERROR: %s(): passed NULL event!\n", __func__);
+		return (0);
+	}
 
 	mtx_lock(&event_lock);
 	mtx_lock(&ie->ie_lock);

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -320,7 +320,18 @@ isrc_release_counters(struct intr_irqsrc *isrc)
 
 	mtx_assert(&isrc_table_lock, MA_OWNED);
 
+	if (isrc->isrc_count == NULL || isrc->isrc_index > nintrcnt) {
+		/* already cleared */
+		printf("WARNING: %s(): counter release called for \"%.*s\" with"
+		    " invalid counters\n", __func__,
+		    (int)sizeof(isrc->isrc_name), isrc->isrc_name);
+		return;
+	}
+
 	bit_nclear(intrcnt_bitmap, idx, idx + 1);
+
+	isrc->isrc_index = ~0;
+	isrc->isrc_count = NULL;
 }
 
 /*

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -404,7 +404,8 @@ intr_isrc_dispatch(struct intr_irqsrc *isrc, struct trapframe *tf)
 			return (0);
 	} else
 #endif
-	if (isrc->isrc_event != NULL) {
+	{
+		MPASS(isrc->isrc_event != NULL);
 		if (intr_event_handle(isrc->isrc_event, tf) == 0)
 			return (0);
 	}
@@ -413,6 +414,113 @@ intr_isrc_dispatch(struct intr_irqsrc *isrc, struct trapframe *tf)
 		isrc_increment_straycount(isrc);
 	return (EINVAL);
 }
+
+/*
+ *  Interrupt source pre_ithread method for MI interrupt framework.
+ */
+static void
+intr_isrc_pre_ithread(void *arg)
+{
+	struct intr_irqsrc *isrc = arg;
+
+	PIC_PRE_ITHREAD(isrc->isrc_dev, isrc);
+}
+
+/*
+ *  Interrupt source post_ithread method for MI interrupt framework.
+ */
+static void
+intr_isrc_post_ithread(void *arg)
+{
+	struct intr_irqsrc *isrc = arg;
+
+	PIC_POST_ITHREAD(isrc->isrc_dev, isrc);
+}
+
+/*
+ *  Interrupt source post_filter method for MI interrupt framework.
+ */
+static void
+intr_isrc_post_filter(void *arg)
+{
+	struct intr_irqsrc *isrc = arg;
+
+	PIC_POST_FILTER(isrc->isrc_dev, isrc);
+}
+
+/*
+ *  Interrupt source assign_cpu method for MI interrupt framework.
+ */
+static int
+intr_isrc_assign_cpu(void *arg, int cpu)
+{
+#ifdef SMP
+	struct intr_irqsrc *isrc = arg;
+	int error;
+
+	mtx_lock(&isrc_table_lock);
+	if (cpu == NOCPU) {
+		CPU_ZERO(&isrc->isrc_cpu);
+		isrc->isrc_flags &= ~INTR_ISRCF_BOUND;
+	} else {
+		CPU_SETOF(cpu, &isrc->isrc_cpu);
+		isrc->isrc_flags |= INTR_ISRCF_BOUND;
+	}
+
+	/*
+	 * In NOCPU case, it's up to PIC to either leave ISRC on same CPU or
+	 * re-balance it to another CPU or enable it on more CPUs. However,
+	 * PIC is expected to change isrc_cpu appropriately to keep us well
+	 * informed if the call is successful.
+	 */
+	if (irq_assign_cpu) {
+		error = PIC_BIND_INTR(isrc->isrc_dev, isrc);
+		if (error) {
+			CPU_ZERO(&isrc->isrc_cpu);
+			mtx_unlock(&isrc_table_lock);
+			return (error);
+		}
+	}
+	mtx_unlock(&isrc_table_lock);
+	return (0);
+#else
+	return (EOPNOTSUPP);
+#endif
+}
+
+/*
+ *  Create interrupt event for interrupt source.
+ */
+static int
+isrc_event_create(struct intr_irqsrc *isrc)
+{
+	int error;
+
+	error = intr_event_create(&isrc->isrc_event, isrc, 0, INTR_IRQ_INVALID,
+	    intr_isrc_pre_ithread, intr_isrc_post_ithread, intr_isrc_post_filter,
+	    intr_isrc_assign_cpu, "%s:", isrc->isrc_name);
+
+	return (error);
+}
+
+#ifdef notyet
+/*
+ *  Destroy interrupt event for interrupt source.
+ */
+static void
+isrc_event_destroy(struct intr_irqsrc *isrc)
+{
+	struct intr_event *ie;
+
+	mtx_lock(&isrc_table_lock);
+	ie = isrc->isrc_event;
+	isrc->isrc_event = NULL;
+	mtx_unlock(&isrc_table_lock);
+
+	if (ie != NULL)
+		intr_event_destroy(ie);
+}
+#endif
 
 /*
  *  Alloc unique interrupt number (resource handle) for interrupt source.
@@ -447,6 +555,7 @@ isrc_alloc_irq(struct intr_irqsrc *isrc)
 	return (ENOSPC);
 
 found:
+	isrc->isrc_event->ie_irq = irq;
 	isrc->isrc_irq = irq;
 	irq_sources[irq] = isrc;
 
@@ -464,6 +573,7 @@ isrc_free_irq(struct intr_irqsrc *isrc)
 {
 
 	mtx_assert(&isrc_table_lock, MA_OWNED);
+	MPASS(isrc->isrc_event != NULL);
 
 	if (isrc->isrc_irq >= intr_nirq)
 		return (EINVAL);
@@ -512,10 +622,18 @@ intr_isrc_register(struct intr_irqsrc *isrc, device_t dev, u_int flags,
 	vsnprintf(isrc->isrc_name, INTR_ISRC_NAMELEN, fmt, ap);
 	va_end(ap);
 
+	error = isrc_event_create(isrc);
+	if (error)
+		return (error);
+
 	mtx_lock(&isrc_table_lock);
 	error = isrc_alloc_irq(isrc);
 	if (error != 0) {
+		int rc;
 		mtx_unlock(&isrc_table_lock);
+		if ((rc = intr_event_destroy(isrc->isrc_event)) != 0)
+			printf("ERROR: %s(): intr_event_destroy() rc = %d!\n",
+			    __func__, rc);
 		return (error);
 	}
 	/*
@@ -603,131 +721,6 @@ iscr_setup_filter(struct intr_irqsrc *isrc, const char *name,
 #endif
 
 /*
- *  Interrupt source pre_ithread method for MI interrupt framework.
- */
-static void
-intr_isrc_pre_ithread(void *arg)
-{
-	struct intr_irqsrc *isrc = arg;
-
-	PIC_PRE_ITHREAD(isrc->isrc_dev, isrc);
-}
-
-/*
- *  Interrupt source post_ithread method for MI interrupt framework.
- */
-static void
-intr_isrc_post_ithread(void *arg)
-{
-	struct intr_irqsrc *isrc = arg;
-
-	PIC_POST_ITHREAD(isrc->isrc_dev, isrc);
-}
-
-/*
- *  Interrupt source post_filter method for MI interrupt framework.
- */
-static void
-intr_isrc_post_filter(void *arg)
-{
-	struct intr_irqsrc *isrc = arg;
-
-	PIC_POST_FILTER(isrc->isrc_dev, isrc);
-}
-
-/*
- *  Interrupt source assign_cpu method for MI interrupt framework.
- */
-static int
-intr_isrc_assign_cpu(void *arg, int cpu)
-{
-#ifdef SMP
-	struct intr_irqsrc *isrc = arg;
-	int error;
-
-	mtx_lock(&isrc_table_lock);
-	if (cpu == NOCPU) {
-		CPU_ZERO(&isrc->isrc_cpu);
-		isrc->isrc_flags &= ~INTR_ISRCF_BOUND;
-	} else {
-		CPU_SETOF(cpu, &isrc->isrc_cpu);
-		isrc->isrc_flags |= INTR_ISRCF_BOUND;
-	}
-
-	/*
-	 * In NOCPU case, it's up to PIC to either leave ISRC on same CPU or
-	 * re-balance it to another CPU or enable it on more CPUs. However,
-	 * PIC is expected to change isrc_cpu appropriately to keep us well
-	 * informed if the call is successful.
-	 */
-	if (irq_assign_cpu) {
-		error = PIC_BIND_INTR(isrc->isrc_dev, isrc);
-		if (error) {
-			CPU_ZERO(&isrc->isrc_cpu);
-			mtx_unlock(&isrc_table_lock);
-			return (error);
-		}
-	}
-	mtx_unlock(&isrc_table_lock);
-	return (0);
-#else
-	return (EOPNOTSUPP);
-#endif
-}
-
-/*
- *  Create interrupt event for interrupt source.
- */
-static int
-isrc_event_create(struct intr_irqsrc *isrc)
-{
-	struct intr_event *ie;
-	int error;
-
-	error = intr_event_create(&ie, isrc, 0, isrc->isrc_irq,
-	    intr_isrc_pre_ithread, intr_isrc_post_ithread, intr_isrc_post_filter,
-	    intr_isrc_assign_cpu, "%s:", isrc->isrc_name);
-	if (error)
-		return (error);
-
-	mtx_lock(&isrc_table_lock);
-	/*
-	 * Make sure that we do not mix the two ways
-	 * how we handle interrupt sources. Let contested event wins.
-	 */
-#ifdef INTR_SOLO
-	if (isrc->isrc_filter != NULL || isrc->isrc_event != NULL) {
-#else
-	if (isrc->isrc_event != NULL) {
-#endif
-		mtx_unlock(&isrc_table_lock);
-		intr_event_destroy(ie);
-		return (isrc->isrc_event != NULL ? EBUSY : 0);
-	}
-	isrc->isrc_event = ie;
-	mtx_unlock(&isrc_table_lock);
-
-	return (0);
-}
-#ifdef notyet
-/*
- *  Destroy interrupt event for interrupt source.
- */
-static void
-isrc_event_destroy(struct intr_irqsrc *isrc)
-{
-	struct intr_event *ie;
-
-	mtx_lock(&isrc_table_lock);
-	ie = isrc->isrc_event;
-	isrc->isrc_event = NULL;
-	mtx_unlock(&isrc_table_lock);
-
-	if (ie != NULL)
-		intr_event_destroy(ie);
-}
-#endif
-/*
  *  Add handler to interrupt source.
  */
 static int
@@ -736,12 +729,6 @@ isrc_add_handler(struct intr_irqsrc *isrc, const char *name,
     enum intr_type flags, void **cookiep)
 {
 	int error;
-
-	if (isrc->isrc_event == NULL) {
-		error = isrc_event_create(isrc);
-		if (error)
-			return (error);
-	}
 
 	error = intr_event_add_handler(isrc->isrc_event, name, filter, handler,
 	    arg, intr_priority(flags), flags, cookiep);
@@ -1307,8 +1294,8 @@ intr_irq_shuffle(void *arg __unused)
 			continue;
 		}
 
-		if (isrc->isrc_event != NULL &&
-		    isrc->isrc_flags & INTR_ISRCF_BOUND &&
+		MPASS(isrc->isrc_event != NULL);
+		if (isrc->isrc_flags & INTR_ISRCF_BOUND &&
 		    isrc->isrc_event->ie_cpu != CPU_FFS(&isrc->isrc_cpu) - 1)
 			panic("%s: CPU inconsistency", __func__);
 

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -568,7 +568,7 @@ found:
 /*
  *  Free unique interrupt number (resource handle) from interrupt source.
  */
-static inline int
+static inline void
 isrc_free_irq(struct intr_irqsrc *isrc)
 {
 
@@ -576,11 +576,22 @@ isrc_free_irq(struct intr_irqsrc *isrc)
 	MPASS(isrc->isrc_event != NULL);
 
 	if (isrc->isrc_irq >= intr_nirq)
-		return (EINVAL);
-	if (irq_sources[isrc->isrc_irq] != isrc)
-		return (EINVAL);
+		return;
+	if (irq_sources[isrc->isrc_irq] == isrc)
+		irq_sources[isrc->isrc_irq] = NULL;
+	else {
+		unsigned int i;
+		unsigned int matches = 0;
 
-	irq_sources[isrc->isrc_irq] = NULL;
+		for (i = 0; i < intr_nirq; ++i)
+			if (irq_sources[i] == isrc) {
+				irq_sources[i] = NULL;
+				++matches;
+			}
+		device_printf(isrc->isrc_dev,
+		    "ERROR: INTRNG: %s(): interrupt %u bad table entry, found "
+		    "%u matches\n", __func__, isrc->isrc_irq, matches);
+	}
 	isrc->isrc_irq = INTR_IRQ_INVALID;	/* just to be safe */
 
 	/*
@@ -591,8 +602,6 @@ isrc_free_irq(struct intr_irqsrc *isrc)
 	 */
 	if (irq_next_free >= intr_nirq)
 		irq_next_free = 0;
-
-	return (0);
 }
 
 device_t
@@ -658,7 +667,7 @@ intr_isrc_deregister(struct intr_irqsrc *isrc)
 	mtx_lock(&isrc_table_lock);
 	if ((isrc->isrc_flags & INTR_ISRCF_IPI) == 0)
 		isrc_release_counters(isrc);
-	error = isrc_free_irq(isrc);
+	isrc_free_irq(isrc);
 	mtx_unlock(&isrc_table_lock);
 	return (error);
 }

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -503,24 +503,24 @@ isrc_event_create(struct intr_irqsrc *isrc)
 	return (error);
 }
 
-#ifdef notyet
 /*
  *  Destroy interrupt event for interrupt source.
  */
-static void
+static int
 isrc_event_destroy(struct intr_irqsrc *isrc)
 {
-	struct intr_event *ie;
+	int rc;
 
-	mtx_lock(&isrc_table_lock);
-	ie = isrc->isrc_event;
-	isrc->isrc_event = NULL;
-	mtx_unlock(&isrc_table_lock);
+	mtx_assert(&isrc_table_lock, MA_OWNED);
+	MPASS(isrc->isrc_event != NULL);
+	MPASS(isrc->isrc_event->ie_irq >= intr_nirq);
 
-	if (ie != NULL)
-		intr_event_destroy(ie);
+	rc = intr_event_destroy(isrc->isrc_event);
+	if (rc == 0)
+		isrc->isrc_event = NULL;
+
+	return (rc);
 }
-#endif
 
 /*
  *  Alloc unique interrupt number (resource handle) for interrupt source.
@@ -665,10 +665,14 @@ intr_isrc_deregister(struct intr_irqsrc *isrc)
 	int error;
 
 	mtx_lock(&isrc_table_lock);
-	if ((isrc->isrc_flags & INTR_ISRCF_IPI) == 0)
-		isrc_release_counters(isrc);
-	isrc_free_irq(isrc);
+	error = isrc_event_destroy(isrc);
+	if (error == 0) {
+		if ((isrc->isrc_flags & INTR_ISRCF_IPI) == 0)
+			isrc_release_counters(isrc);
+		isrc_free_irq(isrc);
+	}
 	mtx_unlock(&isrc_table_lock);
+
 	return (error);
 }
 

--- a/sys/netpfil/pf/if_pfsync.c
+++ b/sys/netpfil/pf/if_pfsync.c
@@ -3377,6 +3377,9 @@ vnet_pfsync_uninit(const void *unused __unused)
 	ret = swi_remove(V_pfsync_swi_cookie);
 	MPASS(ret == 0);
 	ret = intr_event_destroy(V_pfsync_swi_ie);
+	if (ret != 0)
+		printf("ERROR: %s(): intr_event_destroy() ret = %d!\n",
+		    __func__, ret);
 	MPASS(ret == 0);
 }
 

--- a/sys/netpfil/pf/pf_ioctl.c
+++ b/sys/netpfil/pf/pf_ioctl.c
@@ -7894,6 +7894,9 @@ pf_unload_vnet(void)
 	ret = swi_remove(V_pf_swi_cookie);
 	MPASS(ret == 0);
 	ret = intr_event_destroy(V_pf_swi_ie);
+	if (ret != 0)
+		printf("ERROR: %s(): intr_event_destroy() ret = %d!\n",
+		    __func__, ret);
 	MPASS(ret == 0);
 
 	pf_unload_vnet_purge();

--- a/sys/netpfil/pf/pflow.c
+++ b/sys/netpfil/pf/pflow.c
@@ -466,6 +466,9 @@ pflow_destroy(int unit, bool drain)
 	error = swi_remove(sc->sc_swi_cookie);
 	MPASS(error == 0);
 	error = intr_event_destroy(sc->sc_swi_ie);
+	if (error != 0)
+		printf("ERROR: %s(): intr_event_destroy() error = %d!\n",
+		    __func__, error);
 	MPASS(error == 0);
 
 	callout_drain(&sc->sc_tmo);

--- a/sys/sys/interrupt.h
+++ b/sys/sys/interrupt.h
@@ -182,7 +182,7 @@ int	intr_event_create(struct intr_event **event, void *source,
 	    __printflike(9, 10);
 int	intr_event_describe_handler(struct intr_event *ie, void *cookie,
 	    const char *descr);
-int	intr_event_destroy(struct intr_event *ie);
+int	intr_event_destroy(struct intr_event *ie) __result_use_check;
 int	intr_event_handle(struct intr_event *ie, struct trapframe *frame);
 int	intr_event_remove_handler(void *cookie);
 int	intr_event_suspend_handler(void *cookie);

--- a/sys/x86/x86/intr_machdep.c
+++ b/sys/x86/x86/intr_machdep.c
@@ -234,8 +234,11 @@ intr_register_source(struct intsrc *isrc)
 		return (error);
 	sx_xlock(&intrsrc_lock);
 	if (interrupt_sources[vector] != NULL) {
+		int rc;
 		sx_xunlock(&intrsrc_lock);
-		intr_event_destroy(isrc->is_event);
+		rc = intr_event_destroy(isrc->is_event);
+			printf("ERROR: %s(): intr_event_destroy() rc = %d!\n",
+			    __func__, rc);
 		return (EEXIST);
 	}
 	intrcnt_register(isrc);


### PR DESCRIPTION
SSIA.

While it is good `intr_isrc_deregister()` exists, it hasn't ever actually been used.  Due to a driver which needs this, fix issues found by reviewing the source and finding solutions.