### PR TITLE
ctld: parse config file independently of getting kernel info

### DIFF
--- a/usr.sbin/ctld/kernel.c
+++ b/usr.sbin/ctld/kernel.c
@@ -414,7 +414,7 @@ cctl_char_handler(void *user_data, const XML_Char *str, int len)
 }
 
 struct conf *
-conf_new_from_kernel(void)
+conf_new_from_kernel(struct kports *kports)
 {
 	struct conf *conf = NULL;
 	struct target *targ;
@@ -559,13 +559,13 @@ retry_port:
 		if (port->cfiscsi_target == NULL) {
 			log_debugx("CTL port %u \"%s\" wasn't managed by ctld; ",
 			    port->port_id, name);
-			pp = pport_find(conf, name);
+			pp = pport_find(kports, name);
 			if (pp == NULL) {
 #if 0
 				log_debugx("found new kernel port %u \"%s\"",
 				    port->port_id, name);
 #endif
-				pp = pport_new(conf, name, port->port_id);
+				pp = pport_new(kports, name, port->port_id);
 				if (pp == NULL) {
 					log_warnx("pport_new failed");
 					continue;

--- a/usr.sbin/ctld/parse.y
+++ b/usr.sbin/ctld/parse.y
@@ -832,42 +832,7 @@ target_portal_group:	PORTAL_GROUP STR STR
 
 target_port:	PORT STR
 	{
-		struct pport *pp;
-		struct port *tp;
-		int ret, i_pp, i_vp = 0;
-
-		ret = sscanf($2, "ioctl/%d/%d", &i_pp, &i_vp);
-		if (ret > 0) {
-			tp = port_new_ioctl(conf, target, i_pp, i_vp);
-			if (tp == NULL) {
-				log_warnx("can't create new ioctl port for "
-				    "target \"%s\"", target->t_name);
-				free($2);
-				return (1);
-			}
-		} else {
-			pp = pport_find(conf, $2);
-			if (pp == NULL) {
-				log_warnx("unknown port \"%s\" for target \"%s\"",
-				    $2, target->t_name);
-				free($2);
-				return (1);
-			}
-			if (!TAILQ_EMPTY(&pp->pp_ports)) {
-				log_warnx("can't link port \"%s\" to target \"%s\", "
-				    "port already linked to some target",
-				    $2, target->t_name);
-				free($2);
-				return (1);
-			}
-			tp = port_new_pp(conf, target, pp);
-			if (tp == NULL) {
-				log_warnx("can't link port \"%s\" to target \"%s\"",
-				    $2, target->t_name);
-				free($2);
-				return (1);
-			}
-		}
+		target->t_pport = strdup($2);
 
 		free($2);
 	}

--- a/usr.sbin/ctld/uclparse.c
+++ b/usr.sbin/ctld/uclparse.c
@@ -853,41 +853,10 @@ uclparse_target(const char *name, const ucl_object_t *top)
 		}
 
 		if (!strcmp(key, "port")) {
-			struct pport *pp;
-			struct port *tp;
-			const char *value = ucl_object_tostring(obj);
-			int ret, i_pp, i_vp = 0;
+			const char *value;
 
-			ret = sscanf(value, "ioctl/%d/%d", &i_pp, &i_vp);
-			if (ret > 0) {
-				tp = port_new_ioctl(conf, target, i_pp, i_vp);
-				if (tp == NULL) {
-					log_warnx("can't create new ioctl port "
-					    "for target \"%s\"", target->t_name);
-					return (1);
-				}
-
-				continue;
-			}
-
-			pp = pport_find(conf, value);
-			if (pp == NULL) {
-				log_warnx("unknown port \"%s\" for target \"%s\"",
-				    value, target->t_name);
-				return (1);
-			}
-			if (!TAILQ_EMPTY(&pp->pp_ports)) {
-				log_warnx("can't link port \"%s\" to target \"%s\", "
-				    "port already linked to some target",
-				    value, target->t_name);
-				return (1);
-			}
-			tp = port_new_pp(conf, target, pp);
-			if (tp == NULL) {
-				log_warnx("can't link port \"%s\" to target \"%s\"",
-				    value, target->t_name);
-				return (1);
-			}
+			value = ucl_object_tostring(obj);
+			target->t_pport = strdup(value);
 		}
 
 		if (!strcmp(key, "redirect")) {


### PR DESCRIPTION
Separate the parsing of the config file from the reading of kernel port information.  This has three benefits:

* Separation of concerns makes future changes easier.
* Allows the config file to be read earlier, which is necessary for fixing PR 271460.
* Reduces total line count, by eliminating duplication between parse.y (for traditional config file) and uclparse.c (for UCL config file).

MFC after:	2 weeks
Sponsored by:	Axcient