### PR TITLE
loader: Correct terminal size

### DIFF
--- a/stand/defaults/loader.conf.5
+++ b/stand/defaults/loader.conf.5
@@ -21,7 +21,7 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.Dd February 2, 2024
+.Dd July 8, 2024
 .Dt LOADER.CONF 5
 .Os
 .Sh NAME
@@ -331,8 +331,8 @@ replacing it with
 character (useful for embedded products and such).
 .It Va screen.font
 Set font size for framebuffer mode.
-Default font size is selected based on screen resolution, to achieve
-terminal dimensions 80x24.
+The default font size is selected based on screen resolution.
+Note that the terminal's size may vary.
 .It Va screen.textmode
 Value
 .Dq 0

--- a/stand/efi/libefi/efi_console.c
+++ b/stand/efi/libefi/efi_console.c
@@ -63,7 +63,7 @@ void HO(void);
 void end_term(void);
 #endif
 
-#define	TEXT_ROWS	24
+#define	TEXT_ROWS	25
 #define	TEXT_COLS	80
 
 static tf_bell_t	efi_cons_bell;


### PR DESCRIPTION
The UEFI spec says:
> It is required that all output devices support at least 80x25 text mode. This mode is defined to be mode 0.

So change the EFI `TEXT_ROWS` macro to reflect this. This also makes it more inline with the BIOS version:
https://github.com/freebsd/freebsd-src/blob/d19851f002862a5510bf31fae4083fab979258be/stand/i386/libi386/vbe.h#L136

Also clarify the man page. The only time we have a fixed resolution terminal is in text mode with the BIOS loader, and that uses 80x25. With the other configurations, the terminal size isn't really guaranteed to be anything.