### PR TITLE
Makefile.inc1: Also cleanup (un)compressed manpages

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -3516,6 +3516,13 @@ delete-old-files: .PHONY
 		fi; \
 	done
 .endif
+.if !empty(MAN_ARCH) && ${MAN_ARCH} != "all"
+	@exec 3<&0; \
+	find -E /usr/share/man/man4/ -mindepth 1 -type d ! -regex '.*/(${MAN_ARCH:C/[[:space:]]+/|/gW})' | \
+	while read dir; do \
+		find $$dir ! -type d -exec rm ${RM_I} {} + <&3; \
+	done
+.endif
 	@echo ">>> Old files removed"
 
 check-old-files: .PHONY
@@ -3556,6 +3563,12 @@ check-old-files: .PHONY
 		if [ -e "$${manpage}.gz" ]; then \
 			echo $${manpage}; \
 		fi; \
+	done | sort
+.endif
+.if !empty(MAN_ARCH) && ${MAN_ARCH} != "all"
+	@find -E /usr/share/man/man4/ -mindepth 1 -type d ! -regex '.*/(${MAN_ARCH:C/[[:space:]]+/|/gW})' | \
+	while read dir; do \
+		find $$dir ! -type d; \
 	done | sort
 .endif
 

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -3497,6 +3497,25 @@ delete-old-files: .PHONY
 			rm ${RM_I} $${catpage} <&3; \
 	        fi; \
 	done
+# Remove compressed copies of uncompressed manpages
+.if ${MK_MANCOMPRESS} != "yes"
+	@exec 3<&0; \
+	find ${DESTDIR}/usr/share/man ${DESTDIR}/usr/share/openssl/man ! -type d ! -name \*.gz 2>/dev/null | \
+	while read manpage; do \
+		if [ -e "$${manpage}.gz" ]; then \
+			rm ${RM_I} $${manpage}.gz <&3; \
+		fi; \
+	done
+# Remove uncompressed copies of compressed manpages
+.else
+	@exec 3<&0; \
+	find ${DESTDIR}/usr/share/man ${DESTDIR}/usr/share/openssl/man ! -type d ! -name \*.gz 2>/dev/null | \
+	while read manpage; do \
+		if [ -e "$${manpage}.gz" ]; then \
+			rm ${RM_I} $${manpage} <&3; \
+		fi; \
+	done
+.endif
 	@echo ">>> Old files removed"
 
 check-old-files: .PHONY
@@ -3522,6 +3541,23 @@ check-old-files: .PHONY
 			echo $${catpage}; \
 	        fi; \
 	done | sort
+# Check for compressed copies of uncompressed manpages
+.if ${MK_MANCOMPRESS} != "yes"
+	@find ${DESTDIR}/usr/share/man ${DESTDIR}/usr/share/openssl/man ! -type d ! -name \*.gz 2>/dev/null | \
+	while read manpage; do \
+		if [ -e "$${manpage}.gz" ]; then \
+			echo $${manpage}.gz; \
+		fi; \
+	done | sort
+# Check for uncompressed copies of compressed manpages
+.else
+	@find ${DESTDIR}/usr/share/man ${DESTDIR}/usr/share/openssl/man ! -type d ! -name \*.gz 2>/dev/null | \
+	while read manpage; do \
+		if [ -e "$${manpage}.gz" ]; then \
+			echo $${manpage}; \
+		fi; \
+	done | sort
+.endif
 
 list-old-libs: .PHONY
 	@cd ${.CURDIR}; \

--- a/share/mk/bsd.man.mk
+++ b/share/mk/bsd.man.mk
@@ -237,11 +237,9 @@ maninstall: ${MAN}
 # On MacOS, assume case folding FS, and don't install links from foo.x to FOO.x.
 .if ${.MAKE.OS} != "Darwin" || ${l:tu} != ${t:tu}
 .if ${MK_MANSPLITPKG} == "no"
-	rm -f ${DESTDIR}${t} ${DESTDIR}${t}${MCOMPRESS_EXT}; \
-	    ${INSTALL_MANLINK} ${TAG_ARGS} ${DESTDIR}${l}${ZEXT} ${DESTDIR}${t}${ZEXT}
+	${INSTALL_MANLINK} ${TAG_ARGS} ${DESTDIR}${l}${ZEXT} ${DESTDIR}${t}${ZEXT}
 .else
-	rm -f ${DESTDIR}${t} ${DESTDIR}${t}${MCOMPRESS_EXT}; \
-	    ${INSTALL_MANLINK} ${TAG_ARGS:D${TAG_ARGS},man} ${DESTDIR}${l}${ZEXT} ${DESTDIR}${t}${ZEXT}
+	${INSTALL_MANLINK} ${TAG_ARGS:D${TAG_ARGS},man} ${DESTDIR}${l}${ZEXT} ${DESTDIR}${t}${ZEXT}
 .endif
 .endif
 .endfor


### PR DESCRIPTION
Cleanup (un)compressed manpages in the `check-old-files` & `delete-old-files` targets.

Also cleanup manpages for arches not included in MAN_ARCH, if specified.

PR:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=279792