### PR TITLE
seems stdbool.h was missed to be included in tzsetup.c, causing build failures

### DIFF
--- a/usr.sbin/tzsetup/tzsetup.c
+++ b/usr.sbin/tzsetup/tzsetup.c
@@ -41,6 +41,7 @@
 #include <err.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>


### PR DESCRIPTION
noticed this, should be a quick fix :)