### PR TITLE
Interrupt counters on `struct intr_event`

### DIFF
--- a/sys/dev/acpica/acpi_apei.c
+++ b/sys/dev/acpica/acpi_apei.c
@@ -730,7 +730,8 @@ apei_attach(device_t dev)
 			TAILQ_INSERT_TAIL(&sc->nges.ges, ge, nlink);
 			if (sc->nges.swi_ih == NULL) {
 				swi_add(&clk_intr_event, "apei", apei_nmi_swi,
-				    &sc->nges, SWI_CLOCK, INTR_MPSAFE,
+				    &sc->nges, SWI_CLOCK,
+				    INTR_MPSAFE | INTR_MULTIPROC,
 				    &sc->nges.swi_ih);
 				apei_nmi_nges = &sc->nges;
 				apei_nmi = apei_nmi_handler;

--- a/sys/dev/acpica/acpi_apei.c
+++ b/sys/dev/acpica/acpi_apei.c
@@ -33,6 +33,7 @@
 #include <sys/systm.h>
 #include <sys/bus.h>
 #include <sys/callout.h>
+#include <sys/clock.h>
 #include <sys/interrupt.h>
 #include <sys/kernel.h>
 #include <sys/malloc.h>

--- a/sys/kern/kern_clock.c
+++ b/sys/kern/kern_clock.c
@@ -569,7 +569,7 @@ start_softintr(void *dummy)
 	    __func__));
 
 	if (swi_add(&clk_intr_event, "clk", NULL, NULL, SWI_CLOCK,
-	    INTR_MPSAFE, NULL))
+	    INTR_MPSAFE | INTR_MULTIPROC, NULL))
 		panic("died while creating clk swi ithread");
 }
 SYSINIT(start_softintr, SI_SUB_SOFTINTR, SI_ORDER_FIRST, start_softintr,

--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -1154,9 +1154,13 @@ swi_sched(void *cookie, int flags)
 
 	if (flags & SWI_FROMNMI) {
 #if defined(SMP) && (defined(__i386__) || defined(__amd64__))
+#ifdef DEV_ACPI
 		KASSERT(ie == clk_intr_event,
 		    ("SWI_FROMNMI used not with clk_intr_event"));
 		ipi_self_from_nmi(IPI_SWI);
+#else
+		KASSERT(0, ("SWI_FROMNMI used not with clk_intr_event"));
+#endif
 #endif
 	} else {
 		VM_CNT_INC(v_soft);

--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 1997, Stefan Esser <se@freebsd.org>
  * All rights reserved.
+ * Copyright © 2023 Elliott Mitchell
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -284,8 +285,8 @@ intr_event_create(struct intr_event **event, void *source, int flags, u_int irq,
 	struct intr_event *ie;
 	va_list ap;
 
-	/* The only valid flag during creation is IE_SOFT. */
-	if ((flags & ~IE_SOFT) != 0)
+	/* The flags valid during creation are IE_SOFT and IE_MULTIPROC. */
+	if ((flags & ~(IE_SOFT | IE_MULTIPROC)) != 0)
 		return (EINVAL);
 	ie = malloc(sizeof(struct intr_event), M_ITHREAD, M_WAITOK | M_ZERO);
 	ie->ie_source = source;

--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -1823,18 +1823,13 @@ out:
  * We do not know the length of intrcnt and intrnames at compile time, so
  * calculate things at run time.
  */
-static int
+int
 sysctl_intrnames(SYSCTL_HANDLER_ARGS)
 {
 	return (sysctl_handle_opaque(oidp, intrnames, sintrnames, req));
 }
 
-SYSCTL_PROC(_hw, OID_AUTO, intrnames,
-    CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
-    sysctl_intrnames, "",
-    "Interrupt Names");
-
-static int
+int
 sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
 {
 #ifdef SCTL_MASK32
@@ -1857,11 +1852,6 @@ sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
 #endif
 	return (sysctl_handle_opaque(oidp, intrcnt, sintrcnt, req));
 }
-
-SYSCTL_PROC(_hw, OID_AUTO, intrcnt,
-    CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
-    sysctl_intrcnt, "",
-    "Interrupt Counts");
 
 #ifdef DDB
 /*

--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -1542,13 +1542,12 @@ intr_event_handle(struct intr_event *ie, struct trapframe *frame)
 	}
 	critical_exit();
 	td->td_intr_nesting_level--;
-#ifdef notyet
+
 	/* The interrupt is not aknowledged by any filter and has no ithread. */
 	if (!thread && !filter) {
 		++ie->ie_stray;
 		return (ie->ie_stray);
 	}
-#endif
 	return (0);
 }
 

--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -641,6 +641,19 @@ intr_event_add_handler(struct intr_event *ie, const char *name,
 		return (EINVAL);
 	}
 
+	if ((flags & INTR_MULTIPROC) && !(ie->ie_flags & IE_MULTIPROC)) {
+#if defined(INVARIANTS) || defined(DEBUG)
+		printf("%s: Requested multi-processor interupt, but got "
+		    "uniprocessor interrupt\n", name);
+#endif
+		return (ENODEV);
+	}
+#if defined(INVARIANTS) || defined(DEBUG)
+	if (!(flags & INTR_MULTIPROC) && (ie->ie_flags & IE_MULTIPROC))
+		printf("%s: Requested uniprocessor interupt, but got "
+		    "multi-processor interrupt\n", name);
+#endif
+
 	/* Allocate and populate an interrupt handler structure. */
 	ih = malloc(sizeof(struct intr_handler), M_ITHREAD, M_WAITOK | M_ZERO);
 	ih->ih_filter = filter;

--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -1814,45 +1814,6 @@ out:
 	return (error);
 }
 
-/*
- * Sysctls used by systat and others: hw.intrnames and hw.intrcnt.
- * The data for this machine dependent, and the declarations are in machine
- * dependent code.  The layout of intrnames and intrcnt however is machine
- * independent.
- *
- * We do not know the length of intrcnt and intrnames at compile time, so
- * calculate things at run time.
- */
-int
-sysctl_intrnames(SYSCTL_HANDLER_ARGS)
-{
-	return (sysctl_handle_opaque(oidp, intrnames, sintrnames, req));
-}
-
-int
-sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
-{
-#ifdef SCTL_MASK32
-	uint32_t *intrcnt32;
-	unsigned i;
-	int error;
-
-	if (req->flags & SCTL_MASK32) {
-		if (!req->oldptr)
-			return (sysctl_handle_opaque(oidp, NULL, sintrcnt / 2, req));
-		intrcnt32 = malloc(sintrcnt / 2, M_TEMP, M_NOWAIT);
-		if (intrcnt32 == NULL)
-			return (ENOMEM);
-		for (i = 0; i < sintrcnt / sizeof (u_long); i++)
-			intrcnt32[i] = intrcnt[i];
-		error = sysctl_handle_opaque(oidp, intrcnt32, sintrcnt / 2, req);
-		free(intrcnt32, M_TEMP);
-		return (error);
-	}
-#endif
-	return (sysctl_handle_opaque(oidp, intrcnt, sintrcnt, req));
-}
-
 #ifdef DDB
 /*
  * DDB command to dump the interrupt statistics.

--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -315,6 +315,11 @@ intr_event_create(struct intr_event **event, void *source, int flags, u_int irq,
 	if (flags & IE_MULTIPROC) {
 		int idx;
 		bit_ffc(intrcnt_multi_inuse, INTRCNT_MULTI_COUNT, &idx);
+
+		if (bootverbose)
+			printf("Allocate multi-processor counter #%d to \"%s"
+			    "\"\n", idx, ie->ie_name);
+
 		if (idx == -1)
 			panic("Exhausted multiprocessor interrupt counters");
 		bit_set(intrcnt_multi_inuse, idx);

--- a/sys/kern/kern_intr.c
+++ b/sys/kern/kern_intr.c
@@ -1109,7 +1109,9 @@ swi_add(struct intr_event **eventp, const char *name, driver_intr_t handler,
 			return (EINVAL);
 	} else {
 		error = intr_event_create(&ie, NULL, ieflags, 0,
-		    NULL, NULL, NULL, swi_assign_cpu, "swi%d:", pri);
+		    NULL, NULL, NULL, swi_assign_cpu,
+		    handler == NULL && name != NULL ? "%2$s swi%1$d:" : "swi%d",
+		    pri, name);
 		if (error)
 			return (error);
 		if (eventp != NULL)

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -172,14 +172,14 @@ u_int intr_nirq = NIRQ;
 SYSCTL_UINT(_machdep, OID_AUTO, nirq, CTLFLAG_RDTUN, &intr_nirq, 0,
     "Number of IRQs");
 
+#ifdef SMP
 /* Data for statistics reporting. */
 static u_long *intrcnt;
 static char *intrnames;
-#ifdef SMP
 static u_int intrcnt_index;
-#endif
 static int nintrcnt;
 static bitstr_t *intrcnt_bitmap;
+#endif
 
 static struct intr_irqsrc *intr_map_get_isrc(u_int res_id);
 static void intr_map_set_isrc(u_int res_id, struct intr_irqsrc *isrc);

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -172,15 +172,13 @@ u_int intr_nirq = NIRQ;
 SYSCTL_UINT(_machdep, OID_AUTO, nirq, CTLFLAG_RDTUN, &intr_nirq, 0,
     "Number of IRQs");
 
-/* Data for MI statistics reporting. */
-u_long *intrcnt;
-char *intrnames;
-size_t sintrcnt;
-size_t sintrnames;
+/* Data for statistics reporting. */
+static u_long *intrcnt;
+static char *intrnames;
 #ifdef SMP
 static u_int intrcnt_index;
 #endif
-int nintrcnt;
+static int nintrcnt;
 static bitstr_t *intrcnt_bitmap;
 
 static struct intr_irqsrc *intr_map_get_isrc(u_int res_id);

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -4,6 +4,7 @@
  * All rights reserved.
  * Copyright (c) 2015-2016 The FreeBSD Foundation
  * Copyright (c) 2021 Jessica Clarke <jrtc27@FreeBSD.org>
+ * Copyright © 2023 Elliott Mitchell
  *
  * Portions of this software were developed by Andrew Turner under
  * sponsorship from the FreeBSD Foundation.
@@ -682,9 +683,12 @@ static int
 isrc_event_create(struct intr_irqsrc *isrc)
 {
 	struct intr_event *ie;
+	u_int flags = 0;
 	int error;
 
-	error = intr_event_create(&ie, isrc, 0, isrc->isrc_irq,
+	if (isrc->isrc_flags & (INTR_ISRCF_IPI | INTR_ISRCF_PPI))
+		flags |= IE_MULTIPROC;
+	error = intr_event_create(&ie, isrc, flags, isrc->isrc_irq,
 	    intr_isrc_pre_ithread, intr_isrc_post_ithread, intr_isrc_post_filter,
 	    intr_isrc_assign_cpu, "%s:", isrc->isrc_name);
 	if (error)

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -1960,3 +1960,13 @@ intr_ipi_dispatch(u_int ipi)
 	ii->ii_handler(ii->ii_handler_arg);
 }
 #endif
+
+SYSCTL_PROC(_hw, OID_AUTO, intrnames,
+    CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
+    sysctl_intrnames,
+    "", "Interrupt Names");
+
+SYSCTL_PROC(_hw, OID_AUTO, intrcnt,
+    CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
+    sysctl_intrcnt,
+    "", "Interrupt Counts");

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -177,6 +177,7 @@ u_long *intrcnt;
 char *intrnames;
 size_t sintrcnt;
 size_t sintrnames;
+static u_int intrcnt_index;
 int nintrcnt;
 static bitstr_t *intrcnt_bitmap;
 
@@ -211,8 +212,6 @@ intr_irq_init(void *dummy __unused)
 	    M_WAITOK | M_ZERO);
 	intrnames = mallocarray(nintrcnt, INTRNAME_LEN, M_INTRNG,
 	    M_WAITOK | M_ZERO);
-	sintrcnt = nintrcnt * sizeof(u_long);
-	sintrnames = nintrcnt * INTRNAME_LEN;
 
 	/* Allocate the bitmap tracking counter allocations. */
 	intrcnt_bitmap = bit_alloc(nintrcnt, M_INTRNG, M_WAITOK | M_ZERO);
@@ -306,6 +305,8 @@ isrc_setup_counters(struct intr_irqsrc *isrc)
 	if (index == -1)
 		panic("Failed to allocate 2 counters. Array exhausted?");
 	bit_nset(intrcnt_bitmap, index, index + 1);
+	if (index >= intrcnt_index)
+		intrcnt_index = index + 2;
 	isrc->isrc_index = index;
 	isrc->isrc_count = &intrcnt[index];
 	isrc_update_name(isrc, NULL);
@@ -1834,6 +1835,8 @@ intr_ipi_setup_counters(const char *name)
 		panic("Failed to allocate %d counters. Array exhausted?",
 		    mp_maxid + 1);
 	bit_nset(intrcnt_bitmap, index, index + mp_maxid);
+	if (index >= intrcnt_index)
+		intrcnt_index = index + mp_maxid + 1;
 	for (i = 0; i < mp_maxid + 1; i++) {
 		snprintf(str, INTRNAME_LEN, "cpu%d:%s", i, name);
 		intrcnt_setname(str, index + i);
@@ -1967,7 +1970,8 @@ intr_ipi_dispatch(u_int ipi)
 static int
 intr_sysctl_intrnames(SYSCTL_HANDLER_ARGS)
 {
-	return (sysctl_handle_opaque(oidp, intrnames, sintrnames, req));
+	return (sysctl_handle_opaque(oidp, intrnames,
+	    intrcnt_index * INTRNAME_LEN, req));
 }
 
 SYSCTL_PROC(_hw, OID_AUTO, intrnames,
@@ -1985,18 +1989,22 @@ intr_sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
 
 	if (req->flags & SCTL_MASK32) {
 		if (!req->oldptr)
-			return (sysctl_handle_opaque(oidp, NULL, sintrcnt / 2, req));
-		intrcnt32 = malloc(sintrcnt / 2, M_TEMP, M_NOWAIT);
+			return (sysctl_handle_opaque(oidp, NULL,
+			    intrcnt_index * sizeof(uint32_t), req));
+		intrcnt32 = malloc(intrcnt_index * sizeof(uint32_t), M_TEMP,
+		    M_NOWAIT);
 		if (intrcnt32 == NULL)
 			return (ENOMEM);
-		for (i = 0; i < sintrcnt / sizeof (u_long); i++)
+		for (i = 0; i < intrcnt_index; i++)
 			intrcnt32[i] = intrcnt[i];
-		error = sysctl_handle_opaque(oidp, intrcnt32, sintrcnt / 2, req);
+		error = sysctl_handle_opaque(oidp, intrcnt32,
+		    intrcnt_index * sizeof(uint32_t), req);
 		free(intrcnt32, M_TEMP);
 		return (error);
 	}
 #endif
-	return (sysctl_handle_opaque(oidp, intrcnt, sintrcnt, req));
+	return (sysctl_handle_opaque(oidp, intrcnt,
+	    intrcnt_index * sizeof(u_long), req));
 }
 
 SYSCTL_PROC(_hw, OID_AUTO, intrcnt,

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -1839,8 +1839,14 @@ intr_ipi_dispatch(u_int ipi)
 static int
 intr_sysctl_intrnames(SYSCTL_HANDLER_ARGS)
 {
-	return (sysctl_handle_opaque(oidp, intrnames,
-	    intrcnt_index * INTRNAME_LEN, req));
+	int error;
+
+	error = sysctl_handle_opaque(oidp, intrnames,
+	    intrcnt_index * INTRNAME_LEN, req);
+	if (error != 0)
+		return (error);
+
+	return (intr_event_sysctl_intrnames(oidp, arg1, arg2, req));
 }
 
 SYSCTL_PROC(_hw, OID_AUTO, intrnames,
@@ -1851,10 +1857,10 @@ SYSCTL_PROC(_hw, OID_AUTO, intrnames,
 static int
 intr_sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
 {
+	int error;
 #ifdef SCTL_MASK32
 	uint32_t *intrcnt32;
 	unsigned i;
-	int error;
 
 	if (req->flags & SCTL_MASK32) {
 		if (!req->oldptr)
@@ -1869,14 +1875,31 @@ intr_sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
 		error = sysctl_handle_opaque(oidp, intrcnt32,
 		    intrcnt_index * sizeof(uint32_t), req);
 		free(intrcnt32, M_TEMP);
-		return (error);
-	}
+	} else
 #endif
-	return (sysctl_handle_opaque(oidp, intrcnt,
-	    intrcnt_index * sizeof(u_long), req));
+		error = sysctl_handle_opaque(oidp, intrcnt,
+		    intrcnt_index * sizeof(u_long), req);
+
+	return (error == 0 ? intr_event_sysctl_intrcnt(oidp, arg1, arg2, req) :
+	    error);
 }
 
 SYSCTL_PROC(_hw, OID_AUTO, intrcnt,
     CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
     intr_sysctl_intrcnt,
     "", "Interrupt Counts");
+
+#ifdef DDB
+/*
+ * DDB command to dump the IPI interrupt statistics.
+ */
+DB_SHOW_COMMAND_FLAGS(ipicnt, db_show_ipicnt, DB_CMD_MEMSAFE)
+{
+	u_int i;
+
+	for (i = 0; i < intrcnt_index && !db_pager_quit; ++i)
+		if (intrcnt[i] != 0)
+			db_printf("%s\t%lu\n", intrnames + i * INTRNAME_LEN,
+			    intrcnt[i]);
+}
+#endif

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -4,7 +4,7 @@
  * All rights reserved.
  * Copyright (c) 2015-2016 The FreeBSD Foundation
  * Copyright (c) 2021 Jessica Clarke <jrtc27@FreeBSD.org>
- * Copyright © 2023 Elliott Mitchell
+ * Copyright © 2022-2023 Elliott Mitchell
  *
  * Portions of this software were developed by Andrew Turner under
  * sponsorship from the FreeBSD Foundation.
@@ -1961,12 +1961,45 @@ intr_ipi_dispatch(u_int ipi)
 }
 #endif
 
+/*
+ * Sysctls used by systat and others: hw.intrnames and hw.intrcnt.
+ */
+static int
+intr_sysctl_intrnames(SYSCTL_HANDLER_ARGS)
+{
+	return (sysctl_handle_opaque(oidp, intrnames, sintrnames, req));
+}
+
 SYSCTL_PROC(_hw, OID_AUTO, intrnames,
     CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
-    sysctl_intrnames,
+    intr_sysctl_intrnames,
     "", "Interrupt Names");
+
+static int
+intr_sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
+{
+#ifdef SCTL_MASK32
+	uint32_t *intrcnt32;
+	unsigned i;
+	int error;
+
+	if (req->flags & SCTL_MASK32) {
+		if (!req->oldptr)
+			return (sysctl_handle_opaque(oidp, NULL, sintrcnt / 2, req));
+		intrcnt32 = malloc(sintrcnt / 2, M_TEMP, M_NOWAIT);
+		if (intrcnt32 == NULL)
+			return (ENOMEM);
+		for (i = 0; i < sintrcnt / sizeof (u_long); i++)
+			intrcnt32[i] = intrcnt[i];
+		error = sysctl_handle_opaque(oidp, intrcnt32, sintrcnt / 2, req);
+		free(intrcnt32, M_TEMP);
+		return (error);
+	}
+#endif
+	return (sysctl_handle_opaque(oidp, intrcnt, sintrcnt, req));
+}
 
 SYSCTL_PROC(_hw, OID_AUTO, intrcnt,
     CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
-    sysctl_intrcnt,
+    intr_sysctl_intrcnt,
     "", "Interrupt Counts");

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -177,7 +177,9 @@ u_long *intrcnt;
 char *intrnames;
 size_t sintrcnt;
 size_t sintrnames;
+#ifdef SMP
 static u_int intrcnt_index;
+#endif
 int nintrcnt;
 static bitstr_t *intrcnt_bitmap;
 
@@ -199,12 +201,11 @@ intr_irq_init(void *dummy __unused)
 
 	mtx_init(&isrc_table_lock, "intr isrc table", NULL, MTX_DEF);
 
+#ifdef SMP
 	/*
 	 * - mp_maxid + 1 counters for each IPI counters for SMP.
 	 */
-#ifdef SMP
 	nintrcnt += INTR_IPI_COUNT * (mp_maxid + 1);
-#endif
 
 	intrcnt = mallocarray(nintrcnt, sizeof(u_long), M_INTRNG,
 	    M_WAITOK | M_ZERO);
@@ -213,12 +214,14 @@ intr_irq_init(void *dummy __unused)
 
 	/* Allocate the bitmap tracking counter allocations. */
 	intrcnt_bitmap = bit_alloc(nintrcnt, M_INTRNG, M_WAITOK | M_ZERO);
+#endif
 
 	irq_sources = mallocarray(intr_nirq, sizeof(struct intr_irqsrc*),
 	    M_INTRNG, M_WAITOK | M_ZERO);
 }
 SYSINIT(intr_irq_init, SI_SUB_INTR, SI_ORDER_FIRST, intr_irq_init, NULL);
 
+#ifdef SMP
 static void
 intrcnt_setname(const char *name, int index)
 {
@@ -1848,12 +1851,18 @@ intr_sysctl_intrnames(SYSCTL_HANDLER_ARGS)
 
 	return (intr_event_sysctl_intrnames(oidp, arg1, arg2, req));
 }
+#endif
 
 SYSCTL_PROC(_hw, OID_AUTO, intrnames,
     CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
+#ifdef SMP
     intr_sysctl_intrnames,
+#else
+    intr_event_sysctl_intrnames,
+#endif
     "", "Interrupt Names");
 
+#ifdef SMP
 static int
 intr_sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
 {
@@ -1883,10 +1892,15 @@ intr_sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
 	return (error == 0 ? intr_event_sysctl_intrcnt(oidp, arg1, arg2, req) :
 	    error);
 }
+#endif
 
 SYSCTL_PROC(_hw, OID_AUTO, intrcnt,
     CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
+#ifdef SMP
     intr_sysctl_intrcnt,
+#else
+    intr_event_sysctl_intrcnt,
+#endif
     "", "Interrupt Counts");
 
 #ifdef DDB

--- a/sys/kern/subr_intr.c
+++ b/sys/kern/subr_intr.c
@@ -200,10 +200,8 @@ intr_irq_init(void *dummy __unused)
 	mtx_init(&isrc_table_lock, "intr isrc table", NULL, MTX_DEF);
 
 	/*
-	 * - 2 counters for each I/O interrupt.
 	 * - mp_maxid + 1 counters for each IPI counters for SMP.
 	 */
-	nintrcnt = intr_nirq * 2;
 #ifdef SMP
 	nintrcnt += INTR_IPI_COUNT * (mp_maxid + 1);
 #endif
@@ -227,102 +225,6 @@ intrcnt_setname(const char *name, int index)
 
 	snprintf(intrnames + INTRNAME_LEN * index, INTRNAME_LEN, "%-*s",
 	    INTRNAME_LEN - 1, name);
-}
-
-/*
- *  Update name for interrupt source with interrupt event.
- */
-static void
-intrcnt_updatename(struct intr_irqsrc *isrc)
-{
-
-	/* QQQ: What about stray counter name? */
-	mtx_assert(&isrc_table_lock, MA_OWNED);
-	intrcnt_setname(isrc->isrc_event->ie_fullname, isrc->isrc_index);
-}
-
-/*
- *  Virtualization for interrupt source interrupt counter increment.
- */
-static inline void
-isrc_increment_count(struct intr_irqsrc *isrc)
-{
-
-	if (isrc->isrc_flags & INTR_ISRCF_PPI)
-		atomic_add_long(&isrc->isrc_count[0], 1);
-	else
-		isrc->isrc_count[0]++;
-}
-
-/*
- *  Virtualization for interrupt source interrupt stray counter increment.
- */
-static inline void
-isrc_increment_straycount(struct intr_irqsrc *isrc)
-{
-
-	isrc->isrc_count[1]++;
-}
-
-/*
- *  Virtualization for interrupt source interrupt name update.
- */
-static void
-isrc_update_name(struct intr_irqsrc *isrc, const char *name)
-{
-	char str[INTRNAME_LEN];
-
-	mtx_assert(&isrc_table_lock, MA_OWNED);
-
-	if (name != NULL) {
-		snprintf(str, INTRNAME_LEN, "%s: %s", isrc->isrc_name, name);
-		intrcnt_setname(str, isrc->isrc_index);
-		snprintf(str, INTRNAME_LEN, "stray %s: %s", isrc->isrc_name,
-		    name);
-		intrcnt_setname(str, isrc->isrc_index + 1);
-	} else {
-		snprintf(str, INTRNAME_LEN, "%s:", isrc->isrc_name);
-		intrcnt_setname(str, isrc->isrc_index);
-		snprintf(str, INTRNAME_LEN, "stray %s:", isrc->isrc_name);
-		intrcnt_setname(str, isrc->isrc_index + 1);
-	}
-}
-
-/*
- *  Virtualization for interrupt source interrupt counters setup.
- */
-static void
-isrc_setup_counters(struct intr_irqsrc *isrc)
-{
-	int index;
-
-	mtx_assert(&isrc_table_lock, MA_OWNED);
-
-	/*
-	 * Allocate two counter values, the second tracking "stray" interrupts.
-	 */
-	bit_ffc_area(intrcnt_bitmap, nintrcnt, 2, &index);
-	if (index == -1)
-		panic("Failed to allocate 2 counters. Array exhausted?");
-	bit_nset(intrcnt_bitmap, index, index + 1);
-	if (index >= intrcnt_index)
-		intrcnt_index = index + 2;
-	isrc->isrc_index = index;
-	isrc->isrc_count = &intrcnt[index];
-	isrc_update_name(isrc, NULL);
-}
-
-/*
- *  Virtualization for interrupt source interrupt counters release.
- */
-static void
-isrc_release_counters(struct intr_irqsrc *isrc)
-{
-	int idx = isrc->isrc_index;
-
-	mtx_assert(&isrc_table_lock, MA_OWNED);
-
-	bit_nclear(intrcnt_bitmap, idx, idx + 1);
 }
 
 /*
@@ -394,9 +296,6 @@ intr_isrc_dispatch(struct intr_irqsrc *isrc, struct trapframe *tf)
 
 	KASSERT(isrc != NULL, ("%s: no source", __func__));
 
-	if ((isrc->isrc_flags & INTR_ISRCF_IPI) == 0)
-		isrc_increment_count(isrc);
-
 #ifdef INTR_SOLO
 	if (isrc->isrc_filter != NULL) {
 		int error;
@@ -411,8 +310,6 @@ intr_isrc_dispatch(struct intr_irqsrc *isrc, struct trapframe *tf)
 			return (0);
 	}
 
-	if ((isrc->isrc_flags & INTR_ISRCF_IPI) == 0)
-		isrc_increment_straycount(isrc);
 	return (EINVAL);
 }
 
@@ -516,19 +413,8 @@ intr_isrc_register(struct intr_irqsrc *isrc, device_t dev, u_int flags,
 
 	mtx_lock(&isrc_table_lock);
 	error = isrc_alloc_irq(isrc);
-	if (error != 0) {
-		mtx_unlock(&isrc_table_lock);
-		return (error);
-	}
-	/*
-	 * Setup interrupt counters, but not for IPI sources. Those are setup
-	 * later and only for used ones (up to INTR_IPI_COUNT) to not exhaust
-	 * our counter pool.
-	 */
-	if ((isrc->isrc_flags & INTR_ISRCF_IPI) == 0)
-		isrc_setup_counters(isrc);
 	mtx_unlock(&isrc_table_lock);
-	return (0);
+	return (error);
 }
 
 /*
@@ -540,8 +426,6 @@ intr_isrc_deregister(struct intr_irqsrc *isrc)
 	int error;
 
 	mtx_lock(&isrc_table_lock);
-	if ((isrc->isrc_flags & INTR_ISRCF_IPI) == 0)
-		isrc_release_counters(isrc);
 	error = isrc_free_irq(isrc);
 	mtx_unlock(&isrc_table_lock);
 	return (error);
@@ -748,15 +632,8 @@ isrc_add_handler(struct intr_irqsrc *isrc, const char *name,
 			return (error);
 	}
 
-	error = intr_event_add_handler(isrc->isrc_event, name, filter, handler,
-	    arg, intr_priority(flags), flags, cookiep);
-	if (error == 0) {
-		mtx_lock(&isrc_table_lock);
-		intrcnt_updatename(isrc);
-		mtx_unlock(&isrc_table_lock);
-	}
-
-	return (error);
+	return (intr_event_add_handler(isrc->isrc_event, name, filter, handler,
+	    arg, intr_priority(flags), flags, cookiep));
 }
 
 /*
@@ -1189,7 +1066,6 @@ intr_teardown_irq(device_t dev, struct resource *res, void *cookie)
 		if (isrc->isrc_handlers == 0)
 			PIC_DISABLE_INTR(isrc->isrc_dev, isrc);
 		PIC_TEARDOWN_INTR(isrc->isrc_dev, isrc, res, data);
-		intrcnt_updatename(isrc);
 		mtx_unlock(&isrc_table_lock);
 	}
 	return (error);
@@ -1199,7 +1075,6 @@ int
 intr_describe_irq(device_t dev, struct resource *res, void *cookie,
     const char *descr)
 {
-	int error;
 	struct intr_irqsrc *isrc;
 	u_int res_id;
 
@@ -1221,13 +1096,7 @@ intr_describe_irq(device_t dev, struct resource *res, void *cookie,
 		return (0);
 	}
 #endif
-	error = intr_event_describe_handler(isrc->isrc_event, cookie, descr);
-	if (error == 0) {
-		mtx_lock(&isrc_table_lock);
-		intrcnt_updatename(isrc);
-		mtx_unlock(&isrc_table_lock);
-	}
-	return (error);
+	return (intr_event_describe_handler(isrc->isrc_event, cookie, descr));
 }
 
 #ifdef SMP
@@ -1616,7 +1485,7 @@ DB_SHOW_COMMAND_FLAGS(irqs, db_show_irqs, DB_CMD_MEMSAFE)
 		if (isrc == NULL)
 			continue;
 
-		num = isrc->isrc_count != NULL ? isrc->isrc_count[0] : 0;
+		num = isrc->isrc_event != NULL ? isrc->isrc_event->ie_intrcnt : 0;
 		db_printf("irq%-3u <%s>: cpu %02lx%s cnt %lu\n", i,
 		    isrc->isrc_name, isrc->isrc_cpu.__bits[0],
 		    isrc->isrc_flags & INTR_ISRCF_BOUND ? " (bound)" : "", num);

--- a/sys/kern/subr_sbuf.c
+++ b/sys/kern/subr_sbuf.c
@@ -632,15 +632,14 @@ sbuf_cpy(struct sbuf *s, const char *str)
 #ifdef _KERNEL
 
 /*
- * Append a non-NUL character to an sbuf.  This prototype signature is
+ * Append a character to an sbuf.  This prototype signature is
  * suitable for use with kvprintf(9).
  */
 static void
 sbuf_putc_func(int c, void *arg)
 {
 
-	if (__predict_true(c != '\0'))
-		sbuf_put_byte(arg, c);
+	sbuf_put_byte(arg, c);
 }
 
 int

--- a/sys/powerpc/powerpc/intr_machdep.c
+++ b/sys/powerpc/powerpc/intr_machdep.c
@@ -692,3 +692,13 @@ powerpc_intr_unmask(u_int irq)
 
 	PIC_UNMASK(i->pic, i->intline, i->priv);
 }
+
+SYSCTL_PROC(_hw, OID_AUTO, intrnames,
+    CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
+    sysctl_intrnames,
+    "", "Interrupt Names");
+
+SYSCTL_PROC(_hw, OID_AUTO, intrcnt,
+    CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
+    sysctl_intrcnt,
+    "", "Interrupt Counts");

--- a/sys/powerpc/powerpc/intr_machdep.c
+++ b/sys/powerpc/powerpc/intr_machdep.c
@@ -164,7 +164,7 @@ intr_init_sources(void *arg __unused)
 
 	powerpc_intrs = mallocarray(num_io_irqs, sizeof(*powerpc_intrs),
 	    M_INTR, M_WAITOK | M_ZERO);
-	nintrcnt = 1 + mp_ncpus * 2;
+	nintrcnt = mp_ncpus * 2;
 #ifdef COUNT_IPIS
 	if (mp_ncpus > 1)
 		nintrcnt += 8 * mp_ncpus;
@@ -173,9 +173,6 @@ intr_init_sources(void *arg __unused)
 	    M_ZERO);
 	intrnames = mallocarray(nintrcnt, INTRNAME_LEN, M_INTR, M_WAITOK |
 	    M_ZERO);
-
-	intrcnt_setname("???", 0);
-	intrcnt_index = 1;
 }
 /*
  * This needs to happen before SI_SUB_CPU

--- a/sys/powerpc/powerpc/intr_machdep.c
+++ b/sys/powerpc/powerpc/intr_machdep.c
@@ -124,12 +124,10 @@ static u_int nirqs = 0;		/* Allocated IRQs. */
 static u_int stray_count;
 
 #define	INTRNAME_LEN	(MAXCOMLEN + 1)
-u_long *intrcnt;
-char *intrnames;
-size_t sintrcnt = sizeof(intrcnt);
-size_t sintrnames = sizeof(intrnames);
+static u_long *intrcnt;
+static char *intrnames;
 static u_int intrcnt_index;
-int nintrcnt;
+static int nintrcnt;
 
 /*
  * Just to start

--- a/sys/powerpc/powerpc/intr_machdep.c
+++ b/sys/powerpc/powerpc/intr_machdep.c
@@ -73,6 +73,7 @@
 #include <sys/mutex.h>
 #include <sys/pcpu.h>
 #include <sys/smp.h>
+#include <sys/sysctl.h>
 #include <sys/syslog.h>
 #include <sys/vmmeter.h>
 #include <sys/proc.h>
@@ -693,12 +694,45 @@ powerpc_intr_unmask(u_int irq)
 	PIC_UNMASK(i->pic, i->intline, i->priv);
 }
 
+/*
+ * Sysctls used by systat and others: hw.intrnames and hw.intrcnt.
+ */
+static int
+powerpc_sysctl_intrnames(SYSCTL_HANDLER_ARGS)
+{
+	return (sysctl_handle_opaque(oidp, intrnames, sintrnames, req));
+}
+
 SYSCTL_PROC(_hw, OID_AUTO, intrnames,
     CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
-    sysctl_intrnames,
+    powerpc_sysctl_intrnames,
     "", "Interrupt Names");
+
+static int
+powerpc_sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
+{
+#ifdef SCTL_MASK32
+	uint32_t *intrcnt32;
+	unsigned i;
+	int error;
+
+	if (req->flags & SCTL_MASK32) {
+		if (!req->oldptr)
+			return (sysctl_handle_opaque(oidp, NULL, sintrcnt / 2, req));
+		intrcnt32 = malloc(sintrcnt / 2, M_TEMP, M_NOWAIT);
+		if (intrcnt32 == NULL)
+			return (ENOMEM);
+		for (i = 0; i < sintrcnt / sizeof (u_long); i++)
+			intrcnt32[i] = intrcnt[i];
+		error = sysctl_handle_opaque(oidp, intrcnt32, sintrcnt / 2, req);
+		free(intrcnt32, M_TEMP);
+		return (error);
+	}
+#endif
+	return (sysctl_handle_opaque(oidp, intrcnt, sintrcnt, req));
+}
 
 SYSCTL_PROC(_hw, OID_AUTO, intrcnt,
     CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
-    sysctl_intrcnt,
+    powerpc_sysctl_intrcnt,
     "", "Interrupt Counts");

--- a/sys/powerpc/powerpc/intr_machdep.c
+++ b/sys/powerpc/powerpc/intr_machdep.c
@@ -265,7 +265,7 @@ intr_lookup(u_int irq)
 
 	if (iscan == NULL && i->vector != -1) {
 		powerpc_intrs[i->vector] = i;
-		i->cntindex = atomic_fetchadd_int(&intrcnt_index, 1);
+		i->cntindex = nintrcnt - 1;
 		i->cntp = &intrcnt[i->cntindex];
 		sprintf(intrname, "irq%u:", i->irq);
 		intrcnt_setname(intrname, i->cntindex);
@@ -698,8 +698,14 @@ powerpc_intr_unmask(u_int irq)
 static int
 powerpc_sysctl_intrnames(SYSCTL_HANDLER_ARGS)
 {
-	return (sysctl_handle_opaque(oidp, intrnames,
-	    intrcnt_index * INTRNAME_LEN, req));
+	int error;
+
+	error = sysctl_handle_opaque(oidp, intrnames,
+	    intrcnt_index * INTRNAME_LEN, req);
+	if (error != 0)
+		return (error);
+
+	return (intr_event_sysctl_intrnames(oidp, arg1, arg2, req));
 }
 
 SYSCTL_PROC(_hw, OID_AUTO, intrnames,
@@ -710,10 +716,10 @@ SYSCTL_PROC(_hw, OID_AUTO, intrnames,
 static int
 powerpc_sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
 {
+	int error;
 #ifdef SCTL_MASK32
 	uint32_t *intrcnt32;
 	unsigned i;
-	int error;
 
 	if (req->flags & SCTL_MASK32) {
 		if (!req->oldptr)
@@ -728,14 +734,31 @@ powerpc_sysctl_intrcnt(SYSCTL_HANDLER_ARGS)
 		error = sysctl_handle_opaque(oidp, intrcnt32,
 		    intrcnt_index * sizeof(uint32_t), req);
 		free(intrcnt32, M_TEMP);
-		return (error);
-	}
+	} else
 #endif
-	return (sysctl_handle_opaque(oidp, intrcnt,
-	    intrcnt_index * sizeof(u_long), req));
+		error = sysctl_handle_opaque(oidp, intrcnt,
+		    intrcnt_index * sizeof(u_long), req);
+
+	return (error == 0 ? intr_event_sysctl_intrcnt(oidp, arg1, arg2, req) :
+	    error);
 }
 
 SYSCTL_PROC(_hw, OID_AUTO, intrcnt,
     CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
     powerpc_sysctl_intrcnt,
     "", "Interrupt Counts");
+
+#ifdef DDB
+/*
+ * DDB command to dump the IPI interrupt statistics.
+ */
+DB_SHOW_COMMAND_FLAGS(ipicnt, db_show_ipicnt, DB_CMD_MEMSAFE)
+{
+	u_int i;
+
+	for (i = 0; i < intrcnt_index && !db_pager_quit; ++i)
+		if (intrcnt[i] != 0)
+			db_printf("%s\t%lu\n", intrnames + i * INTRNAME_LEN,
+			    intrcnt[i]);
+}
+#endif

--- a/sys/sys/bus.h
+++ b/sys/sys/bus.h
@@ -281,7 +281,8 @@ enum intr_type {
 	INTR_MD1 = 4096,		/* flag reserved for MD use */
 	INTR_MD2 = 8192,		/* flag reserved for MD use */
 	INTR_MD3 = 16384,		/* flag reserved for MD use */
-	INTR_MD4 = 32768		/* flag reserved for MD use */
+	INTR_MD4 = 32768,		/* flag reserved for MD use */
+	INTR_MULTIPROC = 0x10000,	/* interrupt occurs on multiple procs */
 };
 
 enum intr_trigger {

--- a/sys/sys/clock.h
+++ b/sys/sys/clock.h
@@ -198,7 +198,9 @@ void clock_dbgprint_ts(device_t dev, int rw, const struct timespec *ts);
 /*
  * SWI for clock events
  */
+#ifdef DEV_ACPI
 extern struct	intr_event *clk_intr_event;
+#endif
 
 #endif /* _KERNEL */
 

--- a/sys/sys/clock.h
+++ b/sys/sys/clock.h
@@ -195,6 +195,11 @@ void clock_dbgprint_ct(device_t dev, int rw, const struct clocktime *ct);
 void clock_dbgprint_err(device_t dev, int rw, int err);
 void clock_dbgprint_ts(device_t dev, int rw, const struct timespec *ts);
 
+/*
+ * SWI for clock events
+ */
+extern struct	intr_event *clk_intr_event;
+
 #endif /* _KERNEL */
 
 #endif /* !_SYS_CLOCK_H_ */

--- a/sys/sys/interrupt.h
+++ b/sys/sys/interrupt.h
@@ -186,6 +186,7 @@ int	intr_event_create(struct intr_event **event, void *source,
 int	intr_event_describe_handler(struct intr_event *ie, void *cookie,
 	    const char *descr);
 int	intr_event_destroy(struct intr_event *ie);
+void	intr_event_incr(struct intr_event *ie);
 int	intr_event_handle(struct intr_event *ie, struct trapframe *frame);
 int	intr_event_remove_handler(void *cookie);
 int	intr_event_suspend_handler(void *cookie);

--- a/sys/sys/interrupt.h
+++ b/sys/sys/interrupt.h
@@ -131,6 +131,7 @@ struct intr_event {
 #define	IE_SOFT		0x000001	/* Software interrupt. */
 #define	IE_SLEEPABLE	0x000002	/* Sleepable ithread */
 #define	IE_ADDING_THREAD 0x000004	/* Currently building an ithread. */
+#define	IE_MULTIPROC	0x000008	/* Interrupt occurs on multiple procs */
 
 /* Flags to pass to swi_sched. */
 #define	SWI_FROMNMI	0x1

--- a/sys/sys/interrupt.h
+++ b/sys/sys/interrupt.h
@@ -205,5 +205,7 @@ int	swi_remove(void *cookie);
 /* For handling the core interrupt counters and names */
 extern int intr_event_sysctl_intrnames(SYSCTL_HANDLER_ARGS);
 extern int intr_event_sysctl_intrcnt(SYSCTL_HANDLER_ARGS);
+extern int sysctl_intrnames(SYSCTL_HANDLER_ARGS);
+extern int sysctl_intrcnt(SYSCTL_HANDLER_ARGS);
 
 #endif

--- a/sys/sys/interrupt.h
+++ b/sys/sys/interrupt.h
@@ -32,6 +32,7 @@
 #include <sys/_lock.h>
 #include <sys/_mutex.h>
 #include <sys/ck.h>
+#include <sys/sysctl.h>
 
 struct intr_event;
 struct intr_thread;
@@ -200,5 +201,9 @@ int	swi_add(struct intr_event **eventp, const char *name,
 	    void **cookiep);
 void	swi_sched(void *cookie, int flags);
 int	swi_remove(void *cookie);
+
+/* For handling the core interrupt counters and names */
+extern int intr_event_sysctl_intrnames(SYSCTL_HANDLER_ARGS);
+extern int intr_event_sysctl_intrcnt(SYSCTL_HANDLER_ARGS);
 
 #endif

--- a/sys/sys/interrupt.h
+++ b/sys/sys/interrupt.h
@@ -160,12 +160,6 @@ struct proc;
 
 extern struct	intr_event *clk_intr_event;
 
-/* Counts and names for statistics (defined in MD code). */
-extern u_long 	*intrcnt;	/* counts for each device and stray */
-extern char 	*intrnames;	/* string table containing device names */
-extern size_t	sintrcnt;	/* size of intrcnt table */
-extern size_t	sintrnames;	/* size of intrnames table */
-
 #ifdef DDB
 void	db_dump_intr_event(struct intr_event *ie, int handlers);
 #endif
@@ -205,7 +199,5 @@ int	swi_remove(void *cookie);
 /* For handling the core interrupt counters and names */
 extern int intr_event_sysctl_intrnames(SYSCTL_HANDLER_ARGS);
 extern int intr_event_sysctl_intrcnt(SYSCTL_HANDLER_ARGS);
-extern int sysctl_intrnames(SYSCTL_HANDLER_ARGS);
-extern int sysctl_intrcnt(SYSCTL_HANDLER_ARGS);
 
 #endif

--- a/sys/sys/interrupt.h
+++ b/sys/sys/interrupt.h
@@ -125,6 +125,8 @@ struct intr_event {
 	int		ie_cpu;		/* CPU this event is bound to. */
 	volatile int	ie_phase;	/* Switched to establish a barrier. */
 	volatile int	ie_active[2];	/* Filters in ISR context. */
+	u_long		ie_stray;	/* Stray interrupt counter */
+	u_long		ie_intrcnt;	/* Interrupt counter(s) */
 };
 
 /* Interrupt event flags kept in ie_flags. */

--- a/sys/sys/interrupt.h
+++ b/sys/sys/interrupt.h
@@ -158,8 +158,6 @@ struct intr_event {
 
 struct proc;
 
-extern struct	intr_event *clk_intr_event;
-
 #ifdef DDB
 void	db_dump_intr_event(struct intr_event *ie, int handlers);
 #endif

--- a/sys/sys/interrupt.h
+++ b/sys/sys/interrupt.h
@@ -180,7 +180,7 @@ int	intr_event_describe_handler(struct intr_event *ie, void *cookie,
 	    const char *descr);
 int	intr_event_destroy(struct intr_event *ie);
 void	intr_event_incr(struct intr_event *ie);
-int	intr_event_handle(struct intr_event *ie, struct trapframe *frame);
+u_long	intr_event_handle(struct intr_event *ie, struct trapframe *frame);
 int	intr_event_remove_handler(void *cookie);
 int	intr_event_suspend_handler(void *cookie);
 int	intr_event_resume_handler(void *cookie);

--- a/sys/sys/intr.h
+++ b/sys/sys/intr.h
@@ -86,8 +86,6 @@ struct intr_irqsrc {
 	u_int			isrc_flags;
 	char			isrc_name[INTR_ISRC_NAMELEN];
 	cpuset_t		isrc_cpu;	/* on which CPUs is enabled */
-	u_int			isrc_index;
-	u_long *		isrc_count;
 	u_int			isrc_handlers;
 	struct intr_event *	isrc_event;
 #ifdef INTR_SOLO

--- a/sys/x86/include/intr_machdep.h
+++ b/sys/x86/include/intr_machdep.h
@@ -106,9 +106,6 @@ enum {
 struct intsrc {
 	struct pic *is_pic;
 	struct intr_event *is_event;
-	u_long *is_count;
-	u_long *is_straycount;
-	u_int is_index;
 	u_int is_handlers;
 	u_int is_domain;
 	u_int is_cpu;

--- a/sys/x86/isa/atpic.c
+++ b/sys/x86/isa/atpic.c
@@ -131,8 +131,6 @@ struct atpic_intsrc {
 	inthand_t *at_intr, *at_intr_pti;
 	int	at_irq;			/* Relative to PIC base. */
 	enum intr_trigger at_trigger;
-	u_long	at_count;
-	u_long	at_straycount;
 };
 
 static void atpic_register_sources(struct pic *pic);
@@ -464,8 +462,6 @@ atpic_startup(void)
 	for (i = 0, ai = atintrs; i < NUM_ISA_IRQS; i++, ai++) {
 		if (i == ICU_SLAVEID)
 			continue;
-		ai->at_intsrc.is_count = &ai->at_count;
-		ai->at_intsrc.is_straycount = &ai->at_straycount;
 		setidt(((struct atpic *)ai->at_intsrc.is_pic)->at_intbase +
 		    ai->at_irq, pti ? ai->at_intr_pti : ai->at_intr, SDT_ATPIC,
 		    SEL_KPL, GSEL_ATPIC);

--- a/sys/x86/x86/intr_machdep.c
+++ b/sys/x86/x86/intr_machdep.c
@@ -807,3 +807,13 @@ intr_next_cpu(int domain)
 	return (PCPU_GET(apic_id));
 }
 #endif
+
+SYSCTL_PROC(_hw, OID_AUTO, intrnames,
+    CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
+    sysctl_intrnames,
+    "", "Interrupt Names");
+
+SYSCTL_PROC(_hw, OID_AUTO, intrcnt,
+    CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
+    sysctl_intrcnt,
+    "", "Interrupt Counts");

--- a/sys/x86/x86/intr_machdep.c
+++ b/sys/x86/x86/intr_machdep.c
@@ -93,12 +93,10 @@ u_int num_io_irqs;
 #endif
 
 #define	INTRNAME_LEN	(MAXCOMLEN + 1)
-u_long *intrcnt;
-char *intrnames;
-size_t sintrcnt = sizeof(intrcnt);
-size_t sintrnames = sizeof(intrnames);
+static u_long *intrcnt;
+static char *intrnames;
 static u_int intrcnt_index;
-int nintrcnt;
+static int nintrcnt;
 
 static MALLOC_DEFINE(M_INTR, "intr", "Interrupt Sources");
 

--- a/sys/x86/x86/intr_machdep.c
+++ b/sys/x86/x86/intr_machdep.c
@@ -171,12 +171,11 @@ intr_init_sources(void *arg)
 #endif
 
 	/*
-	 * - 1 ??? dummy counter.
 	 * - 1 counter for each CPU for lapic timer.
 	 * - 1 counter for each CPU for hypervisor drivers.
 	 * - 8 counters for each CPU for IPI counters for SMP.
 	 */
-	nintrcnt = 1 + mp_ncpus * 2;
+	nintrcnt = mp_ncpus * 2;
 #ifdef COUNT_IPIS
 	if (mp_ncpus > 1)
 		nintrcnt += 8 * mp_ncpus;
@@ -185,9 +184,6 @@ intr_init_sources(void *arg)
 	    M_ZERO);
 	intrnames = mallocarray(nintrcnt, INTRNAME_LEN, M_INTR, M_WAITOK |
 	    M_ZERO);
-
-	intrcnt_setname("???", 0);
-	intrcnt_index = 1;
 
 	/*
 	 * NB: intrpic_lock is not held here to avoid LORs due to

--- a/sys/x86/x86/mp_x86.c
+++ b/sys/x86/x86/mp_x86.c
@@ -43,6 +43,7 @@
 #include <sys/asan.h>
 #include <sys/bus.h>
 #include <sys/cons.h>	/* cngetc() */
+#include <sys/clock.h>
 #include <sys/cpuset.h>
 #include <sys/csan.h>
 #include <sys/interrupt.h>

--- a/sys/x86/x86/mp_x86.c
+++ b/sys/x86/x86/mp_x86.c
@@ -1733,7 +1733,10 @@ void
 ipi_swi_handler(struct trapframe *frame)
 {
 
-	intr_event_handle(clk_intr_event, frame);
+#ifdef DEV_ACPI
+	if (!CK_SLIST_EMPTY(&clk_intr_event->ie_handlers))
+		intr_event_handle(clk_intr_event, frame);
+#endif
 }
 
 /*


### PR DESCRIPTION
Every architecture has counters just outside `struct intr_event`.  As such it seems appropriate to try to move them onto `struct intr_event` to reduce differences between architectures.

There is also an issue of the interface between architecture and core.  The core has been implementing `hw.intrcnt` and `hw.intrnames`, yet forcing architectures to handle the tables behind these.  This results in rather troublesome mixing.