### PR TITLE
Update default pool/path in pam_zfs_key.c

### DIFF
--- a/sys/contrib/openzfs/contrib/pam_zfs_key/pam_zfs_key.c
+++ b/sys/contrib/openzfs/contrib/pam_zfs_key/pam_zfs_key.c
@@ -449,7 +449,7 @@ static int
 zfs_key_config_load(pam_handle_t *pamh, zfs_key_config_t *config,
     int argc, const char **argv)
 {
-	config->homes_prefix = strdup("rpool/home");
+	config->homes_prefix = strdup("zroot/home");
 	if (config->homes_prefix == NULL) {
 		pam_syslog(pamh, LOG_ERR, "strdup failure");
 		return (PAM_SERVICE_ERR);


### PR DESCRIPTION
While _rpool_ is the default name throughout OpenZFS codebase -- in comments and tests, primarily -- this instance directly impacts the ease of use of pam_zfs_key, improving POLA.

With this change, the default value for the pam_zfs_key paramater `homes=...` matches what _bsdinstall_ (https://cgit.freebsd.org/src/tree/usr.sbin/bsdinstall/scripts/zfsboot#n44)  creates by default on a zfs install: _zroot/home_.