### PR TITLE
hier.7: installations by pkg(8), not pkg(7)

### DIFF
--- a/share/man/man7/hier.7
+++ b/share/man/man7/hier.7
@@ -479,7 +479,7 @@ Z file system utilities
 .Pp
 .It Pa local/
 local executables, libraries, etc, installed by
-.Xr pkg 7
+.Xr pkg 8
 or
 .Xr ports 7
 .Pp


### PR DESCRIPTION
```text
Consistent with
https://github.com/freebsd/freebsd-src/pull/831
```