### PR TITLE
fwget: add needed firmware for AMD Raphael GPUs

### DIFF
--- a/usr.sbin/fwget/pci/pci_video_amd
+++ b/usr.sbin/fwget/pci/pci_video_amd
@@ -26,6 +26,9 @@
 
 pci_video_amd()
 {
+	# A table listing the required firmware versions for each GPU series
+	# is available at https://docs.kernel.org/gpu/amdgpu/driver-misc.html
+
 	case "$1" in
 		0x678*|0x679*)
 			addpkg "gpu-firmware-amd-kmod-tahiti"
@@ -149,6 +152,13 @@ pci_video_amd()
 			addpkg "gpu-firmware-amd-kmod-dcn-3-1-4"
 			addpkg "gpu-firmware-amd-kmod-sdma-6-0-1"
 			addpkg "gpu-firmware-amd-kmod-vcn-4-0-2"
+			;;
+		0x164e)
+			addpkg "gpu-firmware-amd-kmod-gc-10-3-6"
+			addpkg "gpu-firmware-amd-kmod-psp-13-0-5"
+			addpkg "gpu-firmware-amd-kmod-dcn-3-1-5"
+			addpkg "gpu-firmware-amd-kmod-sdma-5-2-6"
+			addpkg "gpu-firmware-amd-kmod-vcn-3-1-2"
 			;;
 	esac
 }


### PR DESCRIPTION
This GPU is found in Ryzen 7000 series CPUs.

For future reference, the list of firmware versions for amdgpu drivers can be found in [1].

[1] - https://docs.kernel.org/gpu/amdgpu/driver-misc.html


Notes:

Without this set of firmwares installed, loading the amdgpu driver will cause a kernel panic.

This is my GPU:

```
vgapci0@pci0:11:0:0:    class=0x030000 rev=0xc1 hdr=0x00 vendor=0x1002 device=0x164e subvendor=0x1043 subdevice=0x8877                                                                                                                         
    vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'                                                                                                                                                                                      
    device     = 'Raphael'                                                                                                                                                                                                                     
    class      = display                                                                                                                                                                                                                       
    subclass   = VGA 
```

fwget output with this patch:

```
$ fwget -n
Needed firmware packages: 'wifi-firmware-iwlwifi-kmod-ax210 gpu-firmware-amd-kmod-gc-10-3-6 gpu-firmware-amd-kmod-psp-13-0-5 gpu-firmware-amd-kmod-dcn-3-1-5 gpu-firmware-amd-kmod-sdma-5-2-6 gpu-firmware-amd-kmod-vcn-3-1-2'
```

fwget will install the packages as expected:

```
[danilo@capeta ~/Sources/freebsd/usr.sbin/fwget]$ pkg info | grep amd
xf86-video-amdgpu-22.0.0_2     X.Org amdgpu display driver
[danilo@capeta ~/Sources/freebsd/usr.sbin/fwget]$ sudo fwget
Needed firmware packages: 'wifi-firmware-iwlwifi-kmod-ax210 gpu-firmware-amd-kmod-gc-10-3-6 gpu-firmware-amd-kmod-psp-13-0-5 gpu-firmware-amd-kmod-dcn-3-1-5 gpu-firmware-amd-kmod-sdma-5-2-6 gpu-firmware-amd-kmod-vcn-3-1-2'
[danilo@capeta ~/Sources/freebsd/usr.sbin/fwget]$ pkg info | grep amd
gpu-firmware-amd-kmod-dcn-3-1-5-20230625_2 Firmware modules for dcn_3_1_5 AMD GPUs
gpu-firmware-amd-kmod-gc-10-3-6-20230625_2 Firmware modules for gc_10_3_6 AMD GPUs
gpu-firmware-amd-kmod-psp-13-0-5-20230625_2 Firmware modules for psp_13_0_5 AMD GPUs
gpu-firmware-amd-kmod-sdma-5-2-6-20230625_2 Firmware modules for sdma_5_2_6 AMD GPUs
gpu-firmware-amd-kmod-vcn-3-1-2-20230625_2 Firmware modules for vcn_3_1_2 AMD GPUs
xf86-video-amdgpu-22.0.0_2     X.Org amdgpu display driver
[danilo@capeta ~/Sources/freebsd/usr.sbin/fwget]$
```