### PR TITLE
freebsd-update: rsautl is deprecated, use pkeyutl

### DIFF
--- a/usr.sbin/freebsd-update/freebsd-update.sh
+++ b/usr.sbin/freebsd-update/freebsd-update.sh
@@ -1307,7 +1307,7 @@ fetch_tag () {
 		return 1
 	fi
 
-	openssl rsautl -pubin -inkey pub.ssl -verify		\
+	openssl pkeyutl -pubin -inkey pub.ssl -verifyrecover	\
 	    < latest.ssl > tag.new 2>${QUIETREDIR} || true
 	rm latest.ssl
 

--- a/usr.sbin/fwget/pci/pci_video_amd
+++ b/usr.sbin/fwget/pci/pci_video_amd
@@ -26,6 +26,9 @@
 
 pci_video_amd()
 {
+	# A table listing the required firmware versions for each GPU series
+	# is available at https://docs.kernel.org/gpu/amdgpu/driver-misc.html
+
 	case "$1" in
 		0x678*|0x679*)
 			addpkg "gpu-firmware-amd-kmod-tahiti"
@@ -149,6 +152,13 @@ pci_video_amd()
 			addpkg "gpu-firmware-amd-kmod-dcn-3-1-4"
 			addpkg "gpu-firmware-amd-kmod-sdma-6-0-1"
 			addpkg "gpu-firmware-amd-kmod-vcn-4-0-2"
+			;;
+		0x164e)
+			addpkg "gpu-firmware-amd-kmod-gc-10-3-6"
+			addpkg "gpu-firmware-amd-kmod-psp-13-0-5"
+			addpkg "gpu-firmware-amd-kmod-dcn-3-1-5"
+			addpkg "gpu-firmware-amd-kmod-sdma-5-2-6"
+			addpkg "gpu-firmware-amd-kmod-vcn-3-1-2"
 			;;
 	esac
 }


### PR DESCRIPTION
The command [openssl-rsautl(1)](https://www.openssl.org/docs/man1.1.1/man1/rsautl.html) has been deprecated in OpenSSL 3.0.  The [openssl-pkeyutl(1)](https://www.openssl.org/docs/man3.1/man1/openssl-pkeyutl.html) command should be used instead.
