### PR TITLE
Stop forcing -g in mpi3mr module because it breaks non-debug install.

### DIFF
--- a/sys/dev/virtio/p9fs/virtio_p9fs.c
+++ b/sys/dev/virtio/p9fs/virtio_p9fs.c
@@ -352,9 +352,9 @@ vt9p_attach(device_t dev)
 	mount_tag = malloc(mount_tag_len + 1, M_P9FS_MNTTAG,
 	    M_WAITOK | M_ZERO);
 
-	virtio_read_device_config(dev,
+	virtio_read_device_config_array(dev,
 	    offsetof(struct virtio_9pnet_config, mount_tag),
-	    mount_tag, mount_tag_len);
+	    mount_tag, 1, mount_tag_len);
 
 	device_printf(dev, "Mount tag: %s\n", mount_tag);
 

--- a/sys/modules/mpi3mr/Makefile
+++ b/sys/modules/mpi3mr/Makefile
@@ -7,7 +7,6 @@ SRCS+=	opt_cam.h
 SRCS+=	device_if.h bus_if.h pci_if.h
 
 CFLAGS+= -I${SRCTOP}/sys/compat/linuxkpi/common/include
-DEBUG_FLAGS= -g
 
 .include <bsd.kmod.mk>
 


### PR DESCRIPTION
Stop forcing -g in mpi3mr module because it breaks non-debug install.