### PR TITLE
Potential typo/copy issue

### DIFF
--- a/sys/dev/cxgb/cxgb_sge.c
+++ b/sys/dev/cxgb/cxgb_sge.c
@@ -266,7 +266,7 @@ check_pkt_coalesce(struct sge_qset *qs)
 	if (cxgb_tx_coalesce_enable_start > COALESCE_START_MAX)
 		cxgb_tx_coalesce_enable_start = COALESCE_START_MAX;
 	if (cxgb_tx_coalesce_enable_stop < COALESCE_STOP_MIN)
-		cxgb_tx_coalesce_enable_start = COALESCE_STOP_MIN;
+		cxgb_tx_coalesce_enable_stop = COALESCE_STOP_MIN;
 	/*
 	 * if the hardware transmit queue is more than 1/8 full
 	 * we mark it as coalescing - we drop back from coalescing


### PR DESCRIPTION
This test here appears to be clamping the start and stop values to a minimum and maximum. But it looks like one of these lines may have been copied incorrectly.

This code pattern is probably intended to test both start and stop against sensible values, but accidentally only changes the start value.

looking at the logic, I suspect that the impact of this bug might be negligible in most cases since it would simply reduce the performance impact of packet coalescing by avoiding aggressive start values.