### PR TITLE
freebsd-version.1: corrections and suggested improvements

### DIFF
--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -81,16 +81,15 @@ userland
 jail userland.
 .El
 .Sh IMPLEMENTATION NOTES
-The
 .Nm
-utility should provide the correct answer in the vast majority of
-cases, including those where
+should provide the correct answer in the vast majority of cases,
+including those where
 .Xr freebsd-update 8 
 changes the patch level of the kernel but not userland (or vice versa).
 .Pp
-To determine the name (and hence the location) of a custom kernel, the
+To determine the name (and hence the location) of a custom kernel,
 .Nm
-utility will attempt to parse
+will attempt to parse
 .Pa /boot/defaults/loader.conf
 and
 .Pa /boot/loader.conf ,
@@ -131,7 +130,7 @@ env ROOT=/mnt /mnt/bin/freebsd-version -ku
 .Sh HISTORY
 The
 .Nm
-command appeared in
+utility first appeared in
 .Fx 10.0 .
 .Sh AUTHORS
 The

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -114,7 +114,8 @@ Path to the root of the filesystem in which to look for
 and the kernel.
 .El
 .Sh EXAMPLES
-To determine the version of the installed userland:
+Show userland information alone, without specifying option
+.It Fl u :
 .Bd -literal -offset indent
 freebsd-version
 .Ed

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -127,6 +127,7 @@ env ROOT=/mnt /mnt/bin/freebsd-version -ku
 .Ed
 .Sh SEE ALSO
 .Xr uname 1 ,
+.Xr freebsd-update 8 ,
 .Xr loader.conf 5
 .Sh HISTORY
 The

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -40,7 +40,6 @@ utility makes a best effort to determine the version and patch level
 of the kernel and / or userland.
 .Pp
 .Ss Options
-.Pp
 .Bl -tag -width Fl
 .It Fl k
 Print the version and patch level of the installed kernel.
@@ -115,7 +114,7 @@ and the kernel.
 .El
 .Sh EXAMPLES
 Show userland information alone, without specifying option
-.It Fl u :
+Fl u :
 .Bd -literal -offset indent
 freebsd-version
 .Ed

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -84,10 +84,9 @@ jail userland.
 The
 .Nm
 utility should provide the correct answer in the vast majority of
-cases, including on systems kept up-to-date using
-.Xr freebsd-update 8 ,
-which does not update the kernel version unless the kernel itself was
-affected by the latest patch.
+cases, including those where
+.Xr freebsd-update 8 
+changes the patch level of the kernel but not userland (or vice versa).
 .Pp
 To determine the name (and hence the location) of a custom kernel, the
 .Nm

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -39,7 +39,7 @@ The
 utility makes a best effort to determine the version and patch level
 of the kernel and / or userland.
 .Pp
-The following options are available:
+.Ss Options
 .Bl -tag -width Fl
 .It Fl k
 Print the version and patch level of the installed kernel.
@@ -66,11 +66,19 @@ or
 This option can be specified multiple times.
 .El
 .Pp
-If several of the above options are specified,
-.Nm
-will print the installed kernel version first, then the running kernel
-version, next the userland version, and finally the userland version
-of the specified jails, on separate lines.
+If multiple options are specified, lines will be printed in a preset
+order (regardless of user-specified order):
+.Pp
+.Bl -dash -compact
+.It
+installed kernel
+.It
+running kernel
+.It
+userland
+.It
+jail userland.
+.El
 .Sh IMPLEMENTATION NOTES
 The
 .Nm

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -40,6 +40,7 @@ utility makes a best effort to determine the version and patch level
 of the kernel and / or userland.
 .Pp
 .Ss Options
+.Pp
 .Bl -tag -width Fl
 .It Fl k
 Print the version and patch level of the installed kernel.
@@ -66,7 +67,7 @@ or
 This option can be specified multiple times.
 .El
 .Pp
-If multiple options are specified, lines will be printed in a preset
+If multiple options are specified, information will be in a preset
 order (regardless of user-specified order):
 .Pp
 .Bl -dash -compact

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -114,7 +114,7 @@ and the kernel.
 .El
 .Sh EXAMPLES
 Show userland information alone, without specifying option
-Fl u :
+.Fl u :
 .Bd -literal -offset indent
 freebsd-version
 .Ed

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -56,9 +56,7 @@ Unlike
 this is unaffected by environment variables.
 .It Fl u
 Print the version and patch level of the installed userland.
-These are hardcoded into
-.Nm
-during the build.
+The same information will be printed if no option is specified.
 .It Fl j Ar jail
 Print the version and patch level of the installed userland in the
 given jail specified by
@@ -73,7 +71,6 @@ If several of the above options are specified,
 will print the installed kernel version first, then the running kernel
 version, next the userland version, and finally the userland version
 of the specified jails, on separate lines.
-If neither is specified, it will print the userland version only.
 .Sh IMPLEMENTATION NOTES
 The
 .Nm
@@ -98,6 +95,9 @@ variables, both with a default value of
 It may however fail to locate the correct kernel if either or both of
 these variables are defined in a non-standard location, such as in
 .Pa /boot/loader.rc .
+Userland information is hardcoded into
+.Nm
+at build time.
 .Sh ENVIRONMENT
 .Bl -tag -width ROOT
 .It Ev ROOT

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd October 1, 2021
+.Dd July 6, 2024
 .Dt FREEBSD-VERSION 1
 .Os
 .Sh NAME
@@ -37,7 +37,7 @@
 The
 .Nm
 utility makes a best effort to determine the version and patch level
-of the installed kernel and / or userland.
+of the kernel and / or userland.
 .Pp
 The following options are available:
 .Bl -tag -width Fl

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -115,9 +115,9 @@ Path to the root of the filesystem in which to look for
 and the kernel.
 .El
 .Sh EXAMPLES
-To determine the version of the currently running userland:
+To determine the version of the installed userland:
 .Bd -literal -offset indent
-/bin/freebsd-version -u
+freebsd-version
 .Ed
 .Pp
 To inspect a system being repaired using a live system:

--- a/bin/freebsd-version/freebsd-version.1
+++ b/bin/freebsd-version/freebsd-version.1
@@ -102,6 +102,7 @@ variables, both with a default value of
 It may however fail to locate the correct kernel if either or both of
 these variables are defined in a non-standard location, such as in
 .Pa /boot/loader.rc .
+.Pp
 Userland information is hardcoded into
 .Nm
 at build time.


### PR DESCRIPTION
For four, the word 'neither' is inappropriate.

Make clearer that with multiple options, user-specified order is disregarded.

Various other suggestions.