### PR TITLE
virtio_p9fs: fix panic on qemu/kvm

### DIFF
--- a/sys/dev/virtio/p9fs/virtio_p9fs.c
+++ b/sys/dev/virtio/p9fs/virtio_p9fs.c
@@ -352,9 +352,9 @@ vt9p_attach(device_t dev)
 	mount_tag = malloc(mount_tag_len + 1, M_P9FS_MNTTAG,
 	    M_WAITOK | M_ZERO);
 
-	virtio_read_device_config(dev,
+	virtio_read_device_config_array(dev,
 	    offsetof(struct virtio_9pnet_config, mount_tag),
-	    mount_tag, mount_tag_len);
+	    mount_tag, 1, mount_tag_len);
 
 	device_printf(dev, "Mount tag: %s\n", mount_tag);
 


### PR DESCRIPTION
When the module is loaded on a system running on qemu/kvm the "modern" virtio infrastructure is used and virtio_read_device_config() will end up calling vtpci_modern_read_dev_config(). This function cannot read values of arbitrary sizes and will panic if the p9fs mount tag size is not supported by it.

Use virtio_read_device_config_array() instead. It was tested on both bhyve and qemu/kvm.

PR:	280098
Co-authored-by:	Mark Peek <mp@FreeBSD.org>



Please see https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=280098 for more details on the investigation.