### PR TITLE
p9fs: remove duplicated code

### DIFF
--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -1,7 +1,7 @@
 .\"-
 .\" SPDX-License-Identifier: BSD-2-Clause
 .\"
-.\" Copyright (c) 2024 Alexander Ziaee <concussious@runbox.com>
+.\" Copyright (c) 2024 Alexander Ziaee. Ohio.
 .\"
 .Dd April 17, 2024
 .Dt "NETWORKING" 7
@@ -92,10 +92,3 @@ will need to be escaped for
 commonly using
 .Ql \e ,
 see the manual page for your shell for more details.
-.Pp
-Currently
-.Ql Ic service netif restart
-does not restart routing.
-A common workaround is to issue
-.Ql Ic service netif restart && service routing restart
-instead.

--- a/sys/fs/p9fs/p9fs_vnops.c
+++ b/sys/fs/p9fs/p9fs_vnops.c
@@ -125,16 +125,6 @@ p9fs_cleanup(struct p9fs_node *np)
 	/* Destroy the vm object and flush associated pages. */
 	vnode_destroy_vobject(vp);
 
-	/* Remove the vnode from hash list if vnode is not already deleted */
-	if ((np->flags & P9FS_NODE_DELETED) == 0)
-		vfs_hash_remove(vp);
-
-	/* Invalidate all entries to a particular vnode. */
-	cache_purge(vp);
-
-	/* Destroy the vm object and flush associated pages. */
-	vnode_destroy_vobject(vp);
-
 	/* Remove all the FID */
 	p9fs_fid_remove_all(np, FALSE);
 


### PR DESCRIPTION
This code is using the vnode after it has been released and causing a panic when a p9fs shared volume is unmounted. In fact, it seems like it's just duplicated code left behind from a bad merge.

PR:		279887
Reported by:	Michael Dexter

---

See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=279887 for more details.

It seems to me that this code originated from here https://github.com/Juniper/virtfs/blob/jnpr/virtfs/sys/dev/virtio/9pfs/virtfs_vnops.c#L97

With this patch I can mount/umount p9fs shares reliably.

Feedback from someone familiar with the code would be appreciated.