### PR TITLE
siphash: allow zero values for final && len in SipBuf()

### DIFF
--- a/sys/crypto/siphash/siphash_test.c
+++ b/sys/crypto/siphash/siphash_test.c
@@ -115,7 +115,7 @@ SipHash24_TestVectors(void)
 	for (i = 0; i < 16; ++i)
 		k[i] = i;
 
-	/* Step through differnet length. */
+	/* Step through different lengths */
 	for (i = 0; i < MAXLEN; ++i) {
 		in[i] = i;
 
@@ -124,14 +124,14 @@ SipHash24_TestVectors(void)
 		SipHash_Update(&ctx, in, i);
 		SipHash_Final(out, &ctx);
 
-		if (memcmp(out, vectors[i], 8))
+		if (memcmp(out, vectors[i], 8)) {
+			fail++;
 #if 0
 			printf("%i: test vector failed\n", i);
-		else
+		} else {
 			printf("%i: test vector correct\n", i);
-#else
-			fail++;
 #endif
+		}
 	}
 
 	return ((fail == 0));


### PR DESCRIPTION
This change is required for the first loop iteration of the unit test in siphash_test.c to pass.
The current assert corresponds to an XOR, but it should also allow the case where both values are zero.
I have therefore simplified it to asserting that at least one of the values is zero.