### PR TITLE
usb: increase USB_PORT_RESET_RECOVERY

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -2022,6 +2022,8 @@ COMMON ITEMS:
 	make -DALWAYS_CHECK_MAKE buildkernel KERNCONF=YOUR_KERNEL_HERE
 	make -DALWAYS_CHECK_MAKE installkernel KERNCONF=YOUR_KERNEL_HERE
 
+	If you are running kernel modules from ports, see FOOTNOTE [1].
+
 	To test a kernel once
 	---------------------
 	If you just want to boot a kernel once (because you are not sure
@@ -2038,8 +2040,7 @@ COMMON ITEMS:
 	<make sure you have good level 0 dumps>
 	make buildworld
 	make buildkernel KERNCONF=YOUR_KERNEL_HERE
-	make installkernel KERNCONF=YOUR_KERNEL_HERE
-							[1]
+	make installkernel KERNCONF=YOUR_KERNEL_HERE	[1]
 	<reboot in single user>				[3]
 	etcupdate -p					[5]
 	make installworld
@@ -2057,7 +2058,7 @@ COMMON ITEMS:
 	<make sure you have good level 0 dumps>
 	<boot into -stable>
 	make buildworld
-	make buildkernel KERNCONF=YOUR_KERNEL_HERE
+	make buildkernel KERNCONF=YOUR_KERNEL_HERE	[1]
 	<maybe newfs current's root partition>
 	<mount current's root partition on directory ${CURRENT_ROOT}>
 	make installworld DESTDIR=${CURRENT_ROOT} -DDB_FROM_SRC
@@ -2076,8 +2077,7 @@ COMMON ITEMS:
 	<make sure you have good level 0 dumps>
 	make buildworld					[9]
 	make buildkernel KERNCONF=YOUR_KERNEL_HERE	[8]
-	make installkernel KERNCONF=YOUR_KERNEL_HERE
-							[1]
+	make installkernel KERNCONF=YOUR_KERNEL_HERE	[1]
 	<reboot in single user>				[3]
 	etcupdate -p					[5]
 	make installworld
@@ -2097,8 +2097,10 @@ COMMON ITEMS:
 	messages there.  If in doubt, please track -stable which has
 	much fewer pitfalls.
 
-	[1] If you have third party modules, such as vmware, you should disable
-	them at this point so they don't crash your system on
+FOOTNOTES:
+
+	[1] If you have third party modules, such as drm-kmod or vmware, you
+	should disable them at this point so they don't crash your system on
 	reboot. Alternatively, you should rebuild all the modules you have in
 	your system and install them as well.  If you are running -current, you
 	should seriously consider placing all sources to all the modules for

--- a/lib/libc/net/getaddrinfo.3
+++ b/lib/libc/net/getaddrinfo.3
@@ -480,7 +480,8 @@ freeaddrinfo(res0);
 .Xr hosts 5 ,
 .Xr resolv.conf 5 ,
 .Xr services 5 ,
-.Xr hostname 7
+.Xr hostname 7 ,
+.Xr ip6addrctl 8
 .Rs
 .%A R. Gilligan
 .%A S. Thomson

--- a/sbin/geom/core/geom.8
+++ b/sbin/geom/core/geom.8
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2004-2005 Pawel Jakub Dawidek <pjd@FreeBSD.org>
 .\" All rights reserved.
 .\"
@@ -27,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm geom
-.Nd "universal control utility for GEOM classes"
+.Nd universal control utility for GEOM classes
 .Sh SYNOPSIS
 .Nm
 .Ar class
@@ -66,7 +69,7 @@ which can be used for existing
 .Nm
 unaware classes.
 Here is the list of standard commands:
-.Bl -tag -width ".Cm status"
+.Bl -tag -width indent
 .It Cm help
 List all available commands for the given class.
 .It Cm list
@@ -74,7 +77,7 @@ Print detailed information (within the given class) about all geoms
 (if no additional arguments were specified) or the given geoms.
 This command is only available if the given class exists in the kernel.
 Additional options include:
-.Bl -tag -width ".Fl a"
+.Bl -tag -width "-a"
 .It Fl a
 Print information for geoms without providers.
 .El
@@ -84,9 +87,11 @@ Print general information (within the given class) about all geoms
 This command is only available if the given class exists in the kernel.
 .Pp
 Additional options include:
-.Bl -tag -width ".Fl s"
+.Bl -tag -width "-s"
 .It Fl a
-When used with -g, print status for geoms without providers.
+When used with
+.Fl g ,
+print status for geoms without providers.
 .It Fl g
 Report statuses for geoms instead of providers.
 .It Fl s
@@ -107,7 +112,7 @@ kernel module.
 .El
 .Pp
 Additional options include:
-.Bl -tag -width ".Cm status"
+.Bl -tag -width indent
 .It Fl p Ar provider-name
 Print detailed information about the geom which provides
 .Ar provider-name .
@@ -170,7 +175,7 @@ VIRSTOR
 .Sh ENVIRONMENT
 The following environment variables affect the execution of
 .Nm :
-.Bl -tag -width ".Ev GEOM_LIBRARY_PATH"
+.Bl -tag -width "GEOM_LIBRARY_PATH"
 .It Ev GEOM_LIBRARY_PATH
 Specifies the path where shared libraries are stored instead of
 .Pa /lib/geom/ .
@@ -213,7 +218,6 @@ geom md unload
 .Xr gnop 8 ,
 .Xr gpart 8 ,
 .Xr graid3 8 ,
-.Xr gsched 8 ,
 .Xr gshsec 8 ,
 .Xr gstripe 8 ,
 .Xr gunion 8 ,

--- a/sbin/growfs/growfs.8
+++ b/sbin/growfs/growfs.8
@@ -61,16 +61,11 @@ The
 .Nm
 utility extends the size of the file system on the specified special file.
 The following options are available:
-.Bl -tag -width indent
+.Bl -tag -width "-s size"
 .It Fl N
 .Dq Test mode .
 Causes the new file system parameters to be printed out without actually
 enlarging the file system.
-.It Fl y
-Causes
-.Nm
-to assume yes
-as the answer to all operator questions.
 .It Fl s Ar size
 Determines the
 .Ar size
@@ -87,6 +82,11 @@ This value defaults to the size of the raw partition specified in
 (in other words,
 .Nm
 will enlarge the file system to the size of the entire partition).
+.It Fl y
+Causes
+.Nm
+to assume yes
+as the answer to all operator questions.
 .El
 .Sh EXIT STATUS
 Exit status is 0 on success, and >= 1 on errors.

--- a/share/man/man4/acpi_ged.4
+++ b/share/man/man4/acpi_ged.4
@@ -53,7 +53,7 @@ This may generate optionally ACPI notify for another device.
 The
 .Nm
 device driver first appeared in
-.Fx 14.0 .
+.Fx 13.3 .
 .Sh AUTHORS
 .An -nosplit
 The

--- a/share/man/man4/gve.4
+++ b/share/man/man4/gve.4
@@ -208,7 +208,7 @@ Please email gvnic-drivers@google.com with the specifics of the issue encountere
 The
 .Nm
 device driver first appeared in
-.Fx 14.0 .
+.Fx 13.3 .
 .Sh AUTHORS
 The
 .Nm

--- a/share/man/man4/ure.4
+++ b/share/man/man4/ure.4
@@ -1,3 +1,5 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
 .\"
 .\" Copyright (c) 2015-2016 Kevin Lo <kevlo@FreeBSD.org>
 .\" All rights reserved.
@@ -23,12 +25,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd May 3, 2024
+.Dd September 3, 2024
 .Dt URE 4
 .Os
 .Sh NAME
 .Nm ure
-.Nd "RealTek RTL8152/RTL8153/RTL8153B/RTL8156/RTL8156B USB to Ethernet controller driver"
+.Nd RealTek RTL8152/RTL8153/RTL8156 USB Ethernet driver
 .Sh SYNOPSIS
 To compile this driver into the kernel,
 place the following lines in your
@@ -52,15 +54,20 @@ if_ure_load="YES"
 The
 .Nm
 driver provides support for USB Ethernet adapters based on the RealTek
-RealTek RTL8152 and RTL8153 USB Ethernet controllers.
+RTL8152, RTL8153/RTL8153B, and RTL8156/RTL8156B USB Ethernet controllers,
+as well as USB Ethernet PHYs provided by
+.Xr rgephy 4 .
 .Pp
-NICs based on the RTL8152 are capable of 10 and 100Mbps speeds.
-NICs based on the RTL8153 are capable of 10, 100 and 1000Mbps operation.
+NICs based on the RTL8152 are capable of 10 and 100Mbps.
+NICs based on the RTL8153 or provided by
+.Xr rgephy 4
+are capable of 10, 100, and 1000Mbps.
+NICs based on the RTL8156 are capable of 10, 100, 1000, and 2500Mbps operation.
 .Pp
 The
 .Nm
 driver supports the following media types:
-.Bl -tag -width ".Cm 10baseT/UTP"
+.Bl -tag -width "10baseT/UTP"
 .It Cm autoselect
 Enable auto selection of the media type and options.
 The user can manually override
@@ -86,7 +93,7 @@ or
 .Cm half-duplex
 modes.
 .It Cm 1000baseTX
-Set 1000baseTX operation over twisted pair.
+Set 1000baseTX (Gigabit Ethernet) operation over twisted pair.
 The RealTek gigE chips support 1000Mbps in
 .Cm full-duplex
 mode only.
@@ -99,12 +106,12 @@ mode only.
 .Pp
 The
 .Nm
-driver supports the following media options:
-.Bl -tag -width ".Cm full-duplex"
+driver supports the following media options for 10/100 operation:
+.Bl -tag -width "full-duplex"
 .It Cm full-duplex
-Force full duplex operation.
+Force full-duplex operation.
 .It Cm half-duplex
-Force half duplex operation.
+Force half-duplex operation.
 .El
 .Pp
 For more information on configuring this device, see

--- a/share/man/man4/wsp.4
+++ b/share/man/man4/wsp.4
@@ -70,6 +70,12 @@ controlled using the sysctl tunable
 .Nm hw.usb.wsp.enable_single_tap_movement ,
 set to 0 to disable the movement on the trackpad until a full release
 or 1 to allow the continued movement (default).
+.Nm hw.usb.wsp.max_finger_area
+defines the maximum area on the trackpad which is registered as a
+finger (lower for greater palm detection).
+.Nm hw.usb.wsp.max_double_tap_distance
+defines the maximum distance between two finger clicks or taps which may
+register as a double-click.
 Z-Axis sensitivity can be controlled using the sysctl tunable
 .Nm hw.usb.wsp.z_factor .
 Z-Axis inversion can be controlled using the sysctl tunable

--- a/share/man/man4/wsp.4
+++ b/share/man/man4/wsp.4
@@ -65,6 +65,11 @@ Pointer sensitivity can be controlled using the sysctl tunable
 Tap to left-click can be controlled using the sysctl tunable
 .Nm hw.usb.wsp.enable_single_tap_clicks ,
 set to 0 to disable single tap clicks or 1 to enable them (default).
+Movement on the trackpad following a partially-released click can be
+controlled using the sysctl tunable
+.Nm hw.usb.wsp.enable_single_tap_movement ,
+set to 0 to disable the movement on the trackpad until a full release
+or 1 to allow the continued movement (default).
 Z-Axis sensitivity can be controlled using the sysctl tunable
 .Nm hw.usb.wsp.z_factor .
 Z-Axis inversion can be controlled using the sysctl tunable

--- a/share/man/man8/diskless.8
+++ b/share/man/man8/diskless.8
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-3-Clause
+.\"
 .\" Copyright (c) 1994 Gordon W. Ross, Theo de Raadt
 .\" Updated by Luigi Rizzo, Robert Watson
 .\" All rights reserved.
@@ -24,12 +27,12 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd May 3, 2020
+.Dd August 11, 2024
 .Dt DISKLESS 8
 .Os
 .Sh NAME
 .Nm diskless
-.Nd booting a system over the network
+.Nd booting a system over the network with PXE
 .Sh DESCRIPTION
 The ability to boot a machine over the network is useful for
 .Em diskless

--- a/sys/amd64/amd64/machdep.c
+++ b/sys/amd64/amd64/machdep.c
@@ -1382,7 +1382,7 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
 	 */
 	for (x = 0; x < NGDT; x++) {
 		if (x != GPROC0_SEL && x != (GPROC0_SEL + 1) &&
-		    x != GUSERLDT_SEL && x != (GUSERLDT_SEL) + 1)
+		    x != GUSERLDT_SEL && x != (GUSERLDT_SEL + 1))
 			ssdtosd(&gdt_segs[x], &gdt[x]);
 	}
 	gdt_segs[GPROC0_SEL].ssd_base = (uintptr_t)&pc->pc_common_tss;

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -99,6 +99,7 @@ static struct wsp_tuning {
 	int	pressure_tap_threshold;
 	int	scr_hor_threshold;
 	int	enable_single_tap_clicks;
+	int	enable_single_tap_movement;
 }
 	wsp_tuning =
 {
@@ -110,6 +111,7 @@ static struct wsp_tuning {
 	.pressure_tap_threshold = 120,
 	.scr_hor_threshold = 20,
 	.enable_single_tap_clicks = 1,
+	.enable_single_tap_movement = 1,
 };
 
 static void
@@ -123,6 +125,7 @@ wsp_runing_rangecheck(struct wsp_tuning *ptun)
 	WSP_CLAMP(ptun->pressure_tap_threshold, 1, 255);
 	WSP_CLAMP(ptun->scr_hor_threshold, 1, 255);
 	WSP_CLAMP(ptun->enable_single_tap_clicks, 0, 1);
+	WSP_CLAMP(ptun->enable_single_tap_movement, 0, 1);
 }
 
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scale_factor, CTLFLAG_RWTUN,
@@ -141,6 +144,9 @@ SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scr_hor_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.scr_hor_threshold, 0, "horizontal scrolling threshold");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_single_tap_clicks, CTLFLAG_RWTUN,
     &wsp_tuning.enable_single_tap_clicks, 0, "enable single tap clicks");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_single_tap_movement, CTLFLAG_RWTUN,
+    &wsp_tuning.enable_single_tap_movement, 0, "enable single tap movement");
+
 
 /*
  * Some tables, structures, definitions and constant values for the
@@ -1149,8 +1155,8 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				dx = sc->pos_x[0] - sc->pre_pos_x;
 				dy = sc->pos_y[0] - sc->pre_pos_y;
 
-				/* Ignore movement during button is releasing */
-				if (sc->ibtn != 0 && sc->sc_status.button == 0)
+				/* Optionally ignore movement during button is releasing */
+				if (tun.enable_single_tap_movement != 1 && sc->ibtn != 0 && sc->sc_status.button == 0)
 					dx = dy = 0;
 
 				/* Ignore movement if ntouch changed */

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -98,6 +98,8 @@ static struct wsp_tuning {
 	int	pressure_untouch_threshold;
 	int	pressure_tap_threshold;
 	int	scr_hor_threshold;
+	int	max_finger_area;
+	int	max_double_tap_distance;
 	int	enable_single_tap_clicks;
 	int	enable_single_tap_movement;
 }
@@ -110,6 +112,8 @@ static struct wsp_tuning {
 	.pressure_untouch_threshold = 10,
 	.pressure_tap_threshold = 120,
 	.scr_hor_threshold = 20,
+	.max_finger_area = 1900,
+	.max_double_tap_distance = 2500,
 	.enable_single_tap_clicks = 1,
 	.enable_single_tap_movement = 1,
 };
@@ -123,6 +127,8 @@ wsp_runing_rangecheck(struct wsp_tuning *ptun)
 	WSP_CLAMP(ptun->pressure_touch_threshold, 1, 255);
 	WSP_CLAMP(ptun->pressure_untouch_threshold, 1, 255);
 	WSP_CLAMP(ptun->pressure_tap_threshold, 1, 255);
+	WSP_CLAMP(ptun->max_finger_area, 1, 2400);
+	WSP_CLAMP(ptun->max_double_tap_distance, 1, 16384);
 	WSP_CLAMP(ptun->scr_hor_threshold, 1, 255);
 	WSP_CLAMP(ptun->enable_single_tap_clicks, 0, 1);
 	WSP_CLAMP(ptun->enable_single_tap_movement, 0, 1);
@@ -140,6 +146,10 @@ SYSCTL_INT(_hw_usb_wsp, OID_AUTO, pressure_untouch_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.pressure_untouch_threshold, 0, "untouch pressure threshold");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, pressure_tap_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.pressure_tap_threshold, 0, "tap pressure threshold");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_finger_area, CTLFLAG_RWTUN,
+    &wsp_tuning.max_finger_area, 0, "maximum finger area");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_double_tap_distance, CTLFLAG_RWTUN,
+    &wsp_tuning.max_double_tap_distance, 0, "maximum double-finger click distance");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scr_hor_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.scr_hor_threshold, 0, "horizontal scrolling threshold");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_single_tap_clicks, CTLFLAG_RWTUN,
@@ -573,13 +583,13 @@ struct wsp_softc {
 	struct tp_finger *index[MAX_FINGERS];	/* finger index data */
 	int16_t	pos_x[MAX_FINGERS];	/* position array */
 	int16_t	pos_y[MAX_FINGERS];	/* position array */
+	int16_t pre_pos_x[MAX_FINGERS];	/* previous position array */
+	int16_t pre_pos_y[MAX_FINGERS]; /* previous position array */
 	u_int	sc_touch;		/* touch status */
 #define	WSP_UNTOUCH		0x00
 #define	WSP_FIRST_TOUCH		0x01
 #define	WSP_SECOND_TOUCH	0x02
 #define	WSP_TOUCHING		0x04
-	int16_t	pre_pos_x;		/* previous position array */
-	int16_t	pre_pos_y;		/* previous position array */
 	int	dx_sum;			/* x axis cumulative movement */
 	int	dy_sum;			/* y axis cumulative movement */
 	int	dz_sum;			/* z axis cumulative movement */
@@ -596,7 +606,6 @@ struct wsp_softc {
 #define	WSP_TAP_THRESHOLD	3
 #define	WSP_TAP_MAX_COUNT	20
 	int	distance;		/* the distance of 2 fingers */
-#define	MAX_DISTANCE		2500	/* the max allowed distance */
 	uint8_t	ibtn;			/* button status in tapping */
 	uint8_t	ntaps;			/* finger status in tapping */
 	uint8_t	scr_mode;		/* scroll status in movement */
@@ -1040,13 +1049,35 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 		sc->sc_status.obutton = sc->sc_status.button;
 		sc->sc_status.button = 0;
 
+		if (ntouch == 2) {
+			sc->distance = max(sc->distance, max(
+			    abs(sc->pos_x[0] - sc->pos_x[1]),
+			    abs(sc->pos_y[0] - sc->pos_y[1])));
+		}
+
 		if (ibt != 0) {
-			if ((params->tp->caps & HAS_INTEGRATED_BUTTON) && ntouch == 2)
-				sc->sc_status.button |= MOUSE_BUTTON3DOWN;
-			else if ((params->tp->caps & HAS_INTEGRATED_BUTTON) && ntouch == 3)
-				sc->sc_status.button |= MOUSE_BUTTON2DOWN;
-			else 
+			if (params->tp->caps & HAS_INTEGRATED_BUTTON) {
+				switch (ntouch) {
+				case 1:
+					sc->sc_status.button |= MOUSE_BUTTON1DOWN;
+					break;
+				case 2:
+					if (sc->distance < tun.max_double_tap_distance && abs(sc->dx_sum) < 5 &&
+					    abs(sc->dy_sum) < 5)
+						sc->sc_status.button |= MOUSE_BUTTON3DOWN;
+					else
+						sc->sc_status.button |= MOUSE_BUTTON1DOWN;
+					break;
+				case 3:
+					sc->sc_status.button |= MOUSE_BUTTON2DOWN;
+					break;
+				default:
+					break;
+				}
+			} else {
 				sc->sc_status.button |= MOUSE_BUTTON1DOWN;
+			}
+
 			sc->ibtn = 1;
 		}
 		sc->intr_count++;
@@ -1055,7 +1086,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 			switch (ntouch) {
 			case 1:
 				if (sc->index[0]->touch_major > tun.pressure_tap_threshold &&
-				    sc->index[0]->tool_major <= 1200)
+				    sc->index[0]->tool_major <= tun.max_finger_area)
 					sc->ntaps = 1;
 				break;
 			case 2:
@@ -1073,11 +1104,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				break;
 			}
 		}
-		if (ntouch == 2) {
-			sc->distance = max(sc->distance, max(
-			    abs(sc->pos_x[0] - sc->pos_x[1]),
-			    abs(sc->pos_y[0] - sc->pos_y[1])));
-		}
+
 		if (sc->index[0]->touch_major < tun.pressure_untouch_threshold &&
 		    sc->sc_status.button == 0) {
 			sc->sc_touch = WSP_UNTOUCH;
@@ -1098,7 +1125,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				case 2:
 					DPRINTFN(WSP_LLEVEL_INFO, "sum_x=%5d, sum_y=%5d\n",
 					    sc->dx_sum, sc->dy_sum);
-					if (sc->distance < MAX_DISTANCE && abs(sc->dx_sum) < 5 &&
+					if (sc->distance < tun.max_double_tap_distance && abs(sc->dx_sum) < 5 &&
 					    abs(sc->dy_sum) < 5) {
 						wsp_add_to_queue(sc, 0, 0, 0, MOUSE_BUTTON3DOWN);
 						DPRINTFN(WSP_LLEVEL_INFO, "RIGHT CLICK!\n");
@@ -1144,16 +1171,16 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 		} else if (sc->index[0]->touch_major >= tun.pressure_touch_threshold &&
 		    sc->sc_touch == WSP_FIRST_TOUCH) {	/* ignore second touch */
 			sc->sc_touch = WSP_SECOND_TOUCH;
-			DPRINTFN(WSP_LLEVEL_INFO, "Fist pre_x=%5d, pre_y=%5d\n",
-			    sc->pre_pos_x, sc->pre_pos_y);
+			DPRINTFN(WSP_LLEVEL_INFO, "First pre_x[0]=%5d, pre_y[0]=%5d\n",
+			    sc->pre_pos_x[0], sc->pre_pos_y[0]);
 		} else {
 			if (sc->sc_touch == WSP_SECOND_TOUCH)
 				sc->sc_touch = WSP_TOUCHING;
 
 			if (ntouch != 0 &&
 			    sc->index[0]->touch_major >= tun.pressure_touch_threshold) {
-				dx = sc->pos_x[0] - sc->pre_pos_x;
-				dy = sc->pos_y[0] - sc->pre_pos_y;
+				dx = sc->pos_x[0] - sc->pre_pos_x[0];
+				dy = sc->pos_y[0] - sc->pre_pos_y[0];
 
 				/* Optionally ignore movement during button is releasing */
 				if (tun.enable_single_tap_movement != 1 && sc->ibtn != 0 && sc->sc_status.button == 0)
@@ -1163,8 +1190,8 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				if (sc->o_ntouch != ntouch)
 					dx = dy = 0;
 
-				/* Ignore unexpeted movement when typing */
-				if (ntouch == 1 && sc->index[0]->tool_major > 1200)
+				/* Ignore unexpected movement when typing (palm detection) */
+				if (ntouch == 1 && sc->index[0]->tool_major > tun.max_finger_area)
 					dx = dy = 0;
 
 				if (sc->ibtn != 0 && ntouch == 1 && 
@@ -1173,8 +1200,8 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 					dx = dy = 0;
 
 				if (ntouch == 2 && sc->sc_status.button != 0) {
-					dx = sc->pos_x[sc->finger] - sc->pre_pos_x;
-					dy = sc->pos_y[sc->finger] - sc->pre_pos_y;
+					dx = sc->pos_x[sc->finger] - sc->pre_pos_x[sc->finger];
+					dy = sc->pos_y[sc->finger] - sc->pre_pos_y[sc->finger];
 					
 					/*
 					 * Ignore movement of switch finger or
@@ -1237,8 +1264,8 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				if (sc->dz_count == 0)
 					dz = (sc->dz_sum / tun.z_factor) * (tun.z_invert ? -1 : 1);
 				if (sc->scr_mode == WSP_SCR_HOR || 
-				    abs(sc->pos_x[0] - sc->pos_x[1]) > MAX_DISTANCE ||
-				    abs(sc->pos_y[0] - sc->pos_y[1]) > MAX_DISTANCE)
+				    abs(sc->pos_x[0] - sc->pos_x[1]) > tun.max_finger_area ||
+				    abs(sc->pos_y[0] - sc->pos_y[1]) > tun.max_finger_area)
 					dz = 0;
 			}
 			if (ntouch == 3)
@@ -1262,12 +1289,12 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				sc->rdz = 0;
 			}
 		}
-		sc->pre_pos_x = sc->pos_x[0];
-		sc->pre_pos_y = sc->pos_y[0];
+		sc->pre_pos_x[0] = sc->pos_x[0];
+		sc->pre_pos_y[0] = sc->pos_y[0];
 
 		if (ntouch == 2 && sc->sc_status.button != 0) {
-			sc->pre_pos_x = sc->pos_x[sc->finger];
-			sc->pre_pos_y = sc->pos_y[sc->finger];
+			sc->pre_pos_x[sc->finger] = sc->pos_x[sc->finger];
+			sc->pre_pos_y[sc->finger] = sc->pos_y[sc->finger];
 		}
 		sc->o_ntouch = ntouch;
 

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -1263,9 +1263,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				dx = dy = 0;
 				if (sc->dz_count == 0)
 					dz = (sc->dz_sum / tun.z_factor) * (tun.z_invert ? -1 : 1);
-				if (sc->scr_mode == WSP_SCR_HOR || 
-				    abs(sc->pos_x[0] - sc->pos_x[1]) > tun.max_finger_area ||
-				    abs(sc->pos_y[0] - sc->pos_y[1]) > tun.max_finger_area)
+				if (sc->scr_mode == WSP_SCR_HOR || sc->distance > tun.max_double_tap_distance)
 					dz = 0;
 			}
 			if (ntouch == 3)

--- a/sys/dev/usb/usb.h
+++ b/sys/dev/usb/usb.h
@@ -114,7 +114,7 @@ MALLOC_DECLARE(M_USBDEV);
 /* Allow for marginal and non-conforming devices. */
 #define	USB_PORT_RESET_DELAY		50	/* ms */
 #define	USB_PORT_ROOT_RESET_DELAY	200	/* ms */
-#define	USB_PORT_RESET_RECOVERY		10	/* ms */
+#define	USB_PORT_RESET_RECOVERY		20	/* ms */
 #define	USB_PORT_POWERUP_DELAY		300	/* ms */
 #define	USB_PORT_RESUME_DELAY		(20*2)	/* ms */
 #define	USB_SET_ADDRESS_SETTLE		10	/* ms */

--- a/sys/kern/kern_ntptime.c
+++ b/sys/kern/kern_ntptime.c
@@ -193,7 +193,7 @@ static l_fp pps_freq;			/* scaled frequency offset (ns/s) */
 static long pps_fcount;			/* frequency accumulator */
 static long pps_jitter;			/* nominal jitter (ns) */
 static long pps_stabil;			/* nominal stability (scaled ns/s) */
-static long pps_lastsec;		/* time at last calibration (s) */
+static time_t pps_lastsec;		/* time at last calibration (s) */
 static int pps_valid;			/* signal watchdog counter */
 static int pps_shift = PPS_FAVG;	/* interval duration (s) (shift) */
 static int pps_shiftmax = PPS_FAVGDEF;	/* max interval duration (s) (shift) */
@@ -742,7 +742,8 @@ hardupdate(long offset /* clock offset (ns) */)
 void
 hardpps(struct timespec *tsp, long delta_nsec)
 {
-	long u_sec, u_nsec, v_nsec; /* temps */
+	long u_nsec, v_nsec; /* temps */
+	time_t u_sec;
 	l_fp ftemp;
 
 	NTP_LOCK();

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -660,9 +660,9 @@ kvprintf(char const *fmt, void (*func)(int, void*), void *arg, int radix, va_lis
 	char *d;
 	const char *p, *percent, *q;
 	u_char *up;
-	int ch, n;
+	int ch, n, sign;
 	uintmax_t num;
-	int base, lflag, qflag, tmp, width, ladjust, sharpflag, neg, sign, dot;
+	int base, lflag, qflag, tmp, width, ladjust, sharpflag, dot;
 	int cflag, hflag, jflag, tflag, zflag;
 	int bconv, dwidth, upper;
 	char padc;
@@ -690,7 +690,7 @@ kvprintf(char const *fmt, void (*func)(int, void*), void *arg, int radix, va_lis
 			PCHAR(ch);
 		}
 		percent = fmt - 1;
-		qflag = 0; lflag = 0; ladjust = 0; sharpflag = 0; neg = 0;
+		qflag = 0; lflag = 0; ladjust = 0; sharpflag = 0;
 		sign = 0; dot = 0; bconv = 0; dwidth = 0; upper = 0;
 		cflag = 0; hflag = 0; jflag = 0; tflag = 0; zflag = 0;
 reswitch:	switch (ch = (u_char)*fmt++) {
@@ -701,7 +701,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			sharpflag = 1;
 			goto reswitch;
 		case '+':
-			sign = 1;
+			sign = '+';
 			goto reswitch;
 		case '-':
 			ladjust = 1;
@@ -771,7 +771,6 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 		case 'd':
 		case 'i':
 			base = 10;
-			sign = 1;
 			goto handle_sign;
 		case 'h':
 			if (hflag) {
@@ -824,8 +823,10 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			goto reswitch;
 		case 'r':
 			base = radix;
-			if (sign)
+			if (sign) {
+				sign = 0;
 				goto handle_sign;
+			}
 			goto handle_nosign;
 		case 's':
 			p = va_arg(ap, char *);
@@ -862,13 +863,11 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			goto handle_nosign;
 		case 'y':
 			base = 16;
-			sign = 1;
 			goto handle_sign;
 		case 'z':
 			zflag = 1;
 			goto reswitch;
 handle_nosign:
-			sign = 0;
 			if (jflag)
 				num = va_arg(ap, uintmax_t);
 			else if (qflag)
@@ -907,11 +906,11 @@ handle_sign:
 				num = (signed char)va_arg(ap, int);
 			else
 				num = va_arg(ap, int);
-number:
-			if (sign && (intmax_t)num < 0) {
-				neg = 1;
+			if ((intmax_t)num < 0) {
+				sign = '-';
 				num = -(intmax_t)num;
 			}
+number:
 			p = ksprintn(nbuf, num, base, &n, upper);
 			tmp = 0;
 			if (sharpflag && num != 0) {
@@ -920,7 +919,7 @@ number:
 				else if (base == 16)
 					tmp += 2;
 			}
-			if (neg)
+			if (sign)
 				tmp++;
 
 			if (!ladjust && padc == '0')
@@ -930,8 +929,8 @@ number:
 			if (!ladjust)
 				while (width-- > 0)
 					PCHAR(' ');
-			if (neg)
-				PCHAR('-');
+			if (sign)
+				PCHAR(sign);
 			if (sharpflag && num != 0) {
 				if (base == 8) {
 					PCHAR('0');

--- a/sys/netpfil/ipfw/dn_sched_fq_pie.c
+++ b/sys/netpfil/ipfw/dn_sched_fq_pie.c
@@ -744,6 +744,9 @@ pie_enqueue(struct fq_pie_flow *q, struct mbuf* m, struct fq_pie_si *si)
 	}
 
 	if (t != DROP) {
+		if (m->m_pkthdr.rcvif != NULL)
+			m_rcvif_serialize(m);
+
 		mq_append(&q->mq, m);
 		fq_update_stats(q, si, len, 0);
 		return 0;

--- a/tools/build/cross-build/fake_sysctl.c
+++ b/tools/build/cross-build/fake_sysctl.c
@@ -53,6 +53,7 @@ __freebsd_sysctlbyname(const char *name, void *oldp, size_t *oldlenp,
 			errx(EX_USAGE, "kern.vm_guest is read-only");
 		strlcpy(oldp, "none", *oldlenp);
 		*oldlenp = strlen("none");
+		return (0);
 	}
 	errx(EX_USAGE, "fatal: unknown sysctl %s\n", name);
 }

--- a/usr.bin/du/du.c
+++ b/usr.bin/du/du.c
@@ -55,6 +55,8 @@
 #define UNITS_2		1
 #define UNITS_SI	2
 
+#define DU_XO_VERSION "1"
+
 static SLIST_HEAD(ignhead, ignentry) ignores;
 struct ignentry {
 	char			*mask;
@@ -259,6 +261,8 @@ main(int argc, char *argv[])
 	if ((fts = fts_open(argv, ftsoptions, NULL)) == NULL)
 		err(1, "fts_open");
 
+
+	xo_set_version(DU_XO_VERSION);
 	xo_open_container("disk-usage-information");
 	xo_open_list("paths");
 	while (errno = 0, (p = fts_read(fts)) != NULL) {

--- a/usr.bin/getaddrinfo/getaddrinfo.1
+++ b/usr.bin/getaddrinfo/getaddrinfo.1
@@ -171,7 +171,8 @@ stream inet tcp 199.233.217.249 80
 .Xr nsswitch.conf 5 ,
 .Xr protocols 5 ,
 .Xr resolv.conf 5 ,
-.Xr services 5
+.Xr services 5 ,
+.Xr ip6addrctl 8
 .Sh HISTORY
 The
 .Nm

--- a/usr.bin/iscsictl/iscsictl.c
+++ b/usr.bin/iscsictl/iscsictl.c
@@ -746,6 +746,7 @@ main(int argc, char **argv)
         if (argc < 0)
                 exit(1);
 
+	xo_set_version(ISCSICTL_XO_VERSION);
 	xo_open_container("iscsictl");
 
 	while ((ch = getopt(argc, argv, "AMRLac:d:e:i:n:p:rt:u:s:vw:")) != -1) {

--- a/usr.bin/iscsictl/iscsictl.h
+++ b/usr.bin/iscsictl/iscsictl.h
@@ -38,6 +38,8 @@
 #define	DEFAULT_CONFIG_PATH		"/etc/iscsi.conf"
 #define	DEFAULT_IQN			"iqn.1994-09.org.freebsd:"
 
+#define	ISCSICTL_XO_VERSION		"1"
+
 #define	MAX_NAME_LEN			223
 
 #define	AUTH_METHOD_UNSPECIFIED		0

--- a/usr.bin/netstat/main.c
+++ b/usr.bin/netstat/main.c
@@ -510,6 +510,7 @@ main(int argc, char *argv[])
 #endif
 	if (iflag && !sflag) {
 		xo_open_container("statistics");
+		xo_set_version(NETSTAT_XO_VERSION);
 		intpr(NULL, af);
 		xo_close_container("statistics");
 		xo_finish();
@@ -517,6 +518,7 @@ main(int argc, char *argv[])
 	}
 	if (rflag) {
 		xo_open_container("statistics");
+		xo_set_version(NETSTAT_XO_VERSION);
 		if (sflag) {
 			if (live) {
 				kresolve_list(nl);
@@ -530,6 +532,7 @@ main(int argc, char *argv[])
 	}
 	if (oflag) {
 		xo_open_container("statistics");
+		xo_set_version(NETSTAT_XO_VERSION);
 		nhops_print(fib, af);
 		xo_close_container("statistics");
 		xo_finish();
@@ -537,6 +540,7 @@ main(int argc, char *argv[])
 	}
 	if (Oflag) {
 		xo_open_container("statistics");
+		xo_set_version(NETSTAT_XO_VERSION);
 		nhgrp_print(fib, af);
 		xo_close_container("statistics");
 		xo_finish();
@@ -547,6 +551,7 @@ main(int argc, char *argv[])
 
 	if (gflag) {
 		xo_open_container("statistics");
+		xo_set_version(NETSTAT_XO_VERSION);
 		if (sflag) {
 			if (af == AF_INET || af == AF_UNSPEC)
 				mrt_stats();
@@ -569,6 +574,7 @@ main(int argc, char *argv[])
 
 	if (tp) {
 		xo_open_container("statistics");
+		xo_set_version(NETSTAT_XO_VERSION);
 		printproto(tp, tp->pr_name, &first);
 		if (!first)
 			xo_close_list("socket");
@@ -578,6 +584,7 @@ main(int argc, char *argv[])
 	}
 
 	xo_open_container("statistics");
+	xo_set_version(NETSTAT_XO_VERSION);
 	if (af == AF_INET || af == AF_UNSPEC)
 		for (tp = protox; tp->pr_name; tp++)
 			printproto(tp, tp->pr_name, &first);

--- a/usr.bin/netstat/netstat.h
+++ b/usr.bin/netstat/netstat.h
@@ -31,6 +31,8 @@
 
 #include <sys/cdefs.h>
 
+#define NETSTAT_XO_VERSION "1"
+
 #define	satosin(sa)	((struct sockaddr_in *)(sa))
 #define	satosin6(sa)	((struct sockaddr_in6 *)(sa))
 #define	sin6tosa(sin6)	((struct sockaddr *)(sin6))

--- a/usr.bin/w/w.c
+++ b/usr.bin/w/w.c
@@ -108,6 +108,8 @@ static struct entry {
 
 #define	debugproc(p) *(&((struct kinfo_proc *)p)->ki_udata)
 
+#define	W_XO_VERSION	"1"
+
 #define	W_DISPUSERSIZE	10
 #define	W_DISPLINESIZE	8
 #define	W_MAXHOSTSIZE	40
@@ -317,6 +319,7 @@ main(int argc, char *argv[])
 	if (fromwidth > W_MAXHOSTSIZE)
 		fromwidth = W_MAXHOSTSIZE;
 
+	xo_set_version(W_XO_VERSION);
 	xo_open_container("uptime-information");
 
 	if (header || wcmd == 0) {

--- a/usr.bin/wc/wc.c
+++ b/usr.bin/wc/wc.c
@@ -51,6 +51,8 @@
 #include <libcasper.h>
 #include <casper/cap_fileargs.h>
 
+#define WC_XO_VERSION "1"
+
 static const char *stdin_filename = "stdin";
 
 static fileargs_t *fa;
@@ -132,6 +134,8 @@ main(int argc, char *argv[])
 		doline = doword = dochar = true;
 
 	stderr_handle = xo_create_to_file(stderr, XO_STYLE_TEXT, 0);
+
+	xo_set_version(WC_XO_VERSION);
 	xo_open_container("wc");
 	xo_open_list("file");
 

--- a/usr.sbin/adduser/adduser.8
+++ b/usr.sbin/adduser/adduser.8
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 1995-1996 Wolfram Schneider <wosch@FreeBSD.org>. Berlin.
 .\" All rights reserved.
 .\" Copyright (c) 2002-2004 Michael Telahun Makonnen <mtm@FreeBSD.org>
@@ -427,7 +430,7 @@ message file for
 .Nm
 .It Pa /usr/share/skel
 skeletal login directory
-.It Pa /var/log/adduser
+.It Pa /var/log/userlog
 logfile for
 .Nm
 .El

--- a/usr.sbin/ip6addrctl/ip6addrctl.8
+++ b/usr.sbin/ip6addrctl/ip6addrctl.8
@@ -27,7 +27,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd September 25, 2001
+.Dd August 10, 2024
 .Dt IP6ADDRCTL 8
 .Os
 .\"
@@ -107,9 +107,12 @@ comments and are ignored.
 .\"
 .Sh SEE ALSO
 .Rs
+.%A "Dave Thaler"
 .%A "Richard Draves"
-.%T "Default Address Selection for IPv6"
-.%N RFC 3484
+.%A "Arifumi Matsumoto"
+.%A "Tim Chown"
+.%T "Default Address Selection for Internet Protocol Version 6 (IPv6)"
+.%R RFC 6724
 .Re
 .\"
 .Sh HISTORY

--- a/usr.sbin/ip6addrctl/ip6addrctl.8
+++ b/usr.sbin/ip6addrctl/ip6addrctl.8
@@ -106,6 +106,8 @@ comments and are ignored.
 .Ex -std
 .\"
 .Sh SEE ALSO
+.Xr getaddrinfo 1 ,
+.Xr getaddrinfo 3
 .Rs
 .%A "Dave Thaler"
 .%A "Richard Draves"

--- a/usr.sbin/ip6addrctl/ip6addrctl.conf.sample
+++ b/usr.sbin/ip6addrctl/ip6addrctl.conf.sample
@@ -1,11 +1,15 @@
-# default policy table based on RFC 3484.
+# default policy table based on RFC 6724.
 # usage: ip6addrctl install path_to_this_file
 #
 #
 #Format:
 #Prefix       Precedence Label
-::1/128               50     0 
-::/0                  40     1 
-2002::/16             30     2 
-::/96                 20     3 
-::ffff:0:0/96         10     4 
+::1/128               50     0
+::/0                  40     1
+::ffff:0:0/96         35     4
+2002::/16             30     2
+2001::/32              5     5
+fc00::/7               3    13
+::/96                  1     3
+fec0::/10              1    11
+3ffe::/16              1    12

--- a/usr.sbin/lastlogin/lastlogin.c
+++ b/usr.sbin/lastlogin/lastlogin.c
@@ -48,6 +48,8 @@ __RCSID("$NetBSD: lastlogin.c,v 1.4 1998/02/03 04:45:35 perry Exp $");
 
 #include <libxo/xo.h>
 
+#define LASTLOGIN_XO_VERSION "1"
+
 	int	main(int, char **);
 static	void	output(struct utmpx *);
 static	void	usage(void);
@@ -103,6 +105,7 @@ main(int argc, char *argv[])
 	argc -= optind;
 	argv += optind;
 
+	xo_set_version(LASTLOGIN_XO_VERSION);
 	xo_open_container("lastlogin-information");
 	xo_open_list("lastlogin");
 


### PR DESCRIPTION
10ms seems to be a little too short for some configurations.

I have two USB devices that needed this change (both Sinowealth mice) to work. From my tests, I could only get the issue to show up on both an `AMD 500 Series Chipset USB 3.1 XHCI Controller` and it's 400 series counterpart. Using other hubs on the system works fine. Note that these hubs work perfectly fine for every other USB device I've tried. I also tried it on two different 500 series controllers, getting the exact same result.

Someone also had a similar issue (I'm 90% sure it was also caused by this) on discord a while ago, and it was fixed by moving the usb device to another hub. I don't have enough info, so I don't know what the problematic device was though.

As a sanity check, I looked at what NetBSD was doing and it looks like they came to the same conclusion.
See https://github.com/NetBSD/src/commit/e988d633755d89def420163bf5224becd55c3bea