### PR TITLE
rm: rm -f should not fail

### DIFF
--- a/bin/ls/tests/ls_tests.sh
+++ b/bin/ls/tests/ls_tests.sh
@@ -932,6 +932,31 @@ atf_test_case 1_flag
 	atf_check_equal "$(cat $WITH_1)" "$(cat $WITHOUT_1)"
 }
 
+atf_test_case l_flag_nonexistent_msdosfs cleanup
+l_flag_nonexistent_msdosfs_head()
+{
+	atf_set "descr" "Verify that -l nonexistent* prints out the right error on MS-DOS file systems"
+	atf_set "require.user" root
+}
+
+l_flag_nonexistent_msdosfs_body()
+{
+	# Create an MS-DOS FS mount
+	md=$(mdconfig -a -t swap -s 5m)
+	mkdir mnt
+	newfs_msdos -h 1 -u 63 "$md"
+	mount_msdosfs /dev/"${md}" mnt
+
+	atf_check -e match:'No such file or directory' -o empty -s exit:1 \
+	    ls -l mnt/nonexistent*
+}
+
+l_flag_nonexistent_msdosfs_cleanup()
+{
+	umount mnt
+	mdconfig -d -u /dev/"${md}"
+}
+
 atf_init_test_cases()
 {
 	export BLOCKSIZE=512
@@ -978,4 +1003,5 @@ atf_init_test_cases()
 	atf_add_test_case x_flag
 	atf_add_test_case y_flag
 	atf_add_test_case 1_flag
+	atf_add_test_case l_flag_nonexistent_msdosfs
 }

--- a/bin/mv/tests/Makefile
+++ b/bin/mv/tests/Makefile
@@ -1,5 +1,6 @@
 .include <bsd.own.mk>
 
+ATF_TESTS_SH=	mv_test
 TAP_TESTS_SH=	legacy_test
 
 .include <bsd.test.mk>

--- a/bin/mv/tests/mv_test.sh
+++ b/bin/mv/tests/mv_test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env atf-sh
+#-
+# Copyright (c) 2024 Stefan Eßer <se@FreeBSD.org>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+atf_test_case wildcard_msdosfs cleanup
+wildcard_msdosfs_head()
+{
+	atf_set "descr" "Verify that moving to * prints out the right error on MS-DOS file systems"
+	atf_set "require.user" root
+}
+wildcard_msdosfs_body()
+{
+	# Create an MS-DOS FS mount
+	md=$(mdconfig -a -t swap -s 5m)
+	mkdir mnt
+	newfs_msdos -h 1 -u 63 "$md"
+	mount_msdosfs /dev/"${md}" mnt
+
+	atf_check -e empty -o empty -s exit:0 touch mnt/A.DAT
+	atf_check -e match:'No such file or directory' -o empty -s exit:1 \
+	    mv mnt/A.DAT mnt/B*.DAT
+}
+wildcard_msdosfs_cleanup()
+{
+	umount mnt
+	mdconfig -d -u /dev/"${md}"
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case wildcard_msdosfs
+}

--- a/bin/rm/rm.c
+++ b/bin/rm/rm.c
@@ -196,7 +196,7 @@ rm_tree(char **argv)
 	while (errno = 0, (p = fts_read(fts)) != NULL) {
 		switch (p->fts_info) {
 		case FTS_DNR:
-			if (!fflag && p->fts_errno != ENOENT) {
+			if (!fflag || p->fts_errno != ENOENT) {
 				warnx("%s: %s",
 				    p->fts_path, strerror(p->fts_errno));
 				eval = 1;
@@ -211,7 +211,7 @@ rm_tree(char **argv)
 			 */
 			if (!needstat)
 				break;
-			if (!fflag && p->fts_errno != ENOENT) {
+			if (!fflag || p->fts_errno != ENOENT) {
 				warnx("%s: %s",
 				    p->fts_path, strerror(p->fts_errno));
 				eval = 1;
@@ -338,7 +338,7 @@ rm_file(char **argv)
 			if (Wflag) {
 				sb.st_mode = S_IFWHT|S_IWUSR|S_IRUSR;
 			} else {
-				if (!fflag && errno != ENOENT) {
+				if (!fflag || errno != ENOENT) {
 					warn("%s", f);
 					eval = 1;
 				}
@@ -370,7 +370,7 @@ rm_file(char **argv)
 			else
 				rval = unlink(f);
 		}
-		if (rval && (!fflag && errno != ENOENT)) {
+		if (rval && (!fflag || errno != ENOENT)) {
 			warn("%s", f);
 			eval = 1;
 		}

--- a/bin/rm/rm.c
+++ b/bin/rm/rm.c
@@ -196,7 +196,7 @@ rm_tree(char **argv)
 	while (errno = 0, (p = fts_read(fts)) != NULL) {
 		switch (p->fts_info) {
 		case FTS_DNR:
-			if (!fflag || p->fts_errno != ENOENT) {
+			if (!fflag && p->fts_errno != ENOENT) {
 				warnx("%s: %s",
 				    p->fts_path, strerror(p->fts_errno));
 				eval = 1;
@@ -211,7 +211,7 @@ rm_tree(char **argv)
 			 */
 			if (!needstat)
 				break;
-			if (!fflag || p->fts_errno != ENOENT) {
+			if (!fflag && p->fts_errno != ENOENT) {
 				warnx("%s: %s",
 				    p->fts_path, strerror(p->fts_errno));
 				eval = 1;
@@ -338,7 +338,7 @@ rm_file(char **argv)
 			if (Wflag) {
 				sb.st_mode = S_IFWHT|S_IWUSR|S_IRUSR;
 			} else {
-				if (!fflag || errno != ENOENT) {
+				if (!fflag && errno != ENOENT) {
 					warn("%s", f);
 					eval = 1;
 				}
@@ -370,7 +370,7 @@ rm_file(char **argv)
 			else
 				rval = unlink(f);
 		}
-		if (rval && (!fflag || errno != ENOENT)) {
+		if (rval && (!fflag && errno != ENOENT)) {
 			warn("%s", f);
 			eval = 1;
 		}

--- a/bin/rm/tests/rm_test.sh
+++ b/bin/rm/tests/rm_test.sh
@@ -38,7 +38,30 @@ unlink_dash_filename_body()
 	atf_check -s exit:0 unlink -- -bar
 }
 
+atf_test_case f_flag_msdosfs cleanup
+f_flag_msdosfs_head()
+{
+	atf_set "descr" "Verify that -f nonexistent* does not print an error on MS-DOS file systems"
+	atf_set "require.user" root
+}
+f_flag_msdosfs_body()
+{
+	# Create an MS-DOS FS mount
+	md=$(mdconfig -a -t swap -s 5m)
+	mkdir mnt
+	newfs_msdos -h 1 -u 63 "$md"
+	mount_msdosfs /dev/"${md}" mnt
+
+	atf_check -s exit:0 rm -f mnt/foo*
+}
+f_flag_msdosfs_cleanup()
+{
+	umount mnt
+	mdconfig -d -u /dev/"${md}"
+}
+
 atf_init_test_cases()
 {
 	atf_add_test_case unlink_dash_filename
+	atf_add_test_case f_flag_msdosfs
 }

--- a/sys/fs/msdosfs/msdosfs_lookup.c
+++ b/sys/fs/msdosfs/msdosfs_lookup.c
@@ -88,9 +88,13 @@ msdosfs_lookup_checker(struct msdosfsmount *pmp, struct vnode *dvp,
 int
 msdosfs_lookup(struct vop_cachedlookup_args *ap)
 {
+	int error;
 
-	return (msdosfs_lookup_ino(ap->a_dvp, ap->a_vpp, ap->a_cnp, NULL,
-	    NULL));
+	error = msdosfs_lookup_ino(ap->a_dvp, ap->a_vpp, ap->a_cnp, NULL,
+	    NULL);
+	if (error == EINVAL)
+		error = ENOENT;
+	return (error);
 }
 
 struct deget_dotdot {


### PR DESCRIPTION
Fix an inverted logic bug, so the `-f` flag is always honored.

When trying to forcefully (`-f`) remove a nonexistent file on an `msdosfs` mount, an error is thrown:

```console
# rm -f /boot/efi/foo*
rm: /boot/efi/foo*: Invalid argument
```

---

It looks like it might be another issue underneath, and maybe other logic "bugs" in the file. At any rate, a more thorough explanation of when `rm -f` can fail (non-POSIX-compliant, etc.). Technically, only the penultimate case is needed to fix the issue.
This pull request can be taken as a bug report, should it be the case.