### PR TITLE
vmstat: Add root element to libxo output

### DIFF
--- a/usr.bin/vmstat/vmstat.c
+++ b/usr.bin/vmstat/vmstat.c
@@ -66,7 +66,7 @@
 #include <libutil.h>
 #include <libxo/xo.h>
 
-#define VMSTAT_XO_VERSION "1"
+#define VMSTAT_XO_VERSION "2"
 
 static char da[] = "da";
 
@@ -282,6 +282,7 @@ main(int argc, char *argv[])
 	argv += optind;
 
 	xo_set_version(VMSTAT_XO_VERSION);
+	xo_open_container("vmstat");
 	if (!hflag)
 		xo_set_options(NULL, "no-humanize");
 	if (todo == 0)
@@ -383,6 +384,7 @@ nlist_ok:
 		dointr(interval, reps);
 	if (todo & VMSTAT)
 		dovmstat(interval, reps);
+	xo_close_container("vmstat");
 	xo_finish();
 	exit(0);
 }


### PR DESCRIPTION
Partial fix for [Bug 254635](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=254635). 

On a side note: The conventions around libxo output seem to be a bit inconsistent. For instance `netstat` and `jls` do not use the program name as root element, but use `statistics` and `jail-information` instead. The `procstat` program uses the `getprogname()` function to set the name of the root element, whilst `arp` hard codes the program name. What are the best practices regarding libxo output?