### PR TITLE
netstat.1: Clarify -d argument

### DIFF
--- a/bin/test/test.c
+++ b/bin/test/test.c
@@ -198,7 +198,7 @@ main(int argc, char **argv)
 		p++;
 	if (strcmp(p, "[") == 0) {
 		if (strcmp(argv[--argc], "]") != 0)
-			error("missing ]");
+			error("missing ']'");
 		argv[argc] = NULL;
 	}
 

--- a/etc/mtree/BSD.include.dist
+++ b/etc/mtree/BSD.include.dist
@@ -310,11 +310,11 @@
     ..
     netinet6
     ..
+    netipsec
+    ..
     netlink
         route
         ..
-    ..
-    netipsec
     ..
     netpfil
         pf

--- a/etc/mtree/BSD.tests.dist
+++ b/etc/mtree/BSD.tests.dist
@@ -91,6 +91,10 @@
         ..
         usr.sbin
             dtrace
+                amd64
+                    arrays
+                    ..
+                ..
                 common
                     aggs
                     ..
@@ -267,10 +271,6 @@
                     pid
                     ..
                     ustack
-                    ..
-                ..
-                amd64
-                    arrays
                     ..
                 ..
             ..
@@ -1201,11 +1201,11 @@
         ..
         tsort
         ..
-        units
-        ..
         unifdef
         ..
         uniq
+        ..
+        units
         ..
         unzip
         ..

--- a/sbin/adjkerntz/adjkerntz.8
+++ b/sbin/adjkerntz/adjkerntz.8
@@ -1,4 +1,7 @@
-.\" Copyright (C) 1993-1998 by Andrey A. Chernov, Moscow, Russia.
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
+.\" Copyright (c) 1993-1998 by Andrey A. Chernov, Moscow, Russia.
 .\" All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -22,12 +25,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd March 8, 2012
+.Dd July 29, 2024
 .Dt ADJKERNTZ 8
 .Os
 .Sh NAME
 .Nm adjkerntz
-.Nd adjust the local time CMOS clock to reflect time zone changes and keep the current timezone offset for the kernel
+.Nd adjust real-time clock (rtc) and kernel timezone offset
 .Sh SYNOPSIS
 .Nm
 .Fl i
@@ -37,7 +40,7 @@
 The
 .Nm
 utility maintains the proper relationship between the kernel clock, which
-is always set to UTC and the CMOS clock, which may be set to local time.
+is always set to UTC and the real-time clock, which may be set to local time.
 The
 .Nm
 utility also informs the kernel about machine timezone shifts in order to
@@ -51,13 +54,13 @@ installed on the same system rather than fixing broken MS-DOS file
 timestamps.
 If the file
 .Pa /etc/wall_cmos_clock
-exists, it means that the CMOS clock keeps local time (MS-DOS and MS-Windows
-compatible mode).
-If that file does not exist, it means that the CMOS clock keeps UTC time.
+exists, it means that the real-time clock keeps local time
+.Pq MS-DOS and MS-Windows compatible mode .
+If that file does not exist, it means that the real-time clock keeps UTC time.
 The
 .Nm
 utility passes this state to the
-.Pa machdep.wall_cmos_clock
+.Va machdep.wall_cmos_clock
 kernel variable.
 .Pp
 Adjustments may be needed at system startup and shutdown, and
@@ -65,7 +68,7 @@ whenever a time zone change occurs.
 To handle these different situations,
 .Nm
 is invoked in two ways:
-.Bl -tag -width 4n
+.Bl -tag -width "-a [-s]"
 .It Fl i
 This form handles system startups and shutdowns.
 The
@@ -76,51 +79,51 @@ on entry to multi-user mode, before any other daemons have been started.
 The
 .Nm
 utility puts itself into the background.
-Then, for a local time CMOS clock,
+Then, for a local time real-time clock,
 .Nm
 reads the local time from it
 and sets the kernel clock to the corresponding UTC time.
 The
 .Nm
 utility also stores the local time zone offset in the
-.Pa machdep.adjkerntz
+.Va machdep.adjkerntz
 kernel variable, for use by subsequent invocations of
-.Em "'adjkerntz -a'"
+.Ql adjkerntz -a
 and by local time file systems.
 .Pp
-For a local time CMOS clock
-.Em "'adjkerntz -i'"
+For a local time real-time clock
+.Ql adjkerntz -i
 pauses and remains inactive as a background daemon until it
 receives a SIGTERM.
 The SIGTERM will normally be sent by
 .Xr init 8
-when the system leaves multi-user mode (usually, because the system
-is being shut down).
+when the system leaves multi-user mode
+.Pq usually, because the system is being shut down .
 After receiving the SIGTERM,
 .Nm
-reads the UTC kernel clock and updates the CMOS clock, if necessary,
+reads the UTC kernel clock and updates the real-time clock, if necessary,
 to ensure that it reflects the current local time zone.
 Then
 .Nm
 exits.
 .It Fl a Op Fl s
-This form is used to update the local time CMOS clock and kernel
-.Pa machdep.adjkerntz
-variable when time zone changes occur,
+This form is used to update the local time real-time clock and
+.Va machdep.adjkerntz
+kernel variable when time zone changes occur,
 e.g., when entering or leaving daylight savings time.
 The
 .Nm
 utility uses the kernel clock's UTC time,
-the previously stored
-time zone offset, and the changed time zone rule to
-calculate a new time zone offset.
+the previously stored time zone offset,
+and the changed time zone rule to calculate a new time zone offset.
 It stores the new offset into the
-.Pa machdep.adjkerntz
-kernel variable and updates the wall CMOS clock to the new local time.
+.Va machdep.adjkerntz
+kernel variable and updates the wall real-time clock to the new local time.
 If
-.Em "'adjkerntz -a'"
-was started at a nonexistent time (during a timezone change), it exits
-with a warning diagnostic unless the
+.Ql adjkerntz -a
+was started at a nonexistent time
+.Pq during a timezone change ,
+it exits with a warning diagnostic unless the
 .Fl s
 option was used, in which case
 .Nm
@@ -128,14 +131,14 @@ sleeps 30 minutes and tries again.
 .Pp
 This form should be invoked from root's
 .Xr crontab 5
-every half hour between midnight and 5am, when most modern time
-zone changes occur.
+every half hour between midnight and 5am,
+when most modern time zone changes occur.
 Warning: do not use the
 .Fl s
 option in a
 .Xr crontab 5
 command line, or multiple
-.Em "'adjkerntz -a'"
+.Ql adjkerntz -a
 instances could conflict with each other.
 .El
 .Pp
@@ -145,7 +148,7 @@ utility clears the kernel timezone structure and makes the kernel clock run
 in the UTC time zone.
 Super-user privileges are required for all operations.
 .Sh ENVIRONMENT
-.Bl -tag -width Fl
+.Bl -tag -width /etc/wall_cmos_clock
 .It Ev TZ
 Time zone change rule, see
 .Xr tzset 3 ;
@@ -164,8 +167,8 @@ and
 .Xr zic 8 .
 .It Pa /etc/wall_cmos_clock
 Empty file.
-Its presence indicates that the machine's CMOS clock is set to local
-time, while its absence indicates a UTC CMOS clock.
+Its presence indicates that the machine's real-time clock is set to local
+time, while its absence indicates a UTC real-time clock.
 .El
 .Sh DIAGNOSTICS
 No diagnostics.
@@ -178,6 +181,7 @@ and exits with a nonzero return code.
 .Xr tzset 3 ,
 .Xr crontab 5 ,
 .Xr mount_msdosfs 8 ,
+.Xr ntpd 8 ,
 .Xr rc 8 ,
 .Xr sysctl 8 ,
 .Xr tzsetup 8 ,

--- a/sys/dev/gpio/bytgpio.c
+++ b/sys/dev/gpio/bytgpio.c
@@ -278,6 +278,8 @@ const struct pinmap_info bytgpio_sus_pins[] = {
 	GPIO_PIN_MAP(40, 0)
 };
 
+static char *bytgpio_gpio_ids[] = { "INT33FC", NULL };
+
 #define	SUS_PINS	nitems(bytgpio_sus_pins)
 
 #define	BYGPIO_PIN_REGISTER(sc, pin, r)	((sc)->sc_pinpad_map[(pin)].reg * 16 + (r))
@@ -538,12 +540,11 @@ bytgpio_pin_toggle(device_t dev, uint32_t pin)
 static int
 bytgpio_probe(device_t dev)
 {
-	static char *gpio_ids[] = { "INT33FC", NULL };
 	int rv;
 
 	if (acpi_disabled("gpio"))
 		return (ENXIO);
-	rv = ACPI_ID_PROBE(device_get_parent(dev), dev, gpio_ids, NULL);
+	rv = ACPI_ID_PROBE(device_get_parent(dev), dev, bytgpio_gpio_ids, NULL);
 	if (rv <= 0)
 		device_set_desc(dev, "Intel Baytrail GPIO Controller");
 	return (rv);
@@ -675,3 +676,4 @@ static driver_t bytgpio_driver = {
 DRIVER_MODULE(bytgpio, acpi, bytgpio_driver, 0, 0);
 MODULE_DEPEND(bytgpio, acpi, 1, 1, 1);
 MODULE_DEPEND(bytgpio, gpiobus, 1, 1, 1);
+ACPI_PNP_INFO(bytgpio_gpio_ids);

--- a/usr.bin/netstat/netstat.1
+++ b/usr.bin/netstat/netstat.1
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 14, 2023
+.Dd July 29, 2024
 .Dt NETSTAT 1
 .Os
 .Sh NAME
@@ -312,7 +312,7 @@ address with which they are associated.
 .It Fl b
 Show the number of bytes in and out.
 .It Fl d
-Show the number of dropped packets.
+Show the number of dropped output packets.
 .It Fl h
 Print all counters in human readable form.
 .It Fl n
@@ -381,7 +381,7 @@ Show IPv6 only.
 See
 .Sx GENERAL OPTIONS .
 .It Fl d
-Show the number of dropped packets.
+Show the number of dropped output packets.
 .It Fl M
 Use an alternative core.
 See

--- a/usr.sbin/pw/pw.8
+++ b/usr.sbin/pw/pw.8
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd November 28, 2022
+.Dd July 29, 2024
 .Dt PW 8
 .Os
 .Sh NAME
@@ -837,7 +837,8 @@ new group
 or replace an existing membership list
 .Pq in Cm groupmod .
 .Ar memberlist
-is a comma separated list of valid and existing user names or uids.
+is a comma, space, or tab-separated list of valid and existing user names or
+uids.
 .It Fl m Ar newmembers
 Similar to
 .Fl M ,


### PR DESCRIPTION
The number of dropped input packets are always shown, the `-d` flag adds the dropped output packets to the output.