### PR TITLE
imgact_elf: Load APE executables faster

### DIFF
--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -85,7 +85,7 @@
 
 static int __elfN(check_header)(const Elf_Ehdr *hdr);
 static Elf_Brandinfo *__elfN(get_brandinfo)(struct image_params *imgp,
-    const char *interp, int32_t *osrel, uint32_t *fctl0);
+    const char *interp, int32_t *osrel, uint32_t *fctl0, const Elf_Ehdr *hdr);
 static int __elfN(load_file)(struct proc *p, const char *file, u_long *addr,
     u_long *entry);
 static int __elfN(load_section)(const struct image_params *imgp,
@@ -97,7 +97,7 @@ static bool __elfN(freebsd_trans_osrel)(const Elf_Note *note,
 static bool kfreebsd_trans_osrel(const Elf_Note *note, int32_t *osrel);
 static bool __elfN(check_note)(struct image_params *imgp,
     Elf_Brandnote *checknote, int32_t *osrel, bool *has_fctl0,
-    uint32_t *fctl0);
+    uint32_t *fctl0, const Elf_Ehdr *hdr);
 static vm_prot_t __elfN(trans_prot)(Elf_Word);
 static Elf_Word __elfN(untrans_prot)(vm_prot_t);
 static size_t __elfN(prepare_register_notes)(struct thread *td,
@@ -335,9 +335,8 @@ __elfN(brand_inuse)(Elf_Brandinfo *entry)
 
 static Elf_Brandinfo *
 __elfN(get_brandinfo)(struct image_params *imgp, const char *interp,
-    int32_t *osrel, uint32_t *fctl0)
+    int32_t *osrel, uint32_t *fctl0, const Elf_Ehdr *hdr)
 {
-	const Elf_Ehdr *hdr = (const Elf_Ehdr *)imgp->image_header;
 	Elf_Brandinfo *bi, *bi_m;
 	bool ret, has_fctl0;
 	int i, interp_name_len;
@@ -365,7 +364,7 @@ __elfN(get_brandinfo)(struct image_params *imgp, const char *interp,
 			*fctl0 = 0;
 			*osrel = 0;
 			ret = __elfN(check_note)(imgp, bi->brand_note, osrel,
-			    &has_fctl0, fctl0);
+			    &has_fctl0, fctl0, hdr);
 			/* Give brand a chance to veto check_note's guess */
 			if (ret && bi->header_supported) {
 				ret = bi->header_supported(imgp, osrel,
@@ -999,6 +998,103 @@ __elfN(enforce_limits)(struct image_params *imgp, const Elf_Ehdr *hdr,
 	return (0);
 }
 
+
+static int
+__elfN(ape_find_printf)(const char *page, int i)
+{
+	for (; i + 8 < 4096; ++i) {
+		if (memcmp(page + i, "printf '", 8) == 0)
+			return (i + 8);
+	}
+	return (-1);
+}
+
+static int
+__elfN(ape_parse_octal)(const char *page, int i, int *pc)
+{
+	int c;
+	if ('0' <= page[i] && page[i] <= '7') {
+		c = page[i++] - '0';
+		if ('0' <= page[i] && page[i] <= '7') {
+			c *= 8;
+			c += page[i++] - '0';
+			if ('0' <= page[i] && page[i] <= '7') {
+				c *= 8;
+				c += page[i++] - '0';
+			}
+		}
+		*pc = c;
+	}
+	return (i);
+}
+
+/*
+ * Files beginning with "MZqFpD" are Actually Portable Executables,
+ * which have a printf statement in the first 4096 bytes with octal
+ * codes that specify the ELF header. APE also specifies `jartsr='`
+ * as an alternative prefix, intended for binaries that do not want
+ * to be identified as Windows executables. Like the \177ELF magic,
+ * all these prefixes decode as x86 jump instructions that could be
+ * used for 16-bit bootloaders or 32-bit / 64-bit flat executables.
+ * Most importantly they provide a fallback path for Thompson shell
+ * compatible command interpreters, which do not require a shebang,
+ * e.g. bash, zsh, fish, bourne, almquist, etc. Please note that in
+ * order to meet the requirements of POSIX.1, the single quote must
+ * be followed by a newline character, before any null bytes occur.
+ * See also: https://www.austingroupbugs.net/view.php?id=1250
+ */
+static int
+__elfN(ape_decode_elf)(const char *page, char *ebuf)
+{
+	int c;
+	int i;
+	int retval;
+	Elf_Ehdr *ehdr;
+	int ebuf_index;
+	int desired_machine;
+
+#if defined(__aarch64__)
+	desired_machine = EM_AARCH64;
+#elif defined(__powerpc64__)
+	desired_machine = EM_PPC64;
+#elif defined(__riscv)
+	desired_machine = EM_RISCV;
+#else
+	desired_machine = EM_X86_64;
+#endif
+
+	i = 0;
+keep_looking:
+	retval = __elfN(ape_find_printf)(page, i);
+	if (retval < 0)
+		return (-1);
+
+	i = retval;
+	retval = -1;
+	ebuf_index = 0;
+	for (;;) {
+		if (i + 4 > 4096)
+			return (-1);
+		c = page[i++] & 255;
+		if (c == '\'')
+			break;
+		if (ebuf_index >= 64)
+			goto keep_looking;
+		if (c == '\\')
+			i = __elfN(ape_parse_octal)(page, i, &c);
+		ebuf[ebuf_index++] = c;
+	}
+	if (ebuf_index != 64)
+		goto keep_looking;
+	if (memcmp(ebuf, ELFMAG, SELFMAG) != 0)
+		goto keep_looking;
+	ehdr = (Elf_Ehdr *)ebuf;
+	if (ehdr->e_machine != desired_machine)
+		goto keep_looking;
+
+	return (0);
+}
+
 static int
 __elfN(get_interp)(struct image_params *imgp, const Elf_Phdr *phdr,
     char **interpp, bool *free_interpp)
@@ -1112,8 +1208,20 @@ __CONCAT(exec_, __elfN(imgact))(struct image_params *imgp)
 	int32_t osrel;
 	bool free_interp;
 	int error, i, n;
+	union {
+		char buf[64];
+		Elf_Ehdr hdr;
+	} ape;
 
 	hdr = (const Elf_Ehdr *)imgp->image_header;
+
+	/*
+	 * Check if this is an Actually Portable Executable.
+	 */
+	if ((memcmp(imgp->image_header, "MZqFpD='", 8) == 0 ||
+	     memcmp(imgp->image_header, "jartsr='", 8) == 0) &&
+	    __elfN(ape_decode_elf)(imgp->image_header, ape.buf) == 0)
+		hdr = &ape.hdr;
 
 	/*
 	 * Do we have a valid ELF header ?
@@ -1227,7 +1335,7 @@ __CONCAT(exec_, __elfN(imgact))(struct image_params *imgp)
 		}
 	}
 
-	brand_info = __elfN(get_brandinfo)(imgp, interp, &osrel, &fctl0);
+	brand_info = __elfN(get_brandinfo)(imgp, interp, &osrel, &fctl0, hdr);
 	if (brand_info == NULL) {
 		uprintf("ELF binary type \"%u\" not known.\n",
 		    hdr->e_ident[EI_OSABI]);
@@ -2850,15 +2958,13 @@ note_fctl_cb(const Elf_Note *note, void *arg0, bool *res)
  */
 static bool
 __elfN(check_note)(struct image_params *imgp, Elf_Brandnote *brandnote,
-    int32_t *osrel, bool *has_fctl0, uint32_t *fctl0)
+    int32_t *osrel, bool *has_fctl0, uint32_t *fctl0, const Elf_Ehdr *hdr)
 {
 	const Elf_Phdr *phdr;
-	const Elf_Ehdr *hdr;
 	struct brandnote_cb_arg b_arg;
 	struct fctl_cb_arg f_arg;
 	int i, j;
 
-	hdr = (const Elf_Ehdr *)imgp->image_header;
 	phdr = (const Elf_Phdr *)(imgp->image_header + hdr->e_phoff);
 	b_arg.brandnote = brandnote;
 	b_arg.osrel = osrel;


### PR DESCRIPTION
Actually Portable Executable (APE) is a file format that polyglots Windows Portable Executable with a UNIX Sixth Edition shell script (which predates the shebang line). It was introduced in 2020 and is specified formally in: https://github.com/jart/cosmopolitan/blob/master/ape/specification.md v0.1 and we even got POSIX to change their rules to let us use this clever hack https://www.austingroupbugs.net/view.php?id=1250 Our file format is widely used on sites like Hugging Face to distribute ML models, and gets hundreds of thousands of downloads per month.

This change improves the performance of loading APE binaries since they'll no longer need to be interpreted by /bin/sh. APE executables are basically just ELF executables, except with a shell script prepended to the start of the file. All we need to do is tell the FreeBSD kernel's normal ELF loader how to find the ELF header.