### PR TITLE
mac_veriexec_parser: Fix open_file error handling

### DIFF
--- a/sys/security/mac_veriexec_parser/mac_veriexec_parser.c
+++ b/sys/security/mac_veriexec_parser/mac_veriexec_parser.c
@@ -241,9 +241,9 @@ open_file(const char *path, struct nameidata *nid)
 
 	NDINIT(nid, LOOKUP, 0, UIO_SYSSPACE, path);
 	rc = vn_open(nid, &flags, 0, NULL);
-	NDFREE_PNBUF(nid);
 	if (rc != 0)
 		return (rc);
+	NDFREE_PNBUF(nid);
 
 	return (0);
 }
@@ -346,7 +346,6 @@ parse_entry(char *entry, char *prefix)
 	}
 
 	rc = open_file(path, &nid);
-	NDFREE_PNBUF(&nid);
 	if (rc != 0)
 		return (rc);
 

--- a/usr.bin/netstat/if.c
+++ b/usr.bin/netstat/if.c
@@ -501,7 +501,10 @@ intpr(void (*pfunc)(char *), int af)
 		    IFA_STAT(ipackets), link|network, 1);
 		show_stat("lu", nerr_len, "received-errors", IFA_STAT(ierrors),
 		    link, 1);
+		/* Below is kept for backwards compatibility. Will be removed in the future. */
 		show_stat("lu", nerr_len, "dropped-packets", IFA_STAT(iqdrops),
+		    link, 1);
+		show_stat("lu", nerr_len, "dropped-packets-in", IFA_STAT(iqdrops),
 		    link, 1);
 		if (bflag)
 			show_stat("lu", nbyte_len, "received-bytes",
@@ -516,7 +519,7 @@ intpr(void (*pfunc)(char *), int af)
 		show_stat("NRSlu", nerr_len, "collisions", IFA_STAT(collisions),
 		    link, 1);
 		if (dflag)
-			show_stat("LSlu", nerr_len, "dropped-packets",
+			show_stat("LSlu", nerr_len, "dropped-packets-out",
 			    IFA_STAT(oqdrops), link, 1);
 		xo_emit("\n");
 
@@ -705,7 +708,10 @@ loop:
 	    new->ift_ip - old->ift_ip, 1, 1);
 	show_stat("lu", 5, "received-errors",
 	    new->ift_ie - old->ift_ie, 1, 1);
+	/* Below is kept for backwards compatibility. Will be removed in the future. */
 	show_stat("lu", 5, "dropped-packets",
+	    new->ift_id - old->ift_id, 1, 1);
+	show_stat("lu", 5, "dropped-packets-in",
 	    new->ift_id - old->ift_id, 1, 1);
 	show_stat("lu", 10, "received-bytes",
 	    new->ift_ib - old->ift_ib, 1, 0);
@@ -718,7 +724,7 @@ loop:
 	show_stat("NRSlu", 5, "collisions",
 	    new->ift_co - old->ift_co, 1, 1);
 	if (dflag)
-		show_stat("LSlu", 5, "dropped-packets",
+		show_stat("LSlu", 5, "dropped-packets-out",
 		    new->ift_od - old->ift_od, 1, 1);
 	xo_close_instance("stats");
 	xo_emit("\n");

--- a/usr.bin/netstat/if.c
+++ b/usr.bin/netstat/if.c
@@ -501,7 +501,7 @@ intpr(void (*pfunc)(char *), int af)
 		    IFA_STAT(ipackets), link|network, 1);
 		show_stat("lu", nerr_len, "received-errors", IFA_STAT(ierrors),
 		    link, 1);
-		/* Below is kept for backwards compatibility. Will be removed in the future. */
+		/* Below is kept for backwards compatibility. Will be removed before FreeBSD 16. */
 		show_stat("lu", nerr_len, "dropped-packets", IFA_STAT(iqdrops),
 		    link, 1);
 		show_stat("lu", nerr_len, "dropped-packets-in", IFA_STAT(iqdrops),
@@ -708,7 +708,7 @@ loop:
 	    new->ift_ip - old->ift_ip, 1, 1);
 	show_stat("lu", 5, "received-errors",
 	    new->ift_ie - old->ift_ie, 1, 1);
-	/* Below is kept for backwards compatibility. Will be removed in the future. */
+	/* Below is kept for backwards compatibility. Will be removed before FreeBSD 16. */
 	show_stat("lu", 5, "dropped-packets",
 	    new->ift_id - old->ift_id, 1, 1);
 	show_stat("lu", 5, "dropped-packets-in",

--- a/usr.bin/netstat/sctp.c
+++ b/usr.bin/netstat/sctp.c
@@ -711,7 +711,7 @@ sctp_stats(u_long off, const char *name, int af1 __unused, int proto __unused)
 	    "secret\n");
 	p(sctps_timopathmtu, "\t\t{:pmtu-timer/%ju} "
 	    "{N:/PMTU timer%s fired}\n");
-	p(sctps_timoshutdownack, "\t\t{:shutdown-timer/%ju} "
+	p(sctps_timoshutdownack, "\t\t{:shutdown-ack-timer/%ju} "
 	    "{N:/shutdown ack timer%s fired}\n");
 	p(sctps_timoshutdownguard, "\t\t{:shutdown-guard-timer/%ju} "
 	    "{N:/shutdown guard timer%s fired}\n");

--- a/usr.sbin/i2c/i2c.c
+++ b/usr.sbin/i2c/i2c.c
@@ -751,6 +751,7 @@ main(int argc, char** argv)
 
 	/* Default values */
 	i2c_opt.off = 0;
+	i2c_opt.addr = 0;
 	i2c_opt.verbose = 0;
 	i2c_opt.dir = 'r';	/* direction = read */
 	i2c_opt.width = "8";
@@ -875,12 +876,6 @@ main(int argc, char** argv)
 		return(EX_USAGE);
 	}
 
-	if (i2c_opt.verbose)
-		fprintf(stderr, "dev: %s, addr: 0x%x, r/w: %c, "
-		    "offset: 0x%02x, width: %s, count: %u\n", dev,
-		    i2c_opt.addr >> 1, i2c_opt.dir, i2c_opt.off,
-		    i2c_opt.width, i2c_opt.count);
-
 	fd = open(dev, O_RDWR);
 	if (fd == -1) {
 		fprintf(stderr, "Error opening I2C controller (%s): %s\n",
@@ -890,6 +885,11 @@ main(int argc, char** argv)
 
 	switch (do_what) {
 	case 'a':
+		if (i2c_opt.verbose)
+			fprintf(stderr, "dev: %s, addr: 0x%x, r/w: %c, "
+			    "offset: 0x%02x, width: %s, count: %u\n", dev,
+			    i2c_opt.addr >> 1, i2c_opt.dir, i2c_opt.off,
+			    i2c_opt.width, i2c_opt.count);
 		error = access_bus(fd, i2c_opt);
 		break;
 	case 's':


### PR DESCRIPTION
NDFREE_PNBUF should be called after checking the return value of vn_open(), and should only be called once.