### PR TITLE
nuageinit: Accept plain text passwords

### DIFF
--- a/libexec/nuageinit/nuage.lua
+++ b/libexec/nuageinit/nuage.lua
@@ -112,7 +112,7 @@ local function adduser(pwd)
 		postcmd = " -H 0 "
 	elseif pwd.plain_text_passwd then
 		precmd = "echo "..pwd.plain_text_passwd .. "| "
-		postcmd = " -H 0 "
+		postcmd = " -h 0 "
 	end
 	cmd = precmd .. "pw "
 	if root then

--- a/libexec/nuageinit/tests/nuageinit.sh
+++ b/libexec/nuageinit/tests/nuageinit.sh
@@ -104,6 +104,7 @@ sys:*:1:0::0:0:Sys:/home/sys:/bin/csh
 freebsd:freebsd:1001:1003::0:0:FreeBSD User:/home/freebsd:/bin/sh
 foobar:H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/:1002:1004::0:0:Foo B. Bar:/home/foobar:/bin/sh
 EOF
+	sed -i "" "s/freebsd:.*:1001/freebsd:freebsd:1001/" ${here}/etc/master.passwd
 	atf_check -o file:expectedpasswd cat ${here}/etc/master.passwd
 	atf_check -o file:expectedgroup cat ${here}/etc/group
 }


### PR DESCRIPTION
Per [pw(8)], when `-H` is set, the password should be supplied already encrypted in a form suitable for writing directly to the password database (`passwd` in cloud-init tems); `-h` provides a special interface by which interactive scripts can set an account password using [pw(8)] in plain text (`plain_text_passwd` in cloud-init terms).

The default user (_freebsd_) is defined with a `plain_text_passwd` (_freebsd_), not with an encrypted one.

[pw(8)]: https://man.freebsd.org/cgi/man.cgi?query=pw&sektion=8&format=html

---

I suppose this is why the default user/password (freebsd/freebsd) of the image [FreeBSD-14.1-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz](https://download.freebsd.org/releases/VM-IMAGES/14.1-RELEASE/amd64/Latest/FreeBSD-14.1-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz) is not working.