### PR TITLE
nuageinit: Set recommended SSH permissions

### DIFF
--- a/libexec/nuageinit/nuage.lua
+++ b/libexec/nuageinit/nuage.lua
@@ -205,9 +205,11 @@ local function addsshkey(homedir, key)
 	f:write(key .. "\n")
 	f:close()
 	if chownak then
+		os.execute("chmod 0600 " .. ak_path)
 		pu.chown(ak_path, dirattrs.uid, dirattrs.gid)
 	end
 	if chowndotssh then
+		os.execute("chmod 0700 " .. dotssh_path)
 		pu.chown(dotssh_path, dirattrs.uid, dirattrs.gid)
 	end
 end

--- a/libexec/nuageinit/tests/nuage.sh
+++ b/libexec/nuageinit/tests/nuage.sh
@@ -17,6 +17,8 @@ addsshkey_body() {
 	if [ ! -f .ssh/authorized_keys ]; then
 		atf_fail "ssh key not added"
 	fi
+	atf_check -o inline:".ssh: 040700 [drwx------ ] -> 040700 [drwx------ ]\n" chmod -vv 0700 .ssh
+	atf_check -o inline:".ssh/authorized_keys: 0100600 [-rw------- ] -> 0100600 [-rw------- ]\n" chmod -vv 0600 .ssh/authorized_keys
 	atf_check -o inline:"mykey\n" cat .ssh/authorized_keys
 	atf_check /usr/libexec/flua $(atf_get_srcdir)/addsshkey.lua
 	atf_check -o inline:"mykey\nmykey\n" cat .ssh/authorized_keys


### PR DESCRIPTION
As stated in [sshd(8)](https://man.freebsd.org/cgi/man.cgi?query=sshd&&sektion=8&format=html), the recommended permissions for `~/.ssh` are read/write/execute for the user, and not accessible by others; and the recommended permissions for `~/.ssh/authorized_keys` are read/write for the user, and not accessible by others.

---

The administrator will likely enforce these permissions using some orchestration tool. At any rate, it is a good practice, and we are already doing it for other release images.
