### PR TITLE
nuageinit: Allow special characters in passwords

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # No locks listed here are valid.  The only strict review requirements
 # are granted by core.  These are documented in head/LOCKS and enforced
 # by svnadmin/conf/approvers.
-# 
+#
 # The source tree is a community effort.  However, some folks go to the
 # trouble of looking after particular areas of the tree.  In return for
 # their active caretaking of the code it is polite to coordinate changes
@@ -11,21 +11,21 @@
 # committers can easily find somebody who is familiar with it.  The notes
 # should specify if there is a 3rd party source tree involved or other
 # things that should be kept in mind.
-# 
+#
 # However, this is not a 'big stick', it is an offer to help and a source
 # of guidance.  It does not override the communal nature of the tree.
 # It is not a registry of 'turf' or private property.
-# 
+#
 # ***
 # This list is prone to becoming stale quickly.  The best way to find the recent
 # maintainer of a sub-system is to check recent logs for that directory or
 # sub-system.
 # ***
-# 
+#
 # ***
 # Maintainers are encouraged to visit:
 # https://reviews.freebsd.org/herald
-# 
+#
 # and configure Phabricator notifications for parts of the tree which they
 # maintain.  Notifications can automatically be sent when someone proposes a
 # revision or makes a commit to the specified subtree.
@@ -58,6 +58,7 @@
 /lib/libsecureboot/	@stephane-rochoy-stormshield
 /lib/libveriexec/	@stephane-rochoy-stormshield
 /lib/libvmmapi	@bsdjhb @grehan-freebsd
+/libexec/nuageinit/	@bapt
 /libexec/rc/rc.d/rctl/	@trasz
 /sbin/ipf		@cschuber
 /sbin/mount_fusefs @asomers

--- a/libexec/nuageinit/nuage.lua
+++ b/libexec/nuageinit/nuage.lua
@@ -108,10 +108,10 @@ local function adduser(pwd)
 	local precmd = ""
 	local postcmd = ""
 	if pwd.passwd then
-		precmd = "echo "..pwd.passwd .. "| "
+		precmd = "echo " .. ("%q"):format(pwd.passwd) .. " | "
 		postcmd = " -H 0 "
 	elseif pwd.plain_text_passwd then
-		precmd = "echo "..pwd.plain_text_passwd .. "| "
+		precmd = "echo " .. ("%q"):format(pwd.plain_text_passwd) .. " | "
 		postcmd = " -h 0 "
 	end
 	cmd = precmd .. "pw "

--- a/libexec/nuageinit/nuage.lua
+++ b/libexec/nuageinit/nuage.lua
@@ -4,6 +4,10 @@
 
 local pu = require("posix.unistd")
 
+function sanitize(str)
+	return ("%q"):format(str)
+end
+
 local function warnmsg(str)
 	io.stderr:write(str.."\n")
 end
@@ -72,12 +76,12 @@ local function adduser(pwd)
 		warnmsg("Argument should be a table")
 		return nil
 	end
-	local root = os.getenv("NUAGE_FAKE_ROOTDIR")
+	local root = sanitize(os.getenv("NUAGE_FAKE_ROOTDIR"))
 	local cmd = "pw "
 	if root then
 		cmd = cmd .. "-R " .. root .. " "
 	end
-	local f = io.popen(cmd .. " usershow " ..pwd.name .. " -7 2>/dev/null")
+	local f = io.popen(cmd .. " usershow " .. sanitize(pwd.name) .. " -7 2>/dev/null")
 	local pwdstr = f:read("*a")
 	f:close()
 	if pwdstr:len() ~= 0 then
@@ -91,13 +95,13 @@ local function adduser(pwd)
 	end
 	local extraargs=""
 	if pwd.groups then
-		local list = splitlist(pwd.groups)
-		extraargs = " -G ".. table.concat(list, ',')
+		local list = splitlist(sanitize(pwd.groups))
+		extraargs = " -G " .. table.concat(list, ',')
 	end
 	-- pw will automatically create a group named after the username
 	-- do not add a -g option in this case
 	if pwd.primary_group and pwd.primary_group ~= pwd.name then
-		extraargs = extraargs .. " -g " .. pwd.primary_group
+		extraargs = extraargs .. " -g " .. sanitize(pwd.primary_group)
 	end
 	if not pwd.no_create_home then
 		extraargs = extraargs .. " -m "
@@ -108,23 +112,23 @@ local function adduser(pwd)
 	local precmd = ""
 	local postcmd = ""
 	if pwd.passwd then
-		precmd = "echo " .. ("%q"):format(pwd.passwd) .. " | "
+		precmd = "echo " .. sanitize(pwd.passwd) .. " | "
 		postcmd = " -H 0 "
 	elseif pwd.plain_text_passwd then
-		precmd = "echo " .. ("%q"):format(pwd.plain_text_passwd) .. " | "
+		precmd = "echo " .. sanitize(pwd.plain_text_passwd) .. " | "
 		postcmd = " -h 0 "
 	end
 	cmd = precmd .. "pw "
 	if root then
 		cmd = cmd .. "-R " .. root .. " "
 	end
-	cmd = cmd .. "useradd -n ".. pwd.name .. " -M 0755 -w none "
-	cmd = cmd .. extraargs .. " -c '".. pwd.gecos
-	cmd = cmd .. "' -d '" .. pwd.homedir .. "' -s "..pwd.shell .. postcmd
+	cmd = cmd .. "useradd -n ".. sanitize(pwd.name) .. " -M 0755 -w none "
+	cmd = cmd .. extraargs .. " -c ".. sanitize(pwd.gecos)
+	cmd = cmd .. " -d " .. sanitize(pwd.homedir) .. " -s ".. sanitize(pwd.shell) .. postcmd
 
 	local r = os.execute(cmd)
 	if not r then
-		warnmsg("nuageinit: fail to add user "..pwd.name);
+		warnmsg("nuageinit: fail to add user " .. sanitize(pwd.name));
 		warnmsg(cmd)
 		return nil
 	end
@@ -133,10 +137,10 @@ local function adduser(pwd)
 		if root then
 			cmd = cmd .. "-R " .. root .. " "
 		end
-		cmd = cmd .. "lock " .. pwd.name
+		cmd = cmd .. "lock " .. sanitize(pwd.name)
 		os.execute(cmd)
 	end
-	return pwd.homedir
+	return sanitize(pwd.homedir)
 end
 
 local function addgroup(grp)

--- a/libexec/nuageinit/nuage.lua
+++ b/libexec/nuageinit/nuage.lua
@@ -86,8 +86,8 @@ local function adduser(pwd)
 	if not pwd.gecos then
 		pwd.gecos = pwd.name .. " User"
 	end
-	if not pwd.home then
-		pwd.home = "/home/" .. pwd.name
+	if not pwd.homedir then
+		pwd.homedir = "/home/" .. pwd.name
 	end
 	local extraargs=""
 	if pwd.groups then
@@ -120,7 +120,7 @@ local function adduser(pwd)
 	end
 	cmd = cmd .. "useradd -n ".. pwd.name .. " -M 0755 -w none "
 	cmd = cmd .. extraargs .. " -c '".. pwd.gecos
-	cmd = cmd .. "' -d '" .. pwd.home .. "' -s "..pwd.shell .. postcmd
+	cmd = cmd .. "' -d '" .. pwd.homedir .. "' -s "..pwd.shell .. postcmd
 
 	local r = os.execute(cmd)
 	if not r then
@@ -136,7 +136,7 @@ local function adduser(pwd)
 		cmd = cmd .. "lock " .. pwd.name
 		os.execute(cmd)
 	end
-	return pwd.home
+	return pwd.homedir
 end
 
 local function addgroup(grp)


### PR DESCRIPTION
When passwords are declared in plain text, the vertical bar (`|`), and other characters should be valid.

Adapt the script accordingly by serializing the password.  While here, change the encrypted path, as well.

---

Take this commit with a pinch of salt. I'm not 100% sure this is the proper way to escape things in lua.