### PR TITLE
Avoid division in round_up

### DIFF
--- a/lib/libthr/thread/thr_stack.c
+++ b/lib/libthr/thread/thr_stack.c
@@ -126,7 +126,7 @@ static char *last_stack = NULL;
 static inline size_t
 round_up(size_t size)
 {
-	return (roundup2(size, _thr_page_size - 1));
+	return (roundup2(size, _thr_page_size));
 }
 
 void

--- a/lib/libthr/thread/thr_stack.c
+++ b/lib/libthr/thread/thr_stack.c
@@ -126,10 +126,7 @@ static char *last_stack = NULL;
 static inline size_t
 round_up(size_t size)
 {
-	if (size % _thr_page_size != 0)
-		size = ((size / _thr_page_size) + 1) *
-		    _thr_page_size;
-	return size;
+	return (roundup2(size, _thr_page_size - 1));
 }
 
 void


### PR DESCRIPTION
Round up to page size using add and mask instead of divide and multiply.  This is slightly faster, but more importantly it avoids a function call when division is not implemented in hardware.  Looking up the target of the call here can lead to deadlock in rtld.  See recent discussion on -arm and -current.

Some older armv7 CPUs do not have hardware divide.  Theoretically FreeBSD could also target a RISC-V CPU without hardware multiply and divide.