### PR TITLE
P9fs fix - Handle "." in a path correctly.

### DIFF
--- a/sys/fs/p9fs/p9fs_vnops.c
+++ b/sys/fs/p9fs/p9fs_vnops.c
@@ -238,7 +238,7 @@ p9fs_lookup(struct vop_lookup_args *ap)
 	if (dnp == NULL)
 		return (ENOENT);
 
-	if (cnp->cn_nameptr[0] == '.' && strlen(cnp->cn_nameptr) == 1) {
+	if (cnp->cn_nameptr[0] == '.' && cnp->cn_namelen == 1) {
 		vref(dvp);
 		*vpp = dvp;
 		return (0);


### PR DESCRIPTION
p9fs: The current logic worked only when "." was the final component but doesn't handle paths like for example "./a.out". Here p9fs_lookup() will be called twice, first for "." (cnp->cn_namelen == 1), and then "a.out" (cn_namelen == 5), but cnp->cn_nameptr is not nul terminated for the current component so much check cn_namelen.