### PR TITLE
Add support for ARM64 FIQs

### DIFF
--- a/sys/arm/allwinner/a10/a10_intc.c
+++ b/sys/arm/allwinner/a10/a10_intc.c
@@ -236,7 +236,7 @@ a10_intr_pic_attach(struct a10_aintc_softc *sc)
 	if (pic == NULL)
 		return (ENXIO);
 
-	return (intr_pic_claim_root(sc->sc_dev, xref, a10_intr, sc));
+	return (intr_pic_claim_root(sc->sc_dev, xref, a10_intr, sc, INTR_ROOT_IRQ));
 }
 
 static void

--- a/sys/arm/arm/exception.S
+++ b/sys/arm/arm/exception.S
@@ -48,6 +48,8 @@
 
 #include "assym.inc"
 
+#include <sys/intr.h>
+
 #include <machine/asm.h>
 #include <machine/armreg.h>
 #include <machine/asmacros.h>
@@ -308,7 +310,8 @@ ASENTRY_NP(irq_entry)
 	PUSHFRAMEINSVC			/* mode stack, build trapframe there. */
 	adr	lr, exception_exit	/* Return from handler via standard */
 	mov	r0, sp			/* exception exit routine.  Pass the */
-	b	_C_LABEL(intr_irq_handler)/* trapframe to the handler. */
+	mov	r1, #INTR_ROOT_IRQ	/* trapframe and PIC root to the handler. */
+	b	_C_LABEL(intr_irq_handler)
 END(irq_entry)
 
 /*

--- a/sys/arm/arm/gic.c
+++ b/sys/arm/arm/gic.c
@@ -200,7 +200,7 @@ gic_cpu_mask(struct arm_gic_softc *sc)
 
 #ifdef SMP
 static void
-arm_gic_init_secondary(device_t dev)
+arm_gic_init_secondary(device_t dev, uint32_t rootnum)
 {
 	struct arm_gic_softc *sc = device_get_softc(dev);
 	u_int irq, cpu;

--- a/sys/arm/arm/gic_acpi.c
+++ b/sys/arm/arm/gic_acpi.c
@@ -227,7 +227,7 @@ gic_acpi_attach(device_t dev)
 	/*
 	 * Controller is root:
 	 */
-	if (intr_pic_claim_root(dev, xref, arm_gic_intr, sc) != 0) {
+	if (intr_pic_claim_root(dev, xref, arm_gic_intr, sc, INTR_ROOT_IRQ) != 0) {
 		device_printf(dev, "could not set PIC as a root\n");
 		intr_pic_deregister(dev, xref);
 		goto cleanup;

--- a/sys/arm/arm/gic_fdt.c
+++ b/sys/arm/arm/gic_fdt.c
@@ -153,7 +153,8 @@ gic_fdt_attach(device_t dev)
 	 */
 	pxref = ofw_bus_find_iparent(ofw_bus_get_node(dev));
 	if (pxref == 0 || xref == pxref) {
-		if (intr_pic_claim_root(dev, xref, arm_gic_intr, sc) != 0) {
+		if (intr_pic_claim_root(dev, xref, arm_gic_intr, sc, INTR_ROOT_IRQ)
+		    != 0) {
 			device_printf(dev, "could not set PIC as a root\n");
 			intr_pic_deregister(dev, xref);
 			goto cleanup;

--- a/sys/arm/broadcom/bcm2835/bcm2835_intr.c
+++ b/sys/arm/broadcom/bcm2835/bcm2835_intr.c
@@ -405,7 +405,8 @@ bcm_intc_attach(device_t dev)
 	sc->intc_irq_res = bus_alloc_resource_any(dev, SYS_RES_IRQ, &rid,
 	    RF_ACTIVE);
 	if (sc->intc_irq_res == NULL) {
-		if (intr_pic_claim_root(dev, xref, bcm2835_intc_intr, sc) != 0) {
+		if (intr_pic_claim_root(dev, xref, bcm2835_intc_intr, sc, INTR_ROOT_IRQ)
+		    != 0) {
 			/* XXX clean up */
 			device_printf(dev, "could not set PIC as a root\n");
 			return (ENXIO);

--- a/sys/arm/broadcom/bcm2835/bcm2836.c
+++ b/sys/arm/broadcom/bcm2835/bcm2836.c
@@ -538,7 +538,7 @@ bcm_lintc_init_pmu_on_ap(struct bcm_lintc_softc *sc, u_int cpu)
 }
 
 static void
-bcm_lintc_init_secondary(device_t dev)
+bcm_lintc_init_secondary(device_t dev, uint32_t rootnum)
 {
 	u_int cpu;
 	struct bcm_lintc_softc *sc;
@@ -646,7 +646,8 @@ bcm_lintc_pic_attach(struct bcm_lintc_softc *sc)
 	if (pic == NULL)
 		return (ENXIO);
 
-	error = intr_pic_claim_root(sc->bls_dev, xref, bcm_lintc_intr, sc);
+	error = intr_pic_claim_root(sc->bls_dev, xref, bcm_lintc_intr, sc,
+	    INTR_ROOT_IRQ);
 	if (error != 0)
 		return (error);
 

--- a/sys/arm/ti/aintc.c
+++ b/sys/arm/ti/aintc.c
@@ -230,7 +230,8 @@ ti_aintc_pic_attach(struct ti_aintc_softc *sc)
 	if (pic == NULL)
 		return (ENXIO);
 
-	return (intr_pic_claim_root(sc->sc_dev, xref, ti_aintc_intr, sc));
+	return (intr_pic_claim_root(sc->sc_dev, xref, ti_aintc_intr, sc,
+	    INTR_ROOT_IRQ));
 }
 
 static int

--- a/sys/arm64/arm64/exception.S
+++ b/sys/arm64/arm64/exception.S
@@ -26,6 +26,7 @@
  */
 
 #include <sys/elf_common.h>
+#include <sys/intr.h>
 
 #include <machine/asm.h>
 #include <machine/armreg.h>
@@ -232,6 +233,7 @@ ENTRY(handle_el1h_irq)
 	save_registers 1
 	KMSAN_ENTER
 	mov	x0, sp
+	mov	x1, #INTR_ROOT_IRQ
 	bl	intr_irq_handler
 	KMSAN_LEAVE
 	restore_registers 1
@@ -266,6 +268,7 @@ ENTRY(handle_el0_irq)
 	save_registers 0
 	KMSAN_ENTER
 	mov	x0, sp
+	mov	x1, #INTR_ROOT_IRQ
 	bl	intr_irq_handler
 	do_ast
 	KMSAN_LEAVE

--- a/sys/arm64/arm64/exception.S
+++ b/sys/arm64/arm64/exception.S
@@ -30,6 +30,7 @@
 
 #include <machine/asm.h>
 #include <machine/armreg.h>
+#include <machine/intr.h>
 #include "assym.inc"
 
 	.text
@@ -170,7 +171,7 @@
 .macro	do_ast
 	mrs	x19, daif
 	/* Make sure the IRQs are enabled before calling ast() */
-	bic	x19, x19, #PSR_I
+	bic	x19, x19, #(PSR_I | PSR_F)
 1:
 	/*
 	 * Mask interrupts while checking the ast pending flag
@@ -240,6 +241,17 @@ ENTRY(handle_el1h_irq)
 	ERET
 END(handle_el1h_irq)
 
+ENTRY(handle_el1h_fiq)
+	save_registers 1
+	KMSAN_ENTER
+	mov	x0, sp
+	mov	x1, #INTR_ROOT_FIQ
+	bl	intr_irq_handler
+	KMSAN_LEAVE
+	restore_registers 1
+	ERET
+END(handle_el1h_fiq)
+
 ENTRY(handle_el1h_serror)
 	save_registers 1
 	KMSAN_ENTER
@@ -275,6 +287,18 @@ ENTRY(handle_el0_irq)
 	restore_registers 0
 	ERET
 END(handle_el0_irq)
+
+ENTRY(handle_el0_fiq)
+	save_registers 0
+	KMSAN_ENTER
+	mov	x0, sp
+	mov	x1, #INTR_ROOT_FIQ
+	bl	intr_irq_handler
+	do_ast
+	KMSAN_LEAVE
+	restore_registers 0
+	ERET
+END(handle_el0_fiq)
 
 ENTRY(handle_el0_serror)
 	save_registers 0
@@ -318,17 +342,17 @@ exception_vectors:
 
 	vector el1h_sync 1	/* Synchronous EL1h */
 	vector el1h_irq 1	/* IRQ EL1h */
-	vempty 1		/* FIQ EL1h */
+	vector el1h_fiq 1	/* FIQ EL1h */
 	vector el1h_serror 1	/* Error EL1h */
 
 	vector el0_sync 0	/* Synchronous 64-bit EL0 */
 	vector el0_irq 0	/* IRQ 64-bit EL0 */
-	vempty 0		/* FIQ 64-bit EL0 */
+	vector el0_fiq 0	/* FIQ 64-bit EL0 */
 	vector el0_serror 0	/* Error 64-bit EL0 */
 
 	vector el0_sync 0	/* Synchronous 32-bit EL0 */
 	vector el0_irq 0	/* IRQ 32-bit EL0 */
-	vempty 0		/* FIQ 32-bit EL0 */
+	vector el0_fiq 0	/* FIQ 32-bit EL0 */
 	vector el0_serror 0	/* Error 32-bit EL0 */
 
 GNU_PROPERTY_AARCH64_FEATURE_1_NOTE(GNU_PROPERTY_AARCH64_FEATURE_1_VAL)

--- a/sys/arm64/arm64/gic_v3.c
+++ b/sys/arm64/arm64/gic_v3.c
@@ -1093,7 +1093,7 @@ gic_v3_bind_intr(device_t dev, struct intr_irqsrc *isrc)
 
 #ifdef SMP
 static void
-gic_v3_init_secondary(device_t dev)
+gic_v3_init_secondary(device_t dev, uint32_t rootnum)
 {
 	struct gic_v3_setup_periph_args pargs;
 	device_t child;
@@ -1140,7 +1140,7 @@ gic_v3_init_secondary(device_t dev)
 
 	for (i = 0; i < sc->gic_nchildren; i++) {
 		child = sc->gic_children[i];
-		PIC_INIT_SECONDARY(child);
+		PIC_INIT_SECONDARY(child, rootnum);
 	}
 }
 

--- a/sys/arm64/arm64/gic_v3_acpi.c
+++ b/sys/arm64/arm64/gic_v3_acpi.c
@@ -345,8 +345,9 @@ gic_v3_acpi_attach(device_t dev)
 		}
 	}
 
-	if (intr_pic_claim_root(dev, ACPI_INTR_XREF, arm_gic_v3_intr, sc)
-	    != 0) {
+	err = intr_pic_claim_root(dev, ACPI_INTR_XREF, arm_gic_v3_intr, sc,
+	    INTR_ROOT_IRQ);
+	if (err != 0) {
 		err = ENXIO;
 		goto error;
 	}

--- a/sys/arm64/arm64/gic_v3_fdt.c
+++ b/sys/arm64/arm64/gic_v3_fdt.c
@@ -161,7 +161,8 @@ gic_v3_fdt_attach(device_t dev)
 	/* Register xref */
 	OF_device_register_xref(xref, dev);
 
-	if (intr_pic_claim_root(dev, xref, arm_gic_v3_intr, sc) != 0) {
+	err = intr_pic_claim_root(dev, xref, arm_gic_v3_intr, sc, INTR_ROOT_IRQ);
+	if (err != 0) {
 		err = ENXIO;
 		goto error;
 	}

--- a/sys/arm64/arm64/gicv3_its.c
+++ b/sys/arm64/arm64/gicv3_its.c
@@ -1284,7 +1284,7 @@ gicv3_its_setup_intr(device_t dev, struct intr_irqsrc *isrc,
 
 #ifdef SMP
 static void
-gicv3_its_init_secondary(device_t dev)
+gicv3_its_init_secondary(device_t dev, uint32_t rootnum)
 {
 	struct gicv3_its_softc *sc;
 

--- a/sys/arm64/include/armreg.h
+++ b/sys/arm64/include/armreg.h
@@ -411,7 +411,7 @@
 #define	DAIF_I			(1 << 1)
 #define	DAIF_F			(1 << 0)
 #define	DAIF_ALL		(DAIF_D | DAIF_A | DAIF_I | DAIF_F)
-#define	DAIF_INTR		(DAIF_I)	/* All exceptions that pass */
+#define	DAIF_INTR		(DAIF_I | DAIF_F)	/* All exceptions that pass */
 						/* through the intr framework */
 
 /* DBGBCR<n>_EL1 - Debug Breakpoint Control Registers */
@@ -2401,7 +2401,7 @@
 #define	PSR_D		0x00000200UL
 #define	PSR_DAIF	(PSR_D | PSR_A | PSR_I | PSR_F)
 /* The default DAIF mask. These bits are valid in spsr_el1 and daif */
-#define	PSR_DAIF_DEFAULT (PSR_F)
+#define	PSR_DAIF_DEFAULT (0)
 #define	PSR_BTYPE	0x00000c00UL
 #define	PSR_SSBS	0x00001000UL
 #define	PSR_ALLINT	0x00002000UL

--- a/sys/arm64/include/intr.h
+++ b/sys/arm64/include/intr.h
@@ -27,6 +27,7 @@
 #ifndef _MACHINE_INTR_H_
 #define	_MACHINE_INTR_H_
 
+#ifndef LOCORE
 #ifdef FDT
 #include <dev/ofw/openfirm.h>
 #endif
@@ -47,5 +48,10 @@ arm_irq_memory_barrier(uintptr_t irq)
 #define	ACPI_MSI_XREF	2
 #define	ACPI_GPIO_XREF	3
 #endif
+
+#endif	/* !LOCORE */
+
+#define	INTR_ROOT_FIQ	1
+#define	INTR_ROOT_NUM	2
 
 #endif	/* _MACHINE_INTR_H */

--- a/sys/kern/pic_if.m
+++ b/sys/kern/pic_if.m
@@ -74,7 +74,7 @@ CODE {
 	}
 
 	static void
-	null_pic_init_secondary(device_t dev)
+	null_pic_init_secondary(device_t dev, uint32_t rootnum)
 	{
 	}
 
@@ -157,6 +157,7 @@ METHOD void pre_ithread {
 
 METHOD void init_secondary {
 	device_t	dev;
+	uint32_t	rootnum;
 } DEFAULT null_pic_init_secondary;
 
 METHOD void ipi_send {

--- a/sys/riscv/riscv/aplic.c
+++ b/sys/riscv/riscv/aplic.c
@@ -321,6 +321,7 @@ aplic_setup_direct_mode(device_t dev)
 	int error = ENXIO;
 	u_int irq;
 	int cpu, hartid, rid, i, nintr, idc;
+	device_t rootdev;
 
 	sc = device_get_softc(dev);
 	node = ofw_bus_get_node(dev);
@@ -407,7 +408,8 @@ aplic_setup_direct_mode(device_t dev)
 		    APLIC_IDC_ITHRESHOLD_DISABLE);
 	}
 
-	iparent = OF_xref_from_node(ofw_bus_get_node(intr_irq_root_dev));
+	rootdev = intr_irq_root_device(INTR_ROOT_IRQ);
+	iparent = OF_xref_from_node(ofw_bus_get_node(rootdev));
 	cell = IRQ_EXTERNAL_SUPERVISOR;
 	irq = ofw_bus_map_intr(dev, iparent, 1, &cell);
 	error = bus_set_resource(dev, SYS_RES_IRQ, 0, irq, 1);

--- a/sys/riscv/riscv/intc.c
+++ b/sys/riscv/riscv/intc.c
@@ -181,7 +181,7 @@ intc_attach(device_t dev)
 	if (pic == NULL)
 		return (ENXIO);
 
-	return (intr_pic_claim_root(sc->dev, xref, intc_intr, sc));
+	return (intr_pic_claim_root(sc->dev, xref, intc_intr, sc, INTR_ROOT_IRQ));
 }
 
 static void
@@ -241,7 +241,7 @@ intc_setup_intr(device_t dev, struct intr_irqsrc *isrc,
 
 #ifdef SMP
 static void
-intc_init_secondary(device_t dev)
+intc_init_secondary(device_t dev, uint32_t rootnum)
 {
 	struct intc_softc *sc;
 	struct intr_irqsrc *isrc;

--- a/sys/riscv/riscv/sbi_ipi.c
+++ b/sys/riscv/riscv/sbi_ipi.c
@@ -141,6 +141,7 @@ sbi_ipi_attach(device_t dev)
 	int irq, rid, error;
 	phandle_t iparent;
 	pcell_t cell;
+	device_t rootdev;
 
 	sc = device_get_softc(dev);
 	sc->dev = dev;
@@ -155,7 +156,8 @@ sbi_ipi_attach(device_t dev)
 		return (ENXIO);
 	}
 
-	iparent = OF_xref_from_node(ofw_bus_get_node(intr_irq_root_dev));
+	rootdev = intr_irq_root_device(INTR_ROOT_IRQ);
+	iparent = OF_xref_from_node(ofw_bus_get_node(rootdev));
 	cell = IRQ_SOFTWARE_SUPERVISOR;
 	irq = ofw_bus_map_intr(dev, iparent, 1, &cell);
 	error = bus_set_resource(dev, SYS_RES_IRQ, 0, irq, 1);

--- a/sys/riscv/riscv/timer.c
+++ b/sys/riscv/riscv/timer.c
@@ -196,6 +196,7 @@ riscv_timer_attach(device_t dev)
 	int irq, rid, error;
 	phandle_t iparent;
 	pcell_t cell;
+	device_t rootdev;
 
 	sc = device_get_softc(dev);
 	if (riscv_timer_sc != NULL)
@@ -211,7 +212,8 @@ riscv_timer_attach(device_t dev)
 
 	riscv_timer_sc = sc;
 
-	iparent = OF_xref_from_node(ofw_bus_get_node(intr_irq_root_dev));
+	rootdev = intr_irq_root_device(INTR_ROOT_IRQ);
+	iparent = OF_xref_from_node(ofw_bus_get_node(rootdev));
 	cell = IRQ_TIMER_SUPERVISOR;
 	irq = ofw_bus_map_intr(dev, iparent, 1, &cell);
 	error = bus_set_resource(dev, SYS_RES_IRQ, 0, irq, 1);

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -74,8 +74,6 @@
 #include <ddb/db_sym.h>
 #endif
 
-void intr_irq_handler(struct trapframe *tf);
-
 int (*dtrace_invop_jump_addr)(struct trapframe *);
 
 /* Called from exception.S */
@@ -319,7 +317,7 @@ do_trap_supervisor(struct trapframe *frame)
 	exception = frame->tf_scause & SCAUSE_CODE;
 	if ((frame->tf_scause & SCAUSE_INTR) != 0) {
 		/* Interrupt */
-		intr_irq_handler(frame);
+		intr_irq_handler(frame, INTR_ROOT_IRQ);
 		return;
 	}
 
@@ -400,7 +398,7 @@ do_trap_user(struct trapframe *frame)
 	exception = frame->tf_scause & SCAUSE_CODE;
 	if ((frame->tf_scause & SCAUSE_INTR) != 0) {
 		/* Interrupt */
-		intr_irq_handler(frame);
+		intr_irq_handler(frame, INTR_ROOT_IRQ);
 		return;
 	}
 	intr_enable();

--- a/sys/sys/intr.h
+++ b/sys/sys/intr.h
@@ -33,10 +33,15 @@
 #error Need INTRNG for this file
 #endif
 
+#ifndef LOCORE
 #include <sys/systm.h>
+#endif
 
 #define	INTR_IRQ_INVALID	0xFFFFFFFF
 
+#define INTR_ROOT_IRQ	0
+
+#ifndef LOCORE
 enum intr_map_data_type {
 	INTR_MAP_DATA_ACPI = 0,
 	INTR_MAP_DATA_FDT,
@@ -110,12 +115,13 @@ u_int intr_irq_next_cpu(u_int current_cpu, cpuset_t *cpumask);
 
 struct intr_pic *intr_pic_register(device_t, intptr_t);
 int intr_pic_deregister(device_t, intptr_t);
-int intr_pic_claim_root(device_t, intptr_t, intr_irq_filter_t *, void *);
+int intr_pic_claim_root(device_t, intptr_t, intr_irq_filter_t *, void *,
+    uint32_t);
 int intr_pic_add_handler(device_t, struct intr_pic *,
     intr_child_irq_filter_t *, void *, uintptr_t, uintptr_t);
 bool intr_is_per_cpu(struct resource *);
 
-extern device_t intr_irq_root_dev;
+device_t intr_irq_root_device(uint32_t);
 
 /* Intr interface for BUS. */
 
@@ -163,4 +169,8 @@ void intr_ipi_send(cpuset_t cpus, u_int ipi);
 void intr_ipi_dispatch(u_int ipi);
 #endif
 
+/* Main interrupt handler called from asm on most archs except riscv. */
+void intr_irq_handler(struct trapframe *tf, uint32_t rootnum);
+
+#endif	/* !LOCORE */
 #endif	/* _SYS_INTR_H */


### PR DESCRIPTION
This adds support for ARM64 fast interrupt requests (FIQs) based off the [suggested approach](https://github.com/strejda/freebsd/commit/396c0b26c33bf99bf660760d68c68c65215b6b3b) in https://reviews.freebsd.org/D40161. Additionally it allows arch-specific code to define the number of interrupt roots supported with `INTR_ROOT_NUM` to avoid changing the number of roots for archs that don't need it. See the individual commit messages for details.

nits: `INTR_ROOT_` was chosen as the prefix to avoid collisions with the unrelated `intr_type` enum but we can bikeshed the name. Also setting up FIQ vectors for ARM64 platforms that don't expect to take FIQ exceptions should be fine, but I'm open to having configs opt-in to FIQ support. I initially considered this but I'm not sure it's worth the extra complexity in arm64/exception.S.

cc @kevans91