### PR TITLE
ntp manuals: describe better

### DIFF
--- a/contrib/ntp/ntpd/ntp.conf.def
+++ b/contrib/ntp/ntpd/ntp.conf.def
@@ -9,7 +9,7 @@ autogen definitions options;
 // file name.
 prog-name	= "ntp.conf";
 file-path	= "/etc/ntp.conf";
-prog-title	= "Network Time Protocol (NTP) daemon configuration file format";
+prog-title	= "Network Time Protocol daemon (ntpd) configuration format";
 
 /* explain: Additional information whenever the usage routine is invoked */
 explain = <<- _END_EXPLAIN

--- a/contrib/ntp/ntpd/ntp.keys.def
+++ b/contrib/ntp/ntpd/ntp.keys.def
@@ -10,7 +10,7 @@ autogen definitions options;
 // file name.
 prog-name	= "ntp.keys";
 file-path	= "/etc/ntp.keys";
-prog-title	= "NTP symmetric key file format";
+prog-title	= "Network Time Protocol symmetric key format";
 
 /* explain: Additional information whenever the usage routine is invoked */
 explain = <<- _END_EXPLAIN

--- a/contrib/ntp/ntpd/ntpd-opts.def
+++ b/contrib/ntp/ntpd/ntpd-opts.def
@@ -5,7 +5,7 @@ autogen definitions options;
 #include copyright.def
 
 prog-name	= "ntpd";
-prog-title	= "NTP daemon program";
+prog-title	= "set clock via Network Time Protocol daemon";
 argument	= "[ <server1> ... <serverN> ]";
 
 #include ntpdbase-opts.def

--- a/contrib/ntp/ntpq/ntpq-opts.def
+++ b/contrib/ntp/ntpq/ntpq-opts.def
@@ -7,7 +7,7 @@ autogen definitions options;
 #include autogen-version.def
 
 prog-name      = "ntpq";
-prog-title     = "standard NTP query program";
+prog-title     = "query Network Time Protocol servers";
 argument       = '[ host ...]';
 
 flag = {

--- a/contrib/ntp/sntp/sntp-opts.def
+++ b/contrib/ntp/sntp/sntp-opts.def
@@ -6,7 +6,7 @@ autogen definitions options;
 #include copyright.def
 
 prog-name      = "sntp";
-prog-title	= "standard Simple Network Time Protocol client program";
+prog-title	= "reference Simple Network Time Protocol client";
 argument	= '[ hostname-or-IP ...]';
 
 #include homerc.def

--- a/contrib/ntp/util/ntp-keygen-opts.def
+++ b/contrib/ntp/util/ntp-keygen-opts.def
@@ -7,7 +7,7 @@ autogen definitions options;
 #include autogen-version.def
 
 prog-name      = "ntp-keygen";
-prog-title     = "Create a NTP host key";
+prog-title     = "create a Network Time Protocol host key";
 package        = ntp;
 
 include        = '#include <stdlib.h>';

--- a/usr.sbin/ntp/doc/ntp-keygen.8
+++ b/usr.sbin/ntp/doc/ntp-keygen.8
@@ -8,7 +8,7 @@
 .\"  and the template file   agmdoc-cmd.tpl
 .Sh NAME
 .Nm ntp-keygen
-.Nd Create a NTP host key
+.Nd create a Network Time Protocol host key
 .Sh SYNOPSIS
 .Nm
 .\" Mixture of short (flag) options and long options

--- a/usr.sbin/ntp/doc/ntp.conf.5
+++ b/usr.sbin/ntp/doc/ntp.conf.5
@@ -8,7 +8,7 @@
 .\"  and the template file   agmdoc-cmd.tpl
 .Sh NAME
 .Nm ntp.conf
-.Nd Network Time Protocol (NTP) daemon configuration file format
+.Nd Network Time Protocol daemon (ntpd) configuration format
 .Sh SYNOPSIS
 .Nm
 .Op Fl \-option\-name

--- a/usr.sbin/ntp/doc/ntp.keys.5
+++ b/usr.sbin/ntp/doc/ntp.keys.5
@@ -12,7 +12,7 @@
 
 .Sh NAME
 .Nm ntp.keys
-.Nd NTP symmetric key file format
+.Nd Network Time Protocol symmetric key format
 .Sh SYNOPSIS
 .Nm
 .Op Fl \-option\-name

--- a/usr.sbin/ntp/doc/ntpd.8
+++ b/usr.sbin/ntp/doc/ntpd.8
@@ -8,7 +8,7 @@
 .\"  and the template file   agmdoc-cmd.tpl
 .Sh NAME
 .Nm ntpd
-.Nd NTP daemon program
+.Nd set clock via Network Time Protocol daemon
 .Sh SYNOPSIS
 .Nm
 .\" Mixture of short (flag) options and long options

--- a/usr.sbin/ntp/doc/ntpq.8
+++ b/usr.sbin/ntp/doc/ntpq.8
@@ -8,7 +8,7 @@
 .\"  and the template file   agmdoc-cmd.tpl
 .Sh NAME
 .Nm ntpq
-.Nd standard NTP query program
+.Nd query Network Time Protocol servers
 .Sh SYNOPSIS
 .Nm
 .\" Mixture of short (flag) options and long options

--- a/usr.sbin/ntp/doc/sntp.8
+++ b/usr.sbin/ntp/doc/sntp.8
@@ -8,7 +8,7 @@
 .\"  and the template file   agmdoc-cmd.tpl
 .Sh NAME
 .Nm sntp
-.Nd standard Simple Network Time Protocol client program
+.Nd reference Simple Network Time Protocol client
 .Sh SYNOPSIS
 .Nm
 .\" Mixture of short (flag) options and long options


### PR DESCRIPTION
Here is a patch to improve the discoverability and aesthetic of our ntp documentation. This was accepted upstream (bugs.ntp.org/show_bug.cgi?id=3936) ~~but I'm proposing expediting improved documentation discovery to the upcomming 13.4 release.~~

Manual page document descriptions are the search keywords, so add "time" to these by expanding the ntp acronym. Add "clock" to ntpd by describing what it does, and add the program it's configuring, "ntpd", to ntp.conf. Finally, since there are other implementations, reword standard to reference.