### PR TITLE
asmc: Add support for MacbookPro11,4.

### DIFF
--- a/sys/dev/asmc/asmc.c
+++ b/sys/dev/asmc/asmc.c
@@ -278,6 +278,12 @@ static const struct asmc_model asmc_models[] = {
 	  ASMC_MBP113_TEMPS, ASMC_MBP113_TEMPNAMES, ASMC_MBP113_TEMPDESCS
 	},
 
+	{
+	  "MacBookPro11,4", "Apple SMC MacBook Pro Retina Core i7 (mid 2015, 15-inch)",
+	  ASMC_SMS_FUNCS_DISABLED, ASMC_FAN_FUNCS, ASMC_LIGHT_FUNCS,
+	  ASMC_MBP114_TEMPS, ASMC_MBP114_TEMPNAMES, ASMC_MBP114_TEMPDESCS
+	},
+
 	/* The Mac Mini has no SMS */
 	{
 	  "Macmini1,1", "Apple SMC Mac Mini",

--- a/sys/dev/asmc/asmcvar.h
+++ b/sys/dev/asmc/asmcvar.h
@@ -432,6 +432,40 @@ struct asmc_softc {
 				  "TM0S", "TP0P", "TPCD", "TW0P", "Ta0P", \
 				  "TaSP", "Th1H", "Th2H", "Ts0P", "Ts0S", \
 				  "Ts1S" }
+
+#define ASMC_MBP114_TEMPS	{ "IC0C", "ID0R", "IHDC", "IPBR", "IC0R", \
+				  "IO3R", "IO5R", "IM0C", "IC1C", "IC2C", \
+				  "IC3C", "ILDC", "IBLC", "IAPC", "IHSC", \
+				  "ICMC", "TC0P", "TP0P", "TM0P", \
+				  "Ta0P", "Th2H", "Th1H", "TW0P", "Ts0P", \
+				  "Ts1P", "TB0T", "TB1T", "TB2T", "TH0A", "TH0B", \
+				  "TC1C", "TC2C", "TC3C", "TC4C", "TCXC", \
+				  "TCGC", "TPCD", "TCSA", "VC0C", "VD0R", \
+				  "VP0R", "ALSL", "F0Ac", "F1Ac", "PCPC", \
+				  "PCPG", "PCPT", "PSTR", "PDTR", NULL }
+
+#define ASMC_MBP114_TEMPNAMES	{ "IC0C", "ID0R", "IHDC", "IPBR", "IC0R", \
+				  "IO3R", "IO5R", "IM0C", "IC1C", "IC2C", \
+				  "IC3C", "ILDC", "IBLC", "IAPC", "IHSC", \
+				  "ICMC", "TC0P", "TP0P", "TM0P", \
+				  "Ta0P", "Th2H", "Th1H", "TW0P", "Ts0P", \
+				  "Ts1P", "TB0T", "TB1T", "TB2T", "TH0A", "TH0B", \
+				  "TC1C", "TC2C", "TC3C", "TC4C", "TCXC", \
+				  "TCGC", "TPCD", "TCSA", "VC0C", "VD0R", \
+				  "VP0R", "ALSL", "F0Ac", "F1Ac", "PCPC", \
+				  "PCPG", "PCPT", "PSTR", "PDTR" }
+
+#define ASMC_MBP114_TEMPDESCS	{ "CPU High (CPU, I/O)", "DC In", "SSD", "Charger (BMON)", "CPU", \
+				  "Other 3.3V", "Other 5V", "Memory", "Platform Controller Hub Core", "CPU Load Current Monitor", \
+				  "CPU DDR", "LCD Panel", "LCD Backlight", "Airport", "Thunderbolt", \
+				  "S2", "CPU Proximity", "Platform Controller Hub", "Memory Proximity", "Air Flow Proximity", \
+				  "Left Fin Stack", "Right Fin Stack", "Airport Proximity", "Palm Rest", "Palm Rest Actuator", \
+				  "Battery Max", "Battery Sensor 1", "Battery Sensor 2", "SSD A", "SSD B", \
+				  "CPU Core 1", "CPU Core 2", "CPU Core 3", "CPU Core 4", "CPU PECI Die", \
+				  "Intel GPU", "Platform Controller Hub PECI", "CPU System Agent Core", "CPU VCore", "DC In", \
+				  "Pbus", "Ambient Light", "Leftside", "Rightside", "CPU Package Core", \
+				  "CPU Package GPU", "CPU Package Total", "System Total", "DC In" }
+
 #define ASMC_MM_TEMPS		{ "TN0P", "TN1P", NULL }
 #define ASMC_MM_TEMPNAMES	{ "northbridge1", "northbridge2" }
 #define ASMC_MM_TEMPDESCS	{ "Northbridge Point 1", \


### PR DESCRIPTION
This patch adds support for asmc with the Macbookpro 11.4.

SMCs were (mostly) taken from https://logi.wiki/index.php/SMC_Sensor_Codes.

Three errors occur when running sysctl:
asmc0: asmc_key_read for key F1Sf failed 10 times, giving up
asmc0: asmc_key_read for key F0Sf failed 10 times, giving up
asmc0: asmc_key_read for key F0Sf failed 10 times, giving up

These correspond to:
dev.asmc.0.fan.1.safespeed
dev.asmc.0.fan.0.safespeed

but cannot be disabled without severely altering the driver, so I've left them as-is.

Keyboard backlight is working nicely, and fan and temp reporting is also working.