### PR TITLE
dhclient: Set default ARP resolution wait to 250 ms, with an option to make it 0 ms

### DIFF
--- a/libexec/rc/rc.conf
+++ b/libexec/rc/rc.conf
@@ -138,6 +138,7 @@ dhclient_flags=""		# Extra flags to pass to dhcp client.
 #dhclient_flags_em0=""		# Extra dhclient flags for em0 only
 background_dhclient="NO"	# Start dhcp client in the background.
 #background_dhclient_em0="YES"	# Start dhcp client on em0 in the background.
+dhclient_arpwait="YES"		# Wait for ARP resolution
 synchronous_dhclient="NO"	# Start dhclient directly on configured
 				# interfaces during startup.
 defaultroute_delay="30"		# Time to wait for a default route on a DHCP interface.

--- a/libexec/rc/rc.d/dhclient
+++ b/libexec/rc/rc.d/dhclient
@@ -48,6 +48,10 @@ dhclient_prestart()
 		rc_flags="${rc_flags} -b"
 	fi
 
+	dhclient_arpwait=$(get_if_var $ifn dhclient_arpwait_IF $dhclient_arpwait)
+	if ! checkyesno dhclient_arpwait; then
+		rc_flags="${rc_flags} -n"
+	fi
 
 	# /var/run/dhclient is not guaranteed to exist,
 	# e.g. if /var/run is a tmpfs

--- a/sbin/dhclient/dhclient.8
+++ b/sbin/dhclient/dhclient.8
@@ -36,7 +36,7 @@
 .\" see ``http://www.isc.org/isc''.  To learn more about Vixie
 .\" Enterprises, see ``http://www.vix.com''.
 .\"
-.Dd August 4, 2018
+.Dd August 1, 2024
 .Dt DHCLIENT 8
 .Os
 .Sh NAME
@@ -82,6 +82,10 @@ will revert to running in the background.
 Specify an alternate location,
 .Ar file ,
 for the leases file.
+.It Fl n
+Make
+.Nm
+not wait for ARP resolution.
 .It Fl p Ar file
 Specify an alternate location for the PID file.
 The default is

--- a/sbin/dhclient/dhclient.c
+++ b/sbin/dhclient/dhclient.c
@@ -121,7 +121,7 @@ struct pidfh *pidfile;
  */
 #define TIME_MAX        ((((time_t) 1 << (sizeof(time_t) * CHAR_BIT - 2)) - 1) * 2 + 1)
 
-static struct timespec arp_timeout = { .tv_sec = 2, .tv_nsec = 0 };
+static struct timespec arp_timeout = { .tv_sec = 0, .tv_nsec = 250 * 1000 * 1000 };
 static const struct timespec zero_timespec = { .tv_sec = 0, .tv_nsec = 0 };
 int		log_priority;
 static int		no_daemon;
@@ -386,7 +386,7 @@ main(int argc, char *argv[])
 	cap_openlog(capsyslog, getprogname(), LOG_PID | LOG_NDELAY, DHCPD_LOG_FACILITY);
 	cap_setlogmask(capsyslog, LOG_UPTO(LOG_DEBUG));
 
-	while ((ch = getopt(argc, argv, "bc:dl:p:qu")) != -1)
+	while ((ch = getopt(argc, argv, "bc:dl:np:qu")) != -1)
 		switch (ch) {
 		case 'b':
 			immediate_daemon = 1;
@@ -399,6 +399,9 @@ main(int argc, char *argv[])
 			break;
 		case 'l':
 			path_dhclient_db = optarg;
+			break;
+		case 'n':
+			arp_timeout = zero_timespec;
 			break;
 		case 'p':
 			path_dhclient_pidfile = optarg;
@@ -576,7 +579,7 @@ void
 usage(void)
 {
 
-	fprintf(stderr, "usage: %s [-bdqu] ", getprogname());
+	fprintf(stderr, "usage: %s [-bdnqu] ", getprogname());
 	fprintf(stderr, "[-c conffile] [-l leasefile] interface\n");
 	exit(1);
 }

--- a/sbin/dhclient/dhclient.c
+++ b/sbin/dhclient/dhclient.c
@@ -91,6 +91,7 @@
 cap_channel_t *capsyslog;
 
 time_t cur_time;
+struct timespec time_now;
 static time_t default_lease_time = 43200; /* 12 hours... */
 
 const char *path_dhclient_conf = _PATH_DHCLIENT_CONF;
@@ -120,6 +121,8 @@ struct pidfh *pidfile;
  */
 #define TIME_MAX        ((((time_t) 1 << (sizeof(time_t) * CHAR_BIT - 2)) - 1) * 2 + 1)
 
+static struct timespec arp_timeout = { .tv_sec = 2, .tv_nsec = 0 };
+static const struct timespec zero_timespec = { .tv_sec = 0, .tv_nsec = 0 };
 int		log_priority;
 static int		no_daemon;
 static int		unknown_ok = 1;
@@ -1022,7 +1025,11 @@ dhcpoffer(struct packet *packet)
 	struct interface_info *ip = packet->interface;
 	struct client_lease *lease, *lp;
 	int i;
-	int arp_timeout_needed, stop_selecting;
+	struct timespec arp_timeout_needed;
+	struct timespec stop_selecting = { .tv_sec = 0, .tv_nsec = 0 };
+	time_now.tv_sec = cur_time;
+	time_now.tv_nsec = 0;
+
 	const char *name = packet->options[DHO_DHCP_MESSAGE_TYPE].len ?
 	    "DHCPOFFER" : "BOOTREPLY";
 
@@ -1078,12 +1085,13 @@ dhcpoffer(struct packet *packet)
 	/* If the script can't send an ARP request without waiting,
 	   we'll be waiting when we do the ARPCHECK, so don't wait now. */
 	if (script_go())
-		arp_timeout_needed = 0;
+		arp_timeout_needed = zero_timespec;
+
 	else
-		arp_timeout_needed = 2;
+		arp_timeout_needed = arp_timeout;
 
 	/* Figure out when we're supposed to stop selecting. */
-	stop_selecting =
+	stop_selecting.tv_sec =
 	    ip->client->first_sending + ip->client->config->select_interval;
 
 	/* If this is the lease we asked for, put it at the head of the
@@ -1099,9 +1107,13 @@ dhcpoffer(struct packet *packet)
 		   offer would take us past the selection timeout,
 		   then don't extend the timeout - just hope for the
 		   best. */
+
+		struct timespec interm_struct;
+		timespecadd(&time_now, &arp_timeout_needed, &interm_struct);
+
 		if (ip->client->offered_leases &&
-		    (cur_time + arp_timeout_needed) > stop_selecting)
-			arp_timeout_needed = 0;
+		    timespeccmp(&interm_struct, &stop_selecting, >))
+			arp_timeout_needed = zero_timespec;
 
 		/* Put the lease at the end of the list. */
 		lease->next = NULL;
@@ -1118,16 +1130,22 @@ dhcpoffer(struct packet *packet)
 	/* If we're supposed to stop selecting before we've had time
 	   to wait for the ARPREPLY, add some delay to wait for
 	   the ARPREPLY. */
-	if (stop_selecting - cur_time < arp_timeout_needed)
-		stop_selecting = cur_time + arp_timeout_needed;
+	struct timespec time_left;
+	timespecsub(&stop_selecting, &time_now, &time_left);
+
+	if (timespeccmp(&time_left, &arp_timeout_needed, <)) {
+		timespecadd(&time_now, &arp_timeout_needed, &stop_selecting);
+	}
 
 	/* If the selecting interval has expired, go immediately to
 	   state_selecting().  Otherwise, time out into
 	   state_selecting at the select interval. */
-	if (stop_selecting <= 0)
+
+
+	if (timespeccmp(&stop_selecting, &zero_timespec, <=))
 		state_selecting(ip);
 	else {
-		add_timeout(stop_selecting, state_selecting, ip);
+		add_timeout_timespec(stop_selecting, state_selecting, ip);
 		cancel_timeout(send_discover, ip);
 	}
 }

--- a/sbin/dhclient/dhclient.c
+++ b/sbin/dhclient/dhclient.c
@@ -446,7 +446,8 @@ main(int argc, char *argv[])
 		log_perror = 0;
 
 	tzset();
-	time(&cur_time);
+	clock_gettime(CLOCK_MONOTONIC, &time_now);
+	cur_time = time_now.tv_sec;
 
 	inaddr_broadcast.s_addr = INADDR_BROADCAST;
 	inaddr_any.s_addr = INADDR_ANY;

--- a/sbin/dhclient/dhcpd.h
+++ b/sbin/dhclient/dhcpd.h
@@ -361,6 +361,7 @@ char *piaddr(struct iaddr);
 extern cap_channel_t *capsyslog;
 extern const char *path_dhclient_conf;
 extern char *path_dhclient_db;
+extern struct timespec time_now;
 extern time_t cur_time;
 extern int log_priority;
 extern int log_perror;

--- a/sbin/dhclient/dhcpd.h
+++ b/sbin/dhclient/dhcpd.h
@@ -218,7 +218,7 @@ struct interface_info {
 
 struct timeout {
 	struct timeout	*next;
-	time_t		 when;
+	struct timespec	 when;
 	void		 (*func)(void *);
 	void		*what;
 };
@@ -320,6 +320,7 @@ void reinitialize_interfaces(void);
 void dispatch(void);
 void got_one(struct protocol *);
 void add_timeout(time_t, void (*)(void *), void *);
+void add_timeout_timespec(struct timespec, void (*)(void *), void *);
 void cancel_timeout(void (*)(void *), void *);
 void add_protocol(const char *, int, void (*)(struct protocol *), void *);
 void remove_protocol(struct protocol *);

--- a/sbin/dhclient/dispatch.c
+++ b/sbin/dhclient/dispatch.c
@@ -156,7 +156,8 @@ dispatch(void)
 	struct protocol *l;
 	struct pollfd *fds;
 	struct timespec howlong;
-	struct timespec time_now = { .tv_sec = cur_time, .tv_nsec = 0 };
+	time_now.tv_sec = cur_time;
+	time_now.tv_nsec = 0;
 
 	for (l = protocols; l; l = l->next)
 		nfds++;

--- a/sbin/dhclient/dispatch.c
+++ b/sbin/dhclient/dispatch.c
@@ -56,6 +56,10 @@
 #define assert_aligned(p, align) assert((((uintptr_t)p) & ((align) - 1)) == 0)
 
 static struct protocol *protocols;
+static const struct timespec timespec_intmax_ms = {
+	.tv_sec = INT_MAX / 1000,
+	.tv_nsec = (INT_MAX % 1000) * 1000000
+};
 static struct timeout *timeouts;
 static struct timeout *free_timeouts;
 static int interfaces_invalidated;
@@ -191,9 +195,9 @@ another:
 			 * negative timeout and blocking indefinitely.
 			 */
 			timespecsub(&timeouts->when, &time_now, &howlong);
-			if (howlong.tv_sec > INT_MAX / 1000)
-				howlong.tv_sec = INT_MAX / 1000;
-			to_msec = howlong.tv_sec * 1000;
+			if (timespeccmp(&howlong, &timespec_intmax_ms, >))
+				howlong = timespec_intmax_ms;
+			to_msec = howlong.tv_sec * 1000 + howlong.tv_nsec / 1000000;
 		} else
 			to_msec = -1;
 
@@ -220,16 +224,16 @@ another:
 		/* Not likely to be transitory... */
 		if (count == -1) {
 			if (errno == EAGAIN || errno == EINTR) {
-				time(&cur_time);
-				time_now.tv_sec = cur_time;
+				clock_gettime(CLOCK_MONOTONIC, &time_now);
+				cur_time = time_now.tv_sec;
 				continue;
 			} else
 				error("poll: %m");
 		}
 
 		/* Get the current time... */
-		time(&cur_time);
-		time_now.tv_sec = cur_time;
+		clock_gettime(CLOCK_MONOTONIC, &time_now);
+		cur_time = time_now.tv_sec;
 
 		i = 0;
 		for (l = protocols; l; l = l->next) {

--- a/share/man/man5/rc.conf.5
+++ b/share/man/man5/rc.conf.5
@@ -618,6 +618,15 @@ When specified, this variable overrides the
 variable for interface
 .Ar iface
 only.
+.It Va dhclient_arpwait
+.Pq Vt bool
+Set to
+.Dq Li NO
+to stop
+.Xr dhclient 8
+from waiting for ARP resolution, to make the system boot faster.
+This may be done on networks where the DHCP server is certain to
+know whether an address is available.
 .It Va synchronous_dhclient
 .Pq Vt bool
 Set to


### PR DESCRIPTION
Make the default ARP resolution wait time 250 ms, and add an option within dhclient to remove it altogether.