### PR TITLE
jail.conf.5: minor cleanup (typos, xrefs, spdx)

### DIFF
--- a/share/man/man7/mitigations.7
+++ b/share/man/man7/mitigations.7
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifer: BSD-2-Clause
+.\"
 .\" Copyright © 2023 The FreeBSD Foundation
 .\"
 .\" This documentation was written by Ed Maste <emaste@freebsd.org>, and
@@ -41,6 +44,7 @@ or per-process basis, some are optionally enabled or disabled at compile time,
 and some are inherent to the implementation and have no controls.
 .Pp
 The following vulnerability mitigations are covered in this document:
+.Pp
 .Bl -bullet -compact
 .It
 Address Space Layout Randomization (ASLR)
@@ -59,9 +63,11 @@ Stack Overflow Protection
 .It
 Supervisor Mode Memory Protection
 .It
-Hardware Vulnerability Mitigation Controls
-.It
 Capsicum
+.It
+Firmware and Microcode
+.It
+Architectural Vulnerability Mitigations
 .El
 .Pp
 Please note that the effectiveness and availability of these mitigations may
@@ -332,18 +338,14 @@ kernel.
 .Pp
 These features are automatically used by the kernel.
 There is no user-facing configuration.
-.Ss Hardware vulnerability controls
-See
-.Xr security 7
-for more information.
 .\"
 .Ss Capsicum
 Capsicum is a lightweight OS capability and sandbox framework.
 See
 .Xr capsicum 4
 for more information.
-.Pp
 .Sh HARDWARE VULNERABILITY MITIGATIONS
+.Ss Firmware and Microcode
 Recent years have seen an unending stream of new hardware vulnerabilities,
 notably CPU ones generally caused by detectable microarchitectural side-effects
 of speculative execution which leak private data from some other thread or
@@ -351,18 +353,36 @@ process or sometimes even internal CPU state that is normally inaccessible.
 Hardware vendors usually address these vulnerabilities as they are discovered by
 releasing microcode updates, which may then be bundled into platform firmware
 updates
-.Pq historically called BIOS updates for PCs .
+.Pq historically called BIOS updates for PCs
+or packages to be updated by the operating system at boot time.
+.Pp
+Platform firmware updates, if available from the manufacturer,
+are the best defense as they provide coverage during early boot.
+Install them with
+.Pa sysutils/flashrom
+from the
+.Fx
+Ports Collection.
+.Pp
+If platform firmware updates are no longer available,
+packaged microcode is available for installation at
+.Pa sysutils/cpu-microcode
+and can be loaded at runtime using
+.Xr loader.conf 5 ,
+see the package message for more details.
 .Pp
 The best defense overall against hardware vulnerabilities is to timely apply
-these updates when available and to disable the affected hardware's problematic
-functionalities when possible (e.g., CPU Simultaneous Multi-Threading).
+these updates when available, as early as possible in the boot process,
+and to disable the affected hardware's problematic functionalities when possible
+(e.g., CPU Simultaneous Multi-Threading).
 Software mitigations are only partial substitutes for these, but they can be
 helpful on out-of-support hardware or as complements for just-discovered
 vulnerabilities not yet addressed by vendors.
 Some software mitigations depend on hardware capabilities provided by a
 microcode update.
-.Pp
-FreeBSD's usual policy is to apply by default all OS-level mitigations that do
+.Ss Architectural Vulnerability Mitigations
+.Fx Ap s
+usual policy is to apply by default all OS-level mitigations that do
 not require recompilation, except those the particular hardware it is running on
 is known not to be vulnerable to
 .Pq which sometimes requires firmware updates ,
@@ -451,6 +471,10 @@ should be considered when configuring and deploying them in a
 .Fx
 system.
 .Pp
+Additional mitigation knobs are listed in the
+.Sx KNOBS AND TWEAKS
+section of
+.Xr security 7 .
 .Sh SEE ALSO
 .Xr elfctl 1 ,
 .Xr proccontrol 1 ,

--- a/usr.sbin/jail/jail.conf.5
+++ b/usr.sbin/jail/jail.conf.5
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2012 James Gritton
 .\" All rights reserved.
 .\"
@@ -22,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd September 5, 2023
+.Dd September 21, 2024
 .Dt JAIL.CONF 5
 .Os
 .Sh NAME
@@ -169,17 +172,17 @@ A line of the form
 .Pp
 will include another file (or files) in the configuration.
 The filename should be either absolute, or relative to the
-configuration file's directory.  It cannot contain variable
-expansions, but may contain
+configuration file's directory.
+It cannot contain variable expansions, but may contain
 .Xr glob 3
 patterns.
 .Pp
 The included file must exist, though a filename glob may match zero or
-more files.  This allows inclusion of any/all files in a directory,
-such as
-.Dq /etc/jail.conf.d/*.conf ,
+more files.
+This allows inclusion of any/all files in a directory, such as
+.Dq Pa /etc/jail.conf.d/*.conf ,
 or conditional inclusion of a single file, such as
-.Dq jail.foo[.]conf .
+.Dq Pa jail.foo[.]conf .
 .Ss Comments
 The configuration file may contain comments in the common C, C++, and
 shell formats:
@@ -238,10 +241,19 @@ bar {
 \[char46]include "/usr/local/etc/jail.*.conf";
 .Ed
 .Sh SEE ALSO
-.Xr jail_set 2 ,
+.Xr jail 2 ,
+.Xr jail 3 ,
+.Xr jail 3lua ,
 .Xr rc.conf 5 ,
 .Xr jail 8 ,
-.Xr jls 8
+.Xr jexec 8 ,
+.Xr jls 8 ,
+.Xr zfs-jail 8
+.Pp
+The
+.Dq Jails and Containers
+chapter of the
+.%B FreeBSD Handbook .
 .Sh HISTORY
 The
 .Xr jail 8

--- a/usr.sbin/jail/jail.conf.5
+++ b/usr.sbin/jail/jail.conf.5
@@ -98,7 +98,7 @@ parameter is implicitly set to the name in the jail definition.
 .Ss String format
 Parameter values, including jail names, can be single tokens or quoted
 strings.
-A token is any sequence of characters that aren't considered special in
+A token is any sequence of characters that are not considered special in
 the syntax of the configuration file (such as a semicolon or
 whitespace).
 If a value contains anything more than letters, numbers, dots, dashes
@@ -146,7 +146,7 @@ definition.
 .Pp
 Variable substitution is done on a per-jail basis, even when that
 substitution is for a parameter defined in a wildcard section.
-This is useful for wildcard parameters based on e.g. a jail's name.
+This is useful for wildcard parameters based on e.g., a jail's name.
 .Pp
 Later definitions in the configuration file supersede earlier ones, so a
 wildcard section placed before (above) a jail definition defines
@@ -196,7 +196,7 @@ shell formats:
 #  This is a shell style comment.
 .Ed
 .Pp
-Comments are legal wherever whitespace is allowed, i.e. anywhere except
+Comments are legal wherever whitespace is allowed, i.e., anywhere except
 in the middle of a string or a token.
 .Sh FILES
 .Bl -tag -width "indent" -compact


### PR DESCRIPTION
Update related crossreferences and tag paths with the path macro. While here, fix 'one sentance per line rule' and tag spdx.

~~Using xrefs in a document description renders incorrectly in apropos ("jail 8" instead of "jail(8)"). Since mdoc(7) says not to assume that document descriptions can accept child macros, use the string verbatim.~~

MFC after:	3 days