### PR TITLE
mcast: fix leaked igmp packets on multicast cleanup

### DIFF
--- a/sys/netinet/in_mcast.c
+++ b/sys/netinet/in_mcast.c
@@ -1181,6 +1181,7 @@ inm_purge(struct in_multi *inm)
 		free(ims, M_IPMSOURCE);
 		inm->inm_nsrc--;
 	}
+	mbufq_drain(&inm->inm_scq);
 }
 
 /*

--- a/sys/netinet/in_mcast.c
+++ b/sys/netinet/in_mcast.c
@@ -915,8 +915,6 @@ imf_purge(struct in_mfilter *imf)
 	imf->imf_st[0] = imf->imf_st[1] = MCAST_UNDEFINED;
 	KASSERT(RB_EMPTY(&imf->imf_sources),
 	    ("%s: imf_sources not empty", __func__));
-	if (imf->imf_inm != NULL)
-		mbufq_drain(&imf->imf_inm->inm_scq);
 }
 
 /*


### PR DESCRIPTION
The commits cherry-picked here have not been added to stable/14.
They have been known to fix IGMP leave messages which are currently
broken on both 14.0 and 14.1. The necessary MFC has been absent from
them for unknown reasons.

Differential Revision: https://reviews.freebsd.org/D46190