### PR TITLE
mk: Add a BTI-report linker feature

### DIFF
--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -99,7 +99,7 @@ LDFLAGS+= -Wl,-zretpolineplt
 LDFLAGS.bfd+= -Wl,-znoexecstack
 .if ${MK_BRANCH_PROTECTION} != "no"
 CFLAGS+=  -mbranch-protection=standard
-.if ${MACHINE_ARCH} == "aarch64" && defined(BTI_REPORT_ERROR)
+.if ${LINKER_FEATURES:Mbti-report} && defined(BTI_REPORT_ERROR)
 LDFLAGS+= -Wl,-zbti-report=error
 .endif
 .endif

--- a/share/mk/bsd.linker.mk
+++ b/share/mk/bsd.linker.mk
@@ -11,9 +11,11 @@
 # LINKER_FEATURES may contain one or more of the following, based on
 # linker support for that feature:
 #
-# - build-id:  support for generating a Build-ID note
-# - retpoline: support for generating PLT with retpoline speculative
-#              execution vulnerability mitigation
+# - build-id:   support for generating a Build-ID note
+# - retpoline:  support for generating PLT with retpoline speculative
+#               execution vulnerability mitigation
+# - bti-report: support for specifying how to report the missing
+#               Branch Target Identification (BTI) property (AArch64)
 #
 # LINKER_FREEBSD_VERSION is the linker's internal source version.
 #
@@ -111,6 +113,9 @@ ${X_}LINKER_FEATURES+=	retpoline
 .endif
 .if ${${X_}LINKER_TYPE} == "lld" && ${${X_}LINKER_VERSION} >= 90000
 ${X_}LINKER_FEATURES+=	ifunc-noplt
+.endif
+.if ${${X_}LINKER_TYPE} == "lld" && ${${X_}LINKER_VERSION} >= 140000
+${X_}LINKER_FEATURES+=	bti-report
 .endif
 .endif
 .else

--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -71,7 +71,7 @@ LDFLAGS+= -Wl,-zretpolineplt
 LDFLAGS.bfd+= -Wl,-znoexecstack
 .if ${MK_BRANCH_PROTECTION} != "no"
 CFLAGS+=  -mbranch-protection=standard
-.if ${MACHINE_ARCH} == "aarch64" && defined(BTI_REPORT_ERROR)
+.if ${LINKER_FEATURES:Mbti-report} && defined(BTI_REPORT_ERROR)
 LDFLAGS+= -Wl,-zbti-report=error
 .endif
 .endif

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -143,7 +143,7 @@ CFLAGS += -mgeneral-regs-only
 CFLAGS += -ffixed-x18
 # Build with BTI+PAC
 CFLAGS += -mbranch-protection=standard
-.if ${LINKER_TYPE} == "lld"
+.if ${LINKER_FEATURES:Mbti-report}
 LDFLAGS += -Wl,-zbti-report=error
 .endif
 # TODO: support outline atomics


### PR DESCRIPTION
Add support for specifying how to report the missing Branch Target Identification (BTI) linker feature on AArch64.

For:

- Kernel: `bti-report` on when the linker supports it
- Userspace: `bti-report` on when the linker supports it and `BTI_REPORT_ERROR` is defined

Fixes:	43e8849bc294 ("conf: Enable BTI checking in the arm64 kernel")