### PR TITLE
Centralize the kernel and module metadata types

### DIFF
--- a/stand/common/bootstrap.h
+++ b/stand/common/bootstrap.h
@@ -230,7 +230,7 @@ struct kernel_module
 struct preloaded_file
 {
 	char *f_name;	/* file name */
-	char *f_type; /* verbose file type, eg 'ELF kernel', 'pnptable', etc. */
+	char *f_type; /* verbose file type, eg 'elf kernel', 'pnptable', etc. */
 	char *f_args;	/* arguments for the file */
 	/* metadata that will be placed in the module directory */
 	struct file_metadata *f_metadata;

--- a/stand/common/bootstrap.h
+++ b/stand/common/bootstrap.h
@@ -271,7 +271,7 @@ void unload(void);
 struct preloaded_file *file_alloc(void);
 struct preloaded_file *file_findfile(const char *name, const char *type);
 struct file_metadata *file_findmetadata(struct preloaded_file *fp, int type);
-struct preloaded_file *file_loadraw(const char *name, char *type, int insert);
+struct preloaded_file *file_loadraw(const char *name, const char *type, int insert);
 void file_discard(struct preloaded_file *fp);
 void file_addmetadata(struct preloaded_file *, int, size_t, void *);
 int file_addmodule(struct preloaded_file *, char *, int,

--- a/stand/common/gfx_fb.c
+++ b/stand/common/gfx_fb.c
@@ -2984,8 +2984,6 @@ build_font_module(vm_offset_t addr)
 
 	fp = file_findfile(NULL, "elf kernel");
 	if (fp == NULL)
-		fp = file_findfile(NULL, "elf64 kernel");
-	if (fp == NULL)
 		panic("can't find kernel file");
 
 	fontp = addr;
@@ -3027,8 +3025,6 @@ build_splash_module(vm_offset_t addr)
 	}
 
 	fp = file_findfile(NULL, "elf kernel");
-	if (fp == NULL)
-		fp = file_findfile(NULL, "elf64 kernel");
 	if (fp == NULL)
 		panic("can't find kernel file");
 

--- a/stand/common/gfx_fb.c
+++ b/stand/common/gfx_fb.c
@@ -102,6 +102,8 @@
 #include <vbe.h>
 #endif
 
+#include "modinfo.h"
+
 /* VGA text mode does use bold font. */
 #if !defined(VGA_8X16_FONT)
 #define	VGA_8X16_FONT		"/boot/fonts/8x16b.fnt"
@@ -2982,7 +2984,7 @@ build_font_module(vm_offset_t addr)
 
 	fi.fi_checksum = -checksum;
 
-	fp = file_findfile(NULL, "elf kernel");
+	fp = file_findfile(NULL, md_kerntype);
 	if (fp == NULL)
 		panic("can't find kernel file");
 
@@ -3024,7 +3026,7 @@ build_splash_module(vm_offset_t addr)
 		return (addr);
 	}
 
-	fp = file_findfile(NULL, "elf kernel");
+	fp = file_findfile(NULL, md_kerntype);
 	if (fp == NULL)
 		panic("can't find kernel file");
 

--- a/stand/common/load_elf_obj.c
+++ b/stand/common/load_elf_obj.c
@@ -37,6 +37,7 @@
 #include <sys/link_elf.h>
 
 #include "bootstrap.h"
+#include "modinfo.h"
 
 #define COPYOUT(s,d,l)	archsw.arch_copyout((vm_offset_t)(s), d, l)
 
@@ -76,9 +77,6 @@ static int __elfN(obj_reloc_ptr)(struct preloaded_file *mp, elf_file_t ef,
 static int __elfN(obj_parse_modmetadata)(struct preloaded_file *mp,
     elf_file_t ef);
 static Elf_Addr __elfN(obj_symaddr)(struct elf_file *ef, Elf_Size symidx);
-
-const char	*__elfN(obj_kerneltype) = "elf kernel";
-const char	*__elfN(obj_moduletype) = "elf obj module";
 
 /*
  * Attempt to load the file (file) as an ELF module.  It will be stored at
@@ -154,7 +152,7 @@ __elfN(obj_loadfile)(char *filename, uint64_t dest,
 	}
 #endif
 
-	kfp = file_findfile(NULL, __elfN(obj_kerneltype));
+	kfp = file_findfile(NULL, md_kerntype);
 	if (kfp == NULL) {
 		printf("elf" __XSTRING(__ELF_WORD_SIZE)
 		    "_obj_loadfile: can't load module before kernel\n");
@@ -178,7 +176,7 @@ __elfN(obj_loadfile)(char *filename, uint64_t dest,
 		goto out;
 	}
 	fp->f_name = strdup(filename);
-	fp->f_type = strdup(__elfN(obj_moduletype));
+	fp->f_type = strdup(md_modtype_obj);
 
 	if (module_verbose > MODULE_VERBOSE_SILENT)
 		printf("%s ", filename);

--- a/stand/common/metadata.c
+++ b/stand/common/metadata.c
@@ -146,7 +146,7 @@ md_load_dual(char *args, vm_offset_t *modulep, vm_offset_t *dtb, int kern64)
 #endif
 
     kernend = 0;
-    kfp = file_findfile(NULL, "elf kernel");
+    kfp = file_findfile(NULL, md_kerntype);
     if (kfp == NULL)
 	panic("can't find kernel file");
     file_addmetadata(kfp, MODINFOMD_HOWTO, sizeof howto, &howto);

--- a/stand/common/metadata.c
+++ b/stand/common/metadata.c
@@ -146,9 +146,7 @@ md_load_dual(char *args, vm_offset_t *modulep, vm_offset_t *dtb, int kern64)
 #endif
 
     kernend = 0;
-    kfp = file_findfile(NULL, kern64 ? "elf64 kernel" : "elf32 kernel");
-    if (kfp == NULL)
-	kfp = file_findfile(NULL, "elf kernel");
+    kfp = file_findfile(NULL, "elf kernel");
     if (kfp == NULL)
 	panic("can't find kernel file");
     file_addmetadata(kfp, MODINFOMD_HOWTO, sizeof howto, &howto);

--- a/stand/common/modinfo.c
+++ b/stand/common/modinfo.c
@@ -109,6 +109,11 @@
 
 #define MOD_ALIGN(l)	roundup(l, align)
 
+const char md_modtype[] = MODTYPE;
+const char md_kerntype[] = KERNTYPE;
+const char md_modtype_obj[] = MODTYPE_OBJ;
+const char md_kerntype_mb[] = KERNTYPE_MB;
+
 vm_offset_t
 md_copymodules(vm_offset_t addr, bool kern64)
 {

--- a/stand/common/modinfo.h
+++ b/stand/common/modinfo.h
@@ -6,6 +6,11 @@
 #ifndef COMMON_MODINFO_H
 #define COMMON_MODINFO_H
 
+extern const char md_modtype[];
+extern const char md_kerntype[];
+extern const char md_modtype_obj[];
+extern const char md_kerntype_mb[];
+
 int md_load(char *args, vm_offset_t *modulep, vm_offset_t *dtb);
 int md_load64(char *args, vm_offset_t *modulep, vm_offset_t *dtb);
 

--- a/stand/common/module.c
+++ b/stand/common/module.c
@@ -652,7 +652,7 @@ file_load_dependencies(struct preloaded_file *base_file)
  * no arguments or anything.
  */
 struct preloaded_file *
-file_loadraw(const char *fname, char *type, int insert)
+file_loadraw(const char *fname, const char *type, int insert)
 {
 	struct preloaded_file	*fp;
 	char			*name;

--- a/stand/efi/loader/arch/amd64/multiboot2.c
+++ b/stand/efi/loader/arch/amd64/multiboot2.c
@@ -51,6 +51,7 @@
 #include "bootstrap.h"
 #include "multiboot2.h"
 #include "loader_efi.h"
+#include "modinfo.h"
 
 extern int elf32_loadfile_raw(char *filename, uint64_t dest,
     struct preloaded_file **result, int multiboot);
@@ -438,7 +439,7 @@ exec(struct preloaded_file *fp)
 	 *  module 0                 module 1
 	 */
 
-	fp = file_findfile(NULL, "elf kernel");
+	fp = file_findfile(NULL, md_kerntype);
 	if (fp == NULL) {
 		printf("No FreeBSD kernel provided, aborting\n");
 		error = EINVAL;
@@ -500,7 +501,7 @@ obj_loadfile(char *filename, uint64_t dest, struct preloaded_file **result)
 	int			 error;
 
 	/* See if there's a multiboot kernel loaded */
-	mfp = file_findfile(NULL, "elf multiboot kernel");
+	mfp = file_findfile(NULL, md_kerntype_mb);
 	if (mfp == NULL)
 		return (EFTYPE);
 
@@ -508,14 +509,14 @@ obj_loadfile(char *filename, uint64_t dest, struct preloaded_file **result)
 	 * We have a multiboot kernel loaded, see if there's a FreeBSD
 	 * kernel loaded also.
 	 */
-	kfp = file_findfile(NULL, "elf kernel");
+	kfp = file_findfile(NULL, md_kerntype);
 	if (kfp == NULL) {
 		/*
 		 * No kernel loaded, this must be it. The kernel has to
 		 * be loaded as a raw file, it will be processed by
 		 * Xen and correctly loaded as an ELF file.
 		 */
-		rfp = file_loadraw(filename, "elf kernel", 0);
+		rfp = file_loadraw(filename, md_kerntype, 0);
 		if (rfp == NULL) {
 			printf(
 			"Unable to load %s as a multiboot payload kernel\n",

--- a/stand/efi/loader/bootinfo.c
+++ b/stand/efi/loader/bootinfo.c
@@ -423,7 +423,7 @@ bi_load(char *args, vm_offset_t *modulep, vm_offset_t *kernendp, bool exit_bs)
 		addr += roundup(dtb_size, PAGE_SIZE);
 #endif
 
-	kfp = file_findfile(NULL, "elf kernel");
+	kfp = file_findfile(NULL, md_kerntype);
 	if (kfp == NULL)
 		panic("can't find kernel file");
 	kernend = 0;	/* fill it in later */

--- a/stand/efi/loader/bootinfo.c
+++ b/stand/efi/loader/bootinfo.c
@@ -425,8 +425,6 @@ bi_load(char *args, vm_offset_t *modulep, vm_offset_t *kernendp, bool exit_bs)
 
 	kfp = file_findfile(NULL, "elf kernel");
 	if (kfp == NULL)
-		kfp = file_findfile(NULL, "elf64 kernel");
-	if (kfp == NULL)
 		panic("can't find kernel file");
 	kernend = 0;	/* fill it in later */
 

--- a/stand/i386/libi386/bootinfo32.c
+++ b/stand/i386/libi386/bootinfo32.c
@@ -131,8 +131,6 @@ bi_load32(char *args, int *howtop, int *bootdevp, vm_offset_t *bip, vm_offset_t 
 
     kfp = file_findfile(NULL, "elf kernel");
     if (kfp == NULL)
-      kfp = file_findfile(NULL, "elf32 kernel");
-    if (kfp == NULL)
 	panic("can't find kernel file");
     kernend = 0;	/* fill it in later */
     file_addmetadata(kfp, MODINFOMD_HOWTO, sizeof howto, &howto);

--- a/stand/i386/libi386/bootinfo32.c
+++ b/stand/i386/libi386/bootinfo32.c
@@ -129,7 +129,7 @@ bi_load32(char *args, int *howtop, int *bootdevp, vm_offset_t *bip, vm_offset_t 
     /* pad to a page boundary */
     addr = roundup(addr, PAGE_SIZE);
 
-    kfp = file_findfile(NULL, "elf kernel");
+    kfp = file_findfile(NULL, md_kerntype);
     if (kfp == NULL)
 	panic("can't find kernel file");
     kernend = 0;	/* fill it in later */

--- a/stand/i386/libi386/bootinfo64.c
+++ b/stand/i386/libi386/bootinfo64.c
@@ -143,7 +143,7 @@ bi_load64(char *args, vm_offset_t *modulep,
     /* place the metadata before anything */
     module = *modulep = addr;
 
-    kfp = file_findfile(NULL, "elf kernel");
+    kfp = file_findfile(NULL, md_kerntype);
     if (kfp == NULL)
 	panic("can't find kernel file");
     kernend = 0;	/* fill it in later */

--- a/stand/i386/libi386/bootinfo64.c
+++ b/stand/i386/libi386/bootinfo64.c
@@ -145,8 +145,6 @@ bi_load64(char *args, vm_offset_t *modulep,
 
     kfp = file_findfile(NULL, "elf kernel");
     if (kfp == NULL)
-      kfp = file_findfile(NULL, "elf64 kernel");
-    if (kfp == NULL)
 	panic("can't find kernel file");
     kernend = 0;	/* fill it in later */
     file_addmetadata(kfp, MODINFOMD_HOWTO, sizeof howto, &howto);

--- a/stand/i386/libi386/multiboot.c
+++ b/stand/i386/libi386/multiboot.c
@@ -48,6 +48,7 @@
 #include "bootstrap.h"
 #include "multiboot.h"
 #include "libi386.h"
+#include "modinfo.h"
 #include <btxv86.h>
 
 #define MULTIBOOT_SUPPORTED_FLAGS \
@@ -256,7 +257,7 @@ multiboot_exec(struct preloaded_file *fp)
 	 *  module 0                 module 1
 	 */
 
-	fp = file_findfile(NULL, "elf kernel");
+	fp = file_findfile(NULL, md_kerntype);
 	if (fp == NULL) {
 		printf("No FreeBSD kernel provided, aborting\n");
 		error = EINVAL;
@@ -324,7 +325,7 @@ multiboot_obj_loadfile(char *filename, uint64_t dest,
 	int			 error, mod_num;
 
 	/* See if there's a multiboot kernel loaded */
-	mfp = file_findfile(NULL, "elf multiboot kernel");
+	mfp = file_findfile(NULL, md_kerntype_mb);
 	if (mfp == NULL)
 		return (EFTYPE);
 
@@ -332,14 +333,14 @@ multiboot_obj_loadfile(char *filename, uint64_t dest,
 	 * We have a multiboot kernel loaded, see if there's a FreeBSD
 	 * kernel loaded also.
 	 */
-	kfp = file_findfile(NULL, "elf kernel");
+	kfp = file_findfile(NULL, md_kerntype);
 	if (kfp == NULL) {
 		/*
 		 * No kernel loaded, this must be it. The kernel has to
 		 * be loaded as a raw file, it will be processed by
 		 * Xen and correctly loaded as an ELF file.
 		 */
-		rfp = file_loadraw(filename, "elf kernel", 0);
+		rfp = file_loadraw(filename, md_kerntype, 0);
 		if (rfp == NULL) {
 			printf(
 			"Unable to load %s as a multiboot payload kernel\n",

--- a/stand/powerpc/ofw/elf_freebsd.c
+++ b/stand/powerpc/ofw/elf_freebsd.c
@@ -58,7 +58,7 @@ __elfN(ofw_loadfile)(char *filename, uint64_t dest,
 	 * No need to sync the icache for modules: this will
 	 * be done by the kernel after relocation.
 	 */
-	if (!strcmp((*result)->f_type, "elf kernel"))
+	if (!strcmp((*result)->f_type, md_kerntype))
 		__syncicache((void *) (*result)->f_addr, (*result)->f_size);
 #endif
 	return (0);

--- a/stand/powerpc/ofw/ppc64_elf_freebsd.c
+++ b/stand/powerpc/ofw/ppc64_elf_freebsd.c
@@ -57,7 +57,7 @@ ppc64_ofw_elf_loadfile(char *filename, uint64_t dest,
 	 * No need to sync the icache for modules: this will
 	 * be done by the kernel after relocation.
 	 */
-	if (!strcmp((*result)->f_type, "elf kernel"))
+	if (!strcmp((*result)->f_type, md_kerntype))
 		__syncicache((void *) (*result)->f_addr, (*result)->f_size);
 	return (0);
 }

--- a/stand/uboot/arch/powerpc/ppc64_elf_freebsd.c
+++ b/stand/uboot/arch/powerpc/ppc64_elf_freebsd.c
@@ -53,7 +53,7 @@ ppc64_uboot_elf_loadfile(char *filename, uint64_t dest,
 	 * No need to sync the icache for modules: this will
 	 * be done by the kernel after relocation.
 	 */
-	if (!strcmp((*result)->f_type, "elf kernel"))
+	if (!strcmp((*result)->f_type, md_kerntype))
 		__syncicache((void *) (*result)->f_addr, (*result)->f_size);
 	return (0);
 }

--- a/stand/uboot/elf_freebsd.c
+++ b/stand/uboot/elf_freebsd.c
@@ -53,7 +53,7 @@ __elfN(uboot_load)(char *filename, uint64_t dest,
 	 * No need to sync the icache for modules: this will
 	 * be done by the kernel after relocation.
 	 */
-	if (!strcmp((*result)->f_type, "elf kernel"))
+	if (!strcmp((*result)->f_type, md_kerntype))
 		__syncicache((void *) (*result)->f_addr, (*result)->f_size);
 #endif
 	return (0);

--- a/stand/userboot/userboot/bootinfo32.c
+++ b/stand/userboot/userboot/bootinfo32.c
@@ -108,7 +108,7 @@ bi_load32(char *args, int *howtop, int *bootdevp, vm_offset_t *bip, vm_offset_t 
     /* pad to a page boundary */
     addr = roundup(addr, PAGE_SIZE);
 
-    kfp = file_findfile(NULL, "elf kernel");
+    kfp = file_findfile(NULL, md_kerntype);
     if (kfp == NULL)
 	panic("can't find kernel file");
     kernend = 0;	/* fill it in later */

--- a/stand/userboot/userboot/bootinfo32.c
+++ b/stand/userboot/userboot/bootinfo32.c
@@ -110,8 +110,6 @@ bi_load32(char *args, int *howtop, int *bootdevp, vm_offset_t *bip, vm_offset_t 
 
     kfp = file_findfile(NULL, "elf kernel");
     if (kfp == NULL)
-      kfp = file_findfile(NULL, "elf32 kernel");
-    if (kfp == NULL)
 	panic("can't find kernel file");
     kernend = 0;	/* fill it in later */
     file_addmetadata(kfp, MODINFOMD_HOWTO, sizeof howto, &howto);

--- a/stand/userboot/userboot/bootinfo64.c
+++ b/stand/userboot/userboot/bootinfo64.c
@@ -140,7 +140,7 @@ bi_load64(char *args, vm_offset_t *modulep, vm_offset_t *kernendp)
     /* pad to a page boundary */
     addr = roundup(addr, PAGE_SIZE);
 
-    kfp = file_findfile(NULL, "elf kernel");
+    kfp = file_findfile(NULL, md_kerntype);
     if (kfp == NULL)
 	panic("can't find kernel file");
     kernend = 0;	/* fill it in later */

--- a/stand/userboot/userboot/bootinfo64.c
+++ b/stand/userboot/userboot/bootinfo64.c
@@ -142,8 +142,6 @@ bi_load64(char *args, vm_offset_t *modulep, vm_offset_t *kernendp)
 
     kfp = file_findfile(NULL, "elf kernel");
     if (kfp == NULL)
-      kfp = file_findfile(NULL, "elf64 kernel");
-    if (kfp == NULL)
 	panic("can't find kernel file");
     kernend = 0;	/* fill it in later */
     file_addmetadata(kfp, MODINFOMD_HOWTO, sizeof howto, &howto);

--- a/sys/amd64/amd64/machdep.c
+++ b/sys/amd64/amd64/machdep.c
@@ -169,10 +169,10 @@ SYSINIT(cpu, SI_SUB_CPU, SI_ORDER_FIRST, cpu_startup, NULL);
 static void native_clock_source_init(void);
 
 /* Preload data parse function */
-static caddr_t native_parse_preload_data(u_int64_t);
+static void native_parse_preload_data(u_int64_t);
 
 /* Native function to fetch and parse the e820 map */
-static void native_parse_memmap(caddr_t, vm_paddr_t *, int *);
+static void native_parse_memmap(vm_paddr_t *, int *);
 
 /* Default init_ops implementation. */
 struct init_ops init_ops = {
@@ -813,7 +813,7 @@ add_efi_map_entries(struct efi_map_header *efihdr, vm_paddr_t *physmap,
 }
 
 static void
-native_parse_memmap(caddr_t kmdp, vm_paddr_t *physmap, int *physmap_idx)
+native_parse_memmap(vm_paddr_t *physmap, int *physmap_idx)
 {
 	struct bios_smap *smap;
 	struct efi_map_header *efihdr;
@@ -827,9 +827,9 @@ native_parse_memmap(caddr_t kmdp, vm_paddr_t *physmap, int *physmap_idx)
 	 * ie: an int32_t immediately precedes smap.
 	 */
 
-	efihdr = (struct efi_map_header *)preload_search_info(kmdp,
+	efihdr = (struct efi_map_header *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_EFI_MAP);
-	smap = (struct bios_smap *)preload_search_info(kmdp,
+	smap = (struct bios_smap *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_SMAP);
 	if (efihdr == NULL && smap == NULL)
 		panic("No BIOS smap or EFI map info from loader!");
@@ -857,7 +857,7 @@ native_parse_memmap(caddr_t kmdp, vm_paddr_t *physmap, int *physmap_idx)
  * XXX first should be vm_paddr_t.
  */
 static void
-getmemsize(caddr_t kmdp, u_int64_t first)
+getmemsize(u_int64_t first)
 {
 	int i, physmap_idx, pa_indx, da_indx;
 	vm_paddr_t pa, physmap[PHYS_AVAIL_ENTRIES];
@@ -876,7 +876,7 @@ getmemsize(caddr_t kmdp, u_int64_t first)
 	bzero(physmap, sizeof(physmap));
 	physmap_idx = 0;
 
-	init_ops.parse_memmap(kmdp, physmap, &physmap_idx);
+	init_ops.parse_memmap(physmap, &physmap_idx);
 	physmap_idx -= 2;
 
 	/*
@@ -1126,10 +1126,9 @@ do_next:
 	TSEXIT();
 }
 
-static caddr_t
+static void
 native_parse_preload_data(u_int64_t modulep)
 {
-	caddr_t kmdp;
 	char *envp;
 #ifdef DDB
 	vm_offset_t ksym_start;
@@ -1138,22 +1137,19 @@ native_parse_preload_data(u_int64_t modulep)
 
 	preload_metadata = (caddr_t)(uintptr_t)(modulep + KERNBASE);
 	preload_bootstrap_relocate(KERNBASE);
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	boothowto = MD_FETCH(kmdp, MODINFOMD_HOWTO, int);
-	envp = MD_FETCH(kmdp, MODINFOMD_ENVP, char *);
+	preload_initkmdp(true);
+	boothowto = MD_FETCH(preload_kmdp, MODINFOMD_HOWTO, int);
+	envp = MD_FETCH(preload_kmdp, MODINFOMD_ENVP, char *);
 	if (envp != NULL)
 		envp += KERNBASE;
 	init_static_kenv(envp, 0);
 #ifdef DDB
-	ksym_start = MD_FETCH(kmdp, MODINFOMD_SSYM, uintptr_t);
-	ksym_end = MD_FETCH(kmdp, MODINFOMD_ESYM, uintptr_t);
+	ksym_start = MD_FETCH(preload_kmdp, MODINFOMD_SSYM, uintptr_t);
+	ksym_end = MD_FETCH(preload_kmdp, MODINFOMD_ESYM, uintptr_t);
 	db_fetch_ksymtab(ksym_start, ksym_end, 0);
 #endif
-	efi_systbl_phys = MD_FETCH(kmdp, MODINFOMD_FW_HANDLE, vm_paddr_t);
-
-	return (kmdp);
+	efi_systbl_phys = MD_FETCH(preload_kmdp, MODINFOMD_FW_HANDLE,
+	    vm_paddr_t);
 }
 
 static void
@@ -1286,7 +1282,6 @@ amd64_loadaddr(void)
 u_int64_t
 hammer_time(u_int64_t modulep, u_int64_t physfree)
 {
-	caddr_t kmdp;
 	int gsel_tss, x;
 	struct pcpu *pc;
 	uint64_t rsp0;
@@ -1301,9 +1296,10 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
 
 	physfree += kernphys;
 
-	kmdp = init_ops.parse_preload_data(modulep);
+	/* Initializes preload_kmdp */
+	init_ops.parse_preload_data(modulep);
 
-	efi_boot = preload_search_info(kmdp, MODINFO_METADATA |
+	efi_boot = preload_search_info(preload_kmdp, MODINFO_METADATA |
 	    MODINFOMD_EFI_MAP) != NULL;
 
 	if (!efi_boot) {
@@ -1349,7 +1345,7 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
 		TUNABLE_INT_FETCH("hw.use_xsave", &use_xsave);
 	}
 
-	link_elf_ireloc(kmdp);
+	link_elf_ireloc();
 
 	/*
 	 * This may be done better later if it gets more high level
@@ -1534,7 +1530,7 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
 		amd64_kdb_init();
 	}
 
-	getmemsize(kmdp, physfree);
+	getmemsize(physfree);
 	init_param2(physmem);
 
 	/* now running on new page tables, configured,and u/iom is accessible */
@@ -1634,19 +1630,15 @@ smap_sysctl_handler(SYSCTL_HANDLER_ARGS)
 {
 	struct bios_smap *smapbase;
 	struct bios_smap_xattr smap;
-	caddr_t kmdp;
 	uint32_t *smapattr;
 	int count, error, i;
 
 	/* Retrieve the system memory map from the loader. */
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	smapbase = (struct bios_smap *)preload_search_info(kmdp,
+	smapbase = (struct bios_smap *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_SMAP);
 	if (smapbase == NULL)
 		return (0);
-	smapattr = (uint32_t *)preload_search_info(kmdp,
+	smapattr = (uint32_t *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_SMAP_XATTR);
 	count = *((uint32_t *)smapbase - 1) / sizeof(*smapbase);
 	error = 0;
@@ -1671,13 +1663,9 @@ static int
 efi_map_sysctl_handler(SYSCTL_HANDLER_ARGS)
 {
 	struct efi_map_header *efihdr;
-	caddr_t kmdp;
 	uint32_t efisize;
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	efihdr = (struct efi_map_header *)preload_search_info(kmdp,
+	efihdr = (struct efi_map_header *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_EFI_MAP);
 	if (efihdr == NULL)
 		return (0);
@@ -1693,13 +1681,8 @@ static int
 efi_arch_sysctl_handler(SYSCTL_HANDLER_ARGS)
 {
 	char *arch;
-	caddr_t kmdp;
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-
-	arch = (char *)preload_search_info(kmdp,
+	arch = (char *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_EFI_ARCH);
 	if (arch == NULL)
 		return (0);

--- a/sys/arm/arm/machdep.c
+++ b/sys/arm/arm/machdep.c
@@ -421,7 +421,6 @@ initarm(struct arm_boot_params *abp)
 	vm_paddr_t lastaddr;
 	vm_offset_t dtbp, kernelstack, dpcpu;
 	char *env;
-	void *kmdp;
 	int err_devmap, mem_regions_sz;
 	phandle_t root;
 	char dts_version[255];
@@ -439,8 +438,7 @@ initarm(struct arm_boot_params *abp)
 	/*
 	 * Find the dtb passed in by the boot loader.
 	 */
-	kmdp = preload_search_by_type("elf kernel");
-	dtbp = MD_FETCH(kmdp, MODINFOMD_DTBP, vm_offset_t);
+	dtbp = MD_FETCH(preload_kmdp, MODINFOMD_DTBP, vm_offset_t);
 #if defined(FDT_DTB_STATIC)
 	/*
 	 * In case the device tree blob was not retrieved (from metadata) try
@@ -461,7 +459,7 @@ initarm(struct arm_boot_params *abp)
 #endif
 
 #ifdef EFI
-	efihdr = (struct efi_map_header *)preload_search_info(kmdp,
+	efihdr = (struct efi_map_header *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_EFI_MAP);
 	if (efihdr != NULL) {
 		arm_add_efi_map_entries(efihdr, mem_regions, &mem_regions_sz);
@@ -571,7 +569,7 @@ initarm(struct arm_boot_params *abp)
 #endif
 
 	debugf("initarm: console initialized\n");
-	debugf(" arg1 kmdp = 0x%08x\n", (uint32_t)kmdp);
+	debugf(" arg1 kmdp = 0x%08x\n", (uint32_t)preload_kmdp);
 	debugf(" boothowto = 0x%08x\n", boothowto);
 	debugf(" dtbp = 0x%08x\n", (uint32_t)dtbp);
 	debugf(" lastaddr1: 0x%08x\n", lastaddr);

--- a/sys/arm/arm/machdep_boot.c
+++ b/sys/arm/arm/machdep_boot.c
@@ -270,7 +270,6 @@ freebsd_parse_boot_param(struct arm_boot_params *abp)
 {
 	vm_offset_t lastaddr = 0;
 	void *mdp;
-	void *kmdp;
 #ifdef DDB
 	vm_offset_t ksym_start;
 	vm_offset_t ksym_end;
@@ -287,17 +286,19 @@ freebsd_parse_boot_param(struct arm_boot_params *abp)
 	if ((mdp = (void *)(abp->abp_r0 & ~PAGE_MASK)) == NULL)
 		return 0;
 	preload_metadata = mdp;
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
+
+	/* Initialize preload_kmdp */
+	preload_initkmdp(false);
+	if (preload_kmdp == NULL)
 		return 0;
 
-	boothowto = MD_FETCH(kmdp, MODINFOMD_HOWTO, int);
-	loader_envp = MD_FETCH(kmdp, MODINFOMD_ENVP, char *);
+	boothowto = MD_FETCH(preload_kmdp, MODINFOMD_HOWTO, int);
+	loader_envp = MD_FETCH(preload_kmdp, MODINFOMD_ENVP, char *);
 	init_static_kenv(loader_envp, 0);
-	lastaddr = MD_FETCH(kmdp, MODINFOMD_KERNEND, vm_offset_t);
+	lastaddr = MD_FETCH(preload_kmdp, MODINFOMD_KERNEND, vm_offset_t);
 #ifdef DDB
-	ksym_start = MD_FETCH(kmdp, MODINFOMD_SSYM, uintptr_t);
-	ksym_end = MD_FETCH(kmdp, MODINFOMD_ESYM, uintptr_t);
+	ksym_start = MD_FETCH(preload_kmdp, MODINFOMD_SSYM, uintptr_t);
+	ksym_end = MD_FETCH(preload_kmdp, MODINFOMD_ESYM, uintptr_t);
 	db_fetch_ksymtab(ksym_start, ksym_end, 0);
 #endif
 	return lastaddr;
@@ -380,6 +381,9 @@ fake_preload_metadata(struct arm_boot_params *abp __unused, void *dtb_ptr,
 	fake_preload[i++] = 0;
 	fake_preload[i] = 0;
 	preload_metadata = (void *)fake_preload;
+
+	/* Initialize preload_kmdp */
+	preload_initkmdp(true);
 
 	init_static_kenv(NULL, 0);
 

--- a/sys/arm/arm/machdep_boot.c
+++ b/sys/arm/arm/machdep_boot.c
@@ -359,9 +359,9 @@ fake_preload_metadata(struct arm_boot_params *abp __unused, void *dtb_ptr,
 	strcpy((char*)&fake_preload[i++], "kernel");
 	i += 1;
 	fake_preload[i++] = MODINFO_TYPE;
-	fake_preload[i++] = strlen("elf kernel") + 1;
-	strcpy((char*)&fake_preload[i++], "elf kernel");
-	i += 2;
+	fake_preload[i++] = strlen(preload_kerntype) + 1;
+	strcpy((char*)&fake_preload[i], preload_kerntype);
+	i += howmany(fake_preload[i - 1], sizeof(uint32_t));
 	fake_preload[i++] = MODINFO_ADDR;
 	fake_preload[i++] = sizeof(vm_offset_t);
 	fake_preload[i++] = KERNVIRTADDR;

--- a/sys/arm64/arm64/machdep_boot.c
+++ b/sys/arm64/arm64/machdep_boot.c
@@ -124,6 +124,9 @@ fake_preload_metadata(void *dtb_ptr, size_t dtb_size)
 
 	preload_metadata = (caddr_t)(uintptr_t)fake_preload;
 
+	/* Initialize preload_kmdp */
+	preload_initkmdp(true);
+
 	init_static_kenv(NULL, 0);
 
 	return (lastaddr);
@@ -188,7 +191,6 @@ static vm_offset_t
 freebsd_parse_boot_param(struct arm64_bootparams *abp)
 {
 	vm_offset_t lastaddr = 0;
-	void *kmdp;
 #ifdef DDB
 	vm_offset_t ksym_start;
 	vm_offset_t ksym_end;
@@ -198,17 +200,19 @@ freebsd_parse_boot_param(struct arm64_bootparams *abp)
 		return (0);
 
 	preload_metadata = (caddr_t)(uintptr_t)(abp->modulep);
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
+
+	/* Initialize preload_kmdp */
+	preload_initkmdp(false);
+	if (preload_kmdp == NULL)
 		return (0);
 
-	boothowto = MD_FETCH(kmdp, MODINFOMD_HOWTO, int);
-	loader_envp = MD_FETCH(kmdp, MODINFOMD_ENVP, char *);
+	boothowto = MD_FETCH(preload_kmdp, MODINFOMD_HOWTO, int);
+	loader_envp = MD_FETCH(preload_kmdp, MODINFOMD_ENVP, char *);
 	init_static_kenv(loader_envp, 0);
-	lastaddr = MD_FETCH(kmdp, MODINFOMD_KERNEND, vm_offset_t);
+	lastaddr = MD_FETCH(preload_kmdp, MODINFOMD_KERNEND, vm_offset_t);
 #ifdef DDB
-	ksym_start = MD_FETCH(kmdp, MODINFOMD_SSYM, uintptr_t);
-	ksym_end = MD_FETCH(kmdp, MODINFOMD_ESYM, uintptr_t);
+	ksym_start = MD_FETCH(preload_kmdp, MODINFOMD_SSYM, uintptr_t);
+	ksym_end = MD_FETCH(preload_kmdp, MODINFOMD_ESYM, uintptr_t);
 	db_fetch_ksymtab(ksym_start, ksym_end, 0);
 #endif
 	return (lastaddr);

--- a/sys/arm64/arm64/machdep_boot.c
+++ b/sys/arm64/arm64/machdep_boot.c
@@ -98,7 +98,7 @@ fake_preload_metadata(void *dtb_ptr, size_t dtb_size)
 	PRELOAD_PUSH_STRING("kernel");
 
 	PRELOAD_PUSH_VALUE(uint32_t, MODINFO_TYPE);
-	PRELOAD_PUSH_STRING("elf kernel");
+	PRELOAD_PUSH_STRING(preload_kerntype);
 
 	PRELOAD_PUSH_VALUE(uint32_t, MODINFO_ADDR);
 	PRELOAD_PUSH_VALUE(uint32_t, sizeof(vm_offset_t));

--- a/sys/compat/linuxkpi/common/include/linux/efi.h
+++ b/sys/compat/linuxkpi/common/include/linux/efi.h
@@ -41,9 +41,6 @@
 static inline bool
 __efi_enabled(int feature)
 {
-#if defined(MODINFOMD_EFI_MAP) && !defined(__amd64__)
-	caddr_t kmdp;
-#endif
 	bool enabled = false;
 
 	switch (feature) {
@@ -52,10 +49,7 @@ __efi_enabled(int feature)
 		/* Use cached value on amd64 */
 		enabled = efi_boot;
 #elif defined(MODINFOMD_EFI_MAP)
-		kmdp = preload_search_by_type("elf kernel");
-		if (kmdp == NULL)
-			kmdp = preload_search_by_type("elf64 kernel");
-		enabled = preload_search_info(kmdp,
+		enabled = preload_search_info(preload_kmdp,
 		    MODINFO_METADATA | MODINFOMD_EFI_MAP) != NULL;
 #endif
 		break;

--- a/sys/dev/efidev/efirt.c
+++ b/sys/dev/efidev/efirt.c
@@ -167,7 +167,6 @@ efi_init(void)
 	struct efi_map_header *efihdr;
 	struct efi_md *map;
 	struct efi_rt *rtdm;
-	caddr_t kmdp;
 	size_t efisz;
 	int ndesc, rt_disabled;
 
@@ -197,10 +196,7 @@ efi_init(void)
 			printf("EFI config table is not present\n");
 	}
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	efihdr = (struct efi_map_header *)preload_search_info(kmdp,
+	efihdr = (struct efi_map_header *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_EFI_MAP);
 	if (efihdr == NULL) {
 		if (bootverbose)

--- a/sys/dev/hyperv/vmbus/vmbus.c
+++ b/sys/dev/hyperv/vmbus/vmbus.c
@@ -1305,18 +1305,14 @@ vmbus_fb_mmio_res(device_t dev)
 #endif /* aarch64 */
 	rman_res_t fb_start, fb_end, fb_count;
 	int fb_height, fb_width;
-	caddr_t kmdp;
 
 	struct vmbus_softc *sc = device_get_softc(dev);
 	int rid = 0;
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	efifb = (struct efi_fb *)preload_search_info(kmdp,
+	efifb = (struct efi_fb *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_EFI_FB);
 #if !defined(__aarch64__)
-	vbefb = (struct vbe_fb *)preload_search_info(kmdp,
+	vbefb = (struct vbe_fb *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_VBE_FB);
 #endif /* aarch64 */
 	if (efifb != NULL) {

--- a/sys/dev/nvdimm/nvdimm_e820.c
+++ b/sys/dev/nvdimm/nvdimm_e820.c
@@ -257,7 +257,6 @@ static void
 nvdimm_e820_identify(driver_t *driver, device_t parent)
 {
 	device_t child;
-	caddr_t kmdp;
 
 	if (resource_disabled(driver->name, 0))
 		return;
@@ -265,10 +264,7 @@ nvdimm_e820_identify(driver_t *driver, device_t parent)
 	if (device_find_child(parent, driver->name, -1) != NULL)
 		return;
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	smapbase = (const void *)preload_search_info(kmdp,
+	smapbase = (const void *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_SMAP);
 
 	/* Only supports BIOS SMAP for now. */

--- a/sys/dev/vt/hw/efifb/efifb.c
+++ b/sys/dev/vt/hw/efifb/efifb.c
@@ -77,17 +77,13 @@ vt_efifb_probe(struct vt_device *vd)
 {
 	int		disabled;
 	struct efi_fb	*efifb;
-	caddr_t		kmdp;
 
 	disabled = 0;
 	TUNABLE_INT_FETCH("hw.syscons.disable", &disabled);
 	if (disabled != 0)
 		return (CN_DEAD);
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	efifb = (struct efi_fb *)preload_search_info(kmdp,
+	efifb = (struct efi_fb *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_EFI_FB);
 	if (efifb == NULL)
 		return (CN_DEAD);
@@ -100,7 +96,6 @@ vt_efifb_init(struct vt_device *vd)
 {
 	struct fb_info	*info;
 	struct efi_fb	*efifb;
-	caddr_t		kmdp;
 	int		memattr;
 	int		roff, goff, boff;
 	char		attr[16];
@@ -132,10 +127,7 @@ vt_efifb_init(struct vt_device *vd)
 	if (info == NULL)
 		info = vd->vd_softc = (void *)&local_info;
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	efifb = (struct efi_fb *)preload_search_info(kmdp,
+	efifb = (struct efi_fb *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_EFI_FB);
 	if (efifb == NULL)
 		return (CN_DEAD);

--- a/sys/dev/vt/hw/vbefb/vbefb.c
+++ b/sys/dev/vt/hw/vbefb/vbefb.c
@@ -77,17 +77,13 @@ vt_vbefb_probe(struct vt_device *vd)
 {
 	int		disabled;
 	struct vbe_fb	*vbefb;
-	caddr_t		kmdp;
 
 	disabled = 0;
 	TUNABLE_INT_FETCH("hw.syscons.disable", &disabled);
 	if (disabled != 0)
 		return (CN_DEAD);
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	vbefb = (struct vbe_fb *)preload_search_info(kmdp,
+	vbefb = (struct vbe_fb *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_VBE_FB);
 	if (vbefb == NULL)
 		return (CN_DEAD);
@@ -100,17 +96,13 @@ vt_vbefb_init(struct vt_device *vd)
 {
 	struct fb_info	*info;
 	struct vbe_fb	*vbefb;
-	caddr_t		kmdp;
 	int		format, roff, goff, boff;
 
 	info = vd->vd_softc;
 	if (info == NULL)
 		info = vd->vd_softc = (void *)&local_vbe_info;
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	vbefb = (struct vbe_fb *)preload_search_info(kmdp,
+	vbefb = (struct vbe_fb *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_VBE_FB);
 	if (vbefb == NULL)
 		return (CN_DEAD);

--- a/sys/dev/vt/vt_core.c
+++ b/sys/dev/vt/vt_core.c
@@ -1658,15 +1658,11 @@ vtterm_done(struct terminal *tm)
 static void
 vtterm_splash(struct vt_device *vd)
 {
-	caddr_t kmdp;
 	struct splash_info *si;
 	uintptr_t image;
 	vt_axis_t top, left;
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	si = MD_FETCH(kmdp, MODINFOMD_SPLASH, struct splash_info *);
+	si = MD_FETCH(preload_kmdp, MODINFOMD_SPLASH, struct splash_info *);
 	if (!(vd->vd_flags & VDF_TEXTMODE) && (boothowto & RB_MUTE)) {
 		if (si == NULL) {
 			top = (vd->vd_height - vt_logo_height) / 2;
@@ -1790,14 +1786,10 @@ parse_font_info(struct font_info *fi)
 static void
 vt_init_font(void *arg)
 {
-	caddr_t kmdp;
 	struct font_info *fi;
 	struct vt_font *font;
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	fi = MD_FETCH(kmdp, MODINFOMD_FONT, struct font_info *);
+	fi = MD_FETCH(preload_kmdp, MODINFOMD_FONT, struct font_info *);
 
 	font = parse_font_info(fi);
 	if (font != NULL)
@@ -1809,14 +1801,10 @@ SYSINIT(vt_init_font, SI_SUB_KMEM, SI_ORDER_ANY, vt_init_font, &vt_consdev);
 static void
 vt_init_font_static(void)
 {
-	caddr_t kmdp;
 	struct font_info *fi;
 	struct vt_font *font;
 
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	fi = MD_FETCH(kmdp, MODINFOMD_FONT, struct font_info *);
+	fi = MD_FETCH(preload_kmdp, MODINFOMD_FONT, struct font_info *);
 
 	font = parse_font_info_static(fi);
 	if (font != NULL)

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -895,9 +895,7 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 	sizeptr = preload_search_info(modptr, MODINFO_SIZE);
 	dynptr = preload_search_info(modptr,
 	    MODINFO_METADATA | MODINFOMD_DYNAMIC);
-	if (type == NULL ||
-	    (strcmp(type, "elf" __XSTRING(__ELF_WORD_SIZE) " module") != 0 &&
-	     strcmp(type, "elf module") != 0))
+	if (type == NULL || strcmp(type, preload_modtype) != 0)
 		return (EFTYPE);
 	if (baseptr == NULL || sizeptr == NULL || dynptr == NULL)
 		return (EINVAL);

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -450,18 +450,14 @@ link_elf_init(void* arg)
 	Elf_Dyn *dp;
 	Elf_Addr *ctors_addrp;
 	Elf_Size *ctors_sizep;
-	caddr_t modptr, baseptr, sizeptr;
+	caddr_t baseptr, sizeptr;
 	elf_file_t ef;
 	const char *modname;
 
 	linker_add_class(&link_elf_class);
 
 	dp = (Elf_Dyn *)&_DYNAMIC;
-	modname = NULL;
-	modptr = preload_search_by_type("elf" __XSTRING(__ELF_WORD_SIZE) " kernel");
-	if (modptr == NULL)
-		modptr = preload_search_by_type("elf kernel");
-	modname = (char *)preload_search_info(modptr, MODINFO_NAME);
+	modname = (char *)preload_search_info(preload_kmdp, MODINFO_NAME);
 	if (modname == NULL)
 		modname = "kernel";
 	linker_kernel_file = linker_make_file(modname, &link_elf_class);
@@ -493,17 +489,17 @@ link_elf_init(void* arg)
 	linker_kernel_file->size = -(intptr_t)linker_kernel_file->address;
 #endif
 
-	if (modptr != NULL) {
-		ef->modptr = modptr;
-		baseptr = preload_search_info(modptr, MODINFO_ADDR);
+	if (preload_kmdp != NULL) {
+		ef->modptr = preload_kmdp;
+		baseptr = preload_search_info(preload_kmdp, MODINFO_ADDR);
 		if (baseptr != NULL)
 			linker_kernel_file->address = *(caddr_t *)baseptr;
-		sizeptr = preload_search_info(modptr, MODINFO_SIZE);
+		sizeptr = preload_search_info(preload_kmdp, MODINFO_SIZE);
 		if (sizeptr != NULL)
 			linker_kernel_file->size = *(size_t *)sizeptr;
-		ctors_addrp = (Elf_Addr *)preload_search_info(modptr,
+		ctors_addrp = (Elf_Addr *)preload_search_info(preload_kmdp,
 			MODINFO_METADATA | MODINFOMD_CTORS_ADDR);
-		ctors_sizep = (Elf_Size *)preload_search_info(modptr,
+		ctors_sizep = (Elf_Size *)preload_search_info(preload_kmdp,
 			MODINFO_METADATA | MODINFOMD_CTORS_SIZE);
 		if (ctors_addrp != NULL && ctors_sizep != NULL) {
 			linker_kernel_file->ctors_addr = ef->address +
@@ -2016,7 +2012,7 @@ elf_lookup_ifunc(linker_file_t lf, Elf_Size symidx, int deps __unused,
 }
 
 void
-link_elf_ireloc(caddr_t kmdp)
+link_elf_ireloc(void)
 {
 	struct elf_file eff;
 	elf_file_t ef;
@@ -2026,7 +2022,7 @@ link_elf_ireloc(caddr_t kmdp)
 
 	bzero_early(ef, sizeof(*ef));
 
-	ef->modptr = kmdp;
+	ef->modptr = preload_kmdp;
 	ef->dynamic = (Elf_Dyn *)&_DYNAMIC;
 
 #ifdef RELOCATABLE_KERNEL

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -365,11 +365,8 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 	    MODINFOMD_ELFHDR);
 	shdr = (Elf_Shdr *)preload_search_info(modptr, MODINFO_METADATA |
 	    MODINFOMD_SHDR);
-	if (type == NULL || (strcmp(type, "elf" __XSTRING(__ELF_WORD_SIZE)
-	    " obj module") != 0 &&
-	    strcmp(type, "elf obj module") != 0)) {
+	if (type == NULL || strcmp(type, preload_modtype_obj) != 0)
 		return (EFTYPE);
-	}
 	if (baseptr == NULL || sizeptr == NULL || hdr == NULL ||
 	    shdr == NULL)
 		return (EINVAL);

--- a/sys/kern/subr_module.c
+++ b/sys/kern/subr_module.c
@@ -46,10 +46,14 @@
 vm_offset_t preload_addr_relocate = 0;
 caddr_t preload_metadata, preload_kmdp;
 
+const char preload_modtype[] = MODTYPE;
+const char preload_kerntype[] = KERNTYPE;
+const char preload_modtype_obj[] = MODTYPE_OBJ;
+
 void
 preload_initkmdp(bool fatal)
 {
-	preload_kmdp = preload_search_by_type("elf kernel");
+	preload_kmdp = preload_search_by_type(preload_kerntype);
 
 	if (preload_kmdp == NULL && fatal)
 		panic("unable to find kernel metadata");

--- a/sys/kern/subr_module.c
+++ b/sys/kern/subr_module.c
@@ -44,7 +44,16 @@
  */
 
 vm_offset_t preload_addr_relocate = 0;
-caddr_t preload_metadata;
+caddr_t preload_metadata, preload_kmdp;
+
+void
+preload_initkmdp(bool fatal)
+{
+	preload_kmdp = preload_search_by_type("elf kernel");
+
+	if (preload_kmdp == NULL && fatal)
+		panic("unable to find kernel metadata");
+}
 
 /*
  * Search for the preloaded module (name)

--- a/sys/opencrypto/crypto.c
+++ b/sys/opencrypto/crypto.c
@@ -253,14 +253,7 @@ static struct keybuf empty_keybuf = {
 static void
 keybuf_init(void)
 {
-	caddr_t kmdp;
-
-	kmdp = preload_search_by_type("elf kernel");
-
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-
-	keybuf = (struct keybuf *)preload_search_info(kmdp,
+	keybuf = (struct keybuf *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_KEYBUF);
 
         if (keybuf == NULL)

--- a/sys/powerpc/powerpc/machdep.c
+++ b/sys/powerpc/powerpc/machdep.c
@@ -264,7 +264,6 @@ powerpc_init(vm_offset_t fdt, vm_offset_t toc, vm_offset_t ofentry, void *mdp,
 	struct cpuref	bsp;
 	vm_offset_t	startkernel, endkernel;
 	char		*env;
-	void		*kmdp = NULL;
         bool		ofw_bootargs = false;
 #ifdef DDB
 	bool		symbols_provided = false;
@@ -336,33 +335,34 @@ powerpc_init(vm_offset_t fdt, vm_offset_t toc, vm_offset_t ofentry, void *mdp,
 			preload_metadata += md_offset;
 			preload_bootstrap_relocate(md_offset);
 		}
-		kmdp = preload_search_by_type("elf kernel");
-		if (kmdp != NULL) {
-			boothowto = MD_FETCH(kmdp, MODINFOMD_HOWTO, int);
-			envp = MD_FETCH(kmdp, MODINFOMD_ENVP, char *);
-			if (envp != NULL)
-				envp += md_offset;
-			init_static_kenv(envp, 0);
-			if (fdt == 0) {
-				fdt = MD_FETCH(kmdp, MODINFOMD_DTBP, uintptr_t);
-				if (fdt != 0)
-					fdt += md_offset;
-			}
-			/* kernelstartphys is already relocated. */
-			kernelendphys = MD_FETCH(kmdp, MODINFOMD_KERNEND,
-			    vm_offset_t);
-			if (kernelendphys != 0)
-				kernelendphys += md_offset;
-			endkernel = ulmax(endkernel, kernelendphys);
-#ifdef DDB
-			ksym_start = MD_FETCH(kmdp, MODINFOMD_SSYM, uintptr_t);
-			ksym_end = MD_FETCH(kmdp, MODINFOMD_ESYM, uintptr_t);
 
-			db_fetch_ksymtab(ksym_start, ksym_end, md_offset);
-			/* Symbols provided by loader. */
-			symbols_provided = true;
-#endif
+		/* Initialize preload_kmdp */
+		preload_initkmdp(true);
+
+		boothowto = MD_FETCH(preload_kmdp, MODINFOMD_HOWTO, int);
+		envp = MD_FETCH(preload_kmdp, MODINFOMD_ENVP, char *);
+		if (envp != NULL)
+			envp += md_offset;
+		init_static_kenv(envp, 0);
+		if (fdt == 0) {
+			fdt = MD_FETCH(preload_kmdp, MODINFOMD_DTBP, uintptr_t);
+			if (fdt != 0)
+				fdt += md_offset;
 		}
+		/* kernelstartphys is already relocated. */
+		kernelendphys = MD_FETCH(preload_kmdp, MODINFOMD_KERNEND,
+		    vm_offset_t);
+		if (kernelendphys != 0)
+			kernelendphys += md_offset;
+		endkernel = ulmax(endkernel, kernelendphys);
+#ifdef DDB
+		ksym_start = MD_FETCH(preload_kmdp, MODINFOMD_SSYM, uintptr_t);
+		ksym_end = MD_FETCH(preload_kmdp, MODINFOMD_ESYM, uintptr_t);
+
+		db_fetch_ksymtab(ksym_start, ksym_end, md_offset);
+		/* Symbols provided by loader. */
+		symbols_provided = true;
+#endif
 	} else {
 		/*
 		 * Self-loading kernel, we have to fake up metadata.
@@ -372,7 +372,8 @@ powerpc_init(vm_offset_t fdt, vm_offset_t toc, vm_offset_t ofentry, void *mdp,
 		 * preload_boostrap_relocate().
 		 */
 		fake_preload_metadata();
-		kmdp = preload_search_by_type("elf kernel");
+		/* Initialize preload_kmdp */
+		preload_initkmdp(true);
 		init_static_kenv(init_kenv, sizeof(init_kenv));
 		ofw_bootargs = true;
 	}
@@ -466,7 +467,7 @@ powerpc_init(vm_offset_t fdt, vm_offset_t toc, vm_offset_t ofentry, void *mdp,
 	 * Bring up MMU
 	 */
 	pmap_mmu_init();
-	link_elf_ireloc(kmdp);
+	link_elf_ireloc();
 	pmap_bootstrap(startkernel, endkernel);
 	mtmsr(psl_kernset & ~PSL_EE);
 

--- a/sys/powerpc/powerpc/machdep.c
+++ b/sys/powerpc/powerpc/machdep.c
@@ -649,10 +649,9 @@ fake_preload_metadata(void) {
 	i += 2;
 
 	fake_preload[i++] = MODINFO_TYPE;
-	fake_preload[i++] = strlen("elf kernel") + 1;
-	strcpy((char*)&fake_preload[i], "elf kernel");
-	/* ['e' 'l' 'f' ' '] ['k' 'e' 'r' 'n'] ['e' 'l' '\0' ..] */
-	i += 3;
+	fake_preload[i++] = strlen(preload_kerntype) + 1;
+	strcpy((char*)&fake_preload[i], preload_kerntype);
+	i += howmany(fake_preload[i - 1], sizeof(uint32_t));
 
 #ifdef __powerpc64__
 	/* Padding -- Fields start on u_long boundaries */

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -370,7 +370,7 @@ fake_preload_metadata(struct riscv_bootparams *rvbp)
 	PRELOAD_PUSH_VALUE(uint32_t, MODINFO_NAME);
 	PRELOAD_PUSH_STRING("kernel");
 	PRELOAD_PUSH_VALUE(uint32_t, MODINFO_TYPE);
-	PRELOAD_PUSH_STRING("elf kernel");
+	PRELOAD_PUSH_STRING(preload_kerntype);
 
 	PRELOAD_PUSH_VALUE(uint32_t, MODINFO_ADDR);
 	PRELOAD_PUSH_VALUE(uint32_t, sizeof(vm_offset_t));

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -301,11 +301,11 @@ init_proc0(vm_offset_t kstack)
 
 #ifdef FDT
 static void
-try_load_dtb(caddr_t kmdp)
+try_load_dtb(void)
 {
 	vm_offset_t dtbp;
 
-	dtbp = MD_FETCH(kmdp, MODINFOMD_DTBP, vm_offset_t);
+	dtbp = MD_FETCH(preload_kmdp, MODINFOMD_DTBP, vm_offset_t);
 
 #if defined(FDT_DTB_STATIC)
 	/*
@@ -439,34 +439,30 @@ parse_fdt_bootargs(void)
 static vm_offset_t
 parse_metadata(void)
 {
-	caddr_t kmdp;
 	vm_offset_t lastaddr;
 #ifdef DDB
 	vm_offset_t ksym_start, ksym_end;
 #endif
 	char *kern_envp;
 
-	/* Find the kernel address */
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	KASSERT(kmdp != NULL, ("No preload metadata found!"));
+	/* Initialize preload_kmdp */
+	preload_initkmdp(true);
 
 	/* Read the boot metadata */
-	boothowto = MD_FETCH(kmdp, MODINFOMD_HOWTO, int);
-	lastaddr = MD_FETCH(kmdp, MODINFOMD_KERNEND, vm_offset_t);
-	kern_envp = MD_FETCH(kmdp, MODINFOMD_ENVP, char *);
+	boothowto = MD_FETCH(preload_kmdp, MODINFOMD_HOWTO, int);
+	lastaddr = MD_FETCH(preload_kmdp, MODINFOMD_KERNEND, vm_offset_t);
+	kern_envp = MD_FETCH(preload_kmdp, MODINFOMD_ENVP, char *);
 	if (kern_envp != NULL)
 		init_static_kenv(kern_envp, 0);
 	else
 		init_static_kenv(static_kenv, sizeof(static_kenv));
 #ifdef DDB
-	ksym_start = MD_FETCH(kmdp, MODINFOMD_SSYM, uintptr_t);
-	ksym_end = MD_FETCH(kmdp, MODINFOMD_ESYM, uintptr_t);
+	ksym_start = MD_FETCH(preload_kmdp, MODINFOMD_SSYM, uintptr_t);
+	ksym_end = MD_FETCH(preload_kmdp, MODINFOMD_ESYM, uintptr_t);
 	db_fetch_ksymtab(ksym_start, ksym_end, 0);
 #endif
 #ifdef FDT
-	try_load_dtb(kmdp);
+	try_load_dtb();
 	if (kern_envp == NULL)
 		parse_fdt_bootargs();
 #endif

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -270,7 +270,7 @@ void linker_kldload_unbusy(int flags);
  * Module lookup
  */
 extern vm_offset_t	preload_addr_relocate;
-extern caddr_t		preload_metadata;
+extern caddr_t		preload_metadata, preload_kmdp;
 
 extern void *		preload_fetch_addr(caddr_t _mod);
 extern size_t		preload_fetch_size(caddr_t _mod);
@@ -278,6 +278,7 @@ extern caddr_t		preload_search_by_name(const char *_name);
 extern caddr_t		preload_search_by_type(const char *_type);
 extern caddr_t		preload_search_next_name(caddr_t _base);
 extern caddr_t		preload_search_info(caddr_t _mod, int _inf);
+extern void		preload_initkmdp(bool _fatal);
 extern void		preload_delete_name(const char *_name);
 extern void		preload_bootstrap_relocate(vm_offset_t _offset);
 extern void		preload_dump(void);
@@ -310,7 +311,7 @@ int	elf_reloc_local(linker_file_t _lf, Elf_Addr base, const void *_rel,
 Elf_Addr elf_relocaddr(linker_file_t _lf, Elf_Addr addr);
 const Elf_Sym *elf_get_sym(linker_file_t _lf, Elf_Size _symidx);
 const char *elf_get_symname(linker_file_t _lf, Elf_Size _symidx);
-void	link_elf_ireloc(caddr_t kmdp);
+void	link_elf_ireloc(void);
 
 #if defined(__aarch64__) || defined(__amd64__)
 int	elf_reloc_late(linker_file_t _lf, Elf_Addr base, const void *_rel,

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -219,6 +219,14 @@ void linker_kldload_unbusy(int flags);
 #endif	/* _KERNEL */
 
 /*
+ * ELF file types
+ */
+#define KERNTYPE_MB	"elf multiboot kernel"
+#define KERNTYPE	"elf kernel"
+#define MODTYPE_OBJ	"elf obj module"
+#define MODTYPE		"elf module"
+
+/*
  * Module information subtypes
  */
 #define MODINFO_END		0x0000		/* End of list */
@@ -271,6 +279,9 @@ void linker_kldload_unbusy(int flags);
  */
 extern vm_offset_t	preload_addr_relocate;
 extern caddr_t		preload_metadata, preload_kmdp;
+extern const char	preload_modtype[];
+extern const char	preload_kerntype[];
+extern const char	preload_modtype_obj[];
 
 extern void *		preload_fetch_addr(caddr_t _mod);
 extern size_t		preload_fetch_size(caddr_t _mod);

--- a/sys/x86/include/init.h
+++ b/sys/x86/include/init.h
@@ -35,10 +35,10 @@
  * hypervisor environment.
  */
 struct init_ops {
-	caddr_t	(*parse_preload_data)(u_int64_t);
+	void	(*parse_preload_data)(u_int64_t);
 	void	(*early_clock_source_init)(void);
 	void	(*early_delay)(int);
-	void	(*parse_memmap)(caddr_t, vm_paddr_t *, int *);
+	void	(*parse_memmap)(vm_paddr_t *, int *);
 };
 
 extern struct init_ops init_ops;

--- a/sys/x86/x86/fdt_machdep.c
+++ b/sys/x86/x86/fdt_machdep.c
@@ -43,7 +43,7 @@
 int
 x86_init_fdt(void)
 {
-	void *dtbp, *mdp;
+	void *dtbp;
 	int error;
 
 	if (!OF_install(OFW_FDT, 0)) {
@@ -51,10 +51,7 @@ x86_init_fdt(void)
 		goto out;
 	}
 
-	mdp = preload_search_by_type("elf kernel");
-	if (mdp == NULL)
-		mdp = preload_search_by_type("elf32 kernel");
-	dtbp = MD_FETCH(mdp, MODINFOMD_DTBP, void *);
+	dtbp = MD_FETCH(preload_kmdp, MODINFOMD_DTBP, void *);
 
 #if defined(FDT_DTB_STATIC)
 	/*

--- a/sys/x86/x86/nexus.c
+++ b/sys/x86/x86/nexus.c
@@ -81,8 +81,6 @@
 #include <isa/isareg.h>
 #endif
 
-#define	ELF_KERN_STR	("elf"__XSTRING(__ELF_WORD_SIZE)" kernel")
-
 static MALLOC_DEFINE(M_NEXUSDEV, "nexusdev", "Nexus device");
 
 #define DEVTONX(dev)	((struct nexus_device *)device_get_ivars(dev))
@@ -647,15 +645,11 @@ ram_attach(device_t dev)
 	struct resource *res;
 	rman_res_t length;
 	vm_paddr_t *p;
-	caddr_t kmdp;
 	uint32_t smapsize;
 	int error, rid;
 
 	/* Retrieve the system memory map from the loader. */
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type(ELF_KERN_STR);
-	smapbase = (struct bios_smap *)preload_search_info(kmdp,
+	smapbase = (struct bios_smap *)preload_search_info(preload_kmdp,
 	    MODINFO_METADATA | MODINFOMD_SMAP);
 	if (smapbase != NULL) {
 		smapsize = *((u_int32_t *)smapbase - 1);

--- a/sys/x86/xen/hvm.c
+++ b/sys/x86/xen/hvm.c
@@ -213,15 +213,6 @@ fixup_console(void)
 		struct vbe_fb vbe;
 	} *fb = NULL;
 	int size;
-	caddr_t kmdp;
-
-	kmdp = preload_search_by_type("elf kernel");
-	if (kmdp == NULL)
-		kmdp = preload_search_by_type("elf64 kernel");
-	if (kmdp == NULL) {
-		xc_printf("Unable to find kernel metadata\n");
-		return;
-	}
 
 	size = HYPERVISOR_platform_op(&op);
 	if (size < 0) {
@@ -231,7 +222,7 @@ fixup_console(void)
 
 	switch (console->video_type) {
 	case XEN_VGATYPE_VESA_LFB:
-		fb = (__typeof__ (fb))preload_search_info(kmdp,
+		fb = (__typeof__ (fb))preload_search_info(preload_kmdp,
 		    MODINFO_METADATA | MODINFOMD_VBE_FB);
 
 		if (fb == NULL) {
@@ -247,7 +238,7 @@ fixup_console(void)
 		/* FALLTHROUGH */
 	case XEN_VGATYPE_EFI_LFB:
 		if (fb == NULL) {
-			fb = (__typeof__ (fb))preload_search_info(kmdp,
+			fb = (__typeof__ (fb))preload_search_info(preload_kmdp,
 			    MODINFO_METADATA | MODINFOMD_EFI_FB);
 			if (fb == NULL) {
 				xc_printf("No EFI FB in kernel metadata\n");


### PR DESCRIPTION
Currently, the way we get the kernel metadata pointer is by calling
preload_search_by_type with one of the following three: "elf kernel",
"elf32 kernel" and "elf64 kernel". Which one(s) we use isn't consistent
though. Sometimes we would only try "elf kernel", and other times we
would try one of the latter two if the first failed. However, the loader
only ever sets "elf kernel" as the kernel type.
See: https://github.com/freebsd/freebsd-src/blob/8afae0caf4c4816eb56b732fcd1a4b185e86098a/stand/common/load_elf.c#L92

Instead, make the kmdp a global, preload_kmdp, and initialize it using
preload_initkmdp in machdep.c (or machdep_boot.c on arm/64).
preload_initkmdp takes a single boolean argument that tells us whether
not finding kmdp is fatal or not.

Also, feel free to critique my commit message. I feel like it's not great,
but that's the best I could word it.