### PR TITLE
linuxkpi: chase spinlock_t in DECLARE_WAIT_QUEUE_HEAD

### DIFF
--- a/sys/compat/linuxkpi/common/include/linux/wait.h
+++ b/sys/compat/linuxkpi/common/include/linux/wait.h
@@ -110,7 +110,7 @@ extern wait_queue_func_t default_wake_function;
 	wait_queue_head_t name = {					\
 		.task_list = LINUX_LIST_HEAD_INIT(name.task_list),	\
 	};								\
-	MTX_SYSINIT(name, &(name).lock.m, spin_lock_name("wqhead"), MTX_DEF)
+	MTX_SYSINIT(name, &(name).lock, spin_lock_name("wqhead"), MTX_DEF)
 
 #define	init_waitqueue_head(wqh) do {					\
 	mtx_init(&(wqh)->lock, spin_lock_name("wqhead"),		\


### PR DESCRIPTION
Remove member m to unbreak consumers, e.g. drm-kmod 5.10-lts branch.
```
[...]
/tmp/drm-kmod/drivers/gpu/drm/ttm/ttm_module.c:38:8: error: no member named 'm' in 'struct mtx'
   38 | static DECLARE_WAIT_QUEUE_HEAD(exit_q);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/src/sys/compat/linuxkpi/common/include/linux/wait.h:113:33: note: expanded from macro 'DECLARE_WAIT_QUEUE_HEAD'
  113 |         MTX_SYSINIT(name, &(name).lock.m, spin_lock_name("wqhead"), MTX_DEF)
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/src/sys/sys/mutex.h:528:4: note: expanded from macro 'MTX_SYSINIT'
  528 |                 (mtx),                                                  \
      |                  ^~~
/tmp/drm-kmod/drivers/gpu/drm/ttm/ttm_module.c:38:8: error: no member named 'm' in 'struct mtx'
   38 | static DECLARE_WAIT_QUEUE_HEAD(exit_q);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/src/sys/compat/linuxkpi/common/include/linux/wait.h:113:33: note: expanded from macro 'DECLARE_WAIT_QUEUE_HEAD'
  113 |         MTX_SYSINIT(name, &(name).lock.m, spin_lock_name("wqhead"), MTX_DEF)
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
```
Fixes:		ae38a1a1bfdf ("linuxkpi: spinlock: Simplify code")
MFC after:	?