### PR TITLE
Backport the security patch of CVE-2024-39894

### DIFF
--- a/crypto/openssh/clientloop.c
+++ b/crypto/openssh/clientloop.c
@@ -607,8 +607,9 @@ obfuscate_keystroke_timing(struct ssh *ssh, struct timespec *timeout,
 		if (timespeccmp(&now, &chaff_until, >=)) {
 			/* Stop if there have been no keystrokes for a while */
 			stop_reason = "chaff time expired";
-		} else if (timespeccmp(&now, &next_interval, >=)) {
-			/* Otherwise if we were due to send, then send chaff */
+		} else if (timespeccmp(&now, &next_interval, >=) &&
+		    !ssh_packet_have_data_to_write(ssh)) {
+			/* If due to send but have no data, then send chaff */
 			if (send_chaff(ssh))
 				nchaff++;
 		}


### PR DESCRIPTION
Hi,
 we find the recurring vulnerability which shares the similarity of CVE-2024-39894 in you project with the version of release/14.0.0 and release/13.3.0. The patch of this CVE is https://github.com/openssh/openssh-portable/commit/146c420d29d055cc75c8606327a1cf8439fe3a08 and we find that you've already fix it in the main branch, which is the commit https://github.com/freebsd/freebsd-src/commit/b81424adf7181d816c10b1345aaa3305ab0ec304. Is there a need to backport it?