### PR TITLE
mfiutil: Fix unsafe assumptions of snprintf(3) return value in function `mfi_autolearn_period`

### DIFF
--- a/usr.sbin/mfiutil/mfi_bbu.c
+++ b/usr.sbin/mfiutil/mfi_bbu.c
@@ -50,10 +50,21 @@ mfi_autolearn_period(uint32_t period, char *buf, size_t sz)
 
 	tmp = buf;
 	if (d != 0) {
-		tmp += snprintf(buf, sz, "%u day%s", d, d == 1 ? "" : "s");
+		int fmt_len;
+		fmt_len = snprintf(buf, sz, "%u day%s", d, d == 1 ? "" : "s");
+		if (fmt_len < 0) {
+			*buf = 0;
+			return;
+		}
+		if ((size_t)fmt_len >= sz) return;
+		tmp += fmt_len;
 		sz -= tmp - buf;
 		if (h != 0) {
-			tmp += snprintf(tmp, sz, ", ");
+			fmt_len = snprintf(tmp, sz, ", ");
+			if (fmt_len < 0 || (size_t)fmt_len >= sz) {
+				return;
+			}
+			tmp += fmt_len;
 			sz -= 2;
 		}
 	}


### PR DESCRIPTION
PR:		[281160](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=281160)

From my portable mfiutil project, commit <https://sourceforge.net/p/mfiutil/code/ci/8ee7bd9112fab7bdf28188fa595f8a8a59cced48/>.

