### PR TITLE
ctl: fix uninitialized data used by PREVENT ALLOW MEDIUM REMOVAL

### DIFF
--- a/sys/cam/ctl/ctl.c
+++ b/sys/cam/ctl/ctl.c
@@ -4630,7 +4630,7 @@ fail:
 	ctl_tpc_lun_init(lun);
 	if (lun->flags & CTL_LUN_REMOVABLE) {
 		lun->prevent = malloc((CTL_MAX_INITIATORS + 31) / 32 * 4,
-		    M_CTL, M_WAITOK);
+		    M_CTL, M_WAITOK | M_ZERO);
 	}
 
 	/*

--- a/tests/sys/cam/ctl/Makefile
+++ b/tests/sys/cam/ctl/Makefile
@@ -2,9 +2,12 @@ PACKAGE=	tests
 
 TESTSDIR=	${TESTSBASE}/sys/cam/ctl
 
+${PACKAGE}FILES+=	ctl.subr
+
 ATF_TESTS_SH+=	read_buffer
+ATF_TESTS_SH+=	start_stop_unit
 
 # Must be exclusive because it disables/enables camsim
-TEST_METADATA.read_buffer+=	is_exclusive="true"
+TEST_METADATA+=	is_exclusive="true"
 
 .include <bsd.test.mk>

--- a/tests/sys/cam/ctl/Makefile
+++ b/tests/sys/cam/ctl/Makefile
@@ -4,6 +4,7 @@ TESTSDIR=	${TESTSBASE}/sys/cam/ctl
 
 ${PACKAGE}FILES+=	ctl.subr
 
+ATF_TESTS_SH+=	prevent
 ATF_TESTS_SH+=	read_buffer
 ATF_TESTS_SH+=	start_stop_unit
 

--- a/tests/sys/cam/ctl/ctl.subr
+++ b/tests/sys/cam/ctl/ctl.subr
@@ -1,0 +1,94 @@
+# vim: filetype=sh
+
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2024 Axcient
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS DOCUMENTATION IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+load_modules() {
+	if ! kldstat -q -m ctl; then
+		kldload ctl || atf_skip "could not load ctl kernel mod"
+	fi
+	if ! ctladm port -o on -p 0; then
+		atf_skip "could not enable the camsim frontend"
+	fi
+}
+
+find_device() {
+	LUN=$1
+
+	# Rescan camsim
+	# XXX  camsim doesn't update when creating a new device.  Worse, a
+	# rescan won't look for new devices.  So we must disable/re-enable it.
+	# Worse still, enabling it isn't synchronous, so we need a retry loop
+	# https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=281000
+	retries=5
+	ctladm port -o off -p 0 >/dev/null
+	ctladm port -o on -p 0 >/dev/null
+	HEXLUN=`printf %x $LUN`
+	while true; do
+		dev=`camcontrol devlist | awk -v lun=$HEXLUN '/FREEBSD CTL/ && $9==lun {split($10, fields, /[,]/); print fields[1];}' | sed 's:[()]::'`
+		if [ -z "$dev" -o ! -c /dev/$dev ]; then
+			retries=$(( $retries - 1 ))
+			if [ $retries -eq 0 ]; then
+				cat lun-create.txt
+				camcontrol devlist
+				atf_fail "Could not find GEOM device"
+			fi
+			sleep 0.1
+			continue
+		fi
+		break
+	done
+	# Ensure that it's actually ready.  camcontrol may report the disk's
+	# ident before it's actually ready to receive commands.  Maybe that's
+	# because all of the GEOM providers must probe it?
+	while true; do
+		dd if=/dev/$dev bs=4096 count=1 of=/dev/null >/dev/null 2>/dev/null && break
+		retries=$(( $retries - 1 ))
+		if [ $retries -eq 0 ]; then
+			atf_fail "Device never became ready"
+		fi
+		sleep 0.1
+	done
+}
+
+# Create a CTL LUN
+create_ramdisk() {
+	EXTRA_ARGS=$*
+
+	atf_check -o save:lun-create.txt ctladm create -b ramdisk -s 1048576 $EXTRA_ARGS
+	atf_check egrep -q "LUN created successfully" lun-create.txt
+	LUN=`awk '/LUN ID:/ {print $NF}' lun-create.txt`
+	if [ -z "$LUN" ]; then
+		atf_fail "Could not find LUN id"
+	fi
+	find_device $LUN
+}
+
+cleanup() {
+	if [ -e "lun-create.txt" ]; then
+		lun_id=`awk '/LUN ID:/ {print $NF}' lun-create.txt`
+		ctladm remove -b ramdisk -l $lun_id > /dev/null
+	fi
+}

--- a/tests/sys/cam/ctl/prevent.sh
+++ b/tests/sys/cam/ctl/prevent.sh
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2024 Axcient
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS DOCUMENTATION IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. $(atf_get_srcdir)/ctl.subr
+
+# TODO
+# * multiple initiators may block removal
+
+# Not Tested
+# * persistent removal (not implemented in CTL)
+
+atf_test_case allow cleanup
+allow_head()
+{
+	atf_set "descr" "SCSI PREVENT ALLOW MEDIUM REMOVAL will prevent a CD from being ejected"
+	atf_set "require.user" "root"
+	atf_set "require.progs" sg_prevent sg_start
+}
+allow_body()
+{
+	# -t 5 for CD/DVD device type
+	create_ramdisk -t 5
+
+	atf_check sg_prevent --prevent 1 /dev/$dev
+
+	# Now sg_start --eject should fail
+	atf_check -s exit:5 -e match:"Illegal request" sg_start --eject /dev/$dev
+
+	atf_check sg_prevent --allow /dev/$dev
+
+	# Now sg_start --eject should work again
+	atf_check -s exit:0 sg_start --eject /dev/$dev
+}
+allow_cleanup()
+{
+	cleanup
+}
+
+atf_test_case allow_idempotent cleanup
+allow_idempotent_head()
+{
+	atf_set "descr" "SCSI PREVENT ALLOW MEDIUM REMOVAL is idempotent when run from the same initiator"
+	atf_set "require.user" "root"
+	atf_set "require.progs" sg_prevent sg_start
+}
+allow_idempotent_body()
+{
+	# -t 5 for CD/DVD device type
+	create_ramdisk -t 5
+
+	atf_check sg_prevent --allow /dev/$dev
+	atf_check sg_prevent --allow /dev/$dev
+	atf_check sg_prevent --prevent 1 /dev/$dev
+
+	# Even though we ran --allow twice, a single --prevent command should
+	# suffice to prevent ejecting.  Multiple ALLOW/PREVENT commands from
+	# the same initiator don't have any additional effect.
+	atf_check -s exit:5 -e match:"Illegal request" sg_start --eject /dev/$dev
+}
+allow_idempotent_cleanup()
+{
+	cleanup
+}
+
+atf_test_case nonremovable cleanup
+nonremovable_head()
+{
+	atf_set "descr" "SCSI PREVENT ALLOW MEDIUM REMOVAL may not be used on non-removable media"
+	atf_set "require.user" "root"
+	atf_set "require.progs" sg_prevent
+}
+nonremovable_body()
+{
+	# Create a HDD, not a CD, device
+	create_ramdisk -t 0
+
+	atf_check -s exit:9 -e match:"Invalid opcode" sg_prevent /dev/$dev
+}
+nonremovable_cleanup()
+{
+	cleanup
+}
+
+atf_test_case prevent cleanup
+prevent_head()
+{
+	atf_set "descr" "SCSI PREVENT ALLOW MEDIUM REMOVAL will prevent a CD from being ejected"
+	atf_set "require.user" "root"
+	atf_set "require.progs" sg_prevent sg_start
+}
+prevent_body()
+{
+	# -t 5 for CD/DVD device type
+	create_ramdisk -t 5
+
+	atf_check sg_prevent --prevent 1 /dev/$dev
+
+	# Now sg_start --eject should fail
+	atf_check -s exit:5 -e match:"Illegal request" sg_start --eject /dev/$dev
+}
+prevent_cleanup()
+{
+	cleanup
+}
+
+atf_test_case prevent_idempotent cleanup
+prevent_idempotent_head()
+{
+	atf_set "descr" "SCSI PREVENT ALLOW MEDIUM REMOVAL is idempotent when run from the same initiator"
+	atf_set "require.user" "root"
+	atf_set "require.progs" sg_prevent sg_start
+}
+prevent_idempotent_body()
+{
+	# -t 5 for CD/DVD device type
+	create_ramdisk -t 5
+
+	atf_check sg_prevent --prevent 1 /dev/$dev
+	atf_check sg_prevent --prevent 1 /dev/$dev
+	atf_check sg_prevent --allow /dev/$dev
+
+	# Even though we ran prevent idempotent and allow only once, eject
+	# should be allowed.  Multiple PREVENT commands from the same initiator
+	# don't have any additional effect.
+	atf_check sg_start --eject /dev/$dev
+}
+prevent_idempotent_cleanup()
+{
+	cleanup
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case allow
+	atf_add_test_case allow_idempotent
+	atf_add_test_case nonremovable
+	atf_add_test_case prevent
+	atf_add_test_case prevent_idempotent
+}

--- a/tests/sys/cam/ctl/start_stop_unit.sh
+++ b/tests/sys/cam/ctl/start_stop_unit.sh
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2024 Axcient
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS DOCUMENTATION IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. $(atf_get_srcdir)/ctl.subr
+
+# TODO:
+# * format layer
+# * IMM bit
+# * LOEJ
+# * noflush
+# * power conditions
+
+# Not Tested
+# * Power Condition Modifier (not implemented in CTL)
+
+atf_test_case eject cleanup
+eject_head()
+{
+	atf_set "descr" "START STOP UNIT can eject a CDROM device"
+	atf_set "require.user" "root"
+	atf_set "require.progs" sg_start sg_readcap
+}
+eject_body()
+{
+	# -t 5 for CD/DVD device type
+	create_ramdisk -t 5
+
+	# Verify that the device is online
+	# Too bad I don't know of any other way to check that it's stopped but
+	# by using sg_readcap.
+	atf_check -o ignore -e not-match:"Device not ready" sg_readcap /dev/$dev
+
+	# eject the device
+	atf_check sg_start --eject /dev/$dev
+
+	# Ejected, it should now return ENXIO
+	atf_check -s exit:1 -o ignore -e match:"Device not configured" dd if=/dev/$dev bs=4096 count=1 of=/dev/null
+}
+eject_cleanup()
+{
+	cleanup
+}
+
+atf_test_case load cleanup
+load_head()
+{
+	atf_set "descr" "START STOP UNIT can load a CDROM device"
+	atf_set "require.user" "root"
+	atf_set "require.progs" sg_start sg_readcap
+}
+load_body()
+{
+	# -t 5 for CD/DVD device type
+	create_ramdisk -t 5
+
+	# eject the device
+	atf_check sg_start --eject /dev/$dev
+
+	# Verify that it's offline it should now return ENXIO
+	atf_check -s exit:1 -o ignore -e match:"Device not configured" dd if=/dev/$dev bs=4096 count=1 of=/dev/null
+
+	# Load it again
+	atf_check sg_start --load /dev/$dev
+
+	atf_check -o ignore -e ignore dd if=/dev/$dev bs=4096 count=1 of=/dev/null
+	atf_check -o ignore -e not-match:"Device not ready" sg_readcap /dev/$dev
+}
+load_cleanup()
+{
+	cleanup
+}
+
+atf_test_case start cleanup
+start_head()
+{
+	atf_set "descr" "START STOP UNIT can start a device"
+	atf_set "require.user" "root"
+	atf_set "require.progs" sg_start sg_readcap
+}
+start_body()
+{
+	create_ramdisk
+
+	# stop the device
+	atf_check sg_start --stop /dev/$dev
+
+	# And start it again
+	atf_check sg_start /dev/$dev
+
+	# Now sg_readcap should succeed.  Too bad I don't know of any other way
+	# to check that it's stopped.
+	atf_check -o ignore -e not-match:"Device not ready" sg_readcap /dev/$dev
+}
+start_cleanup()
+{
+	cleanup
+}
+
+atf_test_case stop cleanup
+stop_head()
+{
+	atf_set "descr" "START STOP UNIT can stop a device"
+	atf_set "require.user" "root"
+	atf_set "require.progs" sg_start sg_readcap
+}
+stop_body()
+{
+	create_ramdisk
+
+	# Stop the device
+	atf_check sg_start --stop /dev/$dev
+
+	# Now sg_readcap should fail.  Too bad I don't know of any other way to
+	# check that it's stopped.
+	atf_check -s exit:2 -e match:"Device not ready" sg_readcap /dev/$dev
+}
+stop_cleanup()
+{
+	cleanup
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case eject
+	atf_add_test_case load
+	atf_add_test_case start
+	atf_add_test_case stop
+}


### PR DESCRIPTION
This is not considered a security risk because the uninitialized data is never directly exposed to user land.  The worse case scenario is that START STOP UNIT might not work correctly.

Also, add ATF tests for START STOP UNIT and PREVENT ALLOW MEDIUM REMOVAL.

This was discussed in https://reviews.freebsd.org/D45952 , but not included as part of that review.