### PR TITLE
powerpc/busdma_machdep.c: Limit sgsize to buflen

### DIFF
--- a/sys/powerpc/powerpc/busdma_machdep.c
+++ b/sys/powerpc/powerpc/busdma_machdep.c
@@ -648,6 +648,7 @@ _bus_dmamap_load_buffer(bus_dma_tag_t dmat,
 		sgsize = MIN(buflen, PAGE_SIZE - (curaddr & PAGE_MASK));
 		if (map->pagesneeded != 0 && must_bounce(dmat, curaddr)) {
 			sgsize = roundup2(sgsize, dmat->alignment);
+			sgsize = MIN(sgsize, buflen);
 			curaddr = add_bounce_page(dmat, map, kvaddr, curaddr,
 			    sgsize);
 		}


### PR DESCRIPTION
Before commit a77e1f0f81df5fa3b4a6a38728ebace599cb18a4, total sum of ds_len will always equal to user requested size (buflen), so user assume that this will always be true and used it as reference. (example https://github.com/freebsd/freebsd-src/pull/1414)

Now since this is no longer true, it causes severe memory corruption.

By simply limit sgsize of last segment to buflen will fix it.