### PR TITLE
Fix gets x

### DIFF
--- a/lib/libc/stdio/gets_s.c
+++ b/lib/libc/stdio/gets_s.c
@@ -87,9 +87,11 @@ _gets_s(char *buf, rsize_t n)
 				}
 		}
 	}
-
 	*s = 0;
-	return (buf);
+	if (n == 0)
+		return (NULL);
+	else
+		return (buf);
 }
 
 /* ISO/IEC 9899:2011 K.3.7.4.1 */

--- a/lib/libc/stdio/gets_s.c
+++ b/lib/libc/stdio/gets_s.c
@@ -54,7 +54,7 @@ _gets_s(char *buf, rsize_t n)
    	 */
 
 	/* This prevents various alert via __throw_constraint_handler_s() if 
- 	 * the user type more than N - 1 characters, when functions flush stdin
+ 	 * the user type more than N - 1 characters, when function flush stdin
   	 * buffer
    	 */
 	signal = 1;

--- a/lib/libc/stdio/gets_s.c
+++ b/lib/libc/stdio/gets_s.c
@@ -49,11 +49,13 @@ _gets_s(char *buf, rsize_t n)
 {
 	int c, signal;
 	char *s;
-	/* This modifications prevents error qhen the user type exactly N - 1
+	/* 
+ 	 * This modifications prevents error qhen the user type exactly N - 1
  	 * Character in stdin buffer and press  <ENTER> key ('\n')
    	 */
 
-	/* This prevents various alert via __throw_constraint_handler_s() if 
+	/* 
+ 	 * This prevents various alert via __throw_constraint_handler_s() if 
  	 * the user type more than N - 1 characters, when function flush stdin
   	 * buffer
    	 */
@@ -66,11 +68,15 @@ _gets_s(char *buf, rsize_t n)
 			} else
 				break;
 		} else {
-			if ( n ) {
+			/*
+   			 * This prevents strange behavior when user types EXATLY N - 1
+			 * character into the stdin buffer
+    			*/
+			if ( n ) {	// if n > 0
 				*s++ = c;
 				n --;
 			} else 
-				if ( signal ) {
+				if ( signal == 1 ) {
 				/*
  	 			* If end of buffer reached, discard until \n or eof.
 	 			* Then throw an error.

--- a/lib/libc/stdio/gets_s.c
+++ b/lib/libc/stdio/gets_s.c
@@ -84,7 +84,8 @@ _gets_s(char *buf, rsize_t n)
 				/* throw the error after lock released prior to exit */
 				__throw_constraint_handler_s("gets_s : end of buffer", E2BIG);
 				signal = 0;
-			}
+				}
+		}
 	}
 
 	*s = 0;


### PR DESCRIPTION
I found strange behavior when I used gets_s function.
When I type characters less or more than N - 1, this function work fine, but when I type exactly N - 1 characters, this functions report a strange result. My proposal for correcting the error fix these issues.
Below I show the result of test with this code in C.

```
#include <stdio.h>
#include <stdlib.h>

int
main(void)
{
        char a1[MAX_STR_LEN];
        char a2[MAX_STR_LEN];
        unsigned int c;

        // Clean the buffer
        for ( c = 0; c < MAX_STR_LEN; c++)
        {
                          a1[c] = '\0';
                          a2[c] = '\0';
        }

        printf("Type a letter:\n");
        gets_s(a1, 5);
        printf("Type a letter:\n");
        gets_s(a2, 5);
        printf("You typed the letter:\na1 = %s\na2 = %s\n",a1, a2);
        return 0;
}
```

Using original gets_s function
         
% ./gets_s 
Type a letter:
aa
Type a letter:
aaaaa
You typed the letter: 
a1 = aa
a2 = aaaa
% ./gets_s
**Type a letter:
aaaa**

Type a letter:
aaaaa
You typed the letter: 
a1 = aaaa
a2 = aaaa

Using new fix gets_s function
% ./fixgets_s
Type a letter:
aa
Type a letter:
aaaaa
You typed the letter: 
a1 = aa
a2 = aaaa
% ./fixgets_s
Type a letter:
aaaa
Type a letter:
aaaaa
You typed the letter: 
a1 = aaaa
a2 = aaaa
