### PR TITLE
bsdinstall: Add pkg install support in live env

### DIFF
--- a/usr.sbin/bsdinstall/startbsdinstall
+++ b/usr.sbin/bsdinstall/startbsdinstall
@@ -102,6 +102,17 @@ $BSDDIALOG_OK)	# Install
 	fi
 	;;
 $BSDDIALOG_CANCEL)	# Live System
+	bsddialog --backtitle "$OSNAME Installer" --title 'Bootstrap pkg' --yesno 'Would you like to bootstrap pkg?' 0 0
+	if [ $? -eq $BSDDIALOG_OK ]; then
+		BSDINSTALL_CONFIGCURRENT=1 bsdinstall netconfig
+		if [ -z "$(mount | grep 'tmpfs on /usr/local')" ]; then mount -o size=700M -t tmpfs tmpfs /usr/local/; fi
+		TMPDIR=/usr/local pkg bootstrap -fy
+		if [ $? -ne 0 ]; then exit 1; fi
+		echo "PKG_DBDIR = \"/usr/local/db/pkg\";" >> /usr/local/etc/pkg.conf
+		echo "PKG_CACHEDIR = \"/usr/local/cache/pkg\";" >> /usr/local/etc/pkg.conf
+		TMPDIR=/usr/local pkg update
+		bsddialog --backtitle "$OSNAME Installer" --title 'Successfully bootstrapped pkg' --msgbox 'pkg is successfully bootstrapped. Exiting to live system.' 0 40
+	fi
 	exit 0
 	;;
 $BSDDIALOG_EXTRA)	# Shell


### PR DESCRIPTION
This patch improves the support of pkg installation in the live environment. Currently, pkg has to be manually bootstrapped before it can install pkgs in the live env. Since the installation media is often used as a tool for inspecting and rescuing systems, it would be great if users can easily install tools in live env using pkg to their needs. 

This patch provides a bsddialog menu for pkg bootstrap after "Live System" option is selected from the installer menu. If "Yes", it goes on asking for network configurations, and bootstraps pkg under `/usr/local`.

This patch is part of the code of the [GSoC 2024 Project - Installer](https://wiki.freebsd.org/SummerOfCode2024Projects/ImprovingRepairAbilityOfTheFreeBSDInstaller), whose work is committed in PR #1395 . This patch is created for the ease of getting this project's work commited.