### PR TITLE
socket: wrap ktrsplice call with KTRACE ifdef

### DIFF
--- a/sys/kern/uipc_socket.c
+++ b/sys/kern/uipc_socket.c
@@ -3954,7 +3954,9 @@ sosetopt(struct socket *so, struct sockopt *sopt)
 			}
 			if (error)
 				goto bad;
+#ifdef KTRACE
 			ktrsplice(&splice);
+#endif
 
 			error = splice_init();
 			if (error != 0)


### PR DESCRIPTION
This fixes a build error when the kernel is built without KTRACE support