### PR TITLE
bsdinstall: Add repair scripts to installer menu

### DIFF
--- a/usr.sbin/bsdinstall/scripts/Makefile
+++ b/usr.sbin/bsdinstall/scripts/Makefile
@@ -16,6 +16,7 @@ SCRIPTS=auto \
 	netconfig \
 	netconfig_ipv4 \
 	netconfig_ipv6 \
+	repair \
 	rootpass \
 	script \
 	services \

--- a/usr.sbin/bsdinstall/scripts/repair
+++ b/usr.sbin/bsdinstall/scripts/repair
@@ -1,0 +1,128 @@
+#!/bin/sh
+
+BSDCFG_SHARE="/usr/share/bsdconfig"
+. $BSDCFG_SHARE/common.subr || exit 1
+
+: ${BSDDIALOG_OK=0}
+
+# echo_title
+#
+# For displaying title during checks
+#
+echo_title() {
+	echo
+	echo $1
+}
+
+# 
+# option fsck parameters and check function
+#
+fsck_name="fsck"
+fsck_desc="fsck partition"
+fsck_onoff="on"
+option_fsck() {
+	echo_title "<=== FSCK ===>"
+	fsck /dev/$part
+}
+
+# 
+# option mtree parameters and check function
+#
+mtree_name="mtree"
+mtree_desc="compare partition mtree with installation media mtree"
+mtree_onoff="on"
+option_mtree() {
+	echo_title "<=== MTREE ===>"
+	mtree -e -p /mnt -f /etc/mtree/BSD.root.dist
+	if [ $? -ne 0 ]; then
+		bsddialog --backtitle "$OSNAME Installer" --title 'mtree detected changes' --yesno 'Some changes were detected. Would you like to reset to defaults?' 0 0
+		if [ $? -eq $BSDDIALOG_OK ]; then
+				mtree -eu -p /mnt -f /etc/mtree/BSD.root.dist
+		fi
+	fi
+}
+
+# 
+# option zpool scrub parameters and check function
+#
+zpool_scrub_name="zpool-scrub"
+zpool_scrub_desc="zpool scrub pools"
+zpool_scrub_onoff="on"
+option_zpool_scrub() {
+	echo_title "<=== ZPOOL SCRUB ===>"
+	zpool scrub zroot
+}
+
+# 
+# Initialize by grepping ufs partitions and zfs pools on the system
+#
+partitions=$(gpart show -p | grep 'freebsd-ufs' | grep -v diskid |  awk '{ print $3, $4 }')
+pools=$(zpool import | grep pool: | awk '{ print $2, "freebsd-zfs" }')
+if [ -z "$partitions" -a -z "$pools" ]; then
+	bsddialog --backtitle "$OSNAME Installer" --title 'No partition detected' --msgbox 'No partition detected. Exiting to live system.' 0 0
+	exit 1
+fi
+
+exec 5>&1
+part=$(echo $partitions $pools | xargs -o bsddialog --backtitle "${OSNAME} Installer" --title "Mount a partition" \
+	--menu "Select one of the partitions to mount" 0 0 0 2>&1 1>&5)
+[ $? -eq $BSDDIALOG_OK ] || exit 0
+
+#
+# Depending on the selected partition/pool, show different repair menu
+#
+fs=$(echo $partitions $pools | xargs -n 2 | grep $part | awk '{ print $2 }')
+if [ "$fs" == "freebsd-ufs" ]; then
+	mount /dev/$part /mnt
+
+	exec 5>&1
+	checks=$(bsddialog --backtitle "$OSNAME Installer" --title 'Inspect selected partition' \
+		--checklist 'Choose from the below commands to inspect partition' 0 0 0 \
+		$fsck_name $fsck_desc $fsck_onoff \
+		$mtree_name $mtree_desc $mtree_onoff \
+		2>&1 1>&5 )
+	retval=$?
+	exec 5>&-
+
+	[ $retval -eq $BSDDIALOG_OK ] || exit 1
+
+	# Perform selected checks
+	for check in $checks; do
+		case "$check" in
+		$fsck_name)
+			option_fsck
+			;;
+		$mtree_name)
+			option_mtree
+			;;
+		esac
+	done
+
+elif [ "$fs" == "freebsd-zfs" ]; then
+	mount -t tmpfs tmpfs /mnt
+	zpool import -o altroot=/mnt $part
+	zfs mount zroot/ROOT/default
+	
+	exec 5>&1
+	checks=$(bsddialog --backtitle "$OSNAME Installer" --title 'Inspect selected partition' \
+		--checklist 'Choose from the below commands to inspect partition' 0 0 0 \
+		$zpool_scrub_name $zpool_scrub_desc $zpool_scrub_onoff \
+		$mtree_name $mtree_desc $mtree_onoff \
+		2>&1 1>&5 )
+	retval=$?
+	exec 5>&-
+
+	[ $retval -eq $BSDDIALOG_OK ] || exit 1
+
+	# Perform selected checks
+	for check in $checks; do
+		case "$check" in
+		zpool_scrub_name)
+			option_zpool_scrub
+			;;
+		mtree_name)
+			option_mtree
+			;;
+		esac
+	done
+fi

--- a/usr.sbin/bsdinstall/startbsdinstall
+++ b/usr.sbin/bsdinstall/startbsdinstall
@@ -8,6 +8,7 @@ BSDCFG_SHARE="/usr/share/bsdconfig"
 : ${BSDDIALOG_HELP=2}
 : ${BSDDIALOG_EXTRA=3}
 : ${BSDDIALOG_ESC=5}
+: ${BSDDIALOG_RIGHT1=9}
 : ${BSDDIALOG_ERROR=255}
 
 kbdcontrol -d >/dev/null 2>&1
@@ -60,7 +61,7 @@ if [ -f /etc/installerconfig ]; then
 	exit 
 fi
 
-bsddialog --backtitle "${OSNAME} Installer" --title "Welcome" --extra-button --extra-label "Shell" --ok-label "Install" --cancel-label "Live System" --yesno "Welcome to ${OSNAME}! Would you like to begin an installation or use the live system?" 0 0
+bsddialog --backtitle "${OSNAME} Installer" --title "Welcome" --extra-button --extra-label "Shell" --ok-label "Install" --cancel-label "Live System" --right1-button "Repair" --yesno "Welcome to ${OSNAME}! Would you like to begin an installation or use the live system?" 0 0
 
 case $? in
 $BSDDIALOG_OK)	# Install
@@ -106,6 +107,13 @@ $BSDDIALOG_CANCEL)	# Live System
 	;;
 $BSDDIALOG_EXTRA)	# Shell
 	clear
+	echo "When finished, type 'exit' to return to the installer."
+	/bin/sh
+	. "$0"
+	;;
+$BSDDIALOG_RIGHT1)	# Repair
+	bsdinstall repair
+	echo "Selected partition is mounted at /mnt."
 	echo "When finished, type 'exit' to return to the installer."
 	/bin/sh
 	. "$0"


### PR DESCRIPTION
This patch adds a script, repair, with a new button to the installer menu, which helps users mount partitions and perform simple checks. This improves the installer by making repair routines more convenient when an installer is used to inspect and repair a system. It is a framework that can have more repairing functions added later on.

This patch is part of the code of the [GSoC 2024 Project - Installer](https://wiki.freebsd.org/SummerOfCode2024Projects/ImprovingRepairAbilityOfTheFreeBSDInstaller), whose work is committed in PR #1395 . This patch is created for the ease of getting this project's work commited.