### PR TITLE
conf: make ZFS depend on XDR sources

### DIFF
--- a/sys/conf/files
+++ b/sys/conf/files
@@ -5296,9 +5296,9 @@ xen/xenbus/xenbusb.c		optional xenhvm
 xen/xenbus/xenbusb_front.c	optional xenhvm
 xen/xenbus/xenbusb_back.c	optional xenhvm
 xen/xenmem/xenmem_if.m		optional xenhvm
-xdr/xdr.c			optional xdr | krpc | nfslockd | nfscl | nfsd
-xdr/xdr_array.c			optional xdr | krpc | nfslockd | nfscl | nfsd
-xdr/xdr_mbuf.c			optional xdr | krpc | nfslockd | nfscl | nfsd
-xdr/xdr_mem.c			optional xdr | krpc | nfslockd | nfscl | nfsd
-xdr/xdr_reference.c		optional xdr | krpc | nfslockd | nfscl | nfsd
-xdr/xdr_sizeof.c		optional xdr | krpc | nfslockd | nfscl | nfsd
+xdr/xdr.c			optional xdr | krpc | nfslockd | nfscl | nfsd | zfs
+xdr/xdr_array.c			optional xdr | krpc | nfslockd | nfscl | nfsd | zfs
+xdr/xdr_mbuf.c			optional xdr | krpc | nfslockd | nfscl | nfsd | zfs
+xdr/xdr_mem.c			optional xdr | krpc | nfslockd | nfscl | nfsd | zfs
+xdr/xdr_reference.c		optional xdr | krpc | nfslockd | nfscl | nfsd | zfs
+xdr/xdr_sizeof.c		optional xdr | krpc | nfslockd | nfscl | nfsd | zfs


### PR DESCRIPTION
ZFS nvpair.c source file depends on XDR unconditionally. This fixes the ZFS build with NFSD kernel options disabled.
