### PR TITLE
manuals: Fix "skipping end of block" .Ed errors

### DIFF
--- a/lib/libcapsicum/capsicum_helpers.3
+++ b/lib/libcapsicum/capsicum_helpers.3
@@ -175,7 +175,6 @@ Functions
 and
 .Fn caph_cache_catpages
 can not fail.
-.Ed
 .Sh SEE ALSO
 .Xr cap_enter 2 ,
 .Xr cap_rights_limit 2 ,

--- a/sbin/ggate/ggatel/ggatel.8
+++ b/sbin/ggate/ggatel/ggatel.8
@@ -133,7 +133,6 @@ To get details about the failure,
 should be called with the
 .Fl v
 option.
-.Ed
 .Sh SEE ALSO
 .Xr geom 4 ,
 .Xr ggatec 8 ,

--- a/share/man/man4/ahc.4
+++ b/share/man/man4/ahc.4
@@ -170,7 +170,6 @@ A hint to define whether the SCSI target mode is enabled, defaults to disabled
 A hint to define whether memory mapped io is enabled or disabled for this
 adapter, defaults to enabled (0 -- disabled, 1 -- enabled).
 .El
-.Ed
 .Sh HARDWARE
 The
 .Nm

--- a/share/man/man4/ahd.4
+++ b/share/man/man4/ahd.4
@@ -108,7 +108,6 @@ and the host adapter's
 .Tn SCSI
 ID.
 .El
-.Ed
 .Sh CONFIGURATION OPTIONS
 To statically configure one or more controllers to assume the target role:
 .Pp
@@ -130,7 +129,6 @@ They are:
 .It Va hint.ahd. Ns Ar N Ns Va .tmode_enable
 A hint to define whether the SCSI target mode is enabled (0 -- disabled, 1 -- enabled).
 .El
-.Ed
 .Sh HARDWARE
 The
 .Nm

--- a/share/man/man4/ddb.4
+++ b/share/man/man4/ddb.4
@@ -299,7 +299,6 @@ If the
 modifier has been specified, contents of structs nested up to
 .Ar depth
 levels deep will also be included in the output.
-.Ed
 .Pp
 .It Ic pprint struct Ns Oo Li / Ns Cm d depth Ic Oc Oo Ar name Oc Ns Op Ns Ar addr
 Print memory at
@@ -313,7 +312,6 @@ If the
 modifier has been specified, contents of structs nested up to
 .Ar depth
 levels deep will also be included in the output.
-.Ed
 .Pp
 .It Xo
 .Ic write Ns Op Li / Ns Cm bhl

--- a/share/man/man4/xen.4
+++ b/share/man/man4/xen.4
@@ -39,7 +39,6 @@ PVH mode only.
 .Pp
 Xen support is built by default in the i386 and amd64 GENERIC kernels; note
 however that host mode is only available on amd64.
-.Ed
 .Sh DESCRIPTION
 The Xen Hypervisor allows multiple virtual machines to be run on a single
 computer system.

--- a/share/man/man5/pf.conf.5
+++ b/share/man/man5/pf.conf.5
@@ -2124,7 +2124,6 @@ pass in proto tcp to port 22 set prio (2, 5)
 Only match packets which were received on the specified
 .Ar interface
 (or interface group).
-.Ed
 .It Ar tag Aq Ar string
 Packets matching this rule will be tagged with the
 specified string.

--- a/share/man/man7/networking.7
+++ b/share/man/man7/networking.7
@@ -43,7 +43,6 @@ Identify your Wi-Fi hardware:
 .Ed
 .Pp
 Configure your Wi-Fi hardware as wlan0 interface:
-.Ed
 .Bd -literal -offset 2n
 .Ic # sysrc wlans_iwn0="wlan0"
 .Ed

--- a/share/man/man9/domain.9
+++ b/share/man/man9/domain.9
@@ -183,7 +183,6 @@ has an empty slot in its
 .Va dom_protosw .
 Dynamically added protocol can later be unloaded with
 .Fn protosw_unregister .
-.Ed
 .Sh RETURN VALUES
 The
 .Fn domain_add


### PR DESCRIPTION
These were reported by `mandoc -T lint ...` as errors; this commit only handles unnecessary .Ed commands.

The rendered output (in ascii and html) is not affected by this commit.