### PR TITLE
manuals: Fix typos in -offset for .Bd and .Bl

### DIFF
--- a/bin/sh/sh.1
+++ b/bin/sh/sh.1
@@ -1074,13 +1074,13 @@ command.
 Commands may be grouped by writing either
 .Pp
 .Sm off
-.Bd -literal -offset -ident
+.Bd -literal -offset indent
 .Po Ar list Pc
 .Ed
 .Sm on
 .Pp
 or
-.Bd -literal -offset -ident
+.Bd -literal -offset indent
 .No { Ar list ; }
 .Ed
 .Pp

--- a/share/man/man4/efidev.4
+++ b/share/man/man4/efidev.4
@@ -34,7 +34,7 @@
 .Sh SYNOPSIS
 To compile this driver into the kernel, place the following lines in your
 kernel configuration file:
-.Bd -ragged -offset -indent
+.Bd -ragged -offset indent
 .Cd "options EFIRT"
 .Ed
 .Pp

--- a/share/man/man4/vmd.4
+++ b/share/man/man4/vmd.4
@@ -34,7 +34,7 @@
 .Sh SYNOPSIS
 To compile this driver into the kernel, place the following lines in your
 kernel configuration file:
-.Bd -ragged -offset -indent
+.Bd -ragged -offset indent
 .Cd "device vmd"
 .Ed
 .Pp

--- a/share/man/man5/motd.5
+++ b/share/man/man5/motd.5
@@ -25,7 +25,7 @@ and the contents are written to
 can be updated without a system reboot by manually restarting the
 motd service after updating
 .Pa /etc/motd.template :
-.Bd -literal -offset -ident -compact
+.Bd -literal -offset indent -compact
 service motd restart
 .Ed
 .Pp

--- a/share/man/man7/arch.7
+++ b/share/man/man7/arch.7
@@ -168,7 +168,7 @@ execution state, however older arm binaries are not supported by
 .Fx .
 .Pp
 On all supported architectures:
-.Bl -column -offset -indent "long long" "Size"
+.Bl -column -offset indent "long long" "Size"
 .It Sy Type Ta Sy Size
 .It short Ta 2
 .It int Ta 4

--- a/usr.bin/elfctl/elfctl.1
+++ b/usr.bin/elfctl/elfctl.1
@@ -87,12 +87,12 @@ elfctl -e +noaslr file
 .Ed
 .Pp
 Features may be specified as numerical values:
-.Bd -literal -offset -indent
+.Bd -literal -offset indent
 elfctl -e =0x0001,0x0004 file
 .Ed
 .Pp
 Features may also be specified as a single combined value:
-.Bd -literal -offset -indent
+.Bd -literal -offset indent
 elfctl -e =0x5 file
 .Ed
 .Sh SEE ALSO

--- a/usr.sbin/binmiscctl/binmiscctl.8
+++ b/usr.sbin/binmiscctl/binmiscctl.8
@@ -308,13 +308,13 @@ specified in the
 .Nm
 command.
 Using the example above:
-.Bd -literal -offset -ident
+.Bd -literal -offset indent
 mkdir $D/usr/local/bin
 cp /usr/local/bin/qemu-arm-static $D/usr/local/bin
 .Ed
 .Pp
 Now the user can chroot into the environment normally, as root:
-.Bd -literal -offset -ident
+.Bd -literal -offset indent
 chroot $D
 .Ed
 .Sh SEE ALSO

--- a/usr.sbin/pwd_mkdb/pwd_mkdb.8
+++ b/usr.sbin/pwd_mkdb/pwd_mkdb.8
@@ -139,7 +139,7 @@ A Version 7 format password file.
 .Sh EXAMPLES
 Regenerate the password database after manually editing or replacing
 the password file:
-.Bd -literal -offset -indent
+.Bd -literal -offset indent
 /usr/sbin/pwd_mkdb -p /etc/master.passwd
 .Ed
 .Sh COMPATIBILITY

--- a/usr.sbin/service/service.8
+++ b/usr.sbin/service/service.8
@@ -141,39 +141,39 @@ For a full list of commands available in most rc.d scripts, see
 .Xr rc 8 .
 .Pp
 Enable a service, then start it:
-.Bd -literal -offset -indent
+.Bd -literal -offset indent
 service sshd enable
 service sshd start
 .Ed
 .Pp
 Stop a service, then disable it:
-.Bd -literal -offset -indent
+.Bd -literal -offset indent
 service sshd stop
 service sshd disable
 .Ed
 .Pp
 Start a service which is not enabled:
-.Bd -literal -offset -indent
+.Bd -literal -offset indent
 service sshd onestart
 .Ed
 .Pp
 Report the status of a service:
-.Bd -literal -offset -ident
+.Bd -literal -offset indent
 service named status
 .Ed
 .Pp
 Restart a service running in a jail:
-.Bd -literal -offset -indent
+.Bd -literal -offset indent
 service -j dns named restart
 .Ed
 .Pp
 Start a service with a specific environment variable set:
-.Bd -literal -offset -indent
+.Bd -literal -offset indent
 service -E LC_ALL=C.UTF-8 named start
 .Ed
 .Pp
 Report a verbose listing of all available services:
-.Bd -literal -offset -indent
+.Bd -literal -offset indent
 service -rv
 .Ed
 .Pp
@@ -189,7 +189,7 @@ complete service 'c/-/(e l r v)/' 'p/1/`service -l`/' \e
 The following programmable completion entry can be used in
 .Xr bash 1
 for the names of the rc.d scripts:
-.Bd -literal -offset -ident
+.Bd -literal -offset indent
 _service () {
 	local cur
 	cur=${COMP_WORDS[COMP_CWORD]}


### PR DESCRIPTION
The intended value is:
    -offset indent
If there's any typo such that the value doesn't match the pre-defined strings, then the offset is the same width as the value.  So by chance, "-offset -ident" ended up being a standard-width indent (since the default indent is 6 chars, and "-ident" also has 6 chars), whereas "-offset -indent" had a longer indent, and "-offset ident" had a shorter one.
