### PR TITLE
sglist.9: fix typo

### DIFF
--- a/share/man/man9/sglist.9
+++ b/share/man/man9/sglist.9
@@ -285,7 +285,7 @@ to the scatter/gather list
 .Fa sg .
 .Pp
 The
-.Nm sglist_append_mbuf
+.Nm sglist_append_single_mbuf
 function appends the physical address ranges described by a single mbuf
 .Fa m
 to the scatter/gather list


### PR DESCRIPTION
In the explanation section sglist_append_mbuf is duplicated. The second reference is meant to be sglist_append_single_mbuf.