### PR TITLE
sh.1: update history + spdx + linter error

### DIFF
--- a/bin/sh/sh.1
+++ b/bin/sh/sh.1
@@ -1,4 +1,6 @@
 .\"-
+.\" SPDX-License-Identifier: BSD-3-Clause
+.\"
 .\" Copyright (c) 1991, 1993
 .\"	The Regents of the University of California.  All rights reserved.
 .\"
@@ -1074,7 +1076,6 @@ or the end of the
 command.
 .Ss Grouping Commands Together
 Commands may be grouped by writing either
-.Pp
 .Sm off
 .Bd -literal -offset indent
 .Po Ar list Pc
@@ -2923,7 +2924,9 @@ This version of
 was rewritten in 1989 under the
 .Bx
 license after the Bourne shell from
-.At V.4 .
+.At V.4
+and first appeared in
+.Bx 4.3 Net/2 .
 .Sh AUTHORS
 This version of
 .Nm

--- a/lib/libc/stdio/vfprintf.c
+++ b/lib/libc/stdio/vfprintf.c
@@ -291,13 +291,9 @@ vfprintf(FILE * __restrict fp, const char * __restrict fmt0, va_list ap)
 /*
  * The size of the buffer we use as scratch space for integer
  * conversions, among other things.  We need enough space to
- * write a uintmax_t in octal (plus one byte).
+ * write a uintmax_t in binary.
  */
-#if UINTMAX_MAX <= UINT64_MAX
-#define	BUF	32
-#else
-#error "BUF must be large enough to format a uintmax_t"
-#endif
+#define BUF	(sizeof(uintmax_t) * CHAR_BIT)
 
 /*
  * Non-MT-safe version

--- a/lib/libc/stdio/vfwprintf.c
+++ b/lib/libc/stdio/vfwprintf.c
@@ -369,13 +369,9 @@ vfwprintf(FILE * __restrict fp, const wchar_t * __restrict fmt0, va_list ap)
 /*
  * The size of the buffer we use as scratch space for integer
  * conversions, among other things.  We need enough space to
- * write a uintmax_t in octal (plus one byte).
+ * write a uintmax_t in binary.
  */
-#if UINTMAX_MAX <= UINT64_MAX
-#define	BUF	32
-#else
-#error "BUF must be large enough to format a uintmax_t"
-#endif
+#define BUF	(sizeof(uintmax_t) * CHAR_BIT)
 
 /*
  * Non-MT-safe version

--- a/share/man/man4/vt.4
+++ b/share/man/man4/vt.4
@@ -56,6 +56,7 @@ In
 In
 .Xr loader.conf 5 or
 .Xr sysctl.conf 5 :
+.Cd kern.consmute=1
 .Cd kern.vt.kbd_halt=1
 .Cd kern.vt.kbd_poweroff=1
 .Cd kern.vt.kbd_reboot=1
@@ -319,6 +320,8 @@ prompt, set in
 or changed at runtime with
 .Xr sysctl 8 .
 .Bl -tag -width indent
+.It Va kern.consmute
+Disable printing kernel messages to the system console.
 .It Va kern.vt.enable_bell
 Enable the terminal bell.
 .El

--- a/sys/amd64/acpica/acpi_wakeup.c
+++ b/sys/amd64/acpica/acpi_wakeup.c
@@ -202,6 +202,9 @@ acpi_sleep_machdep(struct acpi_softc *sc, int state)
 
 	intr_suspend();
 
+	if (vmm_suspend_p != NULL)
+		vmm_suspend_p();
+
 	pcb = &susppcbs[0]->sp_pcb;
 	if (savectx(pcb)) {
 		fpususpend(susppcbs[0]->sp_fpususpend);

--- a/sys/amd64/amd64/machdep.c
+++ b/sys/amd64/amd64/machdep.c
@@ -213,6 +213,7 @@ struct mem_range_softc mem_range_softc;
 
 struct mtx dt_lock;	/* lock for GDT and LDT */
 
+void (*vmm_suspend_p)(void);
 void (*vmm_resume_p)(void);
 
 bool efi_boot;

--- a/sys/amd64/include/cpu.h
+++ b/sys/amd64/include/cpu.h
@@ -70,7 +70,8 @@ extern char	btext[];
 extern char	_end[];
 extern char	etext[];
 
-/* Resume hook for VMM. */
+/* Suspend and resume hook for VMM. */
+extern	void (*vmm_suspend_p)(void);
 extern	void (*vmm_resume_p)(void);
 
 void	cpu_halt(void);

--- a/sys/amd64/include/vmm.h
+++ b/sys/amd64/include/vmm.h
@@ -170,6 +170,7 @@ struct vm_eventinfo {
 
 typedef int	(*vmm_init_func_t)(int ipinum);
 typedef int	(*vmm_cleanup_func_t)(void);
+typedef void	(*vmm_suspend_func_t)(void);
 typedef void	(*vmm_resume_func_t)(void);
 typedef void *	(*vmi_init_func_t)(struct vm *vm, struct pmap *pmap);
 typedef int	(*vmi_run_func_t)(void *vcpui, register_t rip,
@@ -194,6 +195,7 @@ typedef int	(*vmi_restore_tsc_t)(void *vcpui, uint64_t now);
 struct vmm_ops {
 	vmm_init_func_t		modinit;	/* module wide initialization */
 	vmm_cleanup_func_t	modcleanup;
+	vmm_resume_func_t	modsuspend;
 	vmm_resume_func_t	modresume;
 
 	vmi_init_func_t		init;		/* vm-specific initialization */

--- a/sys/amd64/vmm/amd/svm.c
+++ b/sys/amd64/vmm/amd/svm.c
@@ -278,6 +278,13 @@ svm_modinit(int ipinum)
 }
 
 static void
+svm_modsuspend(void)
+{
+
+	return;
+}
+
+static void
 svm_modresume(void)
 {
 

--- a/sys/amd64/vmm/intel/vmx.c
+++ b/sys/amd64/vmm/intel/vmx.c
@@ -649,11 +649,19 @@ vmx_enable(void *arg __unused)
 }
 
 static void
+vmx_modsuspend(void)
+{
+
+	if (vmxon_enabled[curcpu])
+		vmx_disable(NULL);
+}
+
+static void
 vmx_modresume(void)
 {
 
 	if (vmxon_enabled[curcpu])
-		vmxon(&vmxon_region[curcpu * PAGE_SIZE]);
+		vmx_enable(NULL);
 }
 
 static int
@@ -4271,6 +4279,7 @@ vmx_restore_tsc(void *vcpui, uint64_t offset)
 const struct vmm_ops vmm_ops_intel = {
 	.modinit	= vmx_modinit,
 	.modcleanup	= vmx_modcleanup,
+	.modsuspend	= vmx_modsuspend,
 	.modresume	= vmx_modresume,
 	.init		= vmx_init,
 	.run		= vmx_run,

--- a/sys/amd64/vmm/vmm.c
+++ b/sys/amd64/vmm/vmm.c
@@ -232,6 +232,7 @@ vmmops_panic(void)
 
 DEFINE_VMMOPS_IFUNC(int, modinit, (int ipinum))
 DEFINE_VMMOPS_IFUNC(int, modcleanup, (void))
+DEFINE_VMMOPS_IFUNC(void, modsuspend, (void))
 DEFINE_VMMOPS_IFUNC(void, modresume, (void))
 DEFINE_VMMOPS_IFUNC(void *, init, (struct vm *vm, struct pmap *pmap))
 DEFINE_VMMOPS_IFUNC(int, run, (void *vcpui, register_t rip, struct pmap *pmap,
@@ -452,6 +453,7 @@ vmm_init(void)
 	if (error)
 		return (error);
 
+	vmm_suspend_p = vmmops_modsuspend;
 	vmm_resume_p = vmmops_modresume;
 
 	return (vmmops_modinit(vmm_ipinum));
@@ -479,6 +481,7 @@ vmm_handler(module_t mod, int what, void *arg)
 		if (vmm_is_hw_supported()) {
 			error = vmmdev_cleanup();
 			if (error == 0) {
+				vmm_suspend_p = NULL;
 				vmm_resume_p = NULL;
 				iommu_cleanup();
 				if (vmm_ipinum != IPI_AST)

--- a/sys/compat/linux/linux_xattr.c
+++ b/sys/compat/linux/linux_xattr.c
@@ -98,7 +98,7 @@ error_to_xattrerror(int attrnamespace, int error)
 }
 
 static int
-xatrr_to_extattr(const char *uattrname, int *attrnamespace, char *attrname)
+xattr_to_extattr(const char *uattrname, int *attrnamespace, char *attrname)
 {
 	char uname[LINUX_XATTR_NAME_MAX + 1], *dot;
 	size_t len, cplen;
@@ -255,7 +255,7 @@ removexattr(struct thread *td, struct removexattr_args *args)
 	char attrname[LINUX_XATTR_NAME_MAX + 1];
 	int attrnamespace, error;
 
-	error = xatrr_to_extattr(args->name, &attrnamespace, attrname);
+	error = xattr_to_extattr(args->name, &attrnamespace, attrname);
 	if (error != 0)
 		return (error);
 	if (args->path != NULL)
@@ -312,7 +312,7 @@ getxattr(struct thread *td, struct getxattr_args *args)
 	char attrname[LINUX_XATTR_NAME_MAX + 1];
 	int attrnamespace, error;
 
-	error = xatrr_to_extattr(args->name, &attrnamespace, attrname);
+	error = xattr_to_extattr(args->name, &attrnamespace, attrname);
 	if (error != 0)
 		return (error);
 	if (args->path != NULL)
@@ -378,7 +378,7 @@ setxattr(struct thread *td, struct setxattr_args *args)
 	if ((args->flags & ~(LINUX_XATTR_FLAGS)) != 0 ||
 	    args->flags == (LINUX_XATTR_FLAGS))
 		return (EINVAL);
-	error = xatrr_to_extattr(args->name, &attrnamespace, attrname);
+	error = xattr_to_extattr(args->name, &attrnamespace, attrname);
 	if (error != 0)
 		return (error);
 

--- a/sys/kern/kern_cons.c
+++ b/sys/kern/kern_cons.c
@@ -525,6 +525,9 @@ cnputc(int c)
 	struct consdev *cn;
 	const char *cp;
 
+	if (cn_mute || c == '\0')
+		return;
+
 #ifdef EARLY_PRINTF
 	if (early_putc != NULL) {
 		if (c == '\n')
@@ -534,8 +537,6 @@ cnputc(int c)
 	}
 #endif
 
-	if (cn_mute || c == '\0')
-		return;
 	STAILQ_FOREACH(cnd, &cn_devlist, cnd_next) {
 		cn = cnd->cnd_cn;
 		if (!kdb_active || !(cn->cn_flags & CN_FLAG_NODEBUG)) {

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -112,6 +112,7 @@ struct snprintf_arg {
 };
 
 extern	int log_open;
+extern	int cn_mute;
 
 static void  msglogchar(int c, int pri);
 static void  msglogstr(char *str, int pri, int filter_cr);
@@ -425,7 +426,7 @@ prf_putchar(int c, int flags, int pri)
 		msgbuftrigger = 1;
 	}
 
-	if (flags & TOCONS) {
+	if ((flags & TOCONS) && !cn_mute) {
 		if ((!KERNEL_PANICKED()) && (constty != NULL))
 			msgbuf_addchar(&consmsgbuf, c);
 
@@ -443,7 +444,7 @@ prf_putbuf(char *bufr, int flags, int pri)
 		msgbuftrigger = 1;
 	}
 
-	if (flags & TOCONS) {
+	if ((flags & TOCONS) && !cn_mute) {
 		if ((!KERNEL_PANICKED()) && (constty != NULL))
 			msgbuf_addstr(&consmsgbuf, -1,
 			    bufr, /*filter_cr*/ 0);
@@ -510,6 +511,11 @@ putchar(int c, void *arg)
 
 	if ((flags & TOTTY) && tp != NULL && !KERNEL_PANICKED())
 		tty_putchar(tp, c);
+
+	if ((flags & TOCONS ) && cn_mute) {
+		flags &= ~TOCONS;
+		ap->flags = flags;
+	}
 
 	if ((flags & (TOCONS | TOLOG)) && c != '\0')
 		putbuf(c, ap);

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -512,7 +512,7 @@ putchar(int c, void *arg)
 	if ((flags & TOTTY) && tp != NULL && !KERNEL_PANICKED())
 		tty_putchar(tp, c);
 
-	if ((flags & TOCONS ) && cn_mute) {
+	if ((flags & TOCONS) && cn_mute) {
 		flags &= ~TOCONS;
 		ap->flags = flags;
 	}

--- a/sys/netpfil/ipfw/ip_fw_dynamic.c
+++ b/sys/netpfil/ipfw/ip_fw_dynamic.c
@@ -144,10 +144,10 @@ struct dyn_data {
 	uint32_t	sync;		/* synchronization time */
 	uint32_t	expire;		/* expire time */
 
-	uint64_t	pcnt_fwd;	/* bytes counter in forward */
-	uint64_t	bcnt_fwd;	/* packets counter in forward */
-	uint64_t	pcnt_rev;	/* bytes counter in reverse */
-	uint64_t	bcnt_rev;	/* packets counter in reverse */
+	uint64_t	pcnt_fwd;	/* packets counter in forward */
+	uint64_t	bcnt_fwd;	/* bytes counter in forward */
+	uint64_t	pcnt_rev;	/* packets counter in reverse */
+	uint64_t	bcnt_rev;	/* bytes counter in reverse */
 };
 
 #define	DPARENT_COUNT_DEC(p)	do {			\

--- a/sys/x86/x86/mp_x86.c
+++ b/sys/x86/x86/mp_x86.c
@@ -1591,6 +1591,11 @@ cpususpend_handler(void)
 
 	mtx_assert(&smp_ipi_mtx, MA_NOTOWNED);
 
+#ifdef __amd64__
+	if (vmm_suspend_p)
+		vmm_suspend_p();
+#endif
+
 	cpu = PCPU_GET(cpuid);
 
 #ifdef XENHVM

--- a/usr.bin/tip/tip/cu.1
+++ b/usr.bin/tip/tip/cu.1
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-3-Clause
+.\"
 .\"	$OpenBSD: cu.1,v 1.3 2006/06/07 06:35:59 mbalmer Exp $
 .\"
 .\" Copyright (c) 1980, 1990, 1993
@@ -32,7 +35,7 @@
 .Os
 .Sh NAME
 .Nm cu
-.Nd call UNIX
+.Nd call UNIX over a serial line
 .Sh SYNOPSIS
 .Nm
 .Op Fl ehot

--- a/usr.bin/xinstall/tests/install_test.sh
+++ b/usr.bin/xinstall/tests/install_test.sh
@@ -32,6 +32,15 @@ copy_to_empty_body() {
 	    install testf ""
 }
 
+atf_test_case copy_to_nonexistent_dir
+copy_to_nonexistent_dir_body() {
+	local dir="/nonexistent"
+
+	printf 'test\n123\r456\r\n789\0z' >testf
+	atf_check -s not-exit:0 -e match:$dir": No such file or directory" \
+	    install testf $dir/testf
+}
+
 copy_to_nonexistent_with_opts() {
 	printf 'test\n123\r456\r\n789\0z' >testf
 	atf_check install "$@" testf copyf
@@ -506,6 +515,7 @@ set_optional_exec_body()
 atf_init_test_cases() {
 	atf_add_test_case copy_to_empty
 	atf_add_test_case copy_to_nonexistent
+	atf_add_test_case copy_to_nonexistent_dir
 	atf_add_test_case copy_to_nonexistent_safe
 	atf_add_test_case copy_to_nonexistent_comparing
 	atf_add_test_case copy_to_nonexistent_safe_comparing

--- a/usr.bin/xinstall/xinstall.c
+++ b/usr.bin/xinstall/xinstall.c
@@ -869,7 +869,7 @@ install(const char *from_name, const char *to_name, u_long fset, u_int flags)
 		to_fd = create_tempfile(to_name, tempfile,
 		    sizeof(tempfile));
 		if (to_fd < 0)
-			err(EX_OSERR, "%s", tempfile);
+			err(EX_OSERR, "%s", dirname(tempfile));
 		if (!devnull) {
 			if (dostrip) {
 				stripped = strip(tempfile, to_fd, from_name,


### PR DESCRIPTION
When I first discovered the history section of the BSD manual, I knew I had stumbled into a cathedral. In just a few sentances, it provides the reader with a idea of how Chestertons fence came to be there, creating context to begin understanding the deeper spiritual meaning of POLA and consistency in the design philosophy of our community. 

Reinforce this elegance by adding the release when Almquists shell first appeared in BSD. While here, tag spdx and remove a redundant macro.

History source:	www.in-ulm.de/~mascheck/various/ash/#bsd