### PR TITLE
sysent: Remove comment aligning

### DIFF
--- a/sys/tools/makesyscalls.lua
+++ b/sys/tools/makesyscalls.lua
@@ -637,15 +637,6 @@ local function get_mask_pat(pflags)
 	return mask
 end
 
-local function align_sysent_comment(col)
-	write_line("sysent", "\t")
-	col = col + 8 - col % 8
-	while col < 56 do
-		write_line("sysent", "\t")
-		col = col + 8
-	end
-end
-
 local function strip_arg_annotations(arg)
 	arg = arg:gsub("_Contains_[^ ]*[_)] ?", "")
 	arg = arg:gsub("_In[^ ]*[_)] ?", "")
@@ -888,20 +879,17 @@ local function handle_noncompat(sysnum, thr_flag, flags, sysflags, rettype,
 
 	write_line("sysent",
 	    string.format("\t{ .sy_narg = %s, .sy_call = (sy_call_t *)", argssize))
-	local column = 8 + 2 + #argssize + 15
 
 	if flags & known_flags.SYSMUX ~= 0 then
 		write_line("sysent", string.format(
 		    "nosys, .sy_auevent = AUE_NULL, " ..
 		    ".sy_flags = %s, .sy_thrcnt = SY_THR_STATIC },",
 		    sysflags))
-		column = column + #"nosys" + #"AUE_NULL" + 3
 	elseif flags & known_flags.NOSTD ~= 0 then
 		write_line("sysent", string.format(
 		    "lkmressys, .sy_auevent = AUE_NULL, " ..
 		    ".sy_flags = %s, .sy_thrcnt = SY_THR_ABSENT },",
 		    sysflags))
-		column = column + #"lkmressys" + #"AUE_NULL" + 3
 	else
 		if funcname == "nosys" or funcname == "lkmnosys" or
 		    funcname == "sysarch" or funcname:find("^freebsd") or
@@ -909,17 +897,14 @@ local function handle_noncompat(sysnum, thr_flag, flags, sysflags, rettype,
 			write_line("sysent", string.format(
 			    "%s, .sy_auevent = %s, .sy_flags = %s, .sy_thrcnt = %s },",
 			    funcname, auditev, sysflags, thr_flag))
-			column = column + #funcname + #auditev + #sysflags + 3
 		else
 			write_line("sysent", string.format(
 			    "sys_%s, .sy_auevent = %s, .sy_flags = %s, .sy_thrcnt = %s },",
 			    funcname, auditev, sysflags, thr_flag))
-			column = column + #funcname + #auditev + #sysflags + 7
 		end
 	end
 
-	align_sysent_comment(column)
-	write_line("sysent", string.format("/* %d = %s */\n",
+	write_line("sysent", string.format("\t/* %d = %s */\n",
 	    sysnum, funcalias))
 	write_line("sysnames", string.format("\t\"%s\",\t\t\t/* %d = %s */\n",
 	    funcalias, sysnum, funcalias))
@@ -987,9 +972,8 @@ local function handle_obsol(sysnum, funcname, comment)
 	write_line("sysent",
 	    "\t{ .sy_narg = 0, .sy_call = (sy_call_t *)nosys, " ..
 	    ".sy_auevent = AUE_NULL, .sy_flags = 0, .sy_thrcnt = SY_THR_ABSENT },")
-	align_sysent_comment(34)
 
-	write_line("sysent", string.format("/* %d = obsolete %s */\n",
+	write_line("sysent", string.format("\t/* %d = obsolete %s */\n",
 	    sysnum, comment))
 	write_line("sysnames", string.format(
 	    "\t\"obs_%s\",\t\t\t/* %d = obsolete %s */\n",
@@ -1058,17 +1042,13 @@ local function handle_compat(sysnum, thr_flag, flags, sysflags, rettype,
 		    ".sy_auevent = %s, .sy_flags = 0, " ..
 		    ".sy_thrcnt = SY_THR_ABSENT },",
 		    "0", "lkmressys", "AUE_NULL"))
-		align_sysent_comment(8 + 2 + #"0" + 15 + #"lkmressys" +
-		    #"AUE_NULL" + 3)
 	else
 		write_line("sysent", string.format(
 		    "\t{ %s(%s,%s), .sy_auevent = %s, .sy_flags = %s, .sy_thrcnt = %s },",
 		    wrap, argssize, funcname, auditev, sysflags, thr_flag))
-		align_sysent_comment(8 + 9 + #argssize + 1 + #funcname +
-		    #auditev + #sysflags + 4)
 	end
 
-	write_line("sysent", string.format("/* %d = %s %s */\n",
+	write_line("sysent", string.format("\t/* %d = %s %s */\n",
 	    sysnum, descr, funcalias))
 	write_line("sysnames", string.format(
 	    "\t\"%s.%s\",\t\t/* %d = %s %s */\n",
@@ -1098,7 +1078,7 @@ local function handle_unimpl(sysnum, sysstart, sysend, comment)
 		write_line("sysent", string.format(
 		    "\t{ .sy_narg = 0, .sy_call = (sy_call_t *)nosys, " ..
 		    ".sy_auevent = AUE_NULL, .sy_flags = 0, " ..
-		    ".sy_thrcnt = SY_THR_ABSENT },\t\t\t/* %d = %s */\n",
+		    ".sy_thrcnt = SY_THR_ABSENT },\t/* %d = %s */\n",
 		    sysnum, comment))
 		write_line("sysnames", string.format(
 		    "\t\"#%d\",\t\t\t/* %d = %s */\n",


### PR DESCRIPTION
Comment aligning was inconsistent and required a ton of book-keeping.
Replaced comment aligning with a simple, single tab out.
See [Refactor makesyscalls.lua #1362](https://github.com/freebsd/freebsd-src/pull/1362).