### PR TITLE
grep: fix output duplication when number of matches is greater than MAX_MATCHES

### DIFF
--- a/usr.bin/grep/grep.h
+++ b/usr.bin/grep/grep.h
@@ -105,6 +105,7 @@ struct parsec {
 	/* XXX TODO: This should be a chunk, not a line */
 	struct str	ln;				/* Current line */
 	size_t		lnstart;			/* Position in line */
+	size_t		prstart;			/* Printing start pos */
 	size_t		matchidx;			/* Latest match index */
 	int		printed;			/* Metadata printed? */
 	bool		binary;				/* Binary file? */

--- a/usr.bin/grep/util.c
+++ b/usr.bin/grep/util.c
@@ -73,6 +73,7 @@ static int litexec(const struct pat *pat, const char *string,
 #endif
 static bool procline(struct parsec *pc);
 static void printline(struct parsec *pc, int sep);
+static void printtail(struct parsec *pc);
 static void printline_metadata(struct str *line, int sep);
 
 bool
@@ -214,6 +215,7 @@ procmatch_match(struct mprintc *mc, struct parsec *pc)
 
 	/* Print the matching line, but only if not quiet/binary */
 	if (mc->printmatch) {
+		pc->prstart = 0;
 		printline(pc, ':');
 		while (pc->matchidx >= MAX_MATCHES) {
 			/* Reset matchidx and try again */
@@ -223,6 +225,9 @@ procmatch_match(struct mprintc *mc, struct parsec *pc)
 			else
 				break;
 		}
+		pc->matchidx = 0;
+		printtail(pc);
+
 		first_match = false;
 		mc->same_file = true;
 		mc->last_outed = 0;
@@ -354,6 +359,7 @@ procfile(const char *fn)
 		pc.printed = 0;
 		pc.matchidx = 0;
 		pc.lnstart = 0;
+		pc.prstart = 0;
 		pc.ln.boff = 0;
 		pc.ln.off += pc.ln.len + 1;
 		/* XXX TODO: Grab a chunk */
@@ -762,6 +768,7 @@ printline(struct parsec *pc, int sep)
 		return;
 
 	matchidx = pc->matchidx;
+	a = pc->prstart;
 
 	/* --color and -o */
 	if ((oflag || color) && matchidx > 0) {
@@ -793,13 +800,28 @@ printline(struct parsec *pc, int sep)
 			if (oflag)
 				putchar('\n');
 		}
-		if (!oflag) {
-			if (pc->ln.len - a > 0)
-				fwrite(pc->ln.dat + a, pc->ln.len - a, 1,
-				    stdout);
-			putchar('\n');
-		}
+		pc->prstart = a;
 	} else
 		grep_printline(&pc->ln, sep);
 	pc->printed++;
+}
+
+/*
+ * Prints tail (a piece after the last match) of the matched line.
+ * When color mode is enabled printline() prints up to MAX_MATCHES at once,
+ * so it can be called multiple times. In this case printtail() is called
+ * after a series of printline() to print end of the matched line.
+ */
+static void
+printtail(struct parsec *pc)
+{
+    if (color && !oflag && pc->prstart > 0) {
+        size_t n = pc->ln.len - pc->prstart;
+        if (n > 0) {
+            fwrite(pc->ln.dat + pc->prstart, n, 1, stdout);
+        }
+        putchar('\n');
+    }
+
+    pc->prstart = pc->ln.len;
 }


### PR DESCRIPTION
When color is enable grep(1) searches for MAX_MATCHES, prints the line and then repeats these steps again untill all matches in the line are found. The issue is that every time grep(1) prints the whole line which leads to the situation when line is duplicated (tripled, quadruple, ...) in stdout.

Bug can be reproduced with the next simple command. It prints line twice when only single line is expected.

$ for i in $(seq 33); do echo -n "foobar"; done | ./grep --color=auto foo