### PR TITLE
Makefile.inc1: allow real-update-packages to be called independently

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -2058,8 +2058,8 @@ PKGMAKEARGS+=	PKG_VERSION=${PKG_VERSION} \
 packages: .PHONY
 	${_+_}${MAKE} -C ${.CURDIR} ${PKGMAKEARGS} real-packages
 
-update-packages: .PHONY
-	${_+_}${MAKE} -C ${.CURDIR} ${PKGMAKEARGS} real-update-packages
+update-packages: stage-packages .PHONY
+	${_+_}${MAKE} -C ${.CURDIR} ${PKGMAKEARGS} create-packages real-update-packages
 
 package-pkg: .PHONY
 	rm -rf /tmp/ports.${TARGET} || :
@@ -2071,8 +2071,7 @@ package-pkg: .PHONY
 
 real-packages:	stage-packages create-packages sign-packages .PHONY
 
-real-update-packages: stage-packages .PHONY
-	${_+_}${MAKE} -C ${.CURDIR} PKG_VERSION=${PKG_VERSION} create-packages
+real-update-packages: .PHONY
 .if defined(PKG_VERSION_FROM_DIR)
 	@echo "==> Checking for new packages (comparing ${PKG_VERSION} to ${PKG_VERSION_FROM})"
 	@for pkg in ${PKG_VERSION_FROM_DIR}/${PKG_NAME_PREFIX}-*; do \

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -2026,8 +2026,8 @@ PKG_EXT=	${PKG_FORMAT}
 PKG_EXT=	pkg
 .endif
 
-.if !defined(PKG_VERSION_FROM) && make(real-update-packages)
-.if exists(${PKG_ABI_FILE}) && exists(${REPODIR}/${PKG_ABI}/latest)
+.if !defined(PKG_VERSION_FROM) && make(real-update-packages) && \
+    exists(${PKG_ABI_FILE}) && exists(${REPODIR}/${PKG_ABI}/latest)
 PKG_VERSION_FROM!=/usr/bin/readlink ${REPODIR}/${PKG_ABI}/latest
 PKG_VERSION_FROM_DIR=	${REPODIR}/${PKG_ABI}/${PKG_VERSION_FROM}
 # Determine the name of the branch base on the version
@@ -2049,11 +2049,6 @@ BRANCH_EXT_FROM=	beta
 BRANCH_EXT_FROM=	rc
 .elif ${PKG_VERSION_FROM:M*.a*}
 BRANCH_EXT_FROM=	alpha
-.endif
-.else
-PKG_VERSION_FROM=
-PKG_VERSION_FROM_DIR=
-BRANCH_EXT_FROM=
 .endif
 .endif
 
@@ -2078,9 +2073,7 @@ real-packages:	stage-packages create-packages sign-packages .PHONY
 
 real-update-packages: stage-packages .PHONY
 	${_+_}${MAKE} -C ${.CURDIR} PKG_VERSION=${PKG_VERSION} create-packages
-.if empty(PKG_VERSION_FROM_DIR)
-	@echo "==> Bootstrapping repository, not checking for new packages"
-.else
+.if defined(PKG_VERSION_FROM_DIR)
 	@echo "==> Checking for new packages (comparing ${PKG_VERSION} to ${PKG_VERSION_FROM})"
 	@for pkg in ${PKG_VERSION_FROM_DIR}/${PKG_NAME_PREFIX}-*; do \
 	  pkgname=$$(pkg query -F $${pkg} '%n' | sed 's/${PKG_NAME_PREFIX}-\(.*\)/\1/') ; \
@@ -2098,9 +2091,10 @@ real-update-packages: stage-packages .PHONY
 	    echo "==> New package $${newpkgname}" ; \
 	  fi ; \
 	done
+.else
+	@echo "==> Bootstrapping repository, not checking for new packages"
 .endif
-	${_+_}@cd ${.CURDIR}; \
-		${MAKE} -f Makefile.inc1 PKG_VERSION=${PKG_VERSION} sign-packages
+	${_+_}${MAKE} -C ${.CURDIR} -f Makefile.inc1 PKG_VERSION=${PKG_VERSION} sign-packages
 
 stage-packages-world: .PHONY
 	@mkdir -p ${WSTAGEDIR}

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -2027,7 +2027,7 @@ PKG_EXT=	pkg
 .endif
 
 .if !defined(PKG_VERSION_FROM) && make(real-update-packages)
-.if exists(${PKG_ABI_FILE}) && exists(${REPODIR}/${PKG_ABI})
+.if exists(${PKG_ABI_FILE}) && exists(${REPODIR}/${PKG_ABI}/latest)
 PKG_VERSION_FROM!=/usr/bin/readlink ${REPODIR}/${PKG_ABI}/latest
 PKG_VERSION_FROM_DIR=	${REPODIR}/${PKG_ABI}/${PKG_VERSION_FROM}
 # Determine the name of the branch base on the version


### PR DESCRIPTION
To perform an incremental update of a pkgbase repo, you would call 'make update-packages', which will stage, create, and incrementally choose newer package versions to sign as part of a pkg repo. However, this forces you to stage the kernel and source packages along with the world packages. For a jail-only installation of FreeBSD, these packages are generally not required.

This patch separates the 'update-packages' target from the 'real-update-packages' target to allow choosing world, kernel, and/or source individually at the command line like so:

Jail-only installation:
```sh
make [...] -j$(nproc) buildworld
make [...] PKG_VERSION='15.snap<date>' \
    stage-packages-world create-packages-world \
    real-update-packages
```
Other minor changes are included to fix the PKG_VERSION variable definition logic and order of operations.