### PR TITLE
ice(4): properly use kernel option RSS

### DIFF
--- a/sys/dev/ice/ice_lib.h
+++ b/sys/dev/ice/ice_lib.h
@@ -40,6 +40,9 @@
 #ifndef _ICE_LIB_H_
 #define _ICE_LIB_H_
 
+/* include kernel options first */
+#include "ice_opts.h"
+
 #include <sys/types.h>
 #include <sys/bus.h>
 #include <sys/rman.h>

--- a/sys/dev/ice/ice_rss.h
+++ b/sys/dev/ice/ice_rss.h
@@ -68,14 +68,6 @@ CTASSERT(ICE_AQC_GET_SET_RSS_KEY_DATA_RSS_KEY_SIZE >= RSS_KEYSIZE);
 #define	RSS_HASHTYPE_RSS_UDP_IPV6	(1 << 9)	/* IPv6 UDP 4-tuple */
 #define	RSS_HASHTYPE_RSS_UDP_IPV6_EX	(1 << 10)	/* IPv6 UDP 4-tuple + ext hdrs */
 
-#define ICE_DEFAULT_RSS_HASH_CONFIG \
-	((u_int)(RSS_HASHTYPE_RSS_IPV4 | \
-		 RSS_HASHTYPE_RSS_TCP_IPV4 | \
-		 RSS_HASHTYPE_RSS_UDP_IPV4 | \
-		 RSS_HASHTYPE_RSS_IPV6 | \
-		 RSS_HASHTYPE_RSS_TCP_IPV6 | \
-		 RSS_HASHTYPE_RSS_UDP_IPV6))
-
 #define rss_getkey(key) ice_get_default_rss_key(key)
 #define rss_getnumbuckets() (mp_ncpus)
 #define rss_get_indirection_to_bucket(index) (index)
@@ -112,5 +104,13 @@ rss_hash2bucket(uint32_t hash_val, uint32_t hash_type, uint32_t *bucket_id)
 }
 
 #endif /* !RSS */
+
+#define ICE_DEFAULT_RSS_HASH_CONFIG \
+	((u_int)(RSS_HASHTYPE_RSS_IPV4 | \
+		 RSS_HASHTYPE_RSS_TCP_IPV4 | \
+		 RSS_HASHTYPE_RSS_UDP_IPV4 | \
+		 RSS_HASHTYPE_RSS_IPV6 | \
+		 RSS_HASHTYPE_RSS_TCP_IPV6 | \
+		 RSS_HASHTYPE_RSS_UDP_IPV6))
 
 #endif /* _ICE_COMMON_COMPAT_H_ */


### PR DESCRIPTION
Header ice_rss.h uses the kernel RSS interface if option RSS is defined. However when ice_rss.h is included by ice_lib.h there is no prior inclusion of ice_opts.h to set RSS causing ifdef RSS to always fail. Add ice_opts.h to the top of ice_lib.h (like ice_iflib.h) so RSS can be defined when ice_rss.h is parsed.

With that in place, compilation fails due to a missing defintion of ICE_DEFAULT_RSS_HASH_CONFIG. It is defined in ice_rss.h only when RSS is not defined. Since this define is not part of the kernel RSS interface but ice-specific, it should always be defined. Move its definition outside of ifdef RSS.

This was reported as [bugzilla 255309](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255309) back in April 2021. erj said in June 2021, "This patch looks valid to me. I'll get it in after this update" but it never was merged. I've been using this patch ever since.