### PR TITLE
wpa_supplicant: xref all important wpa_passphrase

### DIFF
--- a/usr.sbin/wpa/wpa_supplicant/wpa_supplicant.8
+++ b/usr.sbin/wpa/wpa_supplicant/wpa_supplicant.8
@@ -160,7 +160,8 @@ Wait for a control interface monitor before starting.
 .Xr wpa_supplicant.conf 5 ,
 .Xr devd 8 ,
 .Xr ifconfig 8 ,
-.Xr wpa_cli 8
+.Xr wpa_cli 8 ,
+.Xr wpa_passphrase 8
 .Sh HISTORY
 The
 .Nm


### PR DESCRIPTION
`wpa_passphrase(8)` is the key to the process of simply configuing client Wi-Fi with atomic commands on FreeBSD, taking the SSID and passphrase and formating it correctly to be appeneded to the configuration file.

Add it to the see also section of `wpa_supplicant(8)`, the daemon that handles the handshake.