### PR TITLE
wifi manuals: polish

### DIFF
--- a/share/man/man4/iwlwifi.4
+++ b/share/man/man4/iwlwifi.4
@@ -1,4 +1,6 @@
 .\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2021-2024 The FreeBSD Foundation
 .\"
 .\" This documentation was written by Bj\xc3\xb6rn Zeeb under sponsorship from
@@ -66,26 +68,20 @@ driver which supports older chipsets.
 .Pp
 The driver uses the
 .\" No LinuxKPI man pages so no .Xr here.
-.Em linuxkpi_wlan
+.Sy linuxkpi_wlan
 and
-.Em linuxkpi
+.Sy linuxkpi
 compat framework to bridge between the Linux and
 native
 .Fx
 driver code as well as to the native
 .Xr net80211 4
 wireless stack.
-.Pp
-While
-.Nm
-supports all 802.11 a/b/g/n/ac/ax
-the compatibility code currently only supports 802.11 a/b/g modes.
-Support for 802.11 n/ac is to come. 802.11ax and 6Ghz support are planned.
 .Sh HARDWARE
 The
 .Nm
 driver supports PCIe devices from the
-.Em mvm
+.Sy mvm
 sub-driver with the following chipset generations:
 .Pp
 .\" awk -F\\t '{ print $5 }' ~/tmp/iwlwifi_pci_ids_name.txt | \
@@ -111,12 +107,12 @@ SC
 These chipset generations match the following common device names:
 .Pp
 .Bl -bullet -compact
-.\" ---------------------------------------------------------------------
+.\" --------------------------------------------------------------------
 .\" This list is manually generated from a sysctl and post-processing.
 .\" Edits will be overwritten on next update.
 .\" awk -F\\t '{ if ($2 == "") { next; } if (seen[$2]) { next; } \
 .\" seen[$2]=1; printf ".It\n%s\n", $2; }' iwlwifi_pci_ids_name.txt
-.\" ---------------------------------------------------------------------
+.\" --------------------------------------------------------------------
 .It
 Intel(R) Dual Band Wireless AC 7260
 .It
@@ -163,8 +159,6 @@ Killer(R) Wireless-AC 1550i Wireless Network Adapter (9560NGW) 160MHz
 Killer(R) Wi-Fi 6E AX1690s 160MHz Wireless Network Adapter (411D2W)
 .It
 Killer(R) Wi-Fi 6E AX1690i 160MHz Wireless Network Adapter (411NGW)
-.It
-Intel(R) Wireless-AC 9260-1
 .It
 Intel(R) Wi-Fi 6 AX200 160MHz
 .It
@@ -237,15 +231,15 @@ Intel(R) TBD Sc device
 Intel(R) TBD Sc2 device
 .It
 Intel(R) TBD Sc2f device
-.\" ---------------------------------------------------------------------
+.\" --------------------------------------------------------------------
 .El
-.Sh BUGS
-Certainly.
 .Sh SEE ALSO
 .Xr iwlwififw 4 ,
 .Xr iwm 4 ,
 .Xr iwn 4 ,
 .Xr wlan 4 ,
+.Xr networking 7 ,
+.Xr fwget 8 ,
 .Xr ifconfig 8 ,
 .Xr wpa_supplicant 8
 .Sh HISTORY
@@ -253,3 +247,12 @@ The
 .Nm
 driver first appeared in
 .Fx 13.1 .
+.Sh BUGS
+Certainly.
+.Pp
+While
+.Nm
+supports 802.11a/b/g/n/ac/ax modes,
+the compatibility code currently only supports 802.11a/b/g modes.
+Support for 802.11n/ac/ax is yet to come.
+802.11ax and 6Ghz support are planned.

--- a/share/man/man4/mt7915.4
+++ b/share/man/man4/mt7915.4
@@ -1,4 +1,6 @@
 .\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2023-2024 Bjoern A. Zeeb
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -62,36 +64,34 @@ Otherwise no
 .Xr wlan 4
 interface can be created using
 .Xr ifconfig 8 .
+One can use
+.Xr fwget 8
+to install the correct firmware package.
 .Pp
 The driver uses the
 .\" No LinuxKPI man pages so no .Xr here.
-.Em linuxkpi_wlan
+.Sy linuxkpi_wlan
 and
-.Em linuxkpi
+.Sy linuxkpi
 compat framework to bridge between the Linux and
 native
 .Fx
 driver code as well as to the native
 .Xr net80211 4
 wireless stack.
-.Pp
-While
-.Nm
-supports all 802.11 a/b/g/n/ac and ax
-the compatibility code currently only supports 802.11 a/b/g modes.
-Support for 802.11 n/ac is to come.
 .Sh HARDWARE
 The
 .Nm
 driver supports PCIe devices with the following chipsets:
 .Pp
-.Bl -tag -width Ds -offset indent -compact
-.It MediaTek MT7915E
+.Bl -bullet -compact
+.It
+MediaTek MT7915E
 .El
-.Sh BUGS
-Certainly.
 .Sh SEE ALSO
 .Xr wlan 4 ,
+.Xr networking 7 ,
+.Xr fwget 8 ,
 .Xr ifconfig 8 ,
 .Xr wpa_supplicant 8
 .Sh HISTORY
@@ -99,3 +99,11 @@ The
 .Nm
 driver first appeared in
 .Fx 14.0 .
+.Sh BUGS
+Certainly.
+.Pp
+While
+.Nm
+supports 802.11a/b/g/n/ac/ax modes,
+the compatibility code currently only supports 802.11a/b/g modes.
+Support for 802.11n/ac/ax is yet to come.

--- a/share/man/man4/mt7921.4
+++ b/share/man/man4/mt7921.4
@@ -1,4 +1,6 @@
 .\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2023-2024 Bjoern A. Zeeb
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -62,36 +64,34 @@ Otherwise no
 .Xr wlan 4
 interface can be created using
 .Xr ifconfig 8 .
+One can use
+.Xr fwget 8
+to install the correct firmware package.
 .Pp
 The driver uses the
 .\" No LinuxKPI man pages so no .Xr here.
-.Em linuxkpi_wlan
+.Sy linuxkpi_wlan
 and
-.Em linuxkpi
+.Sy linuxkpi
 compat framework to bridge between the Linux and
 native
 .Fx
 driver code as well as to the native
 .Xr net80211 4
 wireless stack.
-.Pp
-While
-.Nm
-supports all 802.11 a/b/g/n/ac and ax
-the compatibility code currently only supports 802.11 a/b/g modes.
-Support for 802.11 n/ac is to come.
 .Sh HARDWARE
 The
 .Nm
 driver supports PCIe devices with the following chipsets:
 .Pp
-.Bl -tag -width Ds -offset indent -compact
-.It MediaTek MT7921E
+.Bl -bullet -compact
+.It
+MediaTek MT7921E
 .El
-.Sh BUGS
-Certainly.
 .Sh SEE ALSO
 .Xr wlan 4 ,
+.Xr networking 7 ,
+.Xr fwget 8 ,
 .Xr ifconfig 8 ,
 .Xr wpa_supplicant 8
 .Sh HISTORY
@@ -99,3 +99,11 @@ The
 .Nm
 driver first appeared in
 .Fx 14.0 .
+.Sh BUGS
+Certainly.
+.Pp
+While
+.Nm
+supports 802.11a/b/g/n/ac/ax modes,
+the compatibility code currently only supports 802.11a/b/g modes.
+Support for 802.11n/ac/ax is to come.

--- a/share/man/man4/rtw88.4
+++ b/share/man/man4/rtw88.4
@@ -1,4 +1,6 @@
 .\"-
+.\" SPDX-License-Identifer: BSD-2-Clause
+.\"
 .\" Copyright (c) 2022-2024 Bjoern A. Zeeb
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -65,21 +67,30 @@ to install the correct firmware package.
 .Pp
 The driver uses the
 .\" No LinuxKPI man pages so no .Xr here.
-.Em linuxkpi_wlan
+.Sy linuxkpi_wlan
 and
-.Em linuxkpi
+.Sy linuxkpi
 compat framework to bridge between the Linux and
 native
 .Fx
 driver code as well as to the native
 .Xr net80211 4
 wireless stack.
-.Pp
-While
+.Sh HARDWARE
+The
 .Nm
-supports all 802.11 a/b/g/n and ac
-the compatibility code currently only supports 802.11 a/b/g modes.
-Support for 802.11 n/ac is to come.
+driver supports PCIe devices with the following chipsets:
+.Pp
+.Bl -bullet -compact
+.It
+Realtek 802.11n  wireless 8723de (RTL8723DE)
+.It
+Realtek 802.11ac wireless 8821ce (RTL8821CE)
+.It
+Realtek 802.11ac wireless 8822be (RTL8822BE)
+.It
+Realtek 802.11ac wireless 8822ce (RTL8822CE)
+.El
 .Sh LOADER TUNABLES
 .Bl -tag -width indent
 .It Va compat.linuxkpi.skb.mem_limit
@@ -93,28 +104,10 @@ This tunable will work around a problem with DMA and limit allocations
 for network buffer memory to the lower 32bit of physical memory and
 make the driver work.
 .El
-.Sh HARDWARE
-The
-.Nm
-driver supports PCIe devices with the following chipsets:
-.Pp
-.Bl -tag -width Ds -offset indent -compact
-.It Realtek 802.11n  wireless 8723de (RTL8723DE)
-.It Realtek 802.11ac wireless 8821ce (RTL8821CE)
-.It Realtek 802.11ac wireless 8822be (RTL8822BE)
-.It Realtek 802.11ac wireless 8822ce (RTL8822CE)
-.El
-.Sh BUGS
-Certainly.
-.Pp
-Does not seem to work (reliably) on machines with more than 4GB of
-main memory.
-See in the
-.Sx LOADER TUNABLES
-section above.
 .Sh SEE ALSO
 .Xr rtw88fw 4 ,
 .Xr wlan 4 ,
+.Xr networking 7 ,
 .Xr fwget 8 ,
 .Xr ifconfig 8 ,
 .Xr wpa_supplicant 8
@@ -123,3 +116,17 @@ The
 .Nm
 driver first appeared in
 .Fx 13.2 .
+.Sh BUGS
+Certainly.
+.Pp
+Does not seem to work (reliably) on machines with more than 4GB of
+main memory.
+See in the
+.Sx LOADER TUNABLES
+section above.
+.Pp
+While
+.Nm
+supports 802.11a/b/g/n/ac modes,
+the compatibility code currently only supports 802.11a/b/g modes.
+Support for 802.11n/ac is yet to come.

--- a/share/man/man4/rtw89.4
+++ b/share/man/man4/rtw89.4
@@ -1,4 +1,6 @@
 .\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2023-2024 Bjoern A. Zeeb
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -21,8 +23,6 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.\"
-.\" $FreeBSD$
 .\"
 .Dd October 12, 2024
 .Dt RTW89 4
@@ -67,21 +67,32 @@ to install the correct firmware package.
 .Pp
 The driver uses the
 .\" No LinuxKPI man pages so no .Xr here.
-.Em linuxkpi_wlan
+.Sy linuxkpi_wlan
 and
-.Em linuxkpi
+.Sy linuxkpi
 compat framework to bridge between the Linux and
 native
 .Fx
 driver code as well as to the native
 .Xr net80211 4
 wireless stack.
-.Pp
-While
+.Sh HARDWARE
+The
 .Nm
-supports all 802.11 a/b/g/n/ac and ax
-the compatibility code currently only supports 802.11 a/b/g modes.
-Support for 802.11 n/ac is to come.
+driver supports PCIe devices with the following chipsets:
+.Pp
+.Bl -bullet -compact
+.It
+Realtek 8851BE Wi-Fi 6  (RTL8851BE)
+.It
+Realtek 8852AE Wi-Fi 6  (RTL8852AE)
+.It
+Realtek 8852BE Wi-Fi 6  (RTL8852BE)
+.It
+Realtek 8852CE Wi-Fi 6E (RTL8852CE)
+.It
+Realtek 8922AE Wi-Fi 7  (RTL8922AE)
+.El
 .Sh LOADER TUNABLES
 .Bl -tag -width indent
 .It Va compat.linuxkpi.skb.mem_limit
@@ -95,28 +106,9 @@ This tunable will work around a problem with DMA and limit allocations
 for network buffer memory to the lower 32bit of physical memory and
 make the driver work.
 .El
-.Sh HARDWARE
-The
-.Nm
-driver supports PCIe devices with the following chipsets:
-.Pp
-.Bl -tag -width Ds -offset indent -compact
-.It Realtek 8851BE Wi-Fi 6  (RTL8851BE)
-.It Realtek 8852AE Wi-Fi 6  (RTL8852AE)
-.It Realtek 8852BE Wi-Fi 6  (RTL8852BE)
-.It Realtek 8852CE Wi-Fi 6E (RTL8852CE)
-.It Realtek 8922AE Wi-Fi 7  (RTL8922AE)
-.El
-.Sh BUGS
-Certainly.
-.Pp
-Does not seem to work (reliably) on machines with more than 4GB of
-main memory.
-See in the
-.Sx LOADER TUNABLES
-section above.
 .Sh SEE ALSO
 .Xr wlan 4 ,
+.Xr networking 7 ,
 .Xr fwget 8 ,
 .Xr ifconfig 8 ,
 .Xr wpa_supplicant 8
@@ -125,3 +117,17 @@ The
 .Nm
 driver first appeared in
 .Fx 14.2 .
+.Sh BUGS
+Certainly.
+.Pp
+Does not seem to work (reliably) on machines with more than 4GB of
+main memory.
+See in the
+.Sx LOADER TUNABLES
+section above.
+.Pp
+While
+.Nm
+supports 802.11a/b/g/n/ac/ax modes,
+the compatibility code currently only supports 802.11a/b/g modes.
+Support for 802.11n/ac/ax is yet to come.


### PR DESCRIPTION
Polish for iwlwifi.4, mt7915.4, mt7921.4, rtw88.4, and rtw89.4:

+ consolidate bugs to bugs section and move bugs section last to enhance flow of information
+ move hardware immediately after description, in line with fdp-primer and proposed [future mdoc(7) spec](https://github.com/freebsd/freebsd-src/pull/1463) so that compatible hardware is immediately noticeable
+ link fwget(8) firmware autodownloader and networking(7) quick start guide to show how easy and well integrated the process is
+ use consistent language explaining compatible and incompatible modes to demonstrate our cathedral design philosophy

~~I think bz needs to review this, but I can't find him on github, I'm going to send him a mail.~~