### PR TITLE
mdoc.7/MANUAL STRUCTURE: add HARDWARE

### DIFF
--- a/contrib/mandoc/mdoc.7
+++ b/contrib/mandoc/mdoc.7
@@ -137,6 +137,9 @@ The
 utility processes files ...
 \&.\e\(dq .Sh CONTEXT
 \&.\e\(dq For section 9 functions only.
+\&.\e\(dq .Sh HARDWARE
+\&.\e\(dq For section 4 only.
+\&.\e\(dq Not used in OpenBSD.
 \&.\e\(dq .Sh IMPLEMENTATION NOTES
 \&.\e\(dq Not used in OpenBSD.
 \&.\e\(dq .Sh RETURN VALUES
@@ -328,6 +331,10 @@ manual.
 .It Em CONTEXT
 This section lists the contexts in which functions can be called in section 9.
 The contexts are autoconf, process, or interrupt.
+.It Em HARDWARE
+This section lists the hardware support
+provided by kernel modules in section 4.
+FreeBSD Hardware Compatibility Notes are generated from this section.
 .It Em IMPLEMENTATION NOTES
 Implementation-specific notes should be kept here.
 This is useful when implementing standard functions that may have side


### PR DESCRIPTION
FreeBSD Release infrastructure has been generating the Hardware Compatibility Notes from the HARDWARE section in manuals for some decades. Add this section to the STANDARD SECTIONS of the cross platform manual page specification.

The goal of this project is to transform supported hardware discovery over the next 5 years by getting all of the supported hardware into the manual in a consistent, easily discoverable way, and enable higher quality Hardware Release Notes.

Opening this here to get any feedback from our community before trying to send this upstream, so **comments or emoji reactions are extremely helpful**.

Cc @bzfbd @cperciva 