### PR TITLE
wsp/evdev/sysmouse: Add wsp(4) horizontal scrolling, improve new tunables, and improve documentation.

### DIFF
--- a/share/man/man4/wsp.4
+++ b/share/man/man4/wsp.4
@@ -107,8 +107,8 @@ Enables movement on the trackpad follow a partially-released left-click.
 Default is 1 (enabled).
 .El
 .Bl -tag -width indent
-.It Va hw.usb.wsp.max_finger_area
-Specifies the maximum area on the trackpad which is registered as a
+.It Va hw.usb.wsp.max_finger_diameter
+Specifies the maximum finger diameter on the trackpad that is registered as a
 finger (a lower value is used for palm detection). Default is 1900.
 .El
 .Bl -tag -width indent

--- a/share/man/man4/wsp.4
+++ b/share/man/man4/wsp.4
@@ -63,24 +63,39 @@ through nodes under
 Pointer sensitivity can be controlled using the sysctl tunable
 .Nm hw.usb.wsp.scale_factor .
 Tap to left-click can be controlled using the sysctl tunable
-.Nm hw.usb.wsp.enable_single_tap_clicks ,
-set to 0 to disable single tap clicks or 1 to enable them (default).
+.Nm hw.usb.wsp.enable_single_tap_clicks
+with 0 disabling single tap clicks and 1 enabling them (default).
 Movement on the trackpad following a partially-released click can be
 controlled using the sysctl tunable
 .Nm hw.usb.wsp.enable_single_tap_movement ,
-set to 0 to disable the movement on the trackpad until a full release
+with 0 to disable the movement on the trackpad until a full release
 or 1 to allow the continued movement (default).
 .Nm hw.usb.wsp.max_finger_area
 defines the maximum area on the trackpad which is registered as a
 finger (lower for greater palm detection).
+.Nm max_scroll_finger_distance
+defines the maximum distance between two fingers where z-axis
+movements are registered.
 .Nm hw.usb.wsp.max_double_tap_distance
 defines the maximum distance between two finger clicks or taps which may
 register as a double-click.
+.Nm hw.usb.wsp.scr_hor_threshold
+defines the minimum required horizontal movement to register as a forward
+/back button click.
 Z-Axis sensitivity can be controlled using the sysctl tunable
 .Nm hw.usb.wsp.z_factor .
 Z-Axis inversion can be controlled using the sysctl tunable
 .Nm hw.usb.wsp.z_invert ,
 set to 0 to disable (default) or 1 to enable inversion.
+.Pp
+.Nm
+may use evdev data (if enabled during kernel compilation) for gesture support
+using the
+.Xr sysctl 8
+value
+.Nm kern.evdev.rcpt_mask .
+On most MacBooks, setting this value to 3 enables gestures, while 12
+disables them.
 .Sh FILES
 .Nm
 creates a blocking pseudo-device file,

--- a/share/man/man4/wsp.4
+++ b/share/man/man4/wsp.4
@@ -67,9 +67,9 @@ pressure detection, tap support, and gestures. At least the second bit
 of the
 .Xr sysctl 8
 tunable
-.Nm kern.evdev.rcpt_mask
+.Va kern.evdev.rcpt_mask
 must be set. This can be enabled with
-.Nm kern.evdev.rcpt_mask=3 .
+.Va kern.evdev.rcpt_mask=3 .
 .Pp
 Vertical scrolling (z-axis) is enabled by default with a two-finger
 tap and the movement of a finger up and down.
@@ -78,12 +78,12 @@ protocol, therefore must be enabled with evdev data. This can be enabled
 with the
 .Xr sysctl 8
 tunable
-.Nm kern.evdev.sysmouse_t_axis=3.
+.Va kern.evdev.sysmouse_t_axis=3.
 Horizontal scrolling can be used with a two-finger tap and the movement
 of a finger from side to side. The
 .Xr sysctl 8
 tunable
-.Nm hw.usb.wsp.t_factor
+.Va hw.usb.wsp.t_factor
 must be greater than 0 for horizontal scrolling to be enabled, too.
 .Pp
 Horizontal swiping with a three-finger tap is registered as mouse buttons

--- a/share/man/man4/wsp.4
+++ b/share/man/man4/wsp.4
@@ -49,53 +49,131 @@ The
 driver provides support for the Apple Internal Trackpad
 device found in many Apple laptops.
 .Pp
-The driver simulates a three-button mouse using multi-finger tap
+The driver simulates a three-button mouse using multi-finger press/tap
 detection.
 A single-finger press generates a left button click.
-A two-finger tap maps to the right button; whereas a three-finger tap
-gets treated as a middle button click.
+A two-finger press maps to the right button; whereas a three-finger
+press gets treated as a middle button click.
 .Pp
-.Nm
-supports dynamic reconfiguration using
-.Xr sysctl 8
-through nodes under
-.Nm hw.usb.wsp .
-Pointer sensitivity can be controlled using the sysctl tunable
-.Nm hw.usb.wsp.scale_factor .
-Tap to left-click can be controlled using the sysctl tunable
-.Nm hw.usb.wsp.enable_single_tap_clicks
-with 0 disabling single tap clicks and 1 enabling them (default).
-Movement on the trackpad following a partially-released click can be
-controlled using the sysctl tunable
-.Nm hw.usb.wsp.enable_single_tap_movement ,
-with 0 to disable the movement on the trackpad until a full release
-or 1 to allow the continued movement (default).
-.Nm hw.usb.wsp.max_finger_area
-defines the maximum area on the trackpad which is registered as a
-finger (lower for greater palm detection).
-.Nm max_scroll_finger_distance
-defines the maximum distance between two fingers where z-axis
-movements are registered.
-.Nm hw.usb.wsp.max_double_tap_distance
-defines the maximum distance between two finger clicks or taps which may
-register as a double-click.
-.Nm hw.usb.wsp.scr_hor_threshold
-defines the minimum required horizontal movement to register as a forward
-/back button click.
-Z-Axis sensitivity can be controlled using the sysctl tunable
-.Nm hw.usb.wsp.z_factor .
-Z-Axis inversion can be controlled using the sysctl tunable
-.Nm hw.usb.wsp.z_invert ,
-set to 0 to disable (default) or 1 to enable inversion.
+The trackpad functions with presses and taps. A press is a full-forced
+press which causes a physical lowering of the trackpad. A tap is a
+touch of the trackpad which does not depress the physical trackpad.
 .Pp
+The
 .Nm
-may use evdev data (if enabled during kernel compilation) for gesture support
-using the
+driver supports receiving evdev input device data if enabled. This data
+is used for extended usage of the touchpad like multi-finger support,
+pressure detection, tap support, and gestures. At least the second bit
+of the
 .Xr sysctl 8
-value
-.Nm kern.evdev.rcpt_mask .
-On most MacBooks, setting this value to 3 enables gestures, while 12
-disables them.
+tunable
+.Nm kern.evdev.rcpt_mask
+must be set. This can be enabled with
+.Nm kern.evdev.rcpt_mask=3 .
+.Pp
+Vertical scrolling (z-axis) is enabled by default with a two-finger
+tap and the movement of a finger up and down.
+Horizontal scrolling (t-axis) is not natively supported by the sysmouse
+protocol, therefore must be enabled with evdev data. This can be enabled
+with the
+.Xr sysctl 8
+tunable
+.Nm kern.evdev.sysmouse_t_axis=3.
+Horizontal scrolling can be used with a two-finger tap and the movement
+of a finger from side to side. The
+.Xr sysctl 8
+tunable
+.Nm hw.usb.wsp.t_factor
+must be greater than 0 for horizontal scrolling to be enabled, too.
+.Pp
+Horizontal swiping with a three-finger tap is registered as mouse buttons
+8 and 9, depending on the direction. These buttons default to backwards
+and forwards keyboard events.
+.Sh SYSCTL VARIABLES
+The following variables are available as
+.Xr sysctl 8
+tunables:
+.Bl -tag -width indent
+.It Va hw.usb.wsp.scale_factor
+Controls the pointer sensitivity. Default is 12.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.enable_single_tap_clicks
+Enables single-tap to register as a left-click. Default is 1 (enabled).
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.enable_single_tap_movement
+Enables movement on the trackpad follow a partially-released left-click.
+Default is 1 (enabled).
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.max_finger_area
+Specifies the maximum area on the trackpad which is registered as a
+finger (a lower value is used for palm detection). Default is 1900.
+.El
+.Bl -tag -width indent
+.It Va max_scroll_finger_distance
+Specifies the maximum distance between two fingers where z-axis
+and t-axis movements are registered. Z-axis and T-axis movements
+are vertical and horizontal movements with more than one finger
+tapped (not clicked), respectively. Default is 8192.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.max_double_tap_distance
+Specifies the maximum distance between two fingers that a two-finger
+click will be registered as a right-click. Default is 2500.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.scr_threshold
+Specifies the minimum horizontal or vertical distance required to
+register as a scrolling gesture. Default is 20.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.z_factor
+Z-axis sensitivity. Default is 5.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.z_invert
+Z-axis inversion. Default is 0 (disabled).
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.t_factor
+T-axis sensitivity. Default is 0 (disabled).
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.t_invert
+T-axis inversion. Default is 0 (disabled).
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.scroll_finger_count
+Specifies the number of tapped fingers which registers as a scrolling
+movement. Default is 2.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.horizontal_swipe_finger_count
+Speifies the number of tapped fingers which registers as a swipe
+gesture. Default is 3.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.pressure_touch_threshold
+Specifies the threshold for a finger to be registered as a click.
+Default is 50.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.pressure_untouch_threshold
+Specifies the threshold for a finger to be registered as an unclick.
+Default is 10.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.pressure_tap_threshold
+Specifies the threadhold for a finger to be registered as a tap.
+Default is 120.
+.El
+.Bl -tag -width indent
+.It Va hw.usb.wsp.debug
+Specifies the
+.Nm
+driver debugging level (0-3). Default is 1.
 .Sh FILES
 .Nm
 creates a blocking pseudo-device file,

--- a/sys/dev/evdev/evdev.c
+++ b/sys/dev/evdev/evdev.c
@@ -82,7 +82,7 @@ SYSCTL_INT(_kern_evdev, OID_AUTO, rcpt_mask, CTLFLAG_RWTUN, &evdev_rcpt_mask, 0,
     "Who is receiving events: bit0 - sysmouse, bit1 - kbdmux, "
     "bit2 - mouse hardware, bit3 - keyboard hardware");
 SYSCTL_INT(_kern_evdev, OID_AUTO, sysmouse_t_axis, CTLFLAG_RWTUN,
-    &evdev_sysmouse_t_axis, 0, "Extract T-axis from 0-none, 1-ums, 2-psm");
+    &evdev_sysmouse_t_axis, 0, "Extract T-axis from 0-none, 1-ums, 2-psm, 3-wsp");
 #endif
 SYSCTL_NODE(_kern_evdev, OID_AUTO, input, CTLFLAG_RD | CTLFLAG_MPSAFE, 0,
     "Evdev input devices");

--- a/sys/dev/evdev/evdev.h
+++ b/sys/dev/evdev/evdev.h
@@ -62,12 +62,14 @@ extern int evdev_rcpt_mask;
  * 0 - do not extract horizontal wheel movement (default).
  * 1 - ums(4) horizontal wheel encoding. T-axis is mapped to buttons 6 and 7
  * 2 - psm(4) wheels encoding: z = 1,-1 - vert. wheel, z = 2,-2 - horiz. wheel
+ * 3 - wsp(4) horizontal and vertical encoding. T-axis is mapped to button 5.
  */
 enum
 {
 	EVDEV_SYSMOUSE_T_AXIS_NONE = 0,
 	EVDEV_SYSMOUSE_T_AXIS_UMS = 1,
 	EVDEV_SYSMOUSE_T_AXIS_PSM = 2,
+	EVDEV_SYSMOUSE_T_AXIS_WSP = 3,
 };
 extern int evdev_sysmouse_t_axis;
 

--- a/sys/dev/syscons/sysmouse.c
+++ b/sys/dev/syscons/sysmouse.c
@@ -94,7 +94,15 @@ smdev_evdev_write(int x, int y, int z, int buttons)
 	evdev_push_event(sysmouse_evdev, EV_REL, REL_X, x);
 	evdev_push_event(sysmouse_evdev, EV_REL, REL_Y, y);
 	switch (evdev_sysmouse_t_axis) {
-	case EVDEV_SYSMOUSE_T_AXIS_PSM:
+	case EVDEV_SYSMOUSE_T_AXIS_WSP: /* 3 */
+		if (buttons & (1 << 5)) {
+			evdev_push_rel(sysmouse_evdev, REL_HWHEEL, z);
+			buttons &= ~(1 << 5);
+		} else {
+			evdev_push_rel(sysmouse_evdev, REL_WHEEL, -z);
+		}
+		break;
+	case EVDEV_SYSMOUSE_T_AXIS_PSM: /* 2 */
 		switch (z) {
 		case 1:
 		case -1:
@@ -106,14 +114,14 @@ smdev_evdev_write(int x, int y, int z, int buttons)
 			break;
 		}
 		break;
-	case EVDEV_SYSMOUSE_T_AXIS_UMS:
+	case EVDEV_SYSMOUSE_T_AXIS_UMS: /* 1 */
 		if (buttons & (1 << 6))
 			evdev_push_rel(sysmouse_evdev, REL_HWHEEL, 1);
 		else if (buttons & (1 << 5))
 			evdev_push_rel(sysmouse_evdev, REL_HWHEEL, -1);
 		buttons &= ~((1 << 5)|(1 << 6));
 		/* PASSTHROUGH */
-	case EVDEV_SYSMOUSE_T_AXIS_NONE:
+	case EVDEV_SYSMOUSE_T_AXIS_NONE: /* 0 */
 	default:
 		evdev_push_rel(sysmouse_evdev, REL_WHEEL, -z);
 	}

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -121,7 +121,7 @@ static struct wsp_tuning {
 };
 
 static void
-wsp_runing_rangecheck(struct wsp_tuning *ptun)
+wsp_running_rangecheck(struct wsp_tuning *ptun)
 {
 	WSP_CLAMP(ptun->scale_factor, 1, 63);
 	WSP_CLAMP(ptun->z_factor, 1, 63);
@@ -959,7 +959,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 	int slot = 0;
 #endif
 
-	wsp_runing_rangecheck(&tun);
+	wsp_running_rangecheck(&tun);
 
 	if (sc->dz_count == 0)
 		sc->dz_count = WSP_DZ_MAX_COUNT;

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -111,7 +111,7 @@ static struct wsp_tuning {
 	.pressure_touch_threshold = 50,
 	.pressure_untouch_threshold = 10,
 	.pressure_tap_threshold = 120,
-	.scr_hor_threshold = 20,
+	.scr_hor_threshold = 50,
 	.max_finger_area = 1900,
 	.max_double_tap_distance = 2500,
 	.enable_single_tap_clicks = 1,

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -102,7 +102,7 @@ static struct wsp_tuning {
 	int	pressure_untouch_threshold;
 	int	pressure_tap_threshold;
 	int	scr_threshold;
-	int	max_finger_area;
+	int	max_finger_diameter;
 	int	max_scroll_finger_distance;
 	int	max_double_tap_distance;
 	int	enable_single_tap_clicks;
@@ -121,7 +121,7 @@ static struct wsp_tuning {
 	.pressure_untouch_threshold = 10,
 	.pressure_tap_threshold = 120,
 	.scr_threshold = 20,
-	.max_finger_area = 1900,
+	.max_finger_diameter = 1900,
 	.max_scroll_finger_distance = MAX_FINGER_ORIENTATION/2,
 	.max_double_tap_distance = 2500,
 	.enable_single_tap_clicks = 1,
@@ -141,7 +141,7 @@ wsp_running_rangecheck(struct wsp_tuning *ptun)
 	WSP_CLAMP(ptun->pressure_touch_threshold, 1, 255);
 	WSP_CLAMP(ptun->pressure_untouch_threshold, 1, 255);
 	WSP_CLAMP(ptun->pressure_tap_threshold, 1, 255);
-	WSP_CLAMP(ptun->max_finger_area, 1, 2400);
+	WSP_CLAMP(ptun->max_finger_diameter, 1, 2400);
 	WSP_CLAMP(ptun->max_scroll_finger_distance, 1, MAX_FINGER_ORIENTATION);
 	WSP_CLAMP(ptun->max_double_tap_distance, 1, MAX_FINGER_ORIENTATION);
 	WSP_CLAMP(ptun->scr_threshold, 1, 255);
@@ -169,8 +169,8 @@ SYSCTL_INT(_hw_usb_wsp, OID_AUTO, pressure_untouch_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.pressure_untouch_threshold, 0, "untouch pressure threshold");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, pressure_tap_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.pressure_tap_threshold, 0, "tap pressure threshold");
-SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_finger_area, CTLFLAG_RWTUN,
-    &wsp_tuning.max_finger_area, 0, "maximum finger area");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_finger_diameter, CTLFLAG_RWTUN,
+    &wsp_tuning.max_finger_diameter, 0, "maximum finger diameter");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_scroll_finger_distance, CTLFLAG_RWTUN,
     &wsp_tuning.max_scroll_finger_distance, 0, "maximum scroll finger distance");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_double_tap_distance, CTLFLAG_RWTUN,
@@ -898,10 +898,10 @@ wsp_attach(device_t dev)
 	WSP_SUPPORT_ABS(sc->sc_evdev, ABS_MT_POSITION_Y, sc->sc_params->y);
 	/* finger pressure */
 	WSP_SUPPORT_ABS(sc->sc_evdev, ABS_MT_PRESSURE, sc->sc_params->p);
-	/* finger touch area */
+	/* finger major/minor axis */
 	WSP_SUPPORT_ABS(sc->sc_evdev, ABS_MT_TOUCH_MAJOR, sc->sc_params->w);
 	WSP_SUPPORT_ABS(sc->sc_evdev, ABS_MT_TOUCH_MINOR, sc->sc_params->w);
-	/* finger approach area */
+	/* finger major/minor approach */
 	WSP_SUPPORT_ABS(sc->sc_evdev, ABS_MT_WIDTH_MAJOR, sc->sc_params->w);
 	WSP_SUPPORT_ABS(sc->sc_evdev, ABS_MT_WIDTH_MINOR, sc->sc_params->w);
 	/* finger orientation */
@@ -1111,7 +1111,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 			switch (ntouch) {
 			case 1:
 				if (sc->index[0]->touch_major > tun.pressure_tap_threshold &&
-				    sc->index[0]->tool_major <= tun.max_finger_area)
+				    sc->index[0]->tool_major <= tun.max_finger_diameter)
 					sc->ntaps = 1;
 				break;
 			case 2:
@@ -1217,7 +1217,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 					dx = dy = 0;
 
 				/* Ignore unexpected movement when typing (palm detection) */
-				if (ntouch == 1 && sc->index[0]->tool_major > tun.max_finger_area)
+				if (ntouch == 1 && sc->index[0]->tool_major > tun.max_finger_diameter)
 					dx = dy = 0;
 
 				if (sc->ibtn != 0 && ntouch == 1 && 

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -87,17 +87,21 @@ enum wsp_log_level {
 static int wsp_debug = WSP_LLEVEL_ERROR;/* the default is to only log errors */
 
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, debug, CTLFLAG_RWTUN,
-    &wsp_debug, WSP_LLEVEL_ERROR, "WSP debug level");
+    &wsp_debug, WSP_LLEVEL_ERROR, "WSP debug level (0-3)");
 #endif					/* USB_DEBUG */
 
 static struct wsp_tuning {
 	int	scale_factor;
+	int	scroll_finger_count;
+	int	horizontal_swipe_finger_count;
 	int	z_factor;
 	int	z_invert;
+	int	t_factor;
+	int	t_invert;
 	int	pressure_touch_threshold;
 	int	pressure_untouch_threshold;
 	int	pressure_tap_threshold;
-	int	scr_hor_threshold;
+	int	scr_threshold;
 	int	max_finger_area;
 	int	max_scroll_finger_distance;
 	int	max_double_tap_distance;
@@ -107,12 +111,16 @@ static struct wsp_tuning {
 	wsp_tuning =
 {
 	.scale_factor = 12,
+	.scroll_finger_count = 2,
+	.horizontal_swipe_finger_count = 3,
 	.z_factor = 5,
 	.z_invert = 0,
+	.t_factor = 0,
+	.t_invert = 0,
 	.pressure_touch_threshold = 50,
 	.pressure_untouch_threshold = 10,
 	.pressure_tap_threshold = 120,
-	.scr_hor_threshold = 50,
+	.scr_threshold = 20,
 	.max_finger_area = 1900,
 	.max_scroll_finger_distance = MAX_FINGER_ORIENTATION/2,
 	.max_double_tap_distance = 2500,
@@ -124,25 +132,37 @@ static void
 wsp_running_rangecheck(struct wsp_tuning *ptun)
 {
 	WSP_CLAMP(ptun->scale_factor, 1, 63);
-	WSP_CLAMP(ptun->z_factor, 1, 63);
+	WSP_CLAMP(ptun->scroll_finger_count, 0, 3);
+	WSP_CLAMP(ptun->horizontal_swipe_finger_count, 0, 3);
+	WSP_CLAMP(ptun->z_factor, 0, 63);
 	WSP_CLAMP(ptun->z_invert, 0, 1);
+	WSP_CLAMP(ptun->t_factor, 0, 63);
+	WSP_CLAMP(ptun->t_invert, 0, 1);
 	WSP_CLAMP(ptun->pressure_touch_threshold, 1, 255);
 	WSP_CLAMP(ptun->pressure_untouch_threshold, 1, 255);
 	WSP_CLAMP(ptun->pressure_tap_threshold, 1, 255);
 	WSP_CLAMP(ptun->max_finger_area, 1, 2400);
 	WSP_CLAMP(ptun->max_scroll_finger_distance, 1, MAX_FINGER_ORIENTATION);
 	WSP_CLAMP(ptun->max_double_tap_distance, 1, MAX_FINGER_ORIENTATION);
-	WSP_CLAMP(ptun->scr_hor_threshold, 1, 255);
+	WSP_CLAMP(ptun->scr_threshold, 1, 255);
 	WSP_CLAMP(ptun->enable_single_tap_clicks, 0, 1);
 	WSP_CLAMP(ptun->enable_single_tap_movement, 0, 1);
 }
 
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scale_factor, CTLFLAG_RWTUN,
     &wsp_tuning.scale_factor, 0, "movement scale factor");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scroll_finger_count, CTLFLAG_RWTUN,
+    &wsp_tuning.scroll_finger_count, 0, "amount of fingers to use scrolling gesture");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, horizontal_swipe_finger_count, CTLFLAG_RWTUN,
+    &wsp_tuning.horizontal_swipe_finger_count, 0, "amount of fingers to use horizontal swipe gesture");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, z_factor, CTLFLAG_RWTUN,
-    &wsp_tuning.z_factor, 0, "Z-axis scale factor");
+    &wsp_tuning.z_factor, 0, "Z-axis (vertical) scale factor");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, z_invert, CTLFLAG_RWTUN,
-    &wsp_tuning.z_invert, 0, "enable Z-axis inversion");
+    &wsp_tuning.z_invert, 0, "enable (vertical) Z-axis inversion");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, t_factor, CTLFLAG_RWTUN,
+    &wsp_tuning.t_factor, 0, "T-axis (horizontal) scale factor");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, t_invert, CTLFLAG_RWTUN,
+    &wsp_tuning.t_invert, 0, "enable T-axis (horizontal) inversion");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, pressure_touch_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.pressure_touch_threshold, 0, "touch pressure threshold");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, pressure_untouch_threshold, CTLFLAG_RWTUN,
@@ -155,8 +175,8 @@ SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_scroll_finger_distance, CTLFLAG_RWTUN,
     &wsp_tuning.max_scroll_finger_distance, 0, "maximum scroll finger distance");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_double_tap_distance, CTLFLAG_RWTUN,
     &wsp_tuning.max_double_tap_distance, 0, "maximum double-finger click distance");
-SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scr_hor_threshold, CTLFLAG_RWTUN,
-    &wsp_tuning.scr_hor_threshold, 0, "horizontal scrolling threshold");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scr_threshold, CTLFLAG_RWTUN,
+    &wsp_tuning.scr_threshold, 0, "scrolling threshold");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_single_tap_clicks, CTLFLAG_RWTUN,
     &wsp_tuning.enable_single_tap_clicks, 0, "enable single tap clicks");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_single_tap_movement, CTLFLAG_RWTUN,
@@ -1145,11 +1165,12 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				}
 				wsp_add_to_queue(sc, 0, 0, 0, 0);	/* button release */
 			}
-			if ((sc->dt_sum / tun.scr_hor_threshold) != 0 &&
-			    sc->ntaps == 2 && sc->scr_mode == WSP_SCR_HOR) {
+
+			if (sc->scr_mode == WSP_SCR_HOR && sc->ntaps == tun.horizontal_swipe_finger_count
+			    && tun.horizontal_swipe_finger_count > 0 && (sc->dt_sum / tun.scr_threshold) != 0) {
 				/*
-				 * translate T-axis into button presses
-				 * until further
+				 * translate T-axis swipe into button
+				 * presses 3 and 4 (forward/back)
 				 */
 				if (sc->dt_sum > 0)
 					wsp_add_to_queue(sc, 0, 0, 0, 1UL << 3);
@@ -1235,11 +1256,18 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 					    dx, dy, sc->finger);
 				}
 				if (sc->dz_count--) {
-					rdz = (dy + sc->rdz) % tun.scale_factor;
-					sc->dz_sum -= (dy + sc->rdz) / tun.scale_factor;
+					if (sc->scr_mode == WSP_SCR_HOR) {
+						rdz = (dx + sc->rdz) % tun.scale_factor;
+						sc->dz_sum -= (dx + sc->rdz) / tun.scale_factor;
+					} else if (sc->scr_mode == WSP_SCR_VER) {
+						rdz = (dy + sc->rdz) % tun.scale_factor;
+						sc->dz_sum -= (dy + sc->rdz) / tun.scale_factor;
+					}
 					sc->rdz = rdz;
 				}
-				if ((sc->dz_sum / tun.z_factor) != 0)
+				if (sc->scr_mode == WSP_SCR_VER && (tun.z_factor == 0 || (sc->dz_sum / tun.z_factor) != 0))
+					sc->dz_count = 0;
+				else if (sc->scr_mode == WSP_SCR_HOR && (tun.t_factor == 0 || (sc->dz_sum / tun.t_factor) != 0))
 					sc->dz_count = 0;
 			}
 			rdx = (dx + sc->rdx) % tun.scale_factor;
@@ -1253,26 +1281,49 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 			sc->dx_sum += dx;
 			sc->dy_sum += dy;
 
-			if (ntouch == 2 && sc->sc_status.button == 0) {
-				if (sc->scr_mode == WSP_SCR_NONE &&
-				    abs(sc->dx_sum) + abs(sc->dy_sum) > tun.scr_hor_threshold)
-					sc->scr_mode = abs(sc->dx_sum) >
-					    abs(sc->dy_sum) * 2 ? WSP_SCR_HOR : WSP_SCR_VER;
-				DPRINTFN(WSP_LLEVEL_INFO, "scr_mode=%5d, count=%d, dx_sum=%d, dy_sum=%d\n",
-				    sc->scr_mode, sc->intr_count, sc->dx_sum, sc->dy_sum);
-				if (sc->scr_mode == WSP_SCR_HOR)
-					sc->dt_sum += dx;
-				else
-					sc->dt_sum = 0;
+			if (sc->sc_status.button == 0 && ntouch > 0) {
+				if (ntouch == tun.scroll_finger_count || ntouch == tun.horizontal_swipe_finger_count) {
+					if (sc->scr_mode == WSP_SCR_NONE && abs(sc->dx_sum) + abs(sc->dy_sum) > tun.scr_threshold)
+						sc->scr_mode = abs(sc->dx_sum) > abs(sc->dy_sum) * 2 ? WSP_SCR_HOR : WSP_SCR_VER;
 
-				dx = dy = 0;
-				if (sc->dz_count == 0)
-					dz = (sc->dz_sum / tun.z_factor) * (tun.z_invert ? -1 : 1);
-				if (sc->scr_mode == WSP_SCR_HOR || sc->distance > tun.max_scroll_finger_distance)
+					DPRINTFN(WSP_LLEVEL_INFO, "scr_mode=%5d, count=%d, dx_sum=%d, dy_sum=%d\n", sc->scr_mode, sc->intr_count, sc->dx_sum, sc->dy_sum);
+				}
+
+				if (ntouch == tun.scroll_finger_count) { /* preference scrolling over swipe if tun.scroll_finger_count == tun.horizontal_swipe_finger_count */
+					if (sc->scr_mode == WSP_SCR_HOR) {
+						sc->sc_status.button = 1 << 5;
+					}
+					dx = dy = dz = 0;
 					dz = 0;
+					sc->dt_sum = 0;
+					if (sc->distance <= tun.max_scroll_finger_distance && sc->dz_count == 0) {
+						if (sc->scr_mode == WSP_SCR_VER) {
+							if (tun.z_factor > 0)
+								dz = (sc->dz_sum / tun.z_factor) * (tun.z_invert ? -1 : 1);
+						} else if (sc->scr_mode == WSP_SCR_HOR) {
+							if (tun.t_factor > 0)
+								dz = (sc->dz_sum / tun.t_factor) * (tun.t_invert ? -1 : 1);
+						}
+					}
+				} else if (ntouch == tun.horizontal_swipe_finger_count) {
+					if (sc->scr_mode == WSP_SCR_HOR) {
+						sc->dt_sum += dx * (tun.t_invert ? -1 : 1);
+					} else {
+						sc->dt_sum = 0;
+					}
+					dx = dy = dz = 0;
+				}
 			}
+
 			if (ntouch == 3)
 				dx = dy = dz = 0;
+
+			if (ntouch != tun.horizontal_swipe_finger_count)
+				sc->dt_sum = 0;
+
+			if (ntouch == 0)
+				sc->scr_mode = WSP_SCR_NONE;
+
 			if (sc->intr_count < WSP_TAP_MAX_COUNT &&
 			    abs(dx) < 3 && abs(dy) < 3 && abs(dz) < 3)
 				dx = dy = dz = 0;

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -74,7 +74,7 @@
 } while (0)
 
 /* Tunables */
-static	SYSCTL_NODE(_hw_usb, OID_AUTO, wsp, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
+static SYSCTL_NODE(_hw_usb, OID_AUTO, wsp, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
     "USB wsp");
 
 #ifdef USB_DEBUG
@@ -122,7 +122,7 @@ static struct wsp_tuning {
 	.pressure_tap_threshold = 120,
 	.scr_threshold = 20,
 	.max_finger_diameter = 1900,
-	.max_scroll_finger_distance = MAX_FINGER_ORIENTATION/2,
+	.max_scroll_finger_distance = 8192,
 	.max_double_tap_distance = 2500,
 	.enable_single_tap_clicks = 1,
 	.enable_single_tap_movement = 1,
@@ -142,8 +142,8 @@ wsp_running_rangecheck(struct wsp_tuning *ptun)
 	WSP_CLAMP(ptun->pressure_untouch_threshold, 1, 255);
 	WSP_CLAMP(ptun->pressure_tap_threshold, 1, 255);
 	WSP_CLAMP(ptun->max_finger_diameter, 1, 2400);
-	WSP_CLAMP(ptun->max_scroll_finger_distance, 1, MAX_FINGER_ORIENTATION);
-	WSP_CLAMP(ptun->max_double_tap_distance, 1, MAX_FINGER_ORIENTATION);
+	WSP_CLAMP(ptun->max_scroll_finger_distance, 1, 16384);
+	WSP_CLAMP(ptun->max_double_tap_distance, 1, 16384);
 	WSP_CLAMP(ptun->scr_threshold, 1, 255);
 	WSP_CLAMP(ptun->enable_single_tap_clicks, 0, 1);
 	WSP_CLAMP(ptun->enable_single_tap_movement, 0, 1);
@@ -330,7 +330,7 @@ struct tp_finger {
 	int16_t	unused[2];		/* zeros */
 	int16_t pressure;		/* pressure on forcetouch touchpad */
 	int16_t	multi;			/* one finger: varies, more fingers:
-				 	 * constant */
+					 * constant */
 } __packed;
 
 /* trackpad finger data size, empirically at least ten fingers */
@@ -1034,7 +1034,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				f->pressure = le16toh((uint16_t)f->pressure);
 				f->multi = le16toh((uint16_t)f->multi);
 			}
-			DPRINTFN(WSP_LLEVEL_INFO, 
+			DPRINTFN(WSP_LLEVEL_INFO,
 			    "[%d]ibt=%d, taps=%d, o=%4d, ax=%5d, ay=%5d, "
 			    "rx=%5d, ry=%5d, tlmaj=%4d, tlmin=%4d, ot=%4x, "
 			    "tchmaj=%4d, tchmin=%4d, presure=%4d, m=%4x\n",
@@ -1177,6 +1177,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				else if (sc->dt_sum < 0)
 					wsp_add_to_queue(sc, 0, 0, 0, 1UL << 4);
 			}
+
 			sc->dz_count = WSP_DZ_MAX_COUNT;
 			sc->dz_sum = 0;
 			sc->intr_count = 0;
@@ -1220,15 +1221,15 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				if (ntouch == 1 && sc->index[0]->tool_major > tun.max_finger_diameter)
 					dx = dy = 0;
 
-				if (sc->ibtn != 0 && ntouch == 1 && 
-				    sc->intr_count < WSP_TAP_MAX_COUNT && 
+				if (sc->ibtn != 0 && ntouch == 1 &&
+				    sc->intr_count < WSP_TAP_MAX_COUNT &&
 				    abs(sc->dx_sum) < 1 && abs(sc->dy_sum) < 1 )
 					dx = dy = 0;
 
 				if (ntouch == 2 && sc->sc_status.button != 0) {
 					dx = sc->pos_x[sc->finger] - sc->pre_pos_x[sc->finger];
 					dy = sc->pos_y[sc->finger] - sc->pre_pos_y[sc->finger];
-					
+
 					/*
 					 * Ignore movement of switch finger or
 					 * movement from ibt=0 to ibt=1
@@ -1408,6 +1409,7 @@ wsp_add_to_queue(struct wsp_softc *sc, int dx, int dy, int dz,
 		buf[6] = dz - (dz >> 1);/* dz - (dz / 2) */
 		buf[7] = (((~buttons_in) >> 3) & MOUSE_SYS_EXTBUTTONS);
 	}
+
 	usb_fifo_put_data_linear(sc->sc_fifo.fp[USB_FIFO_RX], buf,
 	    sc->sc_mode.packetsize, 1);
 }

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -99,6 +99,7 @@ static struct wsp_tuning {
 	int	pressure_tap_threshold;
 	int	scr_hor_threshold;
 	int	max_finger_area;
+	int	max_scroll_finger_distance;
 	int	max_double_tap_distance;
 	int	enable_single_tap_clicks;
 	int	enable_single_tap_movement;
@@ -113,6 +114,7 @@ static struct wsp_tuning {
 	.pressure_tap_threshold = 120,
 	.scr_hor_threshold = 50,
 	.max_finger_area = 1900,
+	.max_scroll_finger_distance = MAX_FINGER_ORIENTATION/2,
 	.max_double_tap_distance = 2500,
 	.enable_single_tap_clicks = 1,
 	.enable_single_tap_movement = 1,
@@ -128,7 +130,8 @@ wsp_runing_rangecheck(struct wsp_tuning *ptun)
 	WSP_CLAMP(ptun->pressure_untouch_threshold, 1, 255);
 	WSP_CLAMP(ptun->pressure_tap_threshold, 1, 255);
 	WSP_CLAMP(ptun->max_finger_area, 1, 2400);
-	WSP_CLAMP(ptun->max_double_tap_distance, 1, 16384);
+	WSP_CLAMP(ptun->max_scroll_finger_distance, 1, MAX_FINGER_ORIENTATION);
+	WSP_CLAMP(ptun->max_double_tap_distance, 1, MAX_FINGER_ORIENTATION);
 	WSP_CLAMP(ptun->scr_hor_threshold, 1, 255);
 	WSP_CLAMP(ptun->enable_single_tap_clicks, 0, 1);
 	WSP_CLAMP(ptun->enable_single_tap_movement, 0, 1);
@@ -148,6 +151,8 @@ SYSCTL_INT(_hw_usb_wsp, OID_AUTO, pressure_tap_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.pressure_tap_threshold, 0, "tap pressure threshold");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_finger_area, CTLFLAG_RWTUN,
     &wsp_tuning.max_finger_area, 0, "maximum finger area");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_scroll_finger_distance, CTLFLAG_RWTUN,
+    &wsp_tuning.max_scroll_finger_distance, 0, "maximum scroll finger distance");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, max_double_tap_distance, CTLFLAG_RWTUN,
     &wsp_tuning.max_double_tap_distance, 0, "maximum double-finger click distance");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scr_hor_threshold, CTLFLAG_RWTUN,
@@ -1263,7 +1268,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				dx = dy = 0;
 				if (sc->dz_count == 0)
 					dz = (sc->dz_sum / tun.z_factor) * (tun.z_invert ? -1 : 1);
-				if (sc->scr_mode == WSP_SCR_HOR || sc->distance > tun.max_double_tap_distance)
+				if (sc->scr_mode == WSP_SCR_HOR || sc->distance > tun.max_scroll_finger_distance)
 					dz = 0;
 			}
 			if (ntouch == 3)

--- a/sys/dev/vt/vt_sysmouse.c
+++ b/sys/dev/vt/vt_sysmouse.c
@@ -128,7 +128,15 @@ sysmouse_evdev_store(int x, int y, int z, int buttons)
 	evdev_push_event(sysmouse_evdev, EV_REL, REL_X, x);
 	evdev_push_event(sysmouse_evdev, EV_REL, REL_Y, y);
 	switch (evdev_sysmouse_t_axis) {
-	case EVDEV_SYSMOUSE_T_AXIS_PSM:
+	case EVDEV_SYSMOUSE_T_AXIS_WSP: /* 3 */
+		if (buttons & (1 << 5)) {
+			evdev_push_rel(sysmouse_evdev, REL_HWHEEL, z);
+			buttons &= ~(1 << 5);
+		} else {
+			evdev_push_rel(sysmouse_evdev, REL_WHEEL, -z);
+		}
+		break;
+	case EVDEV_SYSMOUSE_T_AXIS_PSM: /* 2 */
 		switch (z) {
 		case 1:
 		case -1:
@@ -140,14 +148,14 @@ sysmouse_evdev_store(int x, int y, int z, int buttons)
 			break;
 		}
 		break;
-	case EVDEV_SYSMOUSE_T_AXIS_UMS:
+	case EVDEV_SYSMOUSE_T_AXIS_UMS: /* 1 */
 		if (buttons & (1 << 6))
 			evdev_push_rel(sysmouse_evdev, REL_HWHEEL, 1);
 		else if (buttons & (1 << 5))
 			evdev_push_rel(sysmouse_evdev, REL_HWHEEL, -1);
 		buttons &= ~((1 << 5)|(1 << 6));
 		/* PASSTHROUGH */
-	case EVDEV_SYSMOUSE_T_AXIS_NONE:
+	case EVDEV_SYSMOUSE_T_AXIS_NONE: /* 0 */
 	default:
 		evdev_push_rel(sysmouse_evdev, REL_WHEEL, -z);
 	}


### PR DESCRIPTION
This PR works on 6 issues:

1) Separates much of the wsp.c constants to a separate header file. This allows for, for example, the `MAX_FINGER_ORIENTATION` macro to be referenced anywhere in the wsp.c file.
2) Changes the `scr_hor_threshold` tunable default. Previously, it was so low than even a few millimeters movement of two fingers on the mousepad would register as a right/left t-axis mouse click.
3) Creates a new tunable, `max_scroll_finger_distance`, which can be used to specify the maximum distance between two fingers which can be used for a z-axis movement. This information and some other missing details in the manual have also been included.
4) Adds a new T-axis reporting method to sysmouse(4) for the wsp(4). This allows wsp to report variable distances of movement in the t-axis by using a fake button-5 press.
6) Add support for horizontal (t-axis) scrolling to wsp(4), and separate forward/backwards swiping from that functionality, which now uses three-fingers instead of two by default -- however this is variable with new tunables.
7) Vastly improve documentation and explanations of each tunable.

Individual commits have longer explanations.