### PR TITLE
iwn.4: move hardware to HARDWARE + minor cleanup

### DIFF
--- a/share/man/man4/iwn.4
+++ b/share/man/man4/iwn.4
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2004-2006
 .\"	Damien Bergamini <damien.bergamini@free.fr>. All rights reserved.
 .\"
@@ -87,38 +90,7 @@ iwn6050fw_load="YES"
 .Sh DESCRIPTION
 The
 .Nm
-driver provides support for:
-.Pp
-.Bl -tag -width Ds -offset indent -compact
-.It Intel Centrino Advanced-N 6200
-.It Intel Centrino Advanced-N 6205
-.It Intel Centrino Advanced-N 6230
-.It Intel Centrino Advanced-N 6235
-.It Intel Centrino Advanced-N + WiMAX 6250
-.It Intel Centrino Ultimate-N 6300
-.It Intel Centrino Wireless-N 100
-.It Intel Centrino Wireless-N 105
-.It Intel Centrino Wireless-N 130
-.It Intel Centrino Wireless-N 135
-.It Intel Centrino Wireless-N 1000
-.It Intel Centrino Wireless-N 1030
-.It Intel Centrino Wireless-N 2200
-.It Intel Centrino Wireless-N 2230
-.It Intel Centrino Wireless-N 4965
-.It Intel Centrino Wireless-N 5100
-.It Intel Centrino Wireless-N 6150
-.It Intel Centrino Wireless-N 6200
-.It Intel Centrino Wireless-N 6250
-.It Intel Centrino Wireless-N + WiMAX 6150
-.It Intel Ultimate N WiFi Link 5300
-.It Intel Wireless WiFi Link 4965
-.It Intel WiFi Link 5100
-.It Intel WiMAX/WiFi Link 5150
-.It Intel WiMAX/WiFi Link 5350
-.El
-.Pp
-.Nm
-supports
+driver supports
 .Cm station
 and
 .Cm monitor
@@ -130,27 +102,84 @@ For more information on configuring this device, see
 This driver requires the firmware built with the
 .Nm iwnfw
 module to work.
+.Sh HARDWARE
+The
+.Nm
+driver provides support for:
+.Pp
+.Bl -bullet -compact
+.It
+Intel Centrino Advanced-N 6200
+.It
+Intel Centrino Advanced-N 6205
+.It
+Intel Centrino Advanced-N 6230
+.It
+Intel Centrino Advanced-N 6235
+.It
+Intel Centrino Advanced-N + WiMAX 6250
+.It
+Intel Centrino Ultimate-N 6300
+.It
+Intel Centrino Wireless-N 100
+.It
+Intel Centrino Wireless-N 105
+.It
+Intel Centrino Wireless-N 130
+.It
+Intel Centrino Wireless-N 135
+.It
+Intel Centrino Wireless-N 1000
+.It
+Intel Centrino Wireless-N 1030
+.It
+Intel Centrino Wireless-N 2200
+.It
+Intel Centrino Wireless-N 2230
+.It
+Intel Centrino Wireless-N 4965
+.It
+Intel Centrino Wireless-N 5100
+.It
+Intel Centrino Wireless-N 6150
+.It
+Intel Centrino Wireless-N 6200
+.It
+Intel Centrino Wireless-N 6250
+.It
+Intel Centrino Wireless-N + WiMAX 6150
+.It
+Intel Ultimate N WiFi Link 5300
+.It
+Intel Wireless WiFi Link 4965
+.It
+Intel WiFi Link 5100
+.It
+Intel WiMAX/WiFi Link 5150
+.It
+Intel WiMAX/WiFi Link 5350
+.El
 .Sh EXAMPLES
 Join an existing BSS network (i.e., connect to an access point):
 .Bd -literal -offset indent
-ifconfig wlan create wlandev iwn0 inet 192.168.0.20 \e
+# ifconfig wlan create wlandev iwn0 inet 192.168.0.20 \e
     netmask 0xffffff00
 .Ed
 .Pp
 Join a specific BSS network with network name
-.Dq Li my_net :
+.Ql my_net :
 .Pp
-.Dl "ifconfig wlan create wlandev iwn0 ssid my_net up"
+.Dl # ifconfig wlan create wlandev iwn0 ssid my_net up
 .Pp
 Join a specific BSS network with 64-bit WEP encryption:
 .Bd -literal -offset indent
-ifconfig wlan create wlandev iwn0 ssid my_net \e
+# ifconfig wlan create wlandev iwn0 ssid my_net \e
 	wepmode on wepkey 0x1234567890 weptxkey 1 up
 .Ed
 .Pp
 Join a specific BSS network with 128-bit WEP encryption:
 .Bd -literal -offset indent
-ifconfig wlan create wlandev iwn0 wlanmode adhoc ssid my_net \e
+# ifconfig wlan create wlandev iwn0 wlanmode adhoc ssid my_net \e
     wepmode on wepkey 0x01020304050607080910111213 weptxkey 1
 .Ed
 .Sh DIAGNOSTICS
@@ -191,6 +220,7 @@ This should not happen.
 .Xr wlan_ccmp 4 ,
 .Xr wlan_tkip 4 ,
 .Xr wlan_wep 4 ,
+.Xr networking 7 ,
 .Xr ifconfig 8 ,
 .Xr wpa_supplicant 8
 .Sh AUTHORS


### PR DESCRIPTION
Add devices supported by this driver to a HARDWARE section for inclusion in the Hardware Compatibility Notes with a change in the doc tree [^1]. While here:

+ add networking(7) quick start guide to see also
+ tweak some examples for clarity
+ tag spdx

Unresolved in Synopsis:
1. What do we want to be going on with synopsis in hardware support drivers? I really like what bz did on the newer drivers explaining for an admin using generic. This page is very different, explaining how to compile the support into the kernel. If manuals should optimally explain both, which one should come first?

2. Are both `device firmware` and `device iwnfw/{specificfw}` really necessary here?

Unresolved in Hardware:
1. Does the build infra require bulletpoints? I don't think it really adds anything to the rendered page compared to what we currently do in iwn(4), but the markup is massively better without them, to me.

2. Should we mention that this is PCIe devices like in other pages?

Cc @bzfbd @cperciva
[^1]: https://reviews.freebsd.org/D47162