### PR TITLE
Update libexec/rc/rc.d/netif - typo fix in comment

### DIFF
--- a/libexec/rc/rc.d/netif
+++ b/libexec/rc/rc.d/netif
@@ -151,7 +151,7 @@ vnet_down()
 
 # netif_common routine
 #	Common configuration subroutine for network interfaces. This
-#	routine takes all the preparatory steps needed for configuriing
+#	routine takes all the preparatory steps needed for configuring
 #	an interface and then calls $routine.
 netif_common()
 {


### PR DESCRIPTION
Just fixing a typo ("configuriing" => "configuring").

Author: Robert William Vesterman
Author email: bob@vesterman.com