### PR TITLE
tools/build/cross-build: Don't include sys/uio.h from linux limits.h

### DIFF
--- a/tools/build/cross-build/include/linux/limits.h
+++ b/tools/build/cross-build/include/linux/limits.h
@@ -45,13 +45,11 @@
 #if !defined(_GNU_SOURCE)
 #warning "Attempting to use limits.h with -std=c89/without _GNU_SOURCE, many macros will be missing"
 #endif
+#endif /* C89 */
 
-#else /* Not C89 */
-/* Not C89 -> check that all macros that we expect are defined */
 #ifndef IOV_MAX
 #error IOV_MAX should be defined
 #endif
-#endif /* C89 */
 
 #ifndef MAXBSIZE
 #define MAXBSIZE 65536 /* must be power of 2 */
@@ -83,7 +81,6 @@
 #endif
 
 #include <sys/types.h>
-#include <sys/uio.h> /* For IOV_MAX */
 
 /* Sanity checks for glibc */
 #ifndef _GNU_SOURCE


### PR DESCRIPTION
This creates a circular dependency for OpenZFS's libspl in sys/uio.h,
and it shouldn't be needed since the system limits.h already defines
IOV_MAX, so delete it, and unconditionally assert that to be the case.
Otherwise the re-include of libspl's sys/uio.h tries to use PAGESIZE
before it has been defined by OpenZFS's own sys/param.h.

Fixes:		7a7741af18d6 ("zfs: merge openzfs/zfs@b10992582")
MFC after:	1 week
