### PR TITLE
ixbge.4: add flow director CAVEAT

### DIFF
--- a/share/man/man4/ixgbe.4
+++ b/share/man/man4/ixgbe.4
@@ -124,3 +124,11 @@ The
 .Nm
 driver was written by
 .An Intel Corporation Aq Mt freebsd@intel.com .
+.Sh CAVEATS
+Intel (R) Flow director support is not fully implemented in
+.Fx
+at this time and additional work is required
+before those features can be supported.
+.Pp
+Enabling flow director may route traffic to the wrong RX queue of the NIC,
+resulting in sub-optimal performance on the receive side.


### PR DESCRIPTION
This was suggested in an attachment on bug 202663 posted in 2017. I do not have this hardware or know if this is true, but I suspect that @kev009 does. Sorry for the noise if this is no good.

This was really written by Diego Casati but I had to edit it a lot to fit the editorial style of manpages. Do I still set him as the author?