### PR TITLE
ixl.4 + ice.4: intro sentence for HARDWARE notes

### DIFF
--- a/share/man/man4/ice.4
+++ b/share/man/man4/ice.4
@@ -114,7 +114,10 @@ Update Utility for Intel Network Adapter 800 series; installed by the
 package.
 .El
 .Sh HARDWARE
-Most adapters in the Intel Ethernet 800 Series with SFP28/QSFP28 cages
+The
+.Nm
+driver supports the Intel Ethernet 800 series.
+Most adapters in this series with SFP28/QSFP28 cages
 have firmware that requires that Intel qualified modules are used; these
 qualified modules are listed below.
 This qualification check cannot be disabled by the driver.

--- a/share/man/man4/ixl.4
+++ b/share/man/man4/ixl.4
@@ -116,7 +116,10 @@ kernel; install the
 package for the latest driver.
 .El
 .Sh HARDWARE
-Most adapters in the Intel Ethernet 700 Series with SFP+/SFP28/QSFP+ cages
+The
+.Nm
+driver supports the Intel Ethernet 700 series.
+Most adapters in this series with SFP+/SFP28/QSFP+ cages
 have firmware that requires that Intel qualified modules are used; these
 qualified modules are listed below.
 This qualification check cannot be disabled by the driver.


### PR DESCRIPTION
Improve future release hardware notes by providing a simple introductory sentence to the hardware section of Intel Ethernet 700 and 800 series manuals. @kev009

Note: ice is not yet listed in https://www.freebsd.org/releases/14.2R/hardware/