### PR TITLE
Update rc.initdiskless, fix error handling of remount_optional

### DIFF
--- a/libexec/rc/rc.initdiskless
+++ b/libexec/rc/rc.initdiskless
@@ -174,7 +174,10 @@ log() {
 chkerr() {
     lastitem () ( n=$(($# - 1)) ; shift $n ; echo $1 )
     mountpoint="$(lastitem $2)"
-    [ -r $mountpoint/remount_optional ] && ( echo "$2 failed: ignoring due to remount_optional" ; return )
+    if [ -r $mountpoint/remount_optional ]; then
+        echo "$2 failed: ignoring due to remount_optional"
+        return
+    fi
     case $1 in
     0)
 	;;


### PR DESCRIPTION
chkerr() ignores the exit code of a preceding mount command in case a file ```remount_optional``` exists. The check is performed and a subshell is launched to log the informational message and return. The return is executed in the context of the subshell, not the context of the chkerr() function, hence is a NOP. The remount_optional check is hence ineffective.

Change the code to if/then/fi, so the return is evaluated in the context of the  chkerr function, to make the check effective.