### PR TITLE
liquidio.4: remove extra search keywords

### DIFF
--- a/share/man/man4/liquidio.4
+++ b/share/man/man4/liquidio.4
@@ -34,7 +34,7 @@
 .Os
 .Sh NAME
 .Nm liquidio
-.Nd "Cavium 10Gb/25Gb Ethernet driver for the FreeBSD operating system"
+.Nd Cavium 10Gb/25Gb Ethernet driver
 .Sh SYNOPSIS
 To compile this driver into the kernel,
 place the following line in your


### PR DESCRIPTION
Remove extra search keywords from document description causing this page to get pulled into unrelated results and wrap on standard console.

This appears to be the last manual which had "for the freebsd operating system" in the title.

@gmshake 