### PR TITLE
msdosfs manuals: describe and link better

### DIFF
--- a/sbin/fsck_msdosfs/fsck_msdosfs.8
+++ b/sbin/fsck_msdosfs/fsck_msdosfs.8
@@ -28,7 +28,7 @@
 .Os
 .Sh NAME
 .Nm fsck_msdosfs
-.Nd DOS/Windows (FAT) file system consistency checker
+.Nd File Allocation Table (FAT) file system consistency checker
 .Sh SYNOPSIS
 .Nm
 .Fl p
@@ -121,9 +121,8 @@ to assume
 as the answer to all operator questions.
 .El
 .Sh SEE ALSO
-.Xr fsck 8 ,
-.Xr fsck_ffs 8 ,
-.Xr mount_msdosfs 8
+.Xr msdosfs 4 ,
+.Xr fsck 8
 .Sh HISTORY
 The
 .Nm

--- a/sbin/mount_msdosfs/mount_msdosfs.8
+++ b/sbin/mount_msdosfs/mount_msdosfs.8
@@ -33,7 +33,7 @@
 .Os
 .Sh NAME
 .Nm mount_msdosfs
-.Nd mount an MS-DOS file system
+.Nd mount a File Allocation Table (FAT) file system
 .Sh SYNOPSIS
 .Nm
 .Op Fl 9ls

--- a/sbin/newfs_msdos/newfs_msdos.8
+++ b/sbin/newfs_msdos/newfs_msdos.8
@@ -28,7 +28,7 @@
 .Os
 .Sh NAME
 .Nm newfs_msdos
-.Nd construct a new MS-DOS (FAT) file system
+.Nd construct a new File Allocation Table (FAT) file system
 .Sh SYNOPSIS
 .Nm
 .Op Fl N
@@ -252,6 +252,7 @@ Create a 30MB image file, with the FAT partition starting
 newfs_msdos -C 30M -@63s ./somefile
 .Ed
 .Sh SEE ALSO
+.Xr msdosfs 4 ,
 .Xr gpart 8 ,
 .Xr newfs 8
 .Sh HISTORY

--- a/share/man/man4/msdosfs.4
+++ b/share/man/man4/msdosfs.4
@@ -6,7 +6,7 @@
 .Os
 .Sh NAME
 .Nm msdosfs
-.Nd MS-DOS file system
+.Nd File Allocation Table (FAT) file system
 .Sh SYNOPSIS
 .Cd "options MSDOSFS"
 .Sh DESCRIPTION
@@ -65,8 +65,10 @@ may also be used to extract this information.
 .Sh SEE ALSO
 .Xr mount 2 ,
 .Xr unmount 2 ,
+.Xr fsck_msdosfs 8 ,
 .Xr mount 8 ,
 .Xr mount_msdosfs 8 ,
+.Xr newfs_msdos 8 ,
 .Xr umount 8
 .Sh AUTHORS
 This manual page was written by


### PR DESCRIPTION
Increase accessibility of msdosfs subsystem by linking all msdosfs utility manuals to msdosfs(4), linking msdosfs(4) to all of them, and rewriting the document descriptions for consistency with other documentation.

Regarding the removal of MSDOS and window, the former is already in the search keywords from the title. The latter hasn't been true in 20 years. The file allocation table fs is used widely in embedded devices, and i think normal people are going to search for it that way. If someone is searching for "windows" in the context of filesystems, they certainly want ntfs-3g or... are over 20 years mistaken?

While here, remove fsck_ufs(8) from fsck_msdosfs(8). It's already linked to fsck(8) if the reader is at the wrong page.

These filesystems and their manuals have worked great for me for a long time. Thanks!