### PR TITLE
Update ipsec.4 - Erroneous cross-reference fix

### DIFF
--- a/share/man/man4/ipsec.4
+++ b/share/man/man4/ipsec.4
@@ -182,7 +182,7 @@ is synonymous with
 which requires that a security association must exist for the packets
 to move, and not be dropped.
 These terms are defined in
-.Xr ipsec_set_policy 8 .
+.Xr ipsec_set_policy 3 .
 .Bl -column net.inet6.ipsec6.esp_trans_deflev integerxxx
 .It Sy "Name	Type	Changeable"
 .It "net.inet.ipsec.esp_trans_deflev	integer	yes"


### PR DESCRIPTION
The manpage for ipsec(4) refers to ipsec_set_policy(8) which does not exist. It is supposed to be ipsec_set_policy(3).