### PR TITLE
resolver.5: Fix example Google DNS server address

### DIFF
--- a/share/man/man5/resolver.5
+++ b/share/man/man5/resolver.5
@@ -236,7 +236,7 @@ nameserver 192.168.2.1
 
 # Fallback nameservers, in this case these from Google.
 nameserver 8.8.8.8
-nameserver 4.4.4.4
+nameserver 8.8.4.4
 
 # Attach an OPT pseudo-RR for the EDNS0 extension,
 # as specified in RFC 2671.


### PR DESCRIPTION
The previouly written example of 4.4.4.4 is not a Google DNS server and shouldn't be used, corrected to their secondary DNS address.