### PR TITLE
Add feature for usr.sbin/newsyslog.c: accept human unit suffix for size fileds in configuration file.

### DIFF
--- a/usr.sbin/newsyslog/Makefile
+++ b/usr.sbin/newsyslog/Makefile
@@ -6,7 +6,7 @@ CONFS=	newsyslog.conf
 PROG=	newsyslog
 MAN=	newsyslog.8 newsyslog.conf.5
 SRCS=	newsyslog.c ptimes.c
-LIBADD=	sbuf
+LIBADD=	sbuf util
 
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests

--- a/usr.sbin/newsyslog/newsyslog.c
+++ b/usr.sbin/newsyslog/newsyslog.c
@@ -77,6 +77,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <libgen.h>
+#include <libutil.h>
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
@@ -1335,8 +1336,21 @@ parse_file(FILE *cf, struct cflist *work_p, struct cflist *glob_p,
 			badline("malformed line (missing fields):\n%s",
 			    errline);
 		*parse = '\0';
-		if (isdigitch(*q))
-			working->trsize = atoi(q);
+		if (isdigitch(*q)) {
+			size_t last_digit = q[strlen(q) - 1];
+			if ('0' <= last_digit && last_digit <= '9')
+				working->trsize = atoi(q);
+			else {
+				uint64_t trsize = 0;
+				if (expand_number(q, &trsize) == 0)
+					working->trsize = trsize / 1024;
+				else {
+					working->trsize = -1;
+					warnx("Invalid value of '%s' for 'size' in line:\n%s",
+						q, errline);
+				}
+			}
+		}
 		else if (strcmp(q, "*") == 0)
 			working->trsize = -1;
 		else {

--- a/usr.sbin/newsyslog/newsyslog.conf.5
+++ b/usr.sbin/newsyslog/newsyslog.conf.5
@@ -117,7 +117,9 @@ This does not consider the current log file.
 .It Ar size
 When the size of the log file reaches
 .Ar size
-in kilobytes, the log file will be trimmed as described above.
+in kilobytes, or by using any suffix (e.g., k, M, G) supported by
+.Xr expanded_number 3 ;
+the log file will be trimmed as described above.
 If this field contains an asterisk
 .Pq Ql * ,
 the log file will not be trimmed based on size.
@@ -438,6 +440,7 @@ entry:
 .Xr gzip 1 ,
 .Xr xz 1 ,
 .Xr zstd 1 ,
+.Xr expanded_number 3 ,
 .Xr syslog 3 ,
 .Xr chown 8 ,
 .Xr newsyslog 8 ,


### PR DESCRIPTION
In previous versions of newsyslog, the size had to be configured in KB, which is too small for modern computers.

With this update, we can use three types of units: K, M, and G. For example,
```
# logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
/var/log/all.log                        600  7     *    @T00  J
/var/log/auth.log                       600  7     1000 @0101T JC
/var/log/console.log                    600  5     100M *     J
/var/log/cron                           600  3     1G   *     JC
/var/log/daemon.log                     644  5     1000K @0101T JC
```