### PR TITLE
XXX: Fix macOS cross-builds

### DIFF
--- a/lib/libcrypt/Makefile
+++ b/lib/libcrypt/Makefile
@@ -45,8 +45,9 @@ libcrypt.ald: ${.CURDIR}/${STATIC_LDSCRIPT}
 all: ${STATIC_LDSCRIPT} libcrypt.ald
 
 install-libcrypt.a: libcrypt.ald
+	# XXX JL
 	${INSTALL} ${TAG_ARGS:D${TAG_ARGS},dev} -S -C -o ${LIBOWN} -g ${LIBGRP} -m ${LIBMODE} \
-	    ${_INSTALLFLAGS} libcrypt.ald ${DESTDIR}${_LIBDIR}/lib${LIB}.a
+	    ${_INSTALLFLAGS} ${DESTDIR}${_LIBDIR}/lib${LIB}${_STATICLIB_SUFFIX}.a ${DESTDIR}${_LIBDIR}/lib${LIB}.a
 
 realinstall: install-libcrypt.a
 


### PR DESCRIPTION
Commit cb5e41b16083 also broke macOS cross-builds. The error message thrown (abbreviated) is:

    ld: unknown file type in '/Users/runner/.../tmp/legacy/usr/lib/libcrypt.a'

The file `libcrypt.a` contains the result of the `sed` manipulation from the `libcrypt.ald` target:

    INPUT(-lcrypt_real -lmd)

This is because the target `install-libcrypt.a` essentially just copies `libcrypt.ald` to `libcrypt.a`

That is what is evidenced in this Pull Request, by copying `libcrypt_real.a` to `libcrypt.a`.  With libncurses, this does not happen.

The reasons why it fails only on macOS are not related, and will hopefully be discussed more extensively in a separate pull request.