### PR TITLE
pf: fix build on kernels without "options INET"

### DIFF
--- a/sys/netpfil/pf/pf.c
+++ b/sys/netpfil/pf/pf.c
@@ -576,8 +576,10 @@ static bool
 pf_is_loopback(sa_family_t af, struct pf_addr *addr)
 {
 	switch (af) {
+#ifdef INET
 	case AF_INET:
 		return IN_LOOPBACK(ntohl(addr->v4.s_addr));
+#endif
 	case AF_INET6:
 		return IN6_IS_ADDR_LOOPBACK(&addr->v6);
 	default:

--- a/sys/netpfil/pf/pf_norm.c
+++ b/sys/netpfil/pf/pf_norm.c
@@ -2224,6 +2224,7 @@ pf_scrub(struct pf_pdesc *pd)
 	}
 
 	/* random-id, but not for fragments */
+#ifdef INET
 	if (pd->af == AF_INET &&
 	    pd->act.flags & PFSTATE_RANDOMID && !(h->ip_off & ~htons(IP_DF))) {
 		uint16_t ip_id = h->ip_id;
@@ -2231,5 +2232,6 @@ pf_scrub(struct pf_pdesc *pd)
 		ip_fillid(h);
 		h->ip_sum = pf_cksum_fixup(h->ip_sum, ip_id, h->ip_id, 0);
 	}
+#endif
 }
 #endif


### PR DESCRIPTION
- IN_LOOPBACK() cannot be used without INET, because it references a VNET symbol vnet_entry_in_loopback_mask.

- ip_fillid() is not available without INET.  since this codepath is only entered in the AF_INET case, guard it with #ifnet INET.

Fixes: 27f54be50bbad ("pf: merge pf_test() and pf_test6()")
Fixes: 4f9e688708f1b ("pf: merge pf_scrub_ip() and pf_scrub_ip6()")

cc @kprovost 