### PR TITLE
Add logger for sys/security/mac_do/mac_do.c

### DIFF
--- a/sys/security/mac_do/mac_do.c
+++ b/sys/security/mac_do/mac_do.c
@@ -17,6 +17,7 @@
 #include <sys/socket.h>
 #include <sys/sx.h>
 #include <sys/sysctl.h>
+#include <sys/syslog.h>
 #include <sys/systm.h>
 #include <sys/ucred.h>
 #include <sys/vnode.h>
@@ -432,6 +433,7 @@ priv_grant(struct ucred *cred, int priv)
 			switch (priv) {
 			case PRIV_CRED_SETGROUPS:
 			case PRIV_CRED_SETUID:
+				log(LOG_SECURITY | LOG_INFO, "Uid %d met the condition and will be granted privileges.\n", cred->cr_uid);
 				mtx_unlock(&pr->pr_mtx);
 				return (0);
 			default:
@@ -439,6 +441,7 @@ priv_grant(struct ucred *cred, int priv)
 			}
 		}
 	}
+	log(LOG_SECURITY | LOG_WARNING, "Uid %d failed to meet the condition.\n", cred->cr_uid);
 	mtx_unlock(&pr->pr_mtx);
 	return (EPERM);
 }


### PR DESCRIPTION
Add logger for mac_do module.

The output format is like following:
```
Nov  4 05:32:43 bsd-workstation syslogd: last message repeated 18 times
Nov  4 05:32:43 bsd-workstation kernel: Uid 1001 met the condition and will be granted privileges.
Nov  4 05:32:43 bsd-workstation syslogd: last message repeated 1 times
Nov  4 05:32:45 bsd-workstation kernel: Uid 1001 failed to meet the condition.
Nov  4 05:32:51 bsd-workstation syslogd: last message repeated 13 times
Nov  4 05:33:00 bsd-workstation kernel: Uid 2 failed to meet the condition.
Nov  4 05:33:00 bsd-workstation syslogd: last message repeated 56 times
Nov  4 05:33:17 bsd-workstation kernel: Uid 1001 failed to meet the condition.
```

I don't know why the message would be repeated so many times, which seems to be irrelevant with the mac_do module, needs some improvement here.