### PR TITLE
vt.4: align tables + 80 character line limit

### DIFF
--- a/share/man/man4/vt.4
+++ b/share/man/man4/vt.4
@@ -312,7 +312,7 @@ or changed at runtime with
 Enable the terminal bell.
 .El
 .Sh FILES
-.Bl -tag -width /usr/share/vt/keymaps/* -compact
+.Bl -tag -width "/usr/share/vt/keymaps/*.kbd" -compact
 .It Pa /dev/console
 .It Pa /dev/consolectl
 .It Pa /dev/ttyv*
@@ -325,13 +325,12 @@ console fonts
 keyboard layouts
 .El
 .Sh DEVCTL MESSAGES
-.Bl -column "System" "Subsystem" "1234567" -compact
+.Bl -column "System" "Subsystem" "Type" "Description"
 .Sy "System" Ta Sy "Subsystem" Ta Sy "Type" Ta Sy "Description"
 .It Li VT Ta BELL Ta RING Ta
 Notification that the console bell has rung.
 .El
-.Pp
-.Bl -column "Variable" "Meaning" -compact
+.Bl -column "duration_ms" "Meaning"
 .Sy "Variable" Ta Sy "Meaning"
 .It Li duration_ms Ta Length of time the bell was requested to ring in milliseconds.
 .It Li enabled Ta true or false indicating whether or not the bell was administratively enabled when rung.
@@ -357,7 +356,8 @@ To set a 1024x768 mode on all output connectors, put the following line in
 .Pp
 .Dl kern.vt.fb.default_mode="1024x768"
 .Pp
-To set a 800x600 only on a laptop builtin screen, use the following line instead:
+To set a 800x600 only on a laptop builtin screen,
+use the following line instead:
 .Pp
 .Dl kern.vt.fb.modes.LVDS-1="800x600"
 .Pp


### PR DESCRIPTION
Fix rendering errors saving 2-3 lines of rendered output on MANWIDTH 80 and 59 by correcting list alignment syntax.

Column lists are already compact, but specifying a width argument for each column is what the spec asks and makes them wrap better.

Please consider mfc to 14.2, this is a tiny polish of the doc on the core UX.

For a future PR, hopefully not holding this up:
What are `/dev/console` and `/dev/consolectl`?