### PR TITLE
ppp.8: Fix typo cuad0 -> cuau0

### DIFF
--- a/usr.sbin/ppp/ppp.8
+++ b/usr.sbin/ppp/ppp.8
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 27, 2022
+.Dd November 18, 2024
 .Dt PPP 8
 .Os
 .Sh NAME
@@ -263,7 +263,8 @@ will force it to exit.
 .It Supports client callback.
 .Nm
 can use either the standard LCP callback protocol or the Microsoft
-CallBack Control Protocol (https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-CBCP/[MS-CBCP].pdf).
+CallBack Control Protocol
+.Pq Lk https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-CBCP/%5bMS-CBCP%5d.pdf .
 .It Supports NAT or packet aliasing.
 Packet aliasing (a.k.a.\& IP masquerading) allows computers on a
 private, unregistered network to access the Internet.
@@ -339,7 +340,7 @@ to check the packet flow over the
 link.
 .It Supports PPP over TCP and PPP over UDP.
 If a device name is specified as
-.Em host Ns No : Ns Em port Ns
+.Em host : Ns Em port Ns
 .Xo
 .Op / Ns tcp|udp ,
 .Xc
@@ -353,7 +354,7 @@ into synchronous mode.
 If
 .Nm
 is given a device specification of the format
-.No PPPoE: Ns Ar iface Ns Xo
+.No PPPoE\&: Ns Ar iface Ns Xo
 .Op \&: Ns Ar provider Ns
 .Xc
 and if
@@ -2166,13 +2167,22 @@ set device /dev/cuau0
 set speed 115200
 .Ed
 .Pp
-Cuad0 is the first serial port on
-.Fx .
+.Pa cuaU0
+and
+.Pa cuau0
+are the first
+.Xr usb 4
+and
+.Xr uart 4
+serial ports found by
+.Fx ,
+respectively.
 If you are running
 .Nm
 on
 .Ox ,
-cua00 is the first.
+.Pa cua00
+is the first.
 A speed of 115200 should be specified
 if you have a modem capable of bit rates of 28800 or more.
 In general, the serial speed should be about four times the modem speed.
@@ -2734,7 +2744,7 @@ Default: Disabled and Denied.
 This option allows DNS negotiation.
 .Pp
 If
-.Dq enable Ns No d,
+.Dq enable Ns No d ,
 .Nm
 will request that the peer confirms the entries in
 .Pa /etc/resolv.conf .
@@ -2743,7 +2753,7 @@ If the peer NAKs our request (suggesting new IP numbers),
 is updated and another request is sent to confirm the new entries.
 .Pp
 If
-.Dq accept Ns No ed,
+.Dq accept Ns No ed ,
 .Nm
 will answer any DNS queries requested by the peer rather than rejecting
 them.
@@ -3446,8 +3456,7 @@ This command gives a summary of available nat commands.
 This option causes various NAT statistics and information to
 be logged to the file
 .Pa /var/log/alias.log .
-.It nat port Ar proto Ar targetIP Ns Xo
-.No : Ns Ar targetPort Ns
+.It nat port Ar proto Ar targetIP Ns Xo : Ns Ar targetPort Ns
 .Oo
 .No - Ns Ar targetPort
 .Oc Ar aliasPort Ns
@@ -4390,8 +4399,8 @@ This is required (in addition to one or more other callback
 options) if you wish callback to be optional.
 .El
 .It set cbcp Oo
-.No *| Ns Ar number Ns Oo
-.No , Ns Ar number Ns ...\& Oc
+.No *| Ns Ar number Ns
+.Oo , Ns Ar number Ns ...\& Oc
 .Op Ar delay Op Ar retry
 .Oc
 If no arguments are given, CBCP (Microsoft's CallBack Control Protocol)
@@ -4403,7 +4412,7 @@ requesting no callback in the CBCP phase.
 Otherwise,
 .Nm
 attempts to use the given phone
-.Ar number Ns No (s).
+.Ar number Ns No (s) .
 .Pp
 In server mode
 .Pq Fl direct ,
@@ -4421,7 +4430,7 @@ is specified,
 .Nm
 will expect the peer to specify the number.
 .It set cd Oo
-.No off| Ns Ar seconds Ns Op !\&
+.No off\&| Ns Ar seconds Ns Op !\&
 .Oc
 Normally,
 .Nm
@@ -4578,7 +4587,7 @@ does not begin with
 it must either begin with an exclamation mark
 .Pq Dq !\& ,
 be of the format
-.No PPPoE: Ns Ar iface Ns Xo
+.No PPPoE\&: Ns Ar iface Ns Xo
 .Op \&: Ns Ar provider Ns
 .Xc
 (on
@@ -4596,7 +4605,7 @@ Standard input, output and error are fed back to
 and are read and written as if they were a regular device.
 .Pp
 If a
-.No PPPoE: Ns Ar iface Ns Xo
+.No PPPoE\&: Ns Ar iface Ns Xo
 .Op \&: Ns Ar provider Ns
 .Xc
 specification is given,
@@ -4635,7 +4644,7 @@ and
 for further details.
 .Pp
 If a
-.Ar host Ns No : Ns Ar port Ns Oo
+.Ar host : Ns Ar port Ns Oo
 .No /tcp|udp
 .Oc
 specification is given,
@@ -4864,7 +4873,7 @@ It allows the user to specify a set of characters that will be
 .Sq escaped
 as they travel across the link.
 .It set filter dial|alive|in|out Ar rule-no Xo
-.No permit|deny|clear| Ns Ar rule-no
+.No permit|deny|clear\&| Ns Ar rule-no
 .Op !\&
 .Oo Op host
 .Ar src_addr Ns Op / Ns Ar width


### PR DESCRIPTION
Move [PR #248359](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=248359) here as part of a cleanup of personal old bug reports.