### PR TITLE
od.1: add "raw" and "byte" to document description

### DIFF
--- a/usr.bin/hexdump/od.1
+++ b/usr.bin/hexdump/od.1
@@ -1,3 +1,6 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-3-Clause
+.\"
 .\" Copyright (c) 1990, 1993
 .\"	The Regents of the University of California.  All rights reserved.
 .\"
@@ -25,12 +28,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 22, 2011
+.Dd November 13, 2024
 .Dt OD 1
 .Os
 .Sh NAME
 .Nm od
-.Nd octal, decimal, hex, ASCII dump
+.Nd raw octal, decimal, hex, ASCII byte dump
 .Sh SYNOPSIS
 .Nm
 .Op Fl aBbcDdeFfHhIiLlOosvXx


### PR DESCRIPTION
Use case: User is looking for a tool to view raw bytes:

`apropos -s1 raw`
`apropos -s1 byte`

Both do not show our excellent, mature tooling for this.

Proposition: They can be added cleanly and elegantly to the document description of od(1), and the resulting title still looks good even in MANWIDTH 59. Since this is a straightforward manual search bug fix for tooling in 14.2, I would like to humbly ask that this is MFC to the beta, that to increase the likelihood that the new generation of people who will starting in 14.2 have a greater chance of learning our culture.

~~Should I do the same for hd(1)?~~ There isn't room to do this in hd(1) without line wrapping.