### PR TITLE
style.mdoc: fix list width alignment instructions

### DIFF
--- a/share/man/man5/style.mdoc.5
+++ b/share/man/man5/style.mdoc.5
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 12, 2024
+.Dd December 12, 2024
 .Dt STYLE.MDOC 5
 .Os
 .Sh NAME
@@ -124,7 +124,8 @@ The
 .Fl width
 argument to the
 .Sy \&.Bl
-macro should match the length of the longest item in the list, e.g.:
+macro should match the length of the longest rendered item in the list,
+e.g.:
 .Bd -literal -offset indent
 \&.Bl -tag -width "-a address"
 \&.It Fl a Ar address


### PR DESCRIPTION
This is what I was trying to do back in May[^1], but it wasn't quite right then.

cc @cperciva, @mhorne,

[^1]: https://github.com/freebsd/freebsd-src/pull/1235