### PR TITLE
uart.4: describe better + spdx

### DIFF
--- a/share/man/man4/uart.4
+++ b/share/man/man4/uart.4
@@ -1,3 +1,5 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
 .\"
 .\" Copyright (c) 2003 Marcel Moolenaar
 .\" All rights reserved.
@@ -23,12 +25,12 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd October 11, 2024
+.Dd December 5, 2024
 .Dt UART 4
 .Os
 .Sh NAME
 .Nm uart
-.Nd driver for Universal Asynchronous Receiver/Transmitter (UART) devices
+.Nd Universal Asynchronous Receiver/Transmitter serial driver
 .Sh SYNOPSIS
 .Cd "device uart"
 .Pp


### PR DESCRIPTION
No information or search keywords are removed because the rendered title will show the acronym first instead of twice.

I think just saying "device" is more elegant than just saying "driver", but it seems like we're moving towards "driver" because it eases the learning curve.