### PR TITLE
readelf: Add support for LoongArch specific e_flags

### DIFF
--- a/contrib/elftoolchain/common/elfdefinitions.h
+++ b/contrib/elftoolchain/common/elfdefinitions.h
@@ -869,7 +869,8 @@ _ELF_DEFINE_EM(EM_KMX32,            211, "KM211 KMX32 32-bit processor") \
 _ELF_DEFINE_EM(EM_KMX16,            212, "KM211 KMX16 16-bit processor") \
 _ELF_DEFINE_EM(EM_KMX8,             213, "KM211 KMX8 8-bit processor")  \
 _ELF_DEFINE_EM(EM_KVARC,            214, "KM211 KMX32 KVARC processor") \
-_ELF_DEFINE_EM(EM_RISCV,            243, "RISC-V")
+_ELF_DEFINE_EM(EM_RISCV,            243, "RISC-V")                      \
+_ELF_DEFINE_EM(EM_LOONGARCH,        258, "LOONGARCH)
 
 #undef	_ELF_DEFINE_EM
 #define	_ELF_DEFINE_EM(N, V, DESCR)	N = V ,

--- a/contrib/elftoolchain/common/elfdefinitions.h
+++ b/contrib/elftoolchain/common/elfdefinitions.h
@@ -33,7 +33,7 @@
  *   See: http://www.sco.com/developers/gabi/latest/ch4.intro.html
  * - The May 1998 (version 1.5) draft of "The ELF-64 object format".
  * - Processor-specific ELF ABI definitions for sparc, i386, amd64, mips,
- *   ia64, powerpc, and RISC-V processors.
+ *   ia64, powerpc, RISC-V, and LoongArch processors.
  * - The "Linkers and Libraries Guide", from Sun Microsystems.
  */
 
@@ -474,6 +474,20 @@ _ELF_DEFINE_EF(EF_RISCV_RVE,	    0x00000008UL,			\
 	"RV32E embedded ABI")						\
 _ELF_DEFINE_EF(EF_RISCV_TSO,	    0x00000010UL,			\
 	"RVTSO memory consistency model")				\
+_ELF_DEFINE_EF(EF_LOONGARCH_ABI_SOFT_FLOAT,	0x00000001UL,		\
+        "LoongArch LP64 ABI with software floating point emulation")	\
+_ELF_DEFINE_EF(EF_LOONGARCH_ABI_SINGLE_FLOAT,   0x00000002UL,		\
+        "LoongArch LP64 ABI with single precision floating point")	\
+_ELF_DEFINE_EF(EF_LOONGARCH_ABI_DOUBLE_FLOAT,   0x00000003UL,		\
+        "LoongArch LP64 ABI with double precision floating point")	\
+_ELF_DEFINE_EF(EF_LOONGARCH_ABI_MODIFIER_MASK,	0x00000007UL,		\
+	"LoongArch LP64 ABI floating point modifiers")			\
+_ELF_DEFINE_EF(EF_LOONGARCH_OBJABI_V0,		0x00000000UL,		\
+        "LoongArch Object file ABI versions")				\
+_ELF_DEFINE_EF(EF_LOONGARCH_OBJABI_V1,		0x00000040UL,		\
+        "LoongArch Object file ABI versions 1")				\
+_ELF_DEFINE_EF(EF_LOONGARCH_OBJABI_MASK,	0x000000C0UL,		\
+        "LoongArch Object File ABI Version Mask")			\
 _ELF_DEFINE_EF(EF_SPARC_EXT_MASK,   0x00ffff00UL,			\
 	"Vendor Extension mask")					\
 _ELF_DEFINE_EF(EF_SPARC_32PLUS,     0x00000100UL,			\

--- a/contrib/elftoolchain/readelf/readelf.c
+++ b/contrib/elftoolchain/readelf/readelf.c
@@ -593,6 +593,7 @@ elf_machine(unsigned int mach)
 	case EM_UNICORE: return "Microprocessor series from PKU-Unity Ltd";
 	case EM_AARCH64: return "AArch64";
 	case EM_RISCV: return "RISC-V";
+	case EM_LOONGARCH: return "LoongArch";
 	default:
 		snprintf(s_mach, sizeof(s_mach), "<unknown: %#x>", mach);
 		return (s_mach);

--- a/contrib/elftoolchain/readelf/readelf.c
+++ b/contrib/elftoolchain/readelf/readelf.c
@@ -456,6 +456,12 @@ static struct eflags_desc riscv_eflags_desc[] = {
 	{0, NULL}
 };
 
+static struct eflags_desc loongarch_eflags_desc[] = {
+	{EF_LOONGARCH_OBJABI_V0, "OBJ-v0"},
+	{EF_LOONGARCH_OBJABI_V1, "OBJ-v1"},
+	{0, NULL}
+};
+
 static struct eflags_desc sparc_eflags_desc[] = {
 	{EF_SPARC_32PLUS, "v8+"},
 	{EF_SPARC_SUN_US1, "ultrasparcI"},
@@ -2438,6 +2444,23 @@ dump_eflags(struct readelf *re, uint64_t e_flags)
 			break;
 		}
 		edesc = riscv_eflags_desc;
+		break;
+	case EM_LOONGARCH:
+		switch (e_flags & EF_LOONGARCH_ABI_MODIFIER_MASK) {
+		case EF_LOONGARCH_ABI_SOFT_FLOAT:
+			printf(", SOFT-FLOAT");
+			break;
+		case EF_LOONGARCH_ABI_SINGLE_FLOAT:
+			printf(", SINGLE-FLOAT");
+			break;
+		case EF_LOONGARCH_ABI_DOUBLE_FLOAT:
+			printf(", DOUBLE-FLOAT");
+			break;
+		case EF_LOONGARCH_ABI_MODIFIER_MASK:
+			printf(", MODIFIER-MASK");
+			break;
+		}
+		edesc = loongarch_eflags_desc;
 		break;
 	case EM_SPARC:
 	case EM_SPARC32PLUS:

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -383,6 +383,21 @@ typedef struct {
 #define	EF_RISCV_RVE		0x00000008
 #define	EF_RISCV_TSO		0x00000010
 
+// Definitions from LoongArch ELF psABI v2.01.
+// Reference: https://github.com/loongson/LoongArch-Documentation
+// (commit hash 296de4def055c871809068e0816325a4ac04eb12)
+
+// LoongArch Base ABI Modifiers
+#define EF_LOONGARCH_ABI_SOFT_FLOAT     0x00000001
+#define EF_LOONGARCH_ABI_SINGLE_FLOAT   0x00000002
+#define EF_LOONGARCH_ABI_DOUBLE_FLOAT   0x00000003
+#define EF_LOONGARCH_ABI_MODIFIER_MASK  0x00000007
+
+// LoongArch Object file ABI versions
+#define EF_LOONGARCH_OBJABI_V0          0x00000000
+#define EF_LOONGARCH_OBJABI_V1          0x00000040
+#define EF_LOONGARCH_OBJABI_MASK        0x000000C0
+
 #define	EF_SPARC_EXT_MASK	0x00ffff00
 #define	EF_SPARC_32PLUS		0x00000100
 #define	EF_SPARC_SUN_US1	0x00000200

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -306,6 +306,7 @@ typedef struct {
 				   and MPRC of Peking University */
 #define	EM_AARCH64	183	/* AArch64 (64-bit ARM) */
 #define	EM_RISCV	243	/* RISC-V */
+#define	EM_LOONGARCH	258	/* LoongArch */
 
 /* Non-standard or deprecated. */
 #define	EM_486		6	/* Intel i486. */

--- a/usr.bin/elfdump/elfdump.c
+++ b/usr.bin/elfdump/elfdump.c
@@ -274,6 +274,7 @@ e_machines(u_int mach)
 	case EM_X86_64:	return "EM_X86_64";
 	case EM_AARCH64:return "EM_AARCH64";
 	case EM_RISCV:	return "EM_RISCV";
+	case EM_LOONGARCH:      return "EM_LOONGARCH";
 	}
 	snprintf(machdesc, sizeof(machdesc),
 	    "(unknown machine) -- type 0x%x", mach);


### PR DESCRIPTION
Hello, I have added support for the LoongArch architecture to readelf, primarily referencing RISC-V/LLVM related commits.