### PR TITLE
bsd.lib.mk: Capitalize "Building"

### DIFF
--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -290,7 +290,7 @@ _STATICLIB_SUFFIX=	_real
 _LIBS=		lib${LIB_PRIVATE}${LIB}${_STATICLIB_SUFFIX}.a
 
 lib${LIB_PRIVATE}${LIB}${_STATICLIB_SUFFIX}.a: ${OBJS} ${STATICOBJS}
-	@${ECHO} building static ${LIB} library
+	@${ECHO} Building static ${LIB} library
 	@rm -f ${.TARGET}
 	${AR} ${ARFLAGS} ${.TARGET} ${OBJS} ${STATICOBJS} ${ARADD}
 .endif
@@ -344,7 +344,7 @@ CLEANFILES+=	${SHLIB_LINK}
 .endif
 
 ${SHLIB_NAME_FULL}: ${SOBJS}
-	@${ECHO} building shared library ${SHLIB_NAME}
+	@${ECHO} Building shared library ${SHLIB_NAME}
 	@rm -f ${SHLIB_NAME} ${SHLIB_LINK}
 .if defined(SHLIB_LINK) && !commands(${SHLIB_LINK:R}.ld) && ${MK_DEBUG_FILES} == "no"
 	# Note: This uses ln instead of ${INSTALL_LIBSYMLINK} since we are in OBJDIR
@@ -375,7 +375,7 @@ ${SHLIB_NAME}.debug: ${SHLIB_NAME_FULL}
 _LIBS+=		lib${LIB_PRIVATE}${LIB}_pic.a
 
 lib${LIB_PRIVATE}${LIB}_pic.a: ${SOBJS}
-	@${ECHO} building special pic ${LIB} library
+	@${ECHO} Building special pic ${LIB} library
 	@rm -f ${.TARGET}
 	${AR} ${ARFLAGS} ${.TARGET} ${SOBJS} ${ARADD}
 .endif
@@ -387,7 +387,7 @@ CLEANFILES+=	${NOSSPSOBJS}
 _LIBS+=		lib${LIB_PRIVATE}${LIB}_nossp_pic.a
 
 lib${LIB_PRIVATE}${LIB}_nossp_pic.a: ${NOSSPSOBJS}
-	@${ECHO} building special nossp pic ${LIB} library
+	@${ECHO} Building special nossp pic ${LIB} library
 	@rm -f ${.TARGET}
 	${AR} ${ARFLAGS} ${.TARGET} ${NOSSPSOBJS} ${ARADD}
 .endif
@@ -402,7 +402,7 @@ CLEANFILES+=	${PIEOBJS}
 _LIBS+=		lib${LIB_PRIVATE}${LIB}_pie.a
 
 lib${LIB_PRIVATE}${LIB}_pie.a: ${PIEOBJS}
-	@${ECHO} building pie ${LIB} library
+	@${ECHO} Building pie ${LIB} library
 	@rm -f ${.TARGET}
 	${AR} ${ARFLAGS} ${.TARGET} ${PIEOBJS} ${ARADD}
 .endif


### PR DESCRIPTION
This changes `building shared library (LIB)` to `Building shared library (LIB)`.

Before:
```
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.bin/vi/ex_yank.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.sbin/wpa/src/ap/pmksa_cache_auth.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.sbin/ntp/libntp/is_ip_address.pieo
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.bin/vi/ex_z.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.sbin/acpi/iasl/dsfield.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.bin/vi/getc.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.bin/kyua/utils/config/tree.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/lib/libthr/tests/dlopen/dso/h_pthread_dlopen.so.1.full
building shared library h_pthread_dlopen.so.1
```

After:
```
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.bin/vi/ex_yank.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.sbin/wpa/src/ap/pmksa_cache_auth.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.sbin/ntp/libntp/is_ip_address.pieo
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.bin/vi/ex_z.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.sbin/acpi/iasl/dsfield.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.bin/vi/getc.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/usr.bin/kyua/utils/config/tree.o
Building /usr/obj/usr/src/freebsd/libecho/amd64.amd64/lib/libthr/tests/dlopen/dso/h_pthread_dlopen.so.1.full
Building shared library h_pthread_dlopen.so.1
```