### PR TITLE
savecore: add missing call to cap_openlog when in capabilities mode

### DIFF
--- a/sbin/savecore/savecore.c
+++ b/sbin/savecore/savecore.c
@@ -101,6 +101,9 @@
 #define	STATUS_GOOD	1
 #define	STATUS_UNKNOWN	2
 
+#define LOG_OPTIONS  LOG_PERROR
+#define LOG_FACILITY LOG_DAEMON
+
 static cap_channel_t *capsyslog;
 static fileargs_t *capfa;
 static bool checkfor, compress, uncompress, clear, force, keep;	/* flags */
@@ -1409,6 +1412,7 @@ init_caps(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 	cap_close(capcas);
+	cap_openlog(capsyslog, "savecore", LOG_OPTIONS, LOG_FACILITY);
 }
 
 static void
@@ -1436,7 +1440,7 @@ main(int argc, char **argv)
 	savedir = ".";
 	comp_desired = KERNELDUMP_COMP_NONE;
 
-	openlog("savecore", LOG_PERROR, LOG_DAEMON);
+	openlog("savecore", LOG_OPTIONS, LOG_FACILITY);
 	signal(SIGINFO, infohandler);
 
 	argc = xo_parse_args(argc, argv);

--- a/sbin/savecore/tests/Makefile
+++ b/sbin/savecore/tests/Makefile
@@ -1,3 +1,3 @@
-ATF_TESTS_SH=	livedump_test
+ATF_TESTS_SH=	livedump_test log_test
 
 .include <bsd.test.mk>

--- a/sbin/savecore/tests/log_test.sh
+++ b/sbin/savecore/tests/log_test.sh
@@ -1,0 +1,25 @@
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2025 Stéphane Rochoy <stephane.rochoy@stormshield.eu>
+#
+
+atf_test_case log_perror
+log_perror_head()
+{
+	atf_set "descr" "Test LOG_PERROR behavior"
+}
+log_perror_body()
+{
+	atf_check -s exit:1 \
+	          -o ignore \
+	          -e save:savecore.err \
+	    savecore -vC /dev/missing
+	grep -qE 'savecore [0-9]+ - - /dev/missing: No such file or directory' savecore.err \
+	    || atf_fail "missing/invalid error output"
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case log_perror
+}


### PR DESCRIPTION
When run in capabilities mode, `savecore` seems to lack a call to `cap_openlog`. Notably it break the use of `LOG_PERROR`.

With the original one:

    $ /sbin/savecore -vC
    checking for kernel dump on device /dev/gpt/swapfs
    No dump exists

With the patched one:

    $ ./savecore -vC
    checking for kernel dump on device /dev/gpt/swapfs
    savecore 1424 - - /dev/gpt/swapfs: Permission denied
    No dump exists

