### PR TITLE
newvers: Set explicit git revision length

### DIFF
--- a/sys/conf/newvers.sh
+++ b/sys/conf/newvers.sh
@@ -255,7 +255,7 @@ if [ -n "$svnversion" ] ; then
 fi
 
 if [ -n "$git_cmd" ] ; then
-	git=$($git_cmd rev-parse --verify --short HEAD 2>/dev/null)
+	git=$($git_cmd rev-parse --verify --short=12 HEAD 2>/dev/null)
 	if [ "$($git_cmd rev-parse --is-shallow-repository)" = false ] ; then
 		git_cnt=$($git_cmd rev-list --first-parent --count HEAD 2>/dev/null)
 		if [ -n "$git_cnt" ] ; then


### PR DESCRIPTION
The --short flag is configurable. Setting an explicit length supports reproducible builds.