### PR TITLE
install: validate -o, -g, and -f values when run with -U

### DIFF
--- a/usr.bin/xinstall/tests/install_test.sh
+++ b/usr.bin/xinstall/tests/install_test.sh
@@ -497,6 +497,30 @@ set_owner_group_mode_unpriv_body() {
 	atf_check_equal "$u:$g:10$cM" "$(stat -f"%u:%g:%p" testc)"
 }
 
+atf_test_case metalog_unpriv
+metalog_unpriv_head() {
+	atf_set "require.user" "unprivileged"
+}
+metalog_unpriv_body() {
+	printf "test" >testf
+
+	atf_check install -U -M METALOG -o root -g wheel -f arch testf testc
+	atf_check grep -q "testc .*uname=root gname=wheel .*flags=arch" METALOG
+
+	rm -f METALOG testc
+	atf_check -s exit:1 -e match:"unknown user no-such-user" install -U -o no-such-user testf testc
+	atf_check [ ! -f testc ]
+	atf_check [ ! -f METALOG ]
+
+	atf_check -s exit:1 -e match:"unknown group no-such-group" install -U -g no-such-group testf testc
+	atf_check [ ! -f testc ]
+	atf_check [ ! -f METALOG ]
+
+	atf_check -s exit:64 -e match:"nosuchflag: invalid flag" install -U -f nosuchflag testf testc
+	atf_check [ ! -f testc ]
+	atf_check [ ! -f METALOG ]
+}
+
 atf_test_case set_optional_exec
 set_optional_exec_head() {
 	atf_set "require.user" "unprivileged"
@@ -556,5 +580,6 @@ atf_init_test_cases() {
 	atf_add_test_case mkdir_simple
 	atf_add_test_case set_owner_group_mode
 	atf_add_test_case set_owner_group_mode_unpriv
+	atf_add_test_case metalog_unpriv
 	atf_add_test_case set_optional_exec
 }

--- a/usr.bin/xinstall/xinstall.c
+++ b/usr.bin/xinstall/xinstall.c
@@ -324,7 +324,7 @@ main(int argc, char *argv[])
 	}
 
 	/* get group and owner id's */
-	if (group != NULL && !dounpriv) {
+	if (group != NULL) {
 		if (gid_from_group(group, &gid) == -1) {
 			id_t id;
 			if (!parseid(group, &id))
@@ -334,7 +334,7 @@ main(int argc, char *argv[])
 	} else
 		gid = (gid_t)-1;
 
-	if (owner != NULL && !dounpriv) {
+	if (owner != NULL) {
 		if (uid_from_user(owner, &uid) == -1) {
 			id_t id;
 			if (!parseid(owner, &id))
@@ -344,7 +344,7 @@ main(int argc, char *argv[])
 	} else
 		uid = (uid_t)-1;
 
-	if (fflags != NULL && !dounpriv) {
+	if (fflags != NULL) {
 		if (strtofflags(&fflags, &fset, NULL))
 			errx(EX_USAGE, "%s: invalid flag", fflags);
 		iflags |= SETFLAGS;


### PR DESCRIPTION
When run as root, install will error if the values given to -o, -g, or -f are invalid. Prior to this change, running with -U (unprivileged) silently accepted any values given to these flags.

Test that the values are correctly recorded to METALOG when called with -M.

[PR: 283355](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=283355)