### PR TITLE
make check: Eliminate "operation not permitted" errors

### DIFF
--- a/share/mk/suite.test.mk
+++ b/share/mk/suite.test.mk
@@ -118,8 +118,7 @@ beforecheck:
 #       times. "aftercheck" won't be run if "make check" fails, is interrupted,
 #       etc.
 aftercheck:
-	@cd ${.CURDIR} && ${MAKE} clean
 	@test ! -e ${DESTDIR} || chflags -R 0 "${DESTDIR}"
-	@rm -Rf "${DESTDIR}"
+	@cd ${.CURDIR} && ${MAKE} clean
 
 .endif


### PR DESCRIPTION
aftercheck calls clean. ${DESTDIR}/var/empty has schg flag set. Prior to this change, every run of `make check` ended with:

rm: checkdir/var/empty: Operation not permitted
rm: checkdir/var: Directory not empty
rm: checkdir: Directory not empty
*** Error code 1 (ignored)

Remove the flags from DESTDIR before running clean, to bypass the noisy output.