### PR TITLE
Fix some locking violations in fusefs

### DIFF
--- a/sys/fs/fuse/fuse_internal.c
+++ b/sys/fs/fuse/fuse_internal.c
@@ -377,6 +377,8 @@ fuse_internal_fsync(struct vnode *vp,
 	int op = FUSE_FSYNC;
 	int err = 0;
 
+	ASSERT_VOP_LOCKED(vp, __func__); /* For fvdat->handles */
+
 	if (fsess_not_impl(vnode_mount(vp),
 	    (vnode_vtype(vp) == VDIR ? FUSE_FSYNCDIR : FUSE_FSYNC))) {
 		return 0;

--- a/sys/fs/fuse/fuse_node.c
+++ b/sys/fs/fuse/fuse_node.c
@@ -367,7 +367,7 @@ fuse_vnode_savesize(struct vnode *vp, struct ucred *cred, pid_t pid)
 	struct fuse_setattr_in *fsai;
 	int err = 0;
 
-	ASSERT_VOP_ELOCKED(vp, "fuse_io_extend");
+	ASSERT_VOP_ELOCKED(vp, __func__);
 
 	if (fuse_isdeadfs(vp)) {
 		return EBADF;
@@ -423,7 +423,7 @@ fuse_vnode_setsize(struct vnode *vp, off_t newsize, bool from_server)
 	struct buf *bp = NULL;
 	int err = 0;
 
-	ASSERT_VOP_ELOCKED(vp, "fuse_vnode_setsize");
+	ASSERT_VOP_ELOCKED(vp, __func__); /* For fvdat->cached_attrs */
 
 	iosize = fuse_iosize(vp);
 	oldsize = fvdat->cached_attrs.va_size;
@@ -480,6 +480,8 @@ fuse_vnode_size(struct vnode *vp, off_t *filesize, struct ucred *cred,
 	struct fuse_vnode_data *fvdat = VTOFUD(vp);
 	int error = 0;
 
+	ASSERT_VOP_LOCKED(vp, __func__); /* For fvdat->cached_attrs */
+
 	if (!(fvdat->flag & FN_SIZECHANGE) &&
 		(!fuse_vnode_attr_cache_valid(vp) ||
 		  fvdat->cached_attrs.va_size == VNOVAL)) 
@@ -509,6 +511,8 @@ fuse_vnode_update(struct vnode *vp, int flags)
 	struct mount *mp = vnode_mount(vp);
 	struct fuse_data *data = fuse_get_mpdata(mp);
 	struct timespec ts;
+
+	ASSERT_VOP_ELOCKED(vp, __func__);
 
 	vfs_timestamp(&ts);
 

--- a/sys/fs/fuse/fuse_node.h
+++ b/sys/fs/fuse/fuse_node.h
@@ -101,7 +101,10 @@ struct fuse_vnode_data {
 	uint64_t	parent_nid;
 
 	/** I/O **/
-	/* List of file handles for all of the vnode's open file descriptors */
+	/*
+	 * List of file handles for all of the vnode's open file descriptors.
+	 * Protected by the vnode lock.
+	 */
 	LIST_HEAD(, fuse_filehandle)	handles;
 
 	/** flags **/

--- a/sys/fs/fuse/fuse_vfsops.c
+++ b/sys/fs/fuse/fuse_vfsops.c
@@ -578,6 +578,7 @@ fuse_vfsop_vget(struct mount *mp, ino_t ino, int flags, struct vnode **vpp)
 	error = fuse_vnode_get(mp, feo, nodeid, NULL, vpp, NULL, vtyp);
 	if (error)
 		goto out;
+	ASSERT_VOP_ELOCKED(*vpp, __func__);
 	fvdat = VTOFUD(*vpp);
 
 	if (timespeccmp(&now, &fvdat->last_local_modify, >)) {

--- a/sys/fs/fuse/fuse_vnops.c
+++ b/sys/fs/fuse/fuse_vnops.c
@@ -1251,6 +1251,8 @@ fuse_vnop_inactive(struct vop_inactive_args *ap)
 
 	int need_flush = 1;
 
+	ASSERT_VOP_ELOCKED(vp, __func__); /* For fvdat->handles */
+
 	LIST_FOREACH_SAFE(fufh, &fvdat->handles, next, fufh_tmp) {
 		if (need_flush && vp->v_type == VREG) {
 			if ((VTOFUD(vp)->flag & FN_SIZECHANGE) != 0) {
@@ -2058,6 +2060,7 @@ fuse_vnop_reclaim(struct vop_reclaim_args *ap)
 	if (!fvdat) {
 		panic("FUSE: no vnode data during recycling");
 	}
+	ASSERT_VOP_ELOCKED(vp, __func__); /* For fvdat->handles */
 	LIST_FOREACH_SAFE(fufh, &fvdat->handles, next, fufh_tmp) {
 		printf("FUSE: vnode being reclaimed with open fufh "
 			"(type=%#x)", fufh->fufh_type);

--- a/tests/sys/fs/fusefs/default_permissions.cc
+++ b/tests/sys/fs/fusefs/default_permissions.cc
@@ -1204,6 +1204,83 @@ TEST_F(Rename, eperm_on_sticky_dstdir)
 	ASSERT_EQ(EPERM, errno);
 }
 
+static volatile int stopit = 0;
+
+static void* setattr_th(void* arg) {
+	char *path = (char*)arg;
+
+	while (stopit == 0)
+		 chmod(path, 0777);
+	return 0;
+}
+
+/*
+ * Rename restarts the syscall to avoid a LOR
+ *
+ * This test triggers a race: the chmod() calls VOP_SETATTR, which locks its
+ * vnode, but fuse_vnop_rename also tries to lock the same vnode in order to
+ * use FUSE_GETATTR on it.  The result is that, in order to avoid a LOR,
+ * fuse_vnop_rename returns ERELOOKUP to restart the syscall.
+ *
+ * To verify that the race is hit, watch the fusefs:fusefs:vnops:erelookup
+ * dtrace probe while the test is running.  On my system, that probe fires 1 - 5
+ * times per second during this test.
+ */
+TEST_F(Rename, erelookup)
+{
+	const char FULLDST[] = "mountpoint/dstdir/dst";
+	const char RELDSTDIR[] = "dstdir";
+	const char RELDST[] = "dst";
+	const char FULLSRC[] = "mountpoint/src";
+	const char RELSRC[] = "src";
+	pthread_t th0;
+	uint64_t ino = 42;
+	uint64_t dst_dir_ino = 43;
+	struct timespec now, timeout;
+
+	expect_getattr(FUSE_ROOT_ID, S_IFDIR | 0777, UINT64_MAX, 1, geteuid());
+	EXPECT_LOOKUP(FUSE_ROOT_ID, RELSRC)
+	.WillRepeatedly(Invoke(
+		ReturnImmediate([=](auto i __unused, auto& out) {
+			SET_OUT_HEADER_LEN(out, entry);
+			out.body.entry.attr.mode = S_IFDIR | 0644;
+			out.body.entry.nodeid = ino;
+			out.body.entry.attr.nlink = 2;
+			out.body.entry.attr_valid = UINT64_MAX;
+			out.body.entry.attr.uid = 0;
+			out.body.entry.attr.gid = 0;
+			out.body.entry.entry_valid = UINT64_MAX;
+		}))
+	);
+	EXPECT_LOOKUP(FUSE_ROOT_ID, RELDSTDIR)
+	.WillRepeatedly(Invoke(ReturnImmediate([=](auto in __unused, auto& out)
+	{
+		SET_OUT_HEADER_LEN(out, entry);
+		out.body.entry.nodeid = dst_dir_ino;
+		out.body.entry.entry_valid = UINT64_MAX;
+		out.body.entry.attr_valid = UINT64_MAX;
+		out.body.entry.attr.mode = S_IFDIR | 0755;
+		out.body.entry.attr.ino = dst_dir_ino;
+		out.body.entry.attr.uid = geteuid();
+		out.body.entry.attr.gid = getegid();
+	})));
+	EXPECT_LOOKUP(dst_dir_ino, RELDST)
+	.WillRepeatedly(Invoke(ReturnErrno(ENOENT)));
+
+	ASSERT_EQ(0, pthread_create(&th0, NULL, setattr_th, (void*)FULLSRC))
+		<< strerror(errno);
+
+	ASSERT_EQ(0, clock_gettime(CLOCK_MONOTONIC, &timeout));
+	timeout.tv_sec += 1;
+	do {
+		ASSERT_EQ(-1, rename(FULLSRC, FULLDST));
+		EXPECT_EQ(EACCES, errno);
+		ASSERT_EQ(0, clock_gettime(CLOCK_MONOTONIC, &now));
+	} while (timespeccmp(&now, &timeout, <));
+	stopit = 1;
+	pthread_join(th0, NULL);
+}
+
 /* Successfully rename a file, overwriting the destination */
 TEST_F(Rename, ok)
 {

--- a/tests/sys/fs/fusefs/read.cc
+++ b/tests/sys/fs/fusefs/read.cc
@@ -89,9 +89,17 @@ virtual void SetUp() {
 };
 
 class AsyncRead: public AioRead {
+public:
 	virtual void SetUp() {
 		m_init_flags = FUSE_ASYNC_READ;
 		AioRead::SetUp();
+	}
+};
+
+class AsyncReadNoatime: public AsyncRead {
+	virtual void SetUp() {
+		m_noatime = true;
+		AsyncRead::SetUp();
 	}
 };
 
@@ -266,10 +274,10 @@ TEST_F(AioRead, async_read_disabled)
 }
 
 /* 
- * With the FUSE_ASYNC_READ mount option, fuse(4) may issue multiple
- * simultaneous read requests on the same file handle.
+ * With the FUSE_ASYNC_READ mount option and atime ignored, fuse(4) may issue
+ * multiple simultaneous read requests on the same file handle.
  */
-TEST_F(AsyncRead, async_read)
+TEST_F(AsyncReadNoatime, async_read)
 {
 	const char FULLPATH[] = "mountpoint/some_file.txt";
 	const char RELPATH[] = "some_file.txt";


### PR DESCRIPTION
Fix several related bugs in fusefs, all relating to activity that ought to require an exclusive vnode lock but was being performed with merely a shared lock.

* Updating a fuse file's atime on read requires an exclusive lock.  This could result in torn writes to the timestamp structure.
* Attempting to clear a file's attribute cache in response to the server returning an error during FUSE_READ requires an exclusive lock.  This could trigger a panic when DEBUG_VFS_LOCKS is enabled.
* fuse_vnop_rename was accessing the source vnode's cached attributes without a vnode lock.  That might result in an incorrect access determination, if it raced with chmod.

Fix these problems by being much more defensive about checking vnode locks within fusefs, upgrading shared locks as needed, and disallowing shared reads when mounted with atime.