### PR TITLE
msdosfs manuals: Improve visibility and linking

### DIFF
--- a/sbin/fsck_msdosfs/fsck_msdosfs.8
+++ b/sbin/fsck_msdosfs/fsck_msdosfs.8
@@ -125,9 +125,8 @@ to assume
 as the answer to all operator questions.
 .El
 .Sh SEE ALSO
-.Xr fsck 8 ,
-.Xr fsck_ffs 8 ,
-.Xr mount_msdosfs 8
+.Xr msdosfs 4 ,
+.Xr fsck 8
 .Sh HISTORY
 The
 .Nm

--- a/sbin/mount_msdosfs/mount_msdosfs.8
+++ b/sbin/mount_msdosfs/mount_msdosfs.8
@@ -33,7 +33,7 @@
 .Os
 .Sh NAME
 .Nm mount_msdosfs
-.Nd mount an MS-DOS file system
+.Nd mount an MS-DOS (FAT) file system
 .Sh SYNOPSIS
 .Nm
 .Op Fl 9ls

--- a/sbin/newfs_msdos/newfs_msdos.8
+++ b/sbin/newfs_msdos/newfs_msdos.8
@@ -252,6 +252,7 @@ Create a 30MB image file, with the FAT partition starting
 newfs_msdos -C 30M -@63s ./somefile
 .Ed
 .Sh SEE ALSO
+.Xr msdosfs 4 ,
 .Xr gpart 8 ,
 .Xr newfs 8
 .Sh HISTORY

--- a/share/man/man4/msdosfs.4
+++ b/share/man/man4/msdosfs.4
@@ -6,7 +6,7 @@
 .Os
 .Sh NAME
 .Nm msdosfs
-.Nd MS-DOS file system
+.Nd MS-DOS (FAT) file system
 .Sh SYNOPSIS
 .Cd "options MSDOSFS"
 .Sh DESCRIPTION
@@ -65,8 +65,10 @@ may also be used to extract this information.
 .Sh SEE ALSO
 .Xr mount 2 ,
 .Xr unmount 2 ,
+.Xr fsck_msdosfs 8 ,
 .Xr mount 8 ,
 .Xr mount_msdosfs 8 ,
+.Xr newfs_msdos 8 ,
 .Xr umount 8
 .Sh AUTHORS
 This manual page was written by


### PR DESCRIPTION
Problem scope: freebsd includes a complete set of fat filesystem utilities, but the manuals are not linked together, and `apropos fat` doesn't find all of them.

Nd: Add (FAT) to all descriptions.
SEE ALSO: Link all utils to msdos(4), and put them all in msdosfs(4).

This time, I just added FAT to the ND's without trying to do anything to make it consistent. If we can do anything non-inflammatory to improve consistency in the document descriptions, I would like to do that.

Tagging everyone from prior discussion and mentors:
@bsdimp, @jlduran, @mhorne, @sergio-carlavilla