### PR TITLE
acpi_gpiobus: assume GPIO_PIN_INPUT for interrupt pins

### DIFF
--- a/sys/dev/gpio/acpi_gpiobus.c
+++ b/sys/dev/gpio/acpi_gpiobus.c
@@ -77,6 +77,7 @@ acpi_gpiobus_convflags(ACPI_RESOURCE_GPIO *gpio_res)
 			break;
 		}
 
+		flags |= GPIO_PIN_INPUT;
 #ifdef NOT_YET
 		/* This is not currently implemented. */
 		if (gpio_res->Shareable == ACPI_SHARED)


### PR DESCRIPTION
Most drivers do nothing when neither GPIO_PIN_INPUT or GPIO_PIN_OUTPUT are set. However, some return `EINVAL` while others (bytgpio is the only example I could find of this) give bad flags to the GPIO controller.

In the case of bytgpio, it causes both the input and output of the GPIO pin to be disabled which the controller doesn't seem to like as it causes the entire machine to lose power shortly after.

To fix this, simply assume GPIO_PIN_INPUT for interrupt pins.

I'll CC everyone from the original revision where this change was suggested (see 0ffd7d4d15d468c60ef274f8368a5722e3f7f6a1)

CC @zxombie @jrtc27 @cperciva 