### PR TITLE
Add __aeabi_ symbols to linker script

### DIFF
--- a/lib/libgcc_s/arm/Symbol.map
+++ b/lib/libgcc_s/arm/Symbol.map
@@ -10,6 +10,31 @@ GCC_3.5 {
 	__aeabi_unwind_cpp_pr1;
 	__aeabi_unwind_cpp_pr2;
 	__gnu_unwind_frame;
+	__aeabi_llsl;
+	__aeabi_lasr;
+	__aeabi_lcmp;
+	__aeabi_idiv;
+	__aeabi_h2f;
+	__aeabi_d2lz;
+	__aeabi_f2lz;
+	__aeabi_d2ulz;
+	__aeabi_f2ulz;
+	__aeabi_ui2d;
+	__aeabi_ui2f;
+	__aeabi_llsr;
+	__aeabi_lmul;
+	__aeabi_d2h;
+	__aeabi_f2h;
+	__aeabi_ulcmp;
+	__aeabi_uidiv;
+	__aeabi_l2d;
+	__aeabi_l2f;
+	__aeabi_ul2d;
+	__aeabi_ul2f;
+	__aeabi_idiv0;
+	__aeabi_ldivmod;
+	__aeabi_uidivmod;
+	__aeabi_uldivmod;
 };
 
 GCC_4.3.0 {


### PR DESCRIPTION
This fixes bug [bug 271087](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271087).