### PR TITLE
amdtemp: add support for AMD Family 1Ah Models 40h-4Fh

### DIFF
--- a/share/man/man4/amdsmn.4
+++ b/share/man/man4/amdsmn.4
@@ -23,14 +23,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd September 5, 2017
+.Dd December 27, 2024
 .Dt AMDSMN 4
 .Os
 .Sh NAME
 .Nm amdsmn
-.Nd device driver for
-.Tn AMD
-processor System Management Network
+.Nd device driver for AMD processor System Management Network
 .Sh SYNOPSIS
 To compile this driver into the kernel, place the following line in your
 kernel configuration file:
@@ -48,9 +46,7 @@ amdsmn_load="YES"
 The
 .Nm
 driver provides support for resources on the System Management Network bus
-in
-.Tn AMD
-Family 17h processors.
+in AMD Family 17h, 19h, and 1Ah processors.
 .Sh SEE ALSO
 .Xr loader 8
 .Sh HISTORY

--- a/share/man/man4/amdtemp.4
+++ b/share/man/man4/amdtemp.4
@@ -23,14 +23,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd September 5, 2017
+.Dd December 27, 2024
 .Dt AMDTEMP 4
 .Os
 .Sh NAME
 .Nm amdtemp
-.Nd device driver for
-.Tn AMD
-processor on-die digital thermal sensor
+.Nd device driver for AMD processor on-die digital thermal sensor
 .Sh SYNOPSIS
 To compile this driver into the kernel,
 place the following line in your
@@ -49,9 +47,7 @@ amdtemp_load="YES"
 The
 .Nm
 driver provides support for the on-die digital thermal sensor present
-in
-.Tn AMD
-Family 0Fh, 10h, 11h, 12h, 14h, 15h, 16h, and 17h processors.
+in AMD Family 0Fh, 10h, 11h, 12h, 14h, 15h, 16h, 17h, 19h, and 1Ah processors.
 .Pp
 For Family 0Fh processors, the
 .Nm
@@ -62,8 +58,8 @@ The driver also creates
 in the corresponding CPU device's sysctl tree, displaying the maximum
 temperature of the two sensors located in each CPU core.
 .Pp
-For Family 10h, 11h, 12h, 14h, 15h, 16h, and 17h processors, the driver reports
-each package's temperature through a sysctl node, named
+For Family 10h, 11h, 12h, 14h, 15h, 16h, 17h, 19h, and 1Ah processors, the
+driver reports each package's temperature through a sysctl node, named
 .Va dev.amdtemp.%d.core0.sensor0 .
 The driver also creates
 .Va dev.cpu.%d.temperature

--- a/sys/dev/amdsmn/amdsmn.c
+++ b/sys/dev/amdsmn/amdsmn.c
@@ -25,7 +25,8 @@
  */
 
 /*
- * Driver for the AMD Family 15h and 17h CPU System Management Network.
+ * Driver for the AMD Family 15h, 17h, 19h, and 1Ah CPU System Management
+ * Network.
  */
 
 #include <sys/param.h>
@@ -53,15 +54,15 @@
 #define	F17H_SMN_ADDR_REG	0x60
 #define	F17H_SMN_DATA_REG	0x64
 
-#define	PCI_DEVICE_ID_AMD_15H_M60H_ROOT		0x1576
-#define	PCI_DEVICE_ID_AMD_17H_ROOT		0x1450
-#define	PCI_DEVICE_ID_AMD_17H_M10H_ROOT		0x15d0
-#define	PCI_DEVICE_ID_AMD_17H_M30H_ROOT		0x1480	/* Also M70H, F19H M00H/M20H */
-#define	PCI_DEVICE_ID_AMD_17H_M60H_ROOT		0x1630
-#define	PCI_DEVICE_ID_AMD_19H_M10H_ROOT		0x14a4
-#define	PCI_DEVICE_ID_AMD_19H_M40H_ROOT		0x14b5
-#define	PCI_DEVICE_ID_AMD_19H_M60H_ROOT		0x14d8
-#define	PCI_DEVICE_ID_AMD_19H_M70H_ROOT		0x14e8
+#define	PCI_DEVICE_ID_AMD_15H_M60H_ROOT	0x1576
+#define	PCI_DEVICE_ID_AMD_17H_ROOT	0x1450
+#define	PCI_DEVICE_ID_AMD_17H_M10H_ROOT	0x15d0
+#define	PCI_DEVICE_ID_AMD_17H_M30H_ROOT	0x1480	/* Also M70H, F19H M00H/M20H */
+#define	PCI_DEVICE_ID_AMD_17H_M60H_ROOT	0x1630
+#define	PCI_DEVICE_ID_AMD_19H_M10H_ROOT	0x14a4
+#define	PCI_DEVICE_ID_AMD_19H_M40H_ROOT	0x14b5
+#define	PCI_DEVICE_ID_AMD_19H_M60H_ROOT	0x14d8	/* Also 1AH M40H */
+#define	PCI_DEVICE_ID_AMD_19H_M70H_ROOT	0x14e8
 
 struct pciid;
 struct amdsmn_softc {
@@ -211,11 +212,12 @@ amdsmn_probe(device_t dev)
 	case 0x15:
 	case 0x17:
 	case 0x19:
+	case 0x1a:
 		break;
 	default:
 		return (ENXIO);
 	}
-	device_set_descf(dev, "AMD Family %xh System Management Network",
+	device_set_descf(dev, "AMD Family %Xh System Management Network",
 	    family);
 
 	return (BUS_PROBE_GENERIC);


### PR DESCRIPTION
Tested with 9900X CPU.

```
amdsmn0: <AMD Family 1ah System Management Network> on hostb0
amdtemp0: <AMD CPU On-Die Thermal Sensors> on hostb0
amdtemp0: Found 24 cores and 1 sensors.
```
The temperatures below match what IPMI reports:
```
$ sysctl dev.cpu | grep temp
dev.cpu.23.temperature: 43.1C
dev.cpu.22.temperature: 43.1C
dev.cpu.21.temperature: 43.1C
dev.cpu.20.temperature: 43.1C
dev.cpu.19.temperature: 43.1C
dev.cpu.18.temperature: 43.1C
dev.cpu.17.temperature: 43.1C
dev.cpu.16.temperature: 43.1C
dev.cpu.15.temperature: 43.1C
dev.cpu.14.temperature: 43.1C
dev.cpu.13.temperature: 43.1C
dev.cpu.12.temperature: 43.1C
dev.cpu.11.temperature: 43.1C
dev.cpu.10.temperature: 43.1C
dev.cpu.9.temperature: 43.1C
dev.cpu.8.temperature: 43.1C
dev.cpu.7.temperature: 43.1C
dev.cpu.6.temperature: 43.1C
dev.cpu.5.temperature: 43.1C
dev.cpu.4.temperature: 43.1C
dev.cpu.3.temperature: 43.1C
dev.cpu.2.temperature: 43.1C
dev.cpu.1.temperature: 43.1C
dev.cpu.0.temperature: 43.1C
```