### PR TITLE
smbfs(4): evaluate filesystems/smbnetfs

### DIFF
--- a/share/man/man4/smbfs.4
+++ b/share/man/man4/smbfs.4
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 6, 2022
+.Dd December 27, 2024
 .Dt SMBFS 4
 .Os
 .Sh NAME
@@ -62,7 +62,7 @@ and
 may be removed from a future version of
 .Fx .
 Users are advised to evaluate the
-.Pa sysutils/fusefs-smbnetfs
+.Pa filesystems/smbnetfs
 port instead.
 .Ef
 .Sh SEE ALSO


### PR DESCRIPTION
RIP sysutils/fusefs-smbnetfs, one of 142 moves that arose from
https://github.com/freebsd/freebsd-ports/pull/302 and
ports 6e2da9672f79 on 2024-11-06. This one involved a change of name
in addition to the change of category.

Instead, advise users to evaluate filesystems/smbnetfs.

MFC after:      1 week