### PR TITLE
ifconfig: output sfp tx power

### DIFF
--- a/lib/libifconfig/libifconfig_sfp.c
+++ b/lib/libifconfig/libifconfig_sfp.c
@@ -407,7 +407,8 @@ get_sfp_status(struct i2c_info *ii, struct ifconfig_sfp_status *ss)
 		return (-1);
 	}
 	ss->channel[0].rx = get_sff_channel(ii, SFF_8472_DIAG, SFF_8472_RX_POWER);
-	ss->channel[0].tx = get_sff_channel(ii, SFF_8472_DIAG, SFF_8472_TX_BIAS);
+	ss->channel[0].tx = get_sff_channel(ii, SFF_8472_DIAG, SFF_8472_TX_POWER);
+	ss->channel[0].tx_bias = get_sff_channel(ii, SFF_8472_DIAG, SFF_8472_TX_BIAS);
 	return (ii->error);
 }
 
@@ -445,10 +446,9 @@ get_qsfp_status(struct i2c_info *ii, struct ifconfig_sfp_status *ss)
 	for (size_t chan = 0; chan < channels; ++chan) {
 		uint8_t rxoffs = SFF_8436_RX_CH1_MSB + chan * sizeof(uint16_t);
 		uint8_t txoffs = SFF_8436_TX_CH1_MSB + chan * sizeof(uint16_t);
-		ss->channel[chan].rx =
-		    get_sff_channel(ii, SFF_8436_BASE, rxoffs);
-		ss->channel[chan].tx =
-		    get_sff_channel(ii, SFF_8436_BASE, txoffs);
+		ss->channel[chan].rx = get_sff_channel(ii, SFF_8436_BASE, rxoffs);
+		ss->channel[chan].tx = NULL;
+		ss->channel[chan].tx_bias = get_sff_channel(ii, SFF_8436_BASE, txoffs);
 	}
 	ss->bitrate = get_qsfp_bitrate(ii);
 	return (ii->error);

--- a/lib/libifconfig/libifconfig_sfp.h
+++ b/lib/libifconfig/libifconfig_sfp.h
@@ -61,8 +61,9 @@ struct ifconfig_sfp_status {
 				     valid range -40.0 to 125.0 */
 	double voltage;		/**< module voltage in volts */
 	struct sfp_channel {
-		uint16_t rx;	/**< channel receive power, LSB 0.1uW */
-		uint16_t tx;	/**< channel transmit bias current, LSB 2uA */
+		uint16_t rx;		/**< channel receive power, LSB 0.1uW */
+		uint16_t tx;		/**< channel transmit power, LSB 0.1uW */
+		uint16_t tx_bias;	/**< channel transmit bias current, LSB 2uA */
 	} *channel;		/**< array of channel rx/tx status */
 	uint32_t bitrate;	/**< link bitrate,
 				     only present for QSFP modules,

--- a/sbin/ifconfig/sfp.c
+++ b/sbin/ifconfig/sfp.c
@@ -98,9 +98,18 @@ sfp_status(if_ctx *ctx)
 		for (size_t chan = 0; chan < channel_count; ++chan) {
 			uint16_t rx = status.channel[chan].rx;
 			uint16_t tx = status.channel[chan].tx;
-			printf("\tlane %zu: "
-			    "RX power: %.2f mW (%.2f dBm) TX bias: %.2f mA\n",
-			    chan + 1, power_mW(rx), power_dBm(rx), bias_mA(tx));
+			uint16_t tx_bias = status.channel[chan].tx_bias;
+
+			if (ifconfig_sfp_id_is_qsfp(info.sfp_id))
+				printf("\tlane %zu: "
+				    "RX power: %.2f mW (%.2f dBm) TX bias: %.2f mA\n",
+				    chan + 1, power_mW(rx), power_dBm(rx), bias_mA(tx_bias));
+			else
+				printf("\tlane %zu: "
+				    "RX power: %.2f mW (%.2f dBm) "
+				    "TX power: %.2f mW (%.2f dBm) TX bias: %.2f mA\n",
+				    chan + 1, power_mW(rx), power_dBm(rx),
+				    power_mW(tx), power_dBm(tx), bias_mA(tx_bias));
 		}
 		ifconfig_sfp_free_sfp_status(&status);
 	}


### PR DESCRIPTION
SFP modules support the TX bias current and TX output power attributes, where the later is useful for calcuating the actual fiber loss, whereas QSFP modules only support the TX bias current attribute.