### PR TITLE
open.2: update description for O_PATH

### DIFF
--- a/lib/libsys/open.2
+++ b/lib/libsys/open.2
@@ -393,7 +393,12 @@ but advisory locking is not allowed
 .It Xr dup 2
 .It Xr close 2
 .It Xr fstat 2
+.It Xr fstatfs 2
+.It Xr fchdir 2
+.It Xr fchroot 2
 .It Xr fexecve 2
+.It Xr funlinkat 2
+can be passed as the third argument
 .It Dv SCM_RIGHTS
 can be passed over a
 .Xr unix 4
@@ -403,16 +408,23 @@ message
 .It Xr kqueue 2
 only with
 .Dv EVFILT_VNODE
-.It Xr readlinkat 2
 .It Xr __acl_get_fd 2
 .It Xr __acl_aclcheck_fd 2
+.It Xr extattr 2
+.It Xr capsicum 4
+can be passed to
+.Fn cap_*_limit
+and
+.Fn cap_*_get
+system calls (such as
+.Xr cap_rights_limit 2 ) .
 .El
 .Pp
 Other operations like
 .Xr read 2 ,
 .Xr ftruncate 2 ,
 and any other that operate on file and not on file descriptor (except
-.Xr fstat 2 ),
+.Xr fstat 2 ) ,
 are not allowed.
 .Pp
 A file descriptor created with the


### PR DESCRIPTION
- Add `fstatfs()`, `fchdir()`, `fchroot()`, `extattr_*_fd()`, `cap_*_get()`, `cap_*_limit()` to the list of syscalls that can take an `O_PATH` fd.
- Remove `readlinkat()` from the list, since it is already discussed in the first few lines of the paragraph.  It was originally added to the list when `readlinkat()` adds support for non-dir fd with an empty relative path (as if with `AT_EMPTY_PATH`), however, such use case is also discussed in the next paragraph.
- Add `funlinkat()` to the list, since it accepts an extra fd (of the file to be unlinked), which is worth extra mentioning.
- Fix a syntax issue which causes a bogus space to be rendered before a closing parentheses.