### PR TITLE
truncate.1: Polish

### DIFF
--- a/usr.bin/truncate/truncate.1
+++ b/usr.bin/truncate/truncate.1
@@ -1,4 +1,6 @@
 .\"
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2000 Sheldon Hearn <sheldonh@FreeBSD.org>.
 .\" All rights reserved.
 .\" Copyright (c) 2021 The FreeBSD Foundation
@@ -27,12 +29,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 19, 2021
+.Dd December 30, 2024
 .Dt TRUNCATE 1
 .Os
 .Sh NAME
 .Nm truncate
-.Nd truncate, extend the length of files, or perform space management in files
+.Nd resize, extend, or perform space management in files
 .Sh SYNOPSIS
 .Nm
 .Op Fl c
@@ -132,7 +134,8 @@ file system space deallocation may be performed in the operation region.
 The space management operation is performed at the given
 .Ar offset
 bytes in the file.
-If this option is not specified, the operation is performed at the beginning of the file.
+If this option is not specified,
+the operation is performed at the beginning of the file.
 .It Fl l Ar length
 The length of the operation range in bytes.
 This option must always be specified if option

--- a/usr.bin/truncate/truncate.1
+++ b/usr.bin/truncate/truncate.1
@@ -199,8 +199,8 @@ truncate -c -s +10M test_file
 Same as above but create the file if it does not exist:
 .Bd -literal -offset indent
 truncate -s +10M test_file
-ls -l test_file
--rw-r--r--  1 root  wheel  10485760 Jul 22 18:48 test_file
+ls -lh test_file
+-rw-r--r--  1 root  wheel    10M Jul 22 18:48 test_file
 .Ed
 .Pp
 Adjust the size of
@@ -210,20 +210,20 @@ to the size of the kernel and create another file
 with the same size:
 .Bd -literal -offset indent
 truncate -r /boot/kernel/kernel test_file test_file2
-ls -l /boot/kernel/kernel test_file*
--r-xr-xr-x  1 root  wheel    31352552 May 15 14:18 /boot/kernel/kernel*
--rw-r--r--  1 root  wheel    31352552 Jul 22 19:15 test_file
--rw-r--r--  1 root  wheel    31352552 Jul 22 19:15 test_file2
+ls -lh /boot/kernel/kernel test_file*
+-r-xr-xr-x  1 root  wheel    30M May 15 14:18 /boot/kernel/kernel*
+-rw-r--r--  1 root  wheel    30M Jul 22 19:15 test_file
+-rw-r--r--  1 root  wheel    30M Jul 22 19:15 test_file2
 .Ed
 .Pp
 Downsize
 .Pa test_file
-in 5 Megabytes:
+by 5 Megabytes:
 .Bd -literal -offset indent
-# truncate -s -5M test_file
-ls -l test_file*
--rw-r--r--  1 root  wheel    26109672 Jul 22 19:17 test_file
--rw-r--r--  1 root  wheel    31352552 Jul 22 19:15 test_file2
+truncate -s -5M test_file
+ls -lh test_file*
+-rw-r--r--  1 root  wheel    25M Jul 22 19:17 test_file
+-rw-r--r--  1 root  wheel    30M Jul 22 19:15 test_file2
 .Ed
 .Sh SEE ALSO
 .Xr dd 1 ,


### PR DESCRIPTION
I was studying this manual and noticed some possible improvements.

+ Rewrite the document description to fit in one line, adding "resize" to the keywords, removing only "length" as a keyword.

+ Switch to human readable ls output for examples. This makes them fit on standard console, and makes it easier to understand since the example operations are in megabytes already.

+ Improve English and roff grammar, eliminating a linter warning and improving rapid reader comprehension.

+ Remove prompt from an example which has it, to create consistency with the rest of them.

+ Tag spdx

Cc @mhorne, @sergio-carlavilla