### PR TITLE
github: add new checklist workflow

### DIFF
--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -1,0 +1,106 @@
+name: Checklist
+
+# Produce a list of things that need to be changed
+# for the submission to align with CONTRIBUTING.md
+
+on:
+  pull_request:
+    types: [ opened, reopened, edited, synchronize ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  checklist:
+    name: commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          # An asynchronous javascript function
+          script: |
+            /*
+             * Github's API returns the results in pages of 30, so
+             * pass the function we want, along with it's arguments,
+             * to paginate() which will handle gathering all the results.
+             */
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            let checklist = {};
+            let checklist_len = 0;
+            let comment_id = -1;
+
+            const msg_prefix = "Thank you for taking the time to contribute to FreeBSD!\n";
+            const addToChecklist = (msg, sha) => {
+              if (!checklist[msg]) {
+                checklist[msg] = [];
+                checklist_len++;
+              }
+              checklist[msg].push(sha);
+            }
+
+            for (const commit of commits) {
+              const sob_lines = commit.commit.message.match(/^[^\S\r\n]*signed-off-by:.*/gim);
+
+              if (sob_lines == null && !commit.commit.author.email.toLowerCase().endsWith("freebsd.org"))
+                addToChecklist("Missing Signed-off-by lines", commit.sha);
+              else if (sob_lines != null) {
+                let author_signed = false;
+                for (const line of sob_lines) {
+                  if (!line.includes("Signed-off-by: "))
+                    /* Only display the part we care about. */
+                    addToChecklist("Expected `Signed-off-by: `, got `" + line.match(/^[^\S\r\n]*signed-off-by:./i) + "`", commit.sha);
+                  if (line.includes(commit.commit.author.email))
+                    author_signed = true;
+                }
+
+                if (!author_signed)
+                  console.log("::warning title=Missing-Author-Signature::Missing Signed-off-by from author");
+              }
+
+              if (commit.commit.author.email.toLowerCase().includes("noreply"))
+                addToChecklist("Real email address is needed", commit.sha);
+            }
+
+            /* Check if we've commented before. */
+            for (const comment of comments) {
+              if (comment.user.login == "github-actions[bot]") {
+                comment_id = comment.id;
+                break;
+              }
+            }
+
+            if (checklist_len != 0) {
+              let msg = msg_prefix +
+                "There " + (checklist_len > 1 ? "are a few issues that need " : "is an issue that needs ") +
+                "to be fixed:\n";
+              let comment_func = comment_id == -1 ? github.rest.issues.createComment : github.rest.issues.updateComment;
+
+              /* Loop for each key in "checklist". */
+              for (const c in checklist)
+                msg += "- " + c + "<sup>" + checklist[c].join(", ") + "</sup>\n";
+
+              comment_func({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: msg,
+                ...(comment_id == -1 ? {issue_number: context.issue.number} : {comment_id: comment_id})
+              });
+            } else if (comment_id != -1) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment_id,
+                body: msg_prefix + "All issues resolved."
+              });
+            }

--- a/tools/build/checkstyle9.pl
+++ b/tools/build/checkstyle9.pl
@@ -1253,8 +1253,6 @@ sub process {
 
 	my $in_header_lines = $file ? 0 : 1;
 	my $in_commit_log = 0;		#Scanning lines before patch
-	my $has_sob = 0;
-	my $author_is_committer = 0;
 	my $non_utf8_charset = 0;
 
 	our @report = ();
@@ -1448,33 +1446,6 @@ sub process {
 # Accept git diff extended headers as valid patches
 		if ($line =~ /^(?:rename|copy) (?:from|to) [\w\/\.\-]+\s*$/) {
 			$is_patch = 1;
-		}
-
-# Filter out bad email addresses.
-		if ($line =~ /^(Author|From): .*noreply.*/) {
-		    ERROR("Real email adress is needed\n" . $herecurr);
-		}
-
-		if ($line =~ /^Author: .*[a-z-0-9]\@freebsd\.org/i) {
-			$author_is_committer = 1
-		}
-
-#check the patch for a signoff:
-		if ($line =~ /^\s*signed-off-by:/i) {
-			# This is a signoff, if ugly, so do not double report.
-			$in_commit_log = 0;
-			$has_sob = 1;
-
-			if (!($line =~ /^\s*Signed-off-by:/)) {
-				ERROR("The correct form is \"Signed-off-by\"\n" .
-					$herecurr);
-				$has_sob = 0;
-			}
-			if ($line =~ /^\s*signed-off-by:\S/i) {
-				ERROR("space required after Signed-off-by:\n" .
-					$herecurr);
-				$has_sob = 0;
-			}
 		}
 
 # Check for wrappage within a valid hunk of the file
@@ -2657,10 +2628,6 @@ sub process {
 		}
 	}
 
-	}
-
-	if ($has_sob == 0 && $author_is_committer == 0) {
-	    WARN("Missing Signed-off-by: line");
 	}
 
 	# If we have no input at all, then there is nothing to report on


### PR DESCRIPTION
Add a new 'checklist' workflow that checks the commit messages on pull
requests. Currently, the workflow creates a comment on the pull request
if any of these conditions are hit:
- Missing Signed-off-by
- Malformed Signed-off-by
- Bad email (i.e \*noreply\*)

A test can be found here: https://github.com/VexedUXR/freebsd-src/pull/6
The comment is edited as the pull request is updated.
The comment get updated to:
```
Thank you for taking the time to contribute to FreeBSD!
All issues resolved.
```
When all issues are resolved.
If no issues are found in the first place, then no comment is added.