### PR TITLE
release/amd64: cleanup code duplication

### DIFF
--- a/release/amd64/make-memstick.sh
+++ b/release/amd64/make-memstick.sh
@@ -61,11 +61,9 @@ fi
 # Make an ESP in a file.
 espfilename=$(mktemp /tmp/efiboot.XXXXXX)
 if [ -f "${BASEBITSDIR}/boot/loader_ia32.efi" ]; then
-	make_esp_file ${espfilename} ${fat32min} ${BASEBITSDIR}/boot/loader.efi bootx64 \
-	    ${BASEBITSDIR}/boot/loader_ia32.efi bootia32
-else
-	make_esp_file ${espfilename} ${fat32min} ${BASEBITSDIR}/boot/loader.efi
+	extra_args="${BASEBITSDIR}/boot/loader_ia32.efi bootia32"
 fi
+make_esp_file ${espfilename} ${fat32min} ${BASEBITSDIR}/boot/loader.efi bootx64 ${extra_args}
 
 mkimg -s mbr \
     -b ${BASEBITSDIR}/boot/mbr \

--- a/release/amd64/mkisoimages.sh
+++ b/release/amd64/mkisoimages.sh
@@ -65,11 +65,9 @@ if [ "$1" = "-b" ]; then
 	# ESP file size in KB.
 	espsize="2048"
 	if [ -f "${BASEBITSDIR}/boot/loader_ia32.efi" ]; then
-		make_esp_file ${espfilename} ${espsize} ${BASEBITSDIR}/boot/loader.efi bootx64 \
-		    ${BASEBITSDIR}/boot/loader_ia32.efi bootia32
-	else
-		make_esp_file ${espfilename} ${espsize} ${BASEBITSDIR}/boot/loader.efi
+		extra_args="${BASEBITSDIR}/boot/loader_ia32.efi bootia32"
 	fi
+	make_esp_file ${espfilename} ${espsize} ${BASEBITSDIR}/boot/loader.efi bootx64 ${extra_args}
 	bootable="$bootable -o bootimage=i386;${espfilename} -o no-emul-boot -o platformid=efi"
 
 	shift


### PR DESCRIPTION
Improve the release script by checking `MK_LOADER_IA32` instead of the janky `if -f "${BASEBITSDIR}/boot/loader_ia32.efi"`

I'm hesitant about putting this in install-boot.sh, it feels out of place.
Maybe a new script in release/amd64 that gets sourced by both `make-memstick` and `mkisoimages` would be better? I'm not sure..

This also makes the script complain if `MK_LOADER_IA32` is `yes` but the file is missing, instead of silently not copying it.
FWIW it also allows the user to build the ia32 loader, but omit it from the img, though I'm not sure what the use case would be.

I've been meaning to do this since 599273f landed but forgot, so here it is.