### PR TITLE
fwget: add needed firmware for AMD Granite Ridge GPUs

### DIFF
--- a/usr.sbin/fwget/pci/pci_video_amd
+++ b/usr.sbin/fwget/pci/pci_video_amd
@@ -160,7 +160,7 @@ pci_video_amd()
 			addpkg "gpu-firmware-amd-kmod-sdma-6-0-1"
 			addpkg "gpu-firmware-amd-kmod-vcn-4-0-2"
 			;;
-		0x164e)
+		0x164e|0x13c0)
 			addpkg "gpu-firmware-amd-kmod-gc-10-3-6"
 			addpkg "gpu-firmware-amd-kmod-psp-13-0-5"
 			addpkg "gpu-firmware-amd-kmod-dcn-3-1-5"


### PR DESCRIPTION
This is from my 9950X:
```
❯ sudo pciconf -lBbcevV | grep vga -A7
vgapci0@pci0:6:0:0:     class=0x030000 rev=0xc1 hdr=0x00 vendor=0x1002 device=0x13c0 subvendor=0x1002 subdevice=0x13c0
    vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
    device     = 'Granite Ridge [Radeon Graphics]'
    class      = display
    subclass   = VGA
    bar   [10] = type Prefetchable Memory, range 64, base 0xfcf0000000, size 268435456, enabled
    bar   [18] = type Prefetchable Memory, range 64, base 0xf6400000, size 2097152, enabled
    bar   [20] = type I/O Port, range 32, base 0xd000, size 256, enabled
```