### PR TITLE
Unsupported hash algorithm should not be considered a success

### DIFF
--- a/lib/libsecureboot/openpgp/opgp_sig.c
+++ b/lib/libsecureboot/openpgp/opgp_sig.c
@@ -341,6 +341,7 @@ openpgp_verify(const char *filename,
 				break;
 			default:
 				warnx("unsupported hash algorithm: %s", hname);
+				rc = -1;
 				goto oops;
 			}
 			md->init(&mctx.vtable);


### PR DESCRIPTION
Honestly I haven't looked deeply into it, it just seems to me that this line is missing here