### PR TITLE
checkstyle9.pl: don't require Signed-off-by for committers

### DIFF
--- a/tools/build/checkstyle9.pl
+++ b/tools/build/checkstyle9.pl
@@ -1254,6 +1254,7 @@ sub process {
 	my $in_header_lines = $file ? 0 : 1;
 	my $in_commit_log = 0;		#Scanning lines before patch
 	my $has_sob = 0;
+	my $author_is_committer = 0;
 	my $non_utf8_charset = 0;
 
 	our @report = ();
@@ -1452,6 +1453,10 @@ sub process {
 # Filter out bad email addresses.
 		if ($line =~ /^(Author|From): .*noreply.*/) {
 		    ERROR("Real email adress is needed\n" . $herecurr);
+		}
+
+		if ($line =~ /^Author: .*[a-z-0-9]\@freebsd\.org/i) {
+			$author_is_committer = 1
 		}
 
 #check the patch for a signoff:
@@ -2654,7 +2659,7 @@ sub process {
 
 	}
 
-	if ($has_sob == 0) {
+	if ($has_sob == 0 && $author_is_committer == 0) {
 	    WARN("Missing Signed-off-by: line");
 	}
 


### PR DESCRIPTION
Silence the warning about Signed-off-by: lines if the Author: is using a FreeBSD.org address.  We don't require the lines so it's just noise in this case.