### PR TITLE
github: Fix checklist workflow

### DIFF
--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -4,7 +4,7 @@ name: Checklist
 # for the submission to align with CONTRIBUTING.md
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, edited, synchronize ]
 
 permissions:


### PR DESCRIPTION
The checklist workflow currently doesn't work since it doesn't have write permissions on pull requests.

Workflows triggered by the 'pull_request' event can't have write permissions. With write permissions a malicious pull request can alter or create a workflow that either leaks the GITHUB_TOKEN with the write permissions or do malicious things in the workflow itself.

The 'pull_request_target' event on the other hand allows workflows to run with write permissions but runs on the merge base of the PR, this way a pull request that alters such a workflow will not have it's code run until it's merged.

I didn't run into this during my testing since all of the test PRs were in the same repo.

Documentation: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target

Sorry about the oversight