### PR TITLE
Optionally silence devmatch, routing rc scripts operations

### DIFF
--- a/libexec/rc/rc.conf
+++ b/libexec/rc/rc.conf
@@ -45,6 +45,8 @@ devd_enable="YES" 	# Run devd, to trigger programs on device tree changes.
 devd_flags=""		# Additional flags for devd(8).
 devmatch_enable="YES"	# Demand load kernel modules based on device ids.
 devmatch_blocklist=""	# List of modules (w/o .ko) to exclude from devmatch.
+devmatch_autoloading_msgs="NO"	# Do not log "Autoloading" to console from devmatch rc.
+
 #kld_list="" 		# Kernel modules to load after local disks are mounted
 kldxref_enable="YES"	# Build linker.hints files with kldxref(8).
 kldxref_clobber="NO"	# Overwrite old linker.hints at boot.

--- a/libexec/rc/rc.conf
+++ b/libexec/rc/rc.conf
@@ -465,6 +465,7 @@ routed_flags="-q"		# Flags for routing daemon.
 arpproxy_all="NO"		# replaces obsolete kernel option ARP_PROXYALL.
 forward_sourceroute="NO"	# do source routing (only if gateway_enable is set to "YES")
 accept_sourceroute="NO"		# accept source routed packets to us
+routing_flags=""		# Flags for adjusting calls to route(8) from routing
 
 ### Bluetooth ###
 hcsecd_enable="NO"		# Enable hcsecd(8) (or NO)

--- a/libexec/rc/rc.d/devmatch
+++ b/libexec/rc/rc.d/devmatch
@@ -74,8 +74,12 @@ devmatch_start()
 		case "${x}" in
 		*"#${m}#"*) continue ;;
 		esac
-		kldstat -q -n ${m} || \
-		    (echo "Autoloading module: ${m}"; kldload -n ${m})
+		if checkyesno devmatch_autoloading_msgs; then
+			kldstat -q -n ${m} || \
+			    (echo "Autoloading module: ${m}"; kldload -n ${m})
+	        else
+			kldstat -q -n ${m} || (kldload -n ${m})
+		fi
 	done
 	devctl thaw
 }

--- a/libexec/rc/rc.d/routing
+++ b/libexec/rc/rc.d/routing
@@ -110,14 +110,14 @@ setroutes()
 
 routing_stop_inet()
 {
-	${ROUTE_CMD} -n flush -inet
+	${ROUTE_CMD} -n ${routing_flags} flush -inet
 }
 
 routing_stop_inet6()
 {
 	local i
 
-	${ROUTE_CMD} -n flush -inet6
+	${ROUTE_CMD} -n ${routing_flags} flush -inet6
 	for i in `list_net_interfaces`; do
 		if ipv6if $i; then
 			ifconfig $i inet6 -defaultif
@@ -190,7 +190,7 @@ static_inet()
 			if [ $_skip = 0 ]; then
 				route_args=`get_if_var ${i%:*} route_IF`
 				if [ -n "$route_args" ]; then
-					${ROUTE_CMD} ${_action} ${route_args}
+					${ROUTE_CMD} ${routing_flags} ${_action} ${route_args}
 				else
 					warn "route_${i%:*} not found."
 				fi
@@ -267,7 +267,7 @@ static_inet6()
 			if [ $_skip = 0 ]; then
 				ipv6_route_args=`get_if_var ${i%:*} ipv6_route_IF`
 				if [ -n "$ipv6_route_args" ]; then
-					${ROUTE_CMD} ${_action} \
+					${ROUTE_CMD} ${routing_flags} ${_action} \
 						-inet6 ${ipv6_route_args}
 				else
 					warn "route_${i%:*} not found"

--- a/libexec/rc/rc.d/routing
+++ b/libexec/rc/rc.d/routing
@@ -110,14 +110,22 @@ setroutes()
 
 routing_stop_inet()
 {
-	${ROUTE_CMD} -n ${routing_flags} flush -inet
+	if check_startmsgs; then
+		${ROUTE_CMD} -n ${routing_flags} flush -inet
+	else
+		${ROUTE_CMD} -n ${routing_flags} flush -inet > /dev/null 2>&1
+	fi
 }
 
 routing_stop_inet6()
 {
 	local i
 
-	${ROUTE_CMD} -n ${routing_flags} flush -inet6
+	if check_startmsgs; then
+		${ROUTE_CMD} -n ${routing_flags} flush -inet6
+	else
+		${ROUTE_CMD} -n ${routing_flags} flush -inet6 > /dev/null 2>&1
+	fi
 	for i in `list_net_interfaces`; do
 		if ipv6if $i; then
 			ifconfig $i inet6 -defaultif
@@ -190,7 +198,11 @@ static_inet()
 			if [ $_skip = 0 ]; then
 				route_args=`get_if_var ${i%:*} route_IF`
 				if [ -n "$route_args" ]; then
-					${ROUTE_CMD} ${routing_flags} ${_action} ${route_args}
+					if check_startmsgs; then
+						${ROUTE_CMD} ${routing_flags} ${_action} ${route_args}
+					else
+						${ROUTE_CMD} ${routing_flags} ${_action} ${route_args} > /dev/null 2>&1
+					fi
 				else
 					warn "route_${i%:*} not found."
 				fi
@@ -267,8 +279,14 @@ static_inet6()
 			if [ $_skip = 0 ]; then
 				ipv6_route_args=`get_if_var ${i%:*} ipv6_route_IF`
 				if [ -n "$ipv6_route_args" ]; then
-					${ROUTE_CMD} ${routing_flags} ${_action} \
-						-inet6 ${ipv6_route_args}
+
+					if check_startmsgs; then
+						${ROUTE_CMD} ${routing_flags} ${_action} \
+							-inet6 ${ipv6_route_args}
+					else
+						${ROUTE_CMD} ${routing_flags} ${_action} \
+							-inet6 ${ipv6_route_args} > /dev/null 2>&1
+					fi
 				else
 					warn "route_${i%:*} not found"
 				fi


### PR DESCRIPTION
I am interested in helping the Laptop working group (a focus of 2025) and was
trying to help smooth any rough edges that might spook a newer installer/user.
One of the items overwhelming is the chattiness of startup. While boot_mute=YES
catches a stage's worth of messages, the rc startup scripts can be daunting
or...well, there's just a lot of them.  The forums and other development
efforts document this. It's a recurrent forum question and [helloSystem] has
done some...extraordinary work to hide them

Looking at the scripts, there didn't seem to be a unified way to lower their
verbosity. Additionally, what's emitting could be the binary where a
more-silent flag is not used e.g. [routing] OR the rc script [devmatch].
Lacking a single "master control" to silence things, I just want after the
chattiest things that irritated, uh, me. ;)

[routing]: https://github.com/sgharms/freebsd-src/blob/main/libexec/rc/rc.d/routing#L22
[devmatch]: https://github.com/sgharms/freebsd-src/blob/main/libexec/rc/rc.d/devmatch#L78
[helloSystem]: https://hellosystem.github.io/docs/developer/boot.html#boot-mute