### PR TITLE
acpi_iicbus: install the address space handler by default

### DIFF
--- a/sys/dev/iicbus/acpi_iicbus.c
+++ b/sys/dev/iicbus/acpi_iicbus.c
@@ -75,7 +75,7 @@ struct acpi_iicbus_ivars {
 	ACPI_HANDLE		handle;
 };
 
-static int install_space_handler = 0;
+static int install_space_handler = 1;
 TUNABLE_INT("hw.iicbus.enable_acpi_space_handler", &install_space_handler);
 
 static inline bool


### PR DESCRIPTION
This was previously left off since it wasn't tested.
I've double checked the implementation of both the address space handler itself and the various smbus commands we issue, everything looks good.

Also tested on my Acer one 10 s1002.