### PR TITLE
Fixed EFI loader for UGA protocol

### DIFF
--- a/stand/efi/libefi/efi_console.c
+++ b/stand/efi/libefi/efi_console.c
@@ -920,7 +920,9 @@ cons_update_mode(bool use_gfx_mode)
 	 * efi_find_framebuffer(). This will populate the fb data,
 	 * which will be passed to kernel.
 	 */
-	if (efi_find_framebuffer(&gfx_state) == 0 && use_gfx_mode) {
+	if (efi_find_framebuffer(&gfx_state) == 0 && use_gfx_mode
+		/* UGA fb graphic is broken, don't use */
+		&& gfx_state.tg_fb_type != FB_UGA) {
 		int roff, goff, boff;
 
 		roff = ffs(gfx_state.tg_fb.fb_mask_red) - 1;

--- a/stand/efi/loader/bootinfo.c
+++ b/stand/efi/loader/bootinfo.c
@@ -207,6 +207,8 @@ bi_load_efi_data(struct preloaded_file *kfp, bool exit_bs)
 		    efifb.fb_mask_reserved);
 
 		file_addmetadata(kfp, MODINFOMD_EFI_FB, sizeof(efifb), &efifb);
+	} else {
+		printf("No EFI framebuffer found!\n");
 	}
 #endif
 


### PR DESCRIPTION
Since `FreeBSD Rel. 13.0`, EFI boot on machines with UGA graphics ends with a black screen, after display of the 'Start @' message.

Apparently `framebuffer.c/efi_find_framebuffer` returned with error when no GOP graphics was found instead of continuing and probing UGA graphics.

Furthermore, switching to the now found UGA graphics blanked the screen until the kernel took over. UGA graphics code in the loader seems to be buggy and needs to be fixed.
Until then, a patch is introduced in `efi_console.c/cons_update_mode` to use text mode in this case.  

CHANGES:
 
stand/efi/loader/framebuffer.c:
- Fixed getting EFI framebuffer settings for UGA protocol.
- Added Apple MacBookPro3,1 framebuffer parameters for 17" model with 1680x1050 screen.
stand/efi/libefi/efi_console.c:
- Disabled switching to UGA graphics since UGA graphics protocol is broken.
stand/efi/loader/bootinfo.c:
- Added 'No framebuffer found' message