### PR TITLE
Add ca-multi VT keymap

### DIFF
--- a/share/vt/keymaps/INDEX.keymaps
+++ b/share/vt/keymaps/INDEX.keymaps
@@ -208,6 +208,9 @@ ca-fr.kbd:fr:Français Canadien (avec accents)
 ca-fr.kbd:es:Francocanadiense (con acentos)
 ca-fr.kbd:uk:Французько-канадська (accent keys)
 
+ca-multi.kbd:en:Canadian Mulitlingual Standard
+ca-multi.kbd:fr:Canadien multilingue standard
+
 de.kbd:en:German
 de.kbd:da:Tysk
 de.kbd:de:Deutsch

--- a/share/vt/keymaps/Makefile
+++ b/share/vt/keymaps/Makefile
@@ -11,6 +11,7 @@ FILES=	INDEX.keymaps \
 	by.kbd \
 	ca.kbd \
 	ca-fr.kbd \
+	ca-multi.kbd \
 	centraleuropean.kbd \
 	centraleuropean.qwerty.kbd \
 	ch-fr.acc.kbd \

--- a/share/vt/keymaps/ca-multi.kbd
+++ b/share/vt/keymaps/ca-multi.kbd
@@ -1,0 +1,142 @@
+# Canadian Multilingual Standard keyboard
+# by Adam Scott (info@adamscott.studio)
+#
+# January 31, 2025
+#
+# Based on French Canadian keyboard
+# by Alexandre Normand (outcast@globetretrotter.net)
+# with the help of Demis (demis@club-internet.fr)
+#
+# July 4, 1999
+
+#                                                         alt
+# scan                       cntrl          alt    alt   cntrl lock
+# code  base   shift  cntrl  shift  alt    shift  cntrl  shift state
+  000   nop    nop    nop    nop    nop    nop    nop    nop     O
+  001   esc    esc    esc    esc    esc    esc    debug  esc     O
+  002   '1'    '!'    nop    nop    0x00A1 0x2248 nop    nop     O      # 0x00A1: '¡', 0x2248: '≈'
+  003   '2'    '@'    nop    nop    '@'    0x0131 nop    nop     O      # 0x0131: 'ı'
+  004   '3'    '#'    nop    nop    0x00A3 0x02C6 nop    nop     O      # 0x00A3: '£', 0x02C6: 'ˆ'
+  005   '4'    '$'    nop    nop    0x20AC 0x02DC nop    nop     O      # 0x20AC: '€', 0x02DC: '˜'
+  006   '5'    '%'    nop    nop    0x221E 0xF8FF nop    nop     O      # 0x221E: '∞', 0xF8FF: ''
+  007   '6'    '?'    nop    nop    0x0020 0x2020 nop    nop     O      # 0x0020: ' ', 0x2020: '†'
+  008   '7'    '&'    nop    nop    '{'    0x2021 nop    nop     O      # 0x2021: '‡'
+  009   '8'    '*'    nop    nop    '}'    0x2022 nop    nop     O      # 0x2022: '•'
+  010   '9'    '('    nop    nop    '['    0x00B1 nop    nop     O      # 0x00B1: '±'
+  011   '0'    ')'    nop    nop    ']'    0x2014 nop    nop     O      # 0x2014: '—'
+  012   '-'    '_'    nop    nop    '|'    0x00BF nop    nop     O      # 0x00BF: '¿'
+  013   '='    '+'    nop    nop    0x00AC 0x2013 nop    nop     O      # 0x00AC: '¬', 0x2013: '–'
+  014   bs     bs     del    del    bs     bs     del    del     O
+  015   ht     btab   nop    nop    ht     btab   nop    nop     O
+  016   'q'    'Q'    dc1    0x03A9 0x0153 0x0152 nop    nop     C      # 0x03A9: 'Ω', 0x0153: 'œ', 0x0152: 'Œ'
+  017   'w'    'W'    etb    etb    0x2211 0x2030 nop    nop     C      # 0x2211: '∑', 0x2030: '‰'
+  018   'e'    'E'    enq    enq    0x2202 0x00AF 0x0153 nop     C      # 0x2202: '∂', 0x00AF: '¯', 0x0153: 'œ'
+  019   'r'    'R'    dc2    0x00AE 0x00B6 0x00AE 0x00B6 dc2     C      # 0x00AE: '®', 0x00B6: '¶'
+  020   't'    'T'    dc4    dc4    0x2122 0x02D8 dc4    dc4     C      # 0x2122: '™', 0x02D8: '˘'
+  021   'y'    'Y'    em     0x00A5 0x00A5 0x02DD em     em      C      # 0x00A5: '¥', 0x02DD: '˝' 
+  022   'u'    'U'    nak    nak    0x0020 0x02DB 0x0020 nak     C      # 0x0020: ' ', 0x02DB: '˛'
+  023   'i'    'I'    ht     0x0131 0x03C0 0x220F ht     ht      C      # 0x0131: 'ı', 0x03C0: 'π', 0x220F: '∏'
+  024   'o'    'O'    si     0x00D8 0x00F8 0x00D8 0x00F8 si      C      # 0x00D8: 'Ø', 0x00F8: 'ø'
+  025   'p'    'P'    dle    dle    0x201C 0x201D dle    dle     C      # 0x201C: '“', 0x201D: '”'
+  026   dcir   dcir   esc    0x02DA dgra   0x201E esc    esc     O      # 0x02DA: '˚', 0x201E: '„'
+  027   0x00E7 0x00C7 gs     gs     '~'    dtil   0x02DC gs      O      # 0x00E7: 'ç', 0x00C7: 'Ç', 0x02DC: '˜'
+  028   cr     cr     nl     nl     cr     cr     nl     nl      O
+  029   lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl   O
+  030   'a'    'A'    soh    soh    0x00E6 0x00C6 0x00E6 soh     C      # 0x00E6: 'æ', 0x00C6: 'Æ'
+  031   's'    'S'    dc3    0x00A7 0x00DF 0x00A7 0x00DF dc3     C      # 0x00A7: '§', 0x00DF: 'ß'
+  032   'd'    'D'    eot    eot    0x00AA eot    eot    eot     C      # 0x00AA: 'ª'
+  033   'f'    'F'    ack    ack    0x0192 0xFB02 ack    ack     C      # 0x0192: 'ƒ', 0xFB02: 'ﬂ'
+  034   'g'    'G'    bel    bel    0xFB02 0xFB01 bel    bel     C      # 0xFB02: '©', 0xFB01: 'ﬁ'
+  035   'h'    'H'    bs     bs     0x02D9 0x00B7 bs     bs      C      # 0x02D9: '˙', 0x00B7: '·'
+  036   'j'    'J'    nl     nl     0x2206 0x201A nl     nl      C      # 0x2206: '∆', 0x201A: '‚'
+  037   'k'    'K'    vt     vt     0x02DA 0x2044 vt     vt      C      # 0x02DA: '˚', 0x2044: '⁄'
+  038   'l'    'L'    ff     ff     0x00A0 0x2026 ff     ff      C      # 0x00A0: ' ', 0x2026: '…'
+  039   ';'    ':'    nop    nop    0x00B0 dacu   0x00B4 ':'     O      # 0x00B0: '°', 0x00B4: '´'
+  040   0x00E8 0x00C8 dcir   nop    '\'    0x2019 nop    dcir    O      # 0x00E8: 'è', 0x00C8: 'È', 0x2019: '’'
+  041   '/'    '\'    '0'    '-'    '|'    ' '    nop    '0'     O
+  042   lshift lshift lshift lshift lshift lshift lshift lshift  O
+  043   0x00E0 0x00C0 nop    nop    0x0060 dgra   nop    nop     O      # 0x00E0: 'à', 0x00C0: 'À', 0x0060: '`'
+  044   'z'    'Z'    sub    sub    0x00AB 0x2039 sub    sub     C      # 0x00AB: '«', 0x2039: '‹'
+  045   'x'    'X'    can    can    0x00BB 0x203A can    can     C      # 0x00BB: '»', 0x203A: '›'
+  046   'c'    'C'    etx    0x00A9 0x00A2 0x2020 etx    etx     C      # 0x00A9: '©', 0x00A2: '¢', 0x2020: '†'
+  047   'v'    'V'    syn    syn    0x221A 0x25CA 0x201C syn     C      # 0x221A: '√', 0x25CA: '◊', 0x201C: '“'
+  048   'b'    'B'    stx    stx    0x222B 0x2264 stx    stx     C      # 0x222B: '∫', 0x2264: '≤'
+  049   'n'    'N'    so     so     0x00A0 0x2265 so     so      C      # 0x00A0: ' ', 0x2265: '≥'
+  050   'm'    'M'    cr     0x00BA 0x00B5 0x00BA 0x00B5 cr      C      # 0x00BA: 'º', 0x00B5: 'µ'
+  051   ','    '''    nop    nop    '<'    'x'    0x2014 ','     O      # 0x2014: '—'
+  052   '.'    '"'    nop    0x00F7 '>'    0x00F7 0x00B7 '.'     O      # 0x00F7: '÷', 0x00B7: '·'
+  053   0x00E9 0x00C9 nop    nop    '/'    0x2260 nop    0x00E9  C      # 0x00E9: 'é', 0x00C9: 'É', 0x2260: '≠'
+  054   rshift rshift rshift rshift rshift rshift rshift rshift  O
+  055   '*'    '*'    '*'    '*'    '*'    '*'    '*'    '*'     O
+  056   lalt   lalt   lalt   lalt   lalt   lalt   lalt   lalt    O
+  057   ' '    ' '    nul    ' '    0x00A0 0x00A0 susp   nop     O      # 0x00A0: ' '
+  058   clock  clock  clock  clock  clock  clock  clock  clock   O
+  059   fkey01 fkey13 fkey25 fkey37 scr01  scr11  scr01  scr11   O
+  060   fkey02 fkey14 fkey26 fkey38 scr02  scr12  scr02  scr12   O
+  061   fkey03 fkey15 fkey27 fkey39 scr03  scr13  scr03  scr13   O
+  062   fkey04 fkey16 fkey28 fkey40 scr04  scr14  scr04  scr14   O
+  063   fkey05 fkey17 fkey29 fkey41 scr05  scr15  scr05  scr15   O
+  064   fkey06 fkey18 fkey30 fkey42 scr06  scr16  scr06  scr16   O
+  065   fkey07 fkey19 fkey31 fkey43 scr07  scr07  scr07  scr07   O
+  066   fkey08 fkey20 fkey32 fkey44 scr08  scr08  scr08  scr08   O
+  067   fkey09 fkey21 fkey33 fkey45 scr09  scr09  scr09  scr09   O
+  068   fkey10 fkey22 fkey34 fkey46 scr10  scr10  scr10  scr10   O
+  069   nlock  nlock  nlock  nlock  nlock  nlock  nlock  nlock   O
+  070   slock  slock  slock  slock  slock  slock  slock  slock   O
+  071   fkey49 '7'    '7'    '7'    '7'    '7'    '7'    '7'     N
+  072   fkey50 '8'    '8'    '8'    '8'    '8'    '8'    '8'     N
+  073   fkey51 '9'    '9'    '9'    '9'    '9'    '9'    '9'     N
+  074   fkey52 '-'    '-'    '-'    '-'    '-'    '-'    '-'     N
+  075   fkey53 '4'    '4'    '4'    '4'    '4'    '4'    '4'     N
+  076   fkey54 '5'    '5'    '5'    '5'    '5'    '5'    '5'     N
+  077   fkey55 '6'    '6'    '6'    '6'    '6'    '6'    '6'     N
+  078   fkey56 '+'    '+'    '+'    '+'    '+'    '+'    '+'     N
+  079   fkey57 '1'    '1'    '1'    '1'    '1'    '1'    '1'     N
+  080   fkey58 '2'    '2'    '2'    '2'    '2'    '2'    '2'     N
+  081   fkey59 '3'    '3'    '3'    '3'    '3'    '3'    '3'     N
+  082   fkey60 '0'    '0'    '0'    '0'    '0'    '0'    '0'     N
+  083   del    '.'    '.'    '.'    '.'    '.'    boot   boot    N
+  084   nop    nop    nop    nop    nop    nop    nop    nop     O
+  085   nop    nop    nop    nop    nop    nop    nop    nop     O
+  086   0x00F9 0x00D9 duml   nop    '\'    0x03A9 nop    duml    O      # 0x00F9: 'ù', 0x00D9: 'Ù', 0x03A9: 'Ω'
+  087   fkey11 fkey23 fkey35 fkey47 scr11  scr11  scr11  scr11   O
+  088   fkey12 fkey24 fkey36 fkey48 scr12  scr12  scr12  scr12   O
+  089   cr     cr     nl     nl     cr     cr     nl     nl      O
+  090   rctrl  rctrl  rctrl  rctrl  rctrl  rctrl  rctrl  rctrl   O
+  091   '/'    '/'    '/'    '/'    '/'    '/'    '/'    '/'     O
+  092   nscr   pscr   debug  debug  nop    nop    nop    nop     O
+  093   ralt   ralt   ralt   ralt   ralt   ralt   ralt   ralt    O
+  094   fkey49 fkey49 fkey49 fkey49 fkey49 fkey49 fkey49 fkey49  O
+  095   fkey50 fkey50 fkey50 fkey50 fkey50 fkey50 fkey50 fkey50  O
+  096   fkey51 fkey51 fkey51 fkey51 fkey51 fkey51 fkey51 fkey51  O
+  097   fkey53 fkey53 fkey53 fkey53 fkey53 fkey53 fkey53 fkey53  O
+  098   fkey55 fkey55 fkey55 fkey55 fkey55 fkey55 fkey55 fkey55  O
+  099   fkey57 fkey57 fkey57 fkey57 fkey57 fkey57 fkey57 fkey57  O
+  100   fkey58 fkey58 fkey58 fkey58 fkey58 fkey58 fkey58 fkey58  O
+  101   fkey59 fkey59 fkey59 fkey59 fkey59 fkey59 fkey59 fkey59  O
+  102   fkey60 paste  fkey60 fkey60 fkey60 fkey60 fkey60 fkey60  O
+  103   fkey61 fkey61 fkey61 fkey61 fkey61 fkey61 boot   fkey61  O
+  104   slock  saver  slock  saver  susp   nop    susp   nop     O
+  105   fkey62 fkey62 fkey62 fkey62 fkey62 fkey62 fkey62 fkey62  O
+  106   fkey63 fkey63 fkey63 fkey63 fkey63 fkey63 fkey63 fkey63  O
+  107   fkey64 fkey64 fkey64 fkey64 fkey64 fkey64 fkey64 fkey64  O
+  108   nop    nop    nop    nop    nop    nop    nop    nop     O
+
+  dgra '`'     ( 'a'    0xe0    ) ( 'A'    0xc0    ) ( 'e'    0xe8    ) ( 'E'    0xc8    )
+               ( 'i'    0xec    ) ( 'I'    0xcc    ) ( 'o'    0xf2    ) ( 'O'    0xd2    )
+               ( 'u'    0xf9    ) ( 'U'    0xd9    )
+
+  dacu 0xb4    ( 'a'    0xe1    ) ( 'A'    0xc1    ) ( 'e'    0xe9    ) ( 'E'    0xc9    )
+               ( 'i'    0xed    ) ( 'I'    0xcd    ) ( 'o'    0xf3    ) ( 'O'    0xd3    )
+               ( 'u'    0xfa    ) ( 'U'    0xda    ) ( 'y'    0xfd    ) ( 'Y'    0xdd    )
+
+  dcir '^'     ( 'a'    0xe2    ) ( 'A'    0xc2    ) ( 'e'    0xea    ) ( 'E'    0xca    )
+               ( 'i'    0xee    ) ( 'I'    0xce    ) ( 'o'    0xf4    ) ( 'O'    0xd4    )
+               ( 'u'    0xfb    ) ( 'U'    0xdb    )
+
+  dtil '~'     ( 'a'    0xe3    ) ( 'A'    0xc3    ) ( 'n'    0xf1    ) ( 'N'    0xd1    )
+               ( 'o'    0xf5    ) ( 'O'    0xd5    )
+
+  duml 0xa8    ( 'a'    0xe4    ) ( 'A'    0xc4    ) ( 'e'    0xeb    ) ( 'E'    0xcb    )
+               ( 'i'    0xef    ) ( 'I'    0xcf    ) ( 'o'    0xf6    ) ( 'O'    0xd6    )
+               ( 'u'    0xfc    ) ( 'U'    0xdc    ) ( 'y'    0xff    )


### PR DESCRIPTION
> [!NOTE]
> I don't have a full keyboard at home, only a MacBook Pro, but it seems to work very well.

This PR adds the Canadian Multilingual Standard keyboard layout (i.e. French Canadian Apple keyboards) for the FreeBSD virtual terminal. It is quite distinct from ca-fr.kbd, as it changes some keys around.