### PR TITLE
linprocfs: Continue on error when reading process limits

### DIFF
--- a/sys/compat/linprocfs/linprocfs.c
+++ b/sys/compat/linprocfs/linprocfs.c
@@ -1915,7 +1915,7 @@ linprocfs_doproclimits(PFS_FILL_ARGS)
 			    "kern.sigqueue.max_pending_per_proc",
 			    &res, &size, 0, 0, 0, 0);
 			if (error != 0)
-				goto out;
+				continue;
 			rl.rlim_cur = res;
 			rl.rlim_max = res;
 			break;
@@ -1923,7 +1923,7 @@ linprocfs_doproclimits(PFS_FILL_ARGS)
 			error = kernel_sysctlbyname(td,
 			    "kern.ipc.msgmnb", &res, &size, 0, 0, 0, 0);
 			if (error != 0)
-				goto out;
+				continue;
 			rl.rlim_cur = res;
 			rl.rlim_max = res;
 			break;
@@ -1945,9 +1945,9 @@ linprocfs_doproclimits(PFS_FILL_ARGS)
 			    li->desc, (unsigned long long)rl.rlim_cur,
 			    (unsigned long long)rl.rlim_max, li->unit);
 	}
-out:
+
 	lim_free(limp);
-	return (error);
+	return (0);
 }
 
 /*


### PR DESCRIPTION
Continue on error when reading process limits.

Fixes https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=283726

Most text utilities with capsicum(4) enabled fail when reading `/compat/linux/proc/*/limits` because both `LINUX_RLIMIT_SIGPENDING`  & `LINUX_RLIMIT_MSGQUEUE` call `kernel_sysctlbyname`.

The alternative would be to make the variables accessed by the `kern.sigqueue.max_pending_per_proc` & `kern.ipc.msgmnb` sysctl's public.  This was done for reading /proc/cpuinfo in https://github.com/freebsd/freebsd-src/commit/d74a742704eb81f0c6f4aa83e4cb0de26a81c400