### PR TITLE
wg.4: document kernel config option

### DIFF
--- a/share/man/man4/wg.4
+++ b/share/man/man4/wg.4
@@ -23,14 +23,21 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 12, 2023
+.Dd February 12, 2025
 .Dt WG 4
 .Os
 .Sh NAME
 .Nm wg
 .Nd "WireGuard protocol driver"
 .Sh SYNOPSIS
-To load the driver as a module at boot time, place the following line in
+To compile this driver into the kernel,
+place the following lines in your kernel configuration file:
+.Bd -ragged -offset indent
+.Cd "device wg"
+.Ed
+.Pp
+Alternatively, to load the driver as a module at boot time,
+place the following line in
 .Xr loader.conf 5 :
 .Bd -literal -offset indent
 if_wg_load="YES"


### PR DESCRIPTION
wg(4) can be compiled into the kernel (device wg), but the wg.4 manpage does not document this.  adjust it to mention this like other drivers do.