### PR TITLE
etc: add config tag to /root/.k5login

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -71,7 +71,7 @@ distribution:
 .if ${MK_KERBEROS} != "no"
 	cd ${.CURDIR}/root; \
 	    ${INSTALL} -o ${BINOWN} -g ${BINGRP} -m 644 \
-		-T "package=runtime" \
+		-T "package=runtime,config" \
 		dot.k5login ${DESTDIR}/root/.k5login;
 .endif
 


### PR DESCRIPTION
this prevents the file being overwritten every time FreeBSD-runtime is upgraded.