### PR TITLE
column(1): add -l flag

### DIFF
--- a/usr.bin/column/column.1
+++ b/usr.bin/column/column.1
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd July 29, 2004
+.Dd February 18, 2025
 .Dt COLUMN 1
 .Os
 .Sh NAME
@@ -35,6 +35,7 @@
 .Nm
 .Op Fl tx
 .Op Fl c Ar columns
+.Op Fl l Ar tblcols
 .Op Fl s Ar sep
 .Op Ar
 .Sh DESCRIPTION
@@ -53,6 +54,14 @@ The options are as follows:
 Output is formatted for a display
 .Ar columns
 wide.
+.It Fl l
+When used with
+.Fl t ,
+limit the table to
+.Ar tblcols
+columns in width.
+The last column will contain the rest of the line,
+including any delimiters.
 .It Fl s
 Specify a set of characters to be used to delimit columns for the
 .Fl t


### PR DESCRIPTION
```
the '-l <tblcols>' flag limits the number of columns that column(1) will
produce in -t mode.  this is syntax-compatible with the same option in
util-linux's column(1), but due to existing differences between the two
implementations, it's not semantically compatible.

as a side-effect, fix a pre-existing bug where empty fields could cause
incorrect output:

	% echo ':' | column -ts:
	(null)
```