### PR TITLE
vt: add US International keymap

### DIFF
--- a/share/vt/keymaps/INDEX.keymaps
+++ b/share/vt/keymaps/INDEX.keymaps
@@ -544,6 +544,13 @@ us.acc.kbd:fr:États Unis d'Amérique (avec accents)
 us.acc.kbd:pt:Estados Unidos da América (com acentos)
 us.acc.kbd:es:Estadounidense (con acentos)
 
+us.intl.acc.kbd:en:United States of America International (accent keys)
+us.intl.acc.kbd:da:USA international (accenttaster)
+us.intl.acc.kbd:de:US-amerikanisch international (mit Akzenten)
+us.intl.acc.kbd:fr:États Unis d'Amérique International (avec accents)
+us.intl.acc.kbd:pt:Estados Unidos da América Internacional (com acentos)
+us.intl.acc.kbd:es:Estadounidense Internacional (con acentos)
+
 us.dvorak.kbd:en:United States of America dvorak
 us.dvorak.kbd:da:USA dvorak
 us.dvorak.kbd:de:US-amerikanisch dvorak

--- a/share/vt/keymaps/us.intl.acc.kbd
+++ b/share/vt/keymaps/us.intl.acc.kbd
@@ -1,0 +1,141 @@
+# Windows US-International Keyboard emulation
+# Differences to the original:
+# striking " and " does NOT yield "" but just " (same for other dead keys)
+# alt shift 9 yields 0x93 (original: empty)
+# alt shift 0 yields 0x94 (original: empty)
+# alt shift - yields ± (original: empty)
+# alt shift . yields · (original: empty)
+# alt shift / yields ¶ (original: empty)
+# ^ - yields ­ (original: empty)
+# ^ shift - yields ¯ (original: empty)
+# ^ shift . yields · (original: empty)
+#                                                         alt
+# scan                       cntrl          alt    alt   cntrl lock
+# code  base   shift  cntrl  shift  alt    shift  cntrl  shift state
+# ------------------------------------------------------------------
+  000   nop    nop    nop    nop    nop    nop    nop    nop     O
+  001   esc    esc    esc    esc    esc    esc    esc    esc     O
+  002   '1'    '!'    nop    nop    161    185    nop    nop     O
+  003   '2'    '@'    nul    nul    178    nop    nul    nul     O
+  004   '3'    '#'    nop    nop    179    nop    nop    nop     O
+  005   '4'    '$'    nop    nop    164    163    nop    nop     O
+  006   '5'    '%'    nop    nop    128    nop    nop    nop     O
+  007   '6'    dcir   rs     rs     188    nop    rs     rs      O
+  008   '7'    '&'    nop    nop    189    nop    nop    nop     O
+  009   '8'    '*'    nop    nop    190    nop    nop    nop     O
+  010   '9'    '('    nop    nop    145    147    nop    nop     O
+  011   '0'    ')'    nop    nop    146    148    nop    nop     O
+  012   '-'    '_'    us     us     165    177    us     us      O
+  013   '='    '+'    nop    nop    215    247    nop    nop     O
+  014   bs     bs     del    del    bs     bs     del    del     O
+  015   ht     btab   nop    nop    ht     btab   nop    nop     O
+  016   'q'    'Q'    dc1    dc1    228    196    dc1    dc1     C
+  017   'w'    'W'    etb    etb    229    197    etb    etb     C
+  018   'e'    'E'    enq    enq    233    201    enq    enq     C
+  019   'r'    'R'    dc2    dc2    174    nop    dc2    dc2     C
+  020   't'    'T'    dc4    dc4    254    222    dc4    dc4     C
+  021   'y'    'Y'    em     em     252    220    em     em      C
+  022   'u'    'U'    nak    nak    250    218    nak    nak     C
+  023   'i'    'I'    ht     ht     237    205    ht     ht      C
+  024   'o'    'O'    si     si     243    211    si     si      C
+  025   'p'    'P'    dle    dle    246    214    dle    dle     C
+  026   '['    '{'    esc    esc    171    nop    esc    esc     O
+  027   ']'    '}'    gs     gs     187    nop    gs     gs      O
+  028   cr     cr     nl     nl     cr     cr     nl     nl      O
+  029   lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl   O
+  030   'a'    'A'    soh    soh    225    193    soh    soh     C
+  031   's'    'S'    dc3    dc3    223    167    dc3    dc3     C
+  032   'd'    'D'    eot    eot    240    208    eot    eot     C
+  033   'f'    'F'    ack    ack    nop    nop    ack    ack     C
+  034   'g'    'G'    bel    bel    nop    nop    bel    bel     C
+  035   'h'    'H'    bs     bs     nop    nop    bs     bs      C
+  036   'j'    'J'    nl     nl     nop    nop    nl     nl      C
+  037   'k'    'K'    vt     vt     nop    nop    vt     vt      C
+  038   'l'    'L'    ff     ff     248    216    ff     ff      C
+  039   ';'    ':'    nop    nop    182    176    nop    nop     O
+  040   dacu   duml   nop    nop    180    168    nop    nop     O
+  041   dgra   dtil   nop    nop    nop    nop    nop    nop     O
+  042   lshift lshift lshift lshift lshift lshift lshift lshift  O
+  043   '\'    '|'    fs     fs     172    166    fs     fs      O
+  044   'z'    'Z'    sub    sub    230    198    sub    sub     C
+  045   'x'    'X'    can    can    nop    nop    can    can     C
+  046   'c'    'C'    etx    etx    169    162    etx    etx     C
+  047   'v'    'V'    syn    syn    nop    nop    syn    syn     C
+  048   'b'    'B'    stx    stx    nop    nop    stx    stx     C
+  049   'n'    'N'    so     so     241    209    so     so      C
+  050   'm'    'M'    cr     cr     181    nop    cr     cr      C
+  051   ','    '<'    nop    nop    231    199    nop    nop     O
+  052   '.'    '>'    nop    nop    133    183    nop    nop     O
+  053   '/'    '?'    nop    nop    191    182    nop    nop     O
+  054   rshift rshift rshift rshift rshift rshift rshift rshift  O
+  055   '*'    '*'    '*'    '*'    '*'    '*'    '*'    '*'     O
+  056   lalt   lalt   lalt   lalt   lalt   lalt   lalt   lalt    O
+  057   ' '    ' '    nul    ' '    ' '    ' '    susp   ' '     O
+  058   clock  clock  clock  clock  clock  clock  clock  clock   O
+  059   fkey01 fkey13 fkey25 fkey37 scr01  scr11  scr01  scr11   O
+  060   fkey02 fkey14 fkey26 fkey38 scr02  scr12  scr02  scr12   O
+  061   fkey03 fkey15 fkey27 fkey39 scr03  scr13  scr03  scr13   O
+  062   fkey04 fkey16 fkey28 fkey40 scr04  scr14  scr04  scr14   O
+  063   fkey05 fkey17 fkey29 fkey41 scr05  scr15  scr05  scr15   O
+  064   fkey06 fkey18 fkey30 fkey42 scr06  scr16  scr06  scr16   O
+  065   fkey07 fkey19 fkey31 fkey43 scr07  scr07  scr07  scr07   O
+  066   fkey08 fkey20 fkey32 fkey44 scr08  scr08  scr08  scr08   O
+  067   fkey09 fkey21 fkey33 fkey45 scr09  scr09  scr09  scr09   O
+  068   fkey10 fkey22 fkey34 fkey46 scr10  scr10  scr10  scr10   O
+  069   nlock  nlock  nlock  nlock  nlock  nlock  nlock  nlock   O
+  070   slock  slock  slock  slock  slock  slock  slock  slock   O
+  071   fkey49 '7'    '7'    '7'    '7'    '7'    '7'    '7'     N
+  072   fkey50 '8'    '8'    '8'    '8'    '8'    '8'    '8'     N
+  073   fkey51 '9'    '9'    '9'    '9'    '9'    '9'    '9'     N
+  074   fkey52 '-'    '-'    '-'    '-'    '-'    '-'    '-'     N
+  075   fkey53 '4'    '4'    '4'    '4'    '4'    '4'    '4'     N
+  076   fkey54 '5'    '5'    '5'    '5'    '5'    '5'    '5'     N
+  077   fkey55 '6'    '6'    '6'    '6'    '6'    '6'    '6'     N
+  078   fkey56 '+'    '+'    '+'    '+'    '+'    '+'    '+'     N
+  079   fkey57 '1'    '1'    '1'    '1'    '1'    '1'    '1'     N
+  080   fkey58 '2'    '2'    '2'    '2'    '2'    '2'    '2'     N
+  081   fkey59 '3'    '3'    '3'    '3'    '3'    '3'    '3'     N
+  082   fkey60 '0'    '0'    '0'    '0'    '0'    '0'    '0'     N
+  083   del    '.'    '.'    '.'    '.'    '.'    '.'    '.'     N
+  084   nop    nop    nop    nop    nop    nop    nop    nop     O
+  085   nop    nop    nop    nop    nop    nop    nop    nop     O
+  086   nop    nop    nop    nop    nop    nop    nop    nop     O
+  087   fkey11 fkey23 fkey35 fkey47 scr11  scr11  scr11  scr11   O
+  088   fkey12 fkey24 fkey36 fkey48 scr12  scr12  scr12  scr12   O
+  089   cr     cr     nl     nl     cr     cr     nl     nl      O
+  090   rctrl  rctrl  rctrl  rctrl  rctrl  rctrl  rctrl  rctrl   O
+  091   '/'    '/'    '/'    '/'    '/'    '/'    '/'    '/'     N
+  092   nscr   nscr   nscr   nscr   nop    nop    nop    nop     O
+  093   ralt   ralt   ralt   ralt   ralt   ralt   ralt   ralt    O
+  094   fkey49 fkey49 fkey49 fkey49 fkey49 fkey49 fkey49 fkey49  O
+  095   fkey50 fkey50 fkey50 fkey50 fkey50 fkey50 fkey50 fkey50  O
+  096   fkey51 fkey51 fkey51 fkey51 fkey51 fkey51 fkey51 fkey51  O
+  097   fkey53 fkey53 fkey53 fkey53 fkey53 fkey53 fkey53 fkey53  O
+  098   fkey55 fkey55 fkey55 fkey55 fkey55 fkey55 fkey55 fkey55  O
+  099   fkey57 fkey57 fkey57 fkey57 fkey57 fkey57 fkey57 fkey57  O
+  100   fkey58 fkey58 fkey58 fkey58 fkey58 fkey58 fkey58 fkey58  O
+  101   fkey59 fkey59 fkey59 fkey59 fkey59 fkey59 fkey59 fkey59  O
+  102   fkey60 fkey60 fkey60 fkey60 fkey60 fkey60 fkey60 fkey60  O
+  103   fkey61 fkey61 fkey61 fkey61 fkey61 fkey61 fkey61 fkey61  O
+  104   slock  saver  slock  saver  susp   nop    susp   nop     O
+  105   fkey62 fkey62 fkey62 fkey62 fkey62 fkey62 fkey62 fkey62  O
+  106   fkey63 fkey63 fkey63 fkey63 fkey63 fkey63 fkey63 fkey63  O
+  107   fkey64 fkey64 fkey64 fkey64 fkey64 fkey64 fkey64 fkey64  O
+  108   nop    nop    nop    nop    nop    nop    nop    nop     O
+
+  dgra  '`'  ( 'A' 192 ) ( 'E' 200 ) ( 'I' 204 ) ( 'O' 210 )
+             ( 'U' 217 ) ( 'a' 224 ) ( 'e' 232 ) ( 'i' 236 )
+             ( 'o' 242 ) ( 'u' 249 )
+  dacu  '''  ( 'A' 193 ) ( 'C' 199 ) ( 'E' 201 ) ( 'I' 205 )
+             ( 'O' 211 ) ( 'U' 218 ) ( 'Y' 221 ) ( 'a' 225 )
+             ( 'c' 231 ) ( 'e' 233 ) ( 'i' 237 ) ( 'o' 243 )
+             ( 'u' 250 ) ( 'y' 253 )
+  dcir  '^'  ( 'A' 194 ) ( 'E' 202 ) ( 'I' 206 ) ( 'O' 212 )
+             ( 'U' 219 ) ( 'a' 226 ) ( 'e' 234 ) ( 'i' 238 )
+             ( 'o' 244 ) ( 'u' 251 ) ( '-' 173 ) ( '_' 175 )
+             ( '.' 183 )
+  dtil  '~'  ( 'A' 195 ) ( 'N' 209 ) ( 'O' 213 ) ( 'a' 227 )
+             ( 'n' 241 ) ( 'o' 245 )
+  duml  '"'  ( 'A' 196 ) ( 'E' 203 ) ( 'I' 207 ) ( 'O' 214 )
+             ( 'U' 220 ) ( 'a' 228 ) ( 'e' 235 ) ( 'i' 239 )
+             ( 'o' 246 ) ( 'u' 252 ) ( 'y' 255 )


### PR DESCRIPTION
In [this old PR 72465](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=72465) from 2004, Heldge Oldach proposed a keymap for US International layout on console but it was never finalized and merged.

I just tested it - though on vt - and it seems fine to me, so I updated the INDEX file and here you go.

```
This adds support for the US International keyboard layout to vt. It 
uses dead keys to generate diacritics such as accents, cedillas and 
umlauts.

PR:             72465
Co-authored-by: Helge Oldach <syscons-us-intl@oldach.net>
MFC after:      2 weeks
```