### PR TITLE
fixed xz bug: xz doesnot't quote uprintable characters when it displays file names given on the command line

### DIFF
--- a/contrib/xz/src/xz/main.c
+++ b/contrib/xz/src/xz/main.c
@@ -55,6 +55,8 @@ set_exit_no_warn(void)
 }
 
 
+#define MAX_FILENAME_LENGTH 4096
+
 static const char *
 read_name(const args_info *args)
 {
@@ -130,8 +132,12 @@ read_name(const args_info *args)
 		// at least for one character to allow terminating the string
 		// with '\0'.
 		if (pos == size) {
-			size *= 2;
+			size_t = new_size = size * 2;
+			if (new_size > MAX_FILENAME_LENGTH)
+				new_size = MAX_FILENAME_LENGTH;
+			name = xrealloc(name, new_size);
 			name = xrealloc(name, size);
+			size = new_size;
 		}
 	}
 

--- a/contrib/xz/src/xz/main.c
+++ b/contrib/xz/src/xz/main.c
@@ -126,6 +126,14 @@ read_name(const args_info *args)
 			return NULL;
 		}
 
+		// Check if we are about to exceed our maximum allowed filename length.
+		if(pos >= MAX_FILENAME_LENGTH - 1) {
+			message_error(_("%s: Filename exceeds maximum allowed length (%d bytes)"),
+				args->files_name, MAX_FILENAME_LENGTH);
+
+			return NULL;
+		}
+
 		name[pos++] = c;
 
 		// Allocate more memory if needed. There must always be space


### PR DESCRIPTION
fixed a bug where The tool doesn’t properly quote unprintable characters when displaying file names from the command line.

This is my first ever pull request to a major open source project.