### PR TITLE
Sync with NetBSD's block points

### DIFF
--- a/crypto/openssh/auth-pam.c
+++ b/crypto/openssh/auth-pam.c
@@ -101,7 +101,6 @@
 #endif
 #include "monitor_wrap.h"
 #include "srclimit.h"
-#include "blacklist_client.h"
 
 extern ServerOptions options;
 extern struct sshbuf *loginmsg;
@@ -937,8 +936,6 @@ sshpam_query(void *ctx, char **name, char **info,
 				sshbuf_free(buffer);
 				return (0);
 			}
-			BLACKLIST_NOTIFY(NULL, BLACKLIST_BAD_USER,
-			    sshpam_authctxt->user);
 			error("PAM: %s for %s%.100s from %.100s", msg,
 			    sshpam_authctxt->valid ? "" : "illegal user ",
 			    sshpam_authctxt->user, sshpam_rhost);

--- a/crypto/openssh/auth.c
+++ b/crypto/openssh/auth.c
@@ -286,8 +286,11 @@ auth_log(struct ssh *ssh, int authenticated, int partial,
 		authmsg = "Postponed";
 	else if (partial)
 		authmsg = "Partial";
-	else
+	else {
 		authmsg = authenticated ? "Accepted" : "Failed";
+		if (authenticated)
+			BLACKLIST_NOTIFY(ssh, BLACKLIST_AUTH_OK, "ssh");
+	}
 
 	if ((extra = format_method_key(authctxt)) == NULL) {
 		if (authctxt->auth_method_info != NULL)

--- a/crypto/openssh/auth.c
+++ b/crypto/openssh/auth.c
@@ -286,11 +286,8 @@ auth_log(struct ssh *ssh, int authenticated, int partial,
 		authmsg = "Postponed";
 	else if (partial)
 		authmsg = "Partial";
-	else {
+	else
 		authmsg = authenticated ? "Accepted" : "Failed";
-		if (authenticated)
-			BLACKLIST_NOTIFY(ssh, BLACKLIST_AUTH_OK, "ssh");
-	}
 
 	if ((extra = format_method_key(authctxt)) == NULL) {
 		if (authctxt->auth_method_info != NULL)
@@ -338,6 +335,7 @@ auth_maxtries_exceeded(struct ssh *ssh)
 {
 	Authctxt *authctxt = (Authctxt *)ssh->authctxt;
 
+	BLACKLIST_NOTIFY(ssh, BLACKLIST_AUTH_FAIL, "ssh");
 	error("maximum authentication attempts exceeded for "
 	    "%s%.100s from %.200s port %d ssh2",
 	    authctxt->valid ? "" : "invalid user ",
@@ -498,7 +496,7 @@ getpwnamallow(struct ssh *ssh, const char *user)
 	aix_restoreauthdb();
 #endif
 	if (pw == NULL) {
-		BLACKLIST_NOTIFY(ssh, BLACKLIST_BAD_USER, user);
+		BLACKLIST_NOTIFY(ssh, BLACKLIST_AUTH_FAIL, user);
 		logit("Invalid user %.100s from %.100s port %d",
 		    user, ssh_remote_ipaddr(ssh), ssh_remote_port(ssh));
 #ifdef CUSTOM_FAILED_LOGIN

--- a/crypto/openssh/auth2.c
+++ b/crypto/openssh/auth2.c
@@ -52,7 +52,6 @@
 #include "dispatch.h"
 #include "pathnames.h"
 #include "ssherr.h"
-#include "blacklist_client.h"
 #ifdef GSSAPI
 #include "ssh-gss.h"
 #endif
@@ -443,10 +442,8 @@ userauth_finish(struct ssh *ssh, int authenticated, const char *packet_method,
 	} else {
 		/* Allow initial try of "none" auth without failure penalty */
 		if (!partial && !authctxt->server_caused_failure &&
-		    (authctxt->attempt > 1 || strcmp(method, "none") != 0)) {
+		    (authctxt->attempt > 1 || strcmp(method, "none") != 0))
 			authctxt->failures++;
-			BLACKLIST_NOTIFY(ssh, BLACKLIST_AUTH_FAIL, "ssh");
-		}
 		if (authctxt->failures >= options.max_authtries) {
 #ifdef SSH_AUDIT_EVENTS
 			mm_audit_event(ssh, SSH_LOGIN_EXCEED_MAXTRIES);

--- a/crypto/openssh/blacklist_client.h
+++ b/crypto/openssh/blacklist_client.h
@@ -57,5 +57,4 @@ void blacklist_notify(struct ssh *, int, const char *);
 
 #endif
 
-
 #endif /* BLACKLIST_CLIENT_H */

--- a/crypto/openssh/packet.c
+++ b/crypto/openssh/packet.c
@@ -96,7 +96,6 @@
 #include "packet.h"
 #include "ssherr.h"
 #include "sshbuf.h"
-#include "blacklist_client.h"
 
 #ifdef PACKET_DEBUG
 #define DBG(x) x
@@ -2022,7 +2021,6 @@ sshpkt_vfatal(struct ssh *ssh, int r, const char *fmt, va_list ap)
 	case SSH_ERR_NO_KEX_ALG_MATCH:
 	case SSH_ERR_NO_HOSTKEY_ALG_MATCH:
 		if (ssh->kex && ssh->kex->failed_choice) {
-			BLACKLIST_NOTIFY(ssh, BLACKLIST_AUTH_FAIL, "ssh");
 			ssh_packet_clear_keys(ssh);
 			errno = oerrno;
 			logdie("Unable to negotiate with %s: %s. "


### PR DESCRIPTION
This is an experiment.

- Use only `BLACKLIST_AUTH_FAIL`, as `BLACKLIST_BAD_USER` will count +2

Test using a honeypot for a few months.
Check to see if there are still some credits for this issue.