### PR TITLE
Updated Bluetooth base structure in lib.

### DIFF
--- a/lib/libbluetooth/bluetooth.h
+++ b/lib/libbluetooth/bluetooth.h
@@ -44,6 +44,7 @@
 
 #include <errno.h>
 #include <netdb.h>
+#include <string.h> // Ensure bcmp is available
 #include <bitstring.h>
 
 #include <netgraph/ng_message.h>
@@ -224,7 +225,12 @@ bdaddr_copy(bdaddr_t *d, const bdaddr_t *s)
 	d->b[5] = s->b[5];
 }
 
+/*
+ * Internal utility functions (used by bt_aton and bt_ntoa)
+ */
+static int bt_hex_byte(char const *str);
+static int bt_hex_nibble(char nibble);
+
 __END_DECLS
 
 #endif /* ndef _BLUETOOTH_H_ */
-


### PR DESCRIPTION
I saw that the libbluetooth wasn't updated for a long time. And.i provided some Updates to it simply 
It might be a simple thing but it might help as i hope.

This pull request introduces improvements to the Bluetooth utility functions in `bluetooth.c` and `bluetooth.h`. The changes focus on enhancing robustness, improving error handling, and ensuring compatibility with modern coding standards. Key updates include

- Added error logging using `perror` for file operations like `fopen` to provide better debugging information when errors occur.
- Ensured proper initialization of pointers, such as `end` in `bt_aton`, to prevent undefined behavior.
- Added a retry counter in `bt_gethostent` to prevent infinite loops when parsing invalid lines in `/etc/bluetooth/hosts`.
- Replaced `sprintf` with `snprintf` in `bt_ntoa` for safer string formatting.
- Added declarations for internal utility functions (`bt_hex_byte` and `bt_hex_nibble`) to the header file for better code organization.
- Improved input validation in `bt_hex_byte` and `bt_hex_nibble` to handle edge cases more gracefully.