### PR TITLE
jail: add JID, JNAME and JPATH to environment for exec.* commands

### DIFF
--- a/usr.sbin/jail/command.c
+++ b/usr.sbin/jail/command.c
@@ -290,7 +290,7 @@ run_command(struct cfjail *j)
 	const struct cfstring *comstring, *s;
 	login_cap_t *lcap;
 	const char **argv;
-	char *acs, *cs, *comcs, *devpath;
+	char *acs, *ajidstr, *cs, *comcs, *devpath;
 	const char *jidstr, *conslog, *fmt, *path, *ruleset, *term, *username;
 	enum intparam comparam;
 	size_t comlen, ret;
@@ -794,6 +794,18 @@ run_command(struct cfjail *j)
 			exit(1);
 		}
 		endpwent();
+	}
+	if (!injail) {
+		if (asprintf(&ajidstr, "%d", j->jid) == -1) {
+			jail_warnx(j, "asprintf jid=%d: %s", j->jid,
+				strerror(errno));
+			exit(1);
+		}
+		setenv("JID", ajidstr, 1);
+		free(ajidstr);
+		setenv("JNAME", string_param(j->intparams[KP_NAME]), 1);
+		path = string_param(j->intparams[KP_PATH]);
+		setenv("JPATH", path ? path : "", 1);
 	}
 
 	if (consfd != 0 && (dup2(consfd, 1) < 0 || dup2(consfd, 2) < 0)) {

--- a/usr.sbin/jail/jail.8
+++ b/usr.sbin/jail/jail.8
@@ -819,6 +819,22 @@ commands in sequence.
 All commands must succeed (return a zero exit status), or the jail will
 not be created or removed, as appropriate.
 .Pp
+The following variables are added to the environment:
+.Bl -tag -width indent -offset indent
+.It Ev JID
+The
+.Va jid
+, or jail identifier.
+.It Ev JNAME
+The
+.Va name
+of the jail.
+.It Ev JPATH
+The
+.Va path
+of the jail.
+.El
+.Pp
 The pseudo-parameters are:
 .Bl -tag -width indent
 .It Va exec.prepare
@@ -883,6 +899,10 @@ is imported from the current environment.
 is set to "/bin:/usr/bin".
 The environment variables from the login class capability database for the
 target login are also set.
+.Ev JID , JNAME
+and
+.Ev JPATH
+are not set.
 If a user is specified (as with
 .Va exec.jail_user ) ,
 commands are run from that (possibly jailed) user's directory.

--- a/usr.sbin/jail/tests/commands.jail.conf
+++ b/usr.sbin/jail/tests/commands.jail.conf
@@ -1,6 +1,9 @@
 
 exec.prestop = "echo STOP";
 exec.prestart = "echo START";
+exec.poststart = "env";
 persist;
+
+path = "/tmp/test_${name}_root";
 
 basejail {}


### PR DESCRIPTION
Although variable substitution is available in the jail configuration file, the jail identifier is often not since it is dynamically attributed at run time.

In order to facilitate scripting of exec.* commands executed on the system, this change sets the JID, JNAME and JPATH environment variables.

These variables are not added when using exec.clean. Neither are they for commands executed inside jails, to avoid disclosing information about the host system.