### PR TITLE
Suppress unimplemented MSR related warnings

### DIFF
--- a/usr.sbin/bhyve/amd64/bhyverun_machdep.c
+++ b/usr.sbin/bhyve/amd64/bhyverun_machdep.c
@@ -63,6 +63,7 @@ bhyve_init_config(void)
 	set_config_bool("acpi_tables_in_memory", true);
 	set_config_value("memory.size", "256M");
 	set_config_bool("x86.strictmsr", true);
+	set_config_bool("x86.verbosemsr", true);
 	set_config_value("lpc.fwcfg", "bhyve");
 }
 
@@ -74,7 +75,7 @@ bhyve_usage(int code)
 	progname = getprogname();
 
 	fprintf(stderr,
-	    "Usage: %s [-aCDeHhPSuWwxY]\n"
+	    "Usage: %s [-aCDeHhPqSuWwxY]\n"
 	    "       %*s [-c [[cpus=]numcpus][,sockets=n][,cores=n][,threads=n]]\n"
 	    "       %*s [-G port] [-k config_file] [-l lpc] [-m mem] [-o var=value]\n"
 	    "       %*s [-p vcpu:hostcpu] [-r file] [-s pci] [-U uuid] vmname\n"
@@ -96,6 +97,7 @@ bhyve_usage(int code)
 #ifdef BHYVE_SNAPSHOT
 	    "       -r: path to checkpoint file\n"
 #endif
+	    "       -q: disable verbose MSR print out\n"
 	    "       -S: guest memory cannot be swapped\n"
 	    "       -s: <slot,driver,configinfo> PCI slot config\n"
 	    "       -U: UUID\n"
@@ -116,9 +118,9 @@ bhyve_optparse(int argc, char **argv)
 	int c;
 
 #ifdef BHYVE_SNAPSHOT
-	optstr = "aehuwxACDHIPSWYk:f:o:p:G:c:s:m:l:K:U:r:";
+	optstr = "aehuwxACDHIPqSWYk:f:o:p:G:c:s:m:l:K:U:r:";
 #else
-	optstr = "aehuwxACDHIPSWYk:f:o:p:G:c:s:m:l:K:U:";
+	optstr = "aehuwxACDHIPqSWYk:f:o:p:G:c:s:m:l:K:U:";
 #endif
 	while ((c = getopt(argc, argv, optstr)) != -1) {
 		switch (c) {
@@ -223,6 +225,9 @@ bhyve_optparse(int argc, char **argv)
 			break;
 		case 'U':
 			set_config_value("uuid", optarg);
+			break;
+		case 'q':
+			set_config_value("x86.verbosemsr", false);
 			break;
 		case 'w':
 			set_config_bool("x86.strictmsr", false);

--- a/usr.sbin/bhyve/amd64/vmexit.c
+++ b/usr.sbin/bhyve/amd64/vmexit.c
@@ -107,8 +107,10 @@ vmexit_rdmsr(struct vmctx *ctx __unused, struct vcpu *vcpu,
 	val = 0;
 	error = emulate_rdmsr(vcpu, vme->u.msr.code, &val);
 	if (error != 0) {
-		EPRINTLN("rdmsr to register %#x on vcpu %d",
-		    vme->u.msr.code, vcpu_id(vcpu));
+		if (get_config_bool("x86.strictmsr") || get_config_bool("x86.verbosemsr")) {
+		    EPRINTLN("rdmsr to register %#x on vcpu %d",
+			    vme->u.msr.code, vcpu_id(vcpu));
+		}
 		if (get_config_bool("x86.strictmsr")) {
 			vm_inject_gp(vcpu);
 			return (VMEXIT_CONTINUE);
@@ -137,8 +139,10 @@ vmexit_wrmsr(struct vmctx *ctx __unused, struct vcpu *vcpu,
 
 	error = emulate_wrmsr(vcpu, vme->u.msr.code, vme->u.msr.wval);
 	if (error != 0) {
-		EPRINTLN("wrmsr to register %#x(%#lx) on vcpu %d",
-		    vme->u.msr.code, vme->u.msr.wval, vcpu_id(vcpu));
+		if (get_config_bool("x86.strictmsr") || get_config_bool("x86.verbosemsr")) {
+			EPRINTLN("wrmsr to register %#x(%#lx) on vcpu %d",
+			    vme->u.msr.code, vme->u.msr.wval, vcpu_id(vcpu));
+		}
 		if (get_config_bool("x86.strictmsr")) {
 			vm_inject_gp(vcpu);
 			return (VMEXIT_CONTINUE);

--- a/usr.sbin/bhyve/bhyve.8
+++ b/usr.sbin/bhyve/bhyve.8
@@ -30,7 +30,7 @@
 .Nd "run a guest operating system inside a virtual machine"
 .Sh SYNOPSIS
 .Nm
-.Op Fl aCDeHhPSuWwxY
+.Op Fl aCDeHhPqSuWwxY
 .Oo
 .Sm off
 .Fl c\~
@@ -295,6 +295,13 @@ To map a 4 vCPU guest to host CPUs 12-15:
 .Bd -literal
 -p 0:12 -p 1:13 -p 2:14 -p 3:15
 .Ed
+.It Fl q
+Disable verbose MSR (Model-Specific Register) print out.
+When this option is enabled, bhyve will suppress messages related to reading
+from (rdmsr) and writing to (wrmsr) MSRs on virtual CPUs.
+This can be useful for reducing log verbosity and preventing the VM console
+from being spammed with informational messages, particularly in environments
+where such messages are not needed for diagnostic purposes.
 .It Fl r Ar file
 Resume a guest from a snapshot.
 The guest memory contents are restored from


### PR DESCRIPTION
While using bhyve on intel machines, if certain MSRs are unimplemented, the bhyve console is spammed with these messages: 

```
rdmsr to register 0x684 on vcpu 1
rdmsr to register 0x6c4 on vcpu 1
rdmsr to register 0x683 on vcpu 1
rdmsr to register 0x6c3 on vcpu 1
rdmsr to register 0x682 on vcpu 1
rdmsr to register 0x6c2 on vcpu 1
rdmsr to register 0x681 on vcpu 1
rdmsr to register 0x6c1 on vcpu 1
rdmsr to register 0x680 on vcpu 1
rdmsr to register 0x6c0 on vcpu 1
Password:
Login incorrect
login:
login:
login:
login: rdmsr to register 0x1c9 on vcpu 0
rdmsr to register 0x1dd on vcpu 0
rdmsr to register 0x1de on vcpu 0
rdmsr to register 0x68f on vcpu 0
rdmsr to register 0x6cf on vcpu 0
rdmsr to register 0x68e on vcpu 0
rdmsr to register 0x6ce on vcpu 0
rdmsr to register 0x68d on vcpu 0
rdmsr to register 0x6cd on vcpu 0
rdmsr to register 0x68c on vcpu 0
rdmsr to register 0x6cc on vcpu 0
rdmsr to register 0x68b on vcpu 0
rdmsr to register 0x6cb on vcpu 0
rdmsr to register 0x68a on vcpu 0
rdmsr to register 0x6ca on vcpu 0
rdmsr to register 0x689 on vcpu 0
rdmsr to register 0x6c9 on vcpu 0
rdmsr to register 0x688 on vcpu 0
rdmsr to register 0x6c8 on vcpu 0
rdmsr to register 0x687 on vcpu 0
rdmsr to register 0x6c7 on vcpu 0
rdmsr to register 0x686 on vcpu 0
```
This does not interfere with the normal operation of bhyve (since I can run the image), and there are already options to ignore unimplmented MSRs and continue (`-w`)   But the warning messages makes it difficult to use the console. A new option `-q` is created to suppress the `rdmsr` and `wrmsr` messages. 
