### PR TITLE
linuxkpi: Correct DIV_ROUND_DOWN_ULL

### DIFF
--- a/sys/compat/linuxkpi/common/include/linux/math.h
+++ b/sys/compat/linuxkpi/common/include/linux/math.h
@@ -46,7 +46,7 @@
 
 #define	DIV_ROUND_UP(x, n)	howmany(x, n)
 #define	DIV_ROUND_UP_ULL(x, n)	DIV_ROUND_UP((unsigned long long)(x), (n))
-#define	DIV_ROUND_DOWN_ULL(x, n) (((unsigned long long)(x) / (n)) * (n))
+#define	DIV_ROUND_DOWN_ULL(x, n) ((unsigned long long)(x) / (n))
 
 #define	DIV_ROUND_CLOSEST(x, divisor)	(((x) + ((divisor) / 2)) / (divisor))
 #define	DIV_ROUND_CLOSEST_ULL(x, divisor) ({		\


### PR DESCRIPTION
This fixes a black screen issue with the i915 DRM driver from Linux v6.8

Fixes: c4e0746 ("LinuxKPI: Add helper macros IS_ALIGNED and DIV_ROUND_DOWN_ULL.")