### PR TITLE
rc.d/zpool: change mountcritlocal dep from BEFORE to REQUIRE

### DIFF
--- a/libexec/rc/rc.d/zpool
+++ b/libexec/rc/rc.d/zpool
@@ -3,8 +3,7 @@
 #
 
 # PROVIDE: zpool
-# REQUIRE: hostid disks
-# BEFORE: mountcritlocal
+# REQUIRE: hostid disks mountcritlocal
 # KEYWORD: nojail
 
 . /etc/rc.subr


### PR DESCRIPTION
In cases where the `/boot` directory is mounted from a different disk through `/etc/fstab`, `/boot/zfs/zpool.cache` will not be found during a `rc.d/zpool` run. This is because `/etc/fstab` mounts are mounted in `rc.d/mountcritlocal`, which currently runs AFTER (i.e. `REQUIRE:`) `rc.d/zpool`.

This change swaps the `rcorder` of `rc.d/zpool`'s dependency on `mountcritlocal` from `BEFORE:` to `REQUIRE:`. This will ensure that `/boot` (or even `/etc/` in some configurations) to be visible while searching for `zpool.cache`.