### PR TITLE
netinet6: allow binding to anycast addresses

### DIFF
--- a/sbin/ifconfig/ifconfig.8
+++ b/sbin/ifconfig/ifconfig.8
@@ -28,7 +28,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 6, 2024
+.Dd March 20, 2025
 .Dt IFCONFIG 8
 .Os
 .Sh NAME
@@ -448,11 +448,12 @@ of specifying the host portion, removing all NS addresses will
 allow you to respecify the host portion.
 .It Cm anycast
 (Inet6 only.)
-Specify that the address configured is an anycast address.
-Based on the current specification,
-only routers may configure anycast addresses.
-Anycast address will not be used as source address of any of outgoing
-IPv6 packets.
+Specify that the address configured is an anycast address,
+as described in RFC 4291 section 2.6.
+Anycast addresses will not be used as source address of any outgoing
+IPv6 packets unless an application explicitly uses
+.Xr bind 2
+to bind a socket to the address.
 .It Cm arp
 Enable the use of the Address Resolution Protocol
 .Pq Xr arp 4

--- a/sys/netinet6/in6_pcb.c
+++ b/sys/netinet6/in6_pcb.c
@@ -214,14 +214,13 @@ in6_pcbbind_avail(struct inpcb *inp, const struct sockaddr_in6 *sin6, int fib,
 		}
 
 		/*
-		 * XXX: bind to an anycast address might accidentally
-		 * cause sending a packet with anycast source address.
-		 * We should allow to bind to a deprecated address, since
-		 * the application dares to use it.
+		 * We used to prohibit binding to an anycast address here,
+		 * based on RFC3513, but that restriction was removed in
+		 * RFC4291.
 		 */
 		if (ifa != NULL &&
 		    ((struct in6_ifaddr *)ifa)->ia6_flags &
-		    (IN6_IFF_ANYCAST | IN6_IFF_NOTREADY | IN6_IFF_DETACHED)) {
+		    (IN6_IFF_NOTREADY | IN6_IFF_DETACHED)) {
 			NET_EPOCH_EXIT(et);
 			return (EADDRNOTAVAIL);
 		}


### PR DESCRIPTION
the restriction on sending packets from anycast source addresses was removed in RFC4291, so there's no reason to forbid binding to such addresses.  this allows anycast services (e.g., DNS) to actually use anycast addresses, which was previously impossible.

RFC4291 also removes the restriction that only routers may configure anycast addresses; this was never enforced in code but was documented in ifconfig.8.  update ifconfig.8 to document both changes.