### PR TITLE
rc.subr: add 'settime' to svcj options

### DIFF
--- a/libexec/rc/rc.subr
+++ b/libexec/rc/rc.subr
@@ -1237,6 +1237,9 @@ run_rc_command()
 				nfsd)
 					_svcj_cmd_options="allow.nfsd enforce_statfs=1 ${_svcj_cmd_options}"
 					;;
+				settime)
+					_svcj_cmd_options="allow.settime ${_svcj_cmd_options}"
+					;;
 				sysvipc)
 					_svcj_sysvipc_x=$((${_svcj_sysvipc_x} + 1))
 					_svcj_cmd_options="sysvmsg=inherit sysvsem=inherit sysvshm=inherit  ${_svcj_cmd_options}"

--- a/share/man/man5/rc.conf.5
+++ b/share/man/man5/rc.conf.5
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 6, 2025
+.Dd March 20, 2025
 .Dt RC.CONF 5
 .Os
 .Sh NAME
@@ -4992,6 +4992,8 @@ of protocol stacks that have not had jail functionality added
 to them.
 .It nfsd
 Allows to run nfsd and affiliated daemons.
+.It settime
+Allows to set and slew the system time.
 .It sysvipc
 Inherits the SysV semaphores, SysV shared memory and
 SysV messages from the host or the parent jail.

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -4203,6 +4203,7 @@ prison_priv_check(struct ucred *cred, int priv)
 		 * Conditionally allow privileged process in the jail set
 		 * machine time.
 		 */
+	case PRIV_SETTIMEOFDAY:
 	case PRIV_CLOCK_SETTIME:
 		if (cred->cr_prison->pr_allow & PR_ALLOW_SETTIME)
 			return (0);


### PR DESCRIPTION
```
<svc>_svcj_options="settime" enables the jail allow.settime privilege,
which allows to set and slew the system clock.  this allows NTP daemons
to run in a service jail.
```

the second commit "jail: allow jails to call settimeofday() if allow.settime is enabled" is not directly required for the first, but fixes chrony in jails in general (including in service jails).

tested using net/chrony 4.6.1_1:

```
Mar 20 13:55:40 daphne chronyd[26109]: chronyd version 4.6.1 starting (+CMDMON +NTP +REFCLOCK -RTC +PRIVDROP -SCFILTER +SIGND +ASYNCDNS +NTS +SECHASH +IPV6 -DEBUG)
Mar 20 13:55:40 daphne chronyd[26109]: Frequency 0.039 +/- 0.024 ppm read from /var/db/chrony/drift
Mar 20 13:55:45 daphne chronyd[26109]: Selected source fd5b:a83:b06b:100::1 (a.ntp.le-fay.dn42)
Mar 20 13:55:45 daphne chronyd[26109]: System clock wrong by -47.785761 seconds
Mar 20 13:54:58 daphne chronyd[26109]: System clock was stepped by -47.785761 seconds
```

```
chronyd 26109   0.0  0.3   22660  6656  -  SJ   13:54   0:00.01 /usr/local/sbin/chronyd -f /usr/local/etc/chrony.conf
root    26770   0.0  0.3   22272  6392  -  SJ   13:54   0:00.00 /usr/local/sbin/chronyd -f /usr/local/etc/chrony.conf
```