### PR TITLE
add jail 'allow.routing' permission and svcj 'routing' option

### DIFF
--- a/libexec/rc/rc.subr
+++ b/libexec/rc/rc.subr
@@ -1237,6 +1237,9 @@ run_rc_command()
 				nfsd)
 					_svcj_cmd_options="allow.nfsd enforce_statfs=1 ${_svcj_cmd_options}"
 					;;
+				routing)
+					_svcj_cmd_options="allow.routing ${_svcj_cmd_options}"
+					;;
 				sysvipc)
 					_svcj_sysvipc_x=$((${_svcj_sysvipc_x} + 1))
 					_svcj_cmd_options="sysvmsg=inherit sysvsem=inherit sysvshm=inherit  ${_svcj_cmd_options}"

--- a/share/man/man5/rc.conf.5
+++ b/share/man/man5/rc.conf.5
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 6, 2025
+.Dd March 21, 2025
 .Dt RC.CONF 5
 .Os
 .Sh NAME
@@ -4992,6 +4992,8 @@ of protocol stacks that have not had jail functionality added
 to them.
 .It nfsd
 Allows to run nfsd and affiliated daemons.
+.It routing
+Allows to modify the system routing table.
 .It sysvipc
 Inherits the SysV semaphores, SysV shared memory and
 SysV messages from the host or the parent jail.

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -231,6 +231,7 @@ static struct bool_flags pr_flag_allow[NBBY * NBPW] = {
 	{"allow.extattr", "allow.noextattr", PR_ALLOW_EXTATTR},
 	{"allow.adjtime", "allow.noadjtime", PR_ALLOW_ADJTIME},
 	{"allow.settime", "allow.nosettime", PR_ALLOW_SETTIME},
+	{"allow.routing", "allow.norouting", PR_ALLOW_ROUTING},
 };
 static unsigned pr_allow_all = PR_ALLOW_ALL_STATIC;
 const size_t pr_flag_allow_size = sizeof(pr_flag_allow);
@@ -4209,6 +4210,16 @@ prison_priv_check(struct ucred *cred, int priv)
 		else
 			return (EPERM);
 
+		/*
+		 * Conditionally allow privileged process in the jail to modify
+		 * the routing table.
+		 */
+	case PRIV_NET_ROUTE:
+		if (cred->cr_prison->pr_allow & PR_ALLOW_ROUTING)
+			return (0);
+		else
+			return (EPERM);
+
 	default:
 		/*
 		 * In all remaining cases, deny the privilege request.  This
@@ -4677,6 +4688,8 @@ SYSCTL_JAIL_PARAM(_allow, adjtime, CTLTYPE_INT | CTLFLAG_RW,
     "B", "Jail may adjust system time");
 SYSCTL_JAIL_PARAM(_allow, settime, CTLTYPE_INT | CTLFLAG_RW,
     "B", "Jail may set system time");
+SYSCTL_JAIL_PARAM(_allow, routing, CTLTYPE_INT | CTLFLAG_RW,
+    "B", "Jail may modify routing table");
 
 SYSCTL_JAIL_PARAM_SUBNODE(allow, mount, "Jail mount/unmount permission flags");
 SYSCTL_JAIL_PARAM(_allow_mount, , CTLTYPE_INT | CTLFLAG_RW,

--- a/sys/netlink/route/rt.c
+++ b/sys/netlink/route/rt.c
@@ -1118,12 +1118,14 @@ static const struct rtnl_cmd_handler cmd_handlers[] = {
 		.name = "RTM_DELROUTE",
 		.cb = &rtnl_handle_delroute,
 		.priv = PRIV_NET_ROUTE,
+		.flags = RTNL_F_ALLOW_NONVNET_JAIL,
 	},
 	{
 		.cmd = NL_RTM_NEWROUTE,
 		.name = "RTM_NEWROUTE",
 		.cb = &rtnl_handle_newroute,
 		.priv = PRIV_NET_ROUTE,
+		.flags = RTNL_F_ALLOW_NONVNET_JAIL,
 	}
 };
 

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -256,7 +256,8 @@ struct prison_racct {
 #define	PR_ALLOW_EXTATTR		0x00040000
 #define	PR_ALLOW_ADJTIME		0x00080000
 #define	PR_ALLOW_SETTIME		0x00100000
-#define	PR_ALLOW_ALL_STATIC		0x001f87ff
+#define	PR_ALLOW_ROUTING		0x00200000
+#define	PR_ALLOW_ALL_STATIC		0x003f87ff
 
 /*
  * PR_ALLOW_DIFFERENCES determines which flags are able to be

--- a/usr.sbin/jail/jail.8
+++ b/usr.sbin/jail/jail.8
@@ -674,6 +674,9 @@ For example through utilities like
 .Xr date 1 .
 This permission includes also
 .Va allow.adjtime .
+.It Va allow.routing
+Allow privileged process in the non-VNET jail to modify the system routing
+table.
 .El
 .El
 .Pp


### PR DESCRIPTION
a jail with `allow.routing` permission can modify the system routing table; the svcj option `routing` enables this permission, allowing routing daemons (e.g., BIRD) to run in a service jail.

split into two commits for the jail changes and the svcj changes.