### PR TITLE
rc.subr: add ${svc}_svcj_ipaddrs option

### DIFF
--- a/libexec/rc/rc.subr
+++ b/libexec/rc/rc.subr
@@ -1196,7 +1196,8 @@ run_rc_command()
 	    _prepend=\$${name}_prepend	_login_class=\${${name}_login_class:-daemon} \
 	    _limits=\$${name}_limits	_oomprotect=\$${name}_oomprotect \
 	    _setup=\$${name}_setup	_env_file=\$${name}_env_file \
-	    _umask=\$${name}_umask	_svcj_options=\$${name}_svcj_options
+	    _umask=\$${name}_umask	_svcj_options=\$${name}_svcj_options \
+	    _svcj_ipaddrs=\$${name}_svcj_ipaddrs
 
 	if [ -n "$_env_file" ] && [ -r "${_env_file}" ]; then	# load env from file
 		set -a
@@ -1210,9 +1211,30 @@ run_rc_command()
 		fi
 	fi
 
-	if [ -n "$_svcj_options" ]; then	# translate service jail options
-		_svcj_cmd_options=""
+	_svcj_ip="inherit"
+	_svcj_ip4_addrs=""
+	_svcj_ip6_addrs=""
 
+	for addr in $_svcj_ipaddrs; do
+		case $addr in
+			*:*) _svcj_ip6_addrs="$addr,${_svcj_ip6_addrs}" ;;
+			*) _svcj_ip4_addrs="$addr,${_svcj_ip4_addrs}" ;;
+		esac
+	done
+
+	_svcj_cmd_options=""
+
+	if [ -n "$_svcj_ip4_addrs" ]; then
+		_svcj_cmd_options="ip4.addr=${_svcj_ip4_addrs%*,} ${_svcj_cmd_options}"
+		_svcj_ip="new"
+	fi
+
+	if [ -n "$_svcj_ip6_addrs" ]; then
+		_svcj_cmd_options="ip6.addr=${_svcj_ip6_addrs%*,} ${_svcj_cmd_options}"
+		_svcj_ip="new"
+	fi
+
+	if [ -n "$_svcj_options" ]; then	# translate service jail options
 		_svcj_sysvipc_x=0
 		for _svcj_option in $_svcj_options; do
 			case "$_svcj_option" in
@@ -1220,19 +1242,19 @@ run_rc_command()
 					_svcj_cmd_options="allow.mlock ${_svcj_cmd_options}"
 					;;
 				netv4)
-					_svcj_cmd_options="ip4=inherit allow.reserved_ports ${_svcj_cmd_options}"
+					_svcj_cmd_options="ip4=${_svcj_ip} allow.reserved_ports ${_svcj_cmd_options}"
 					;;
 				netv6)
-					_svcj_cmd_options="ip6=inherit allow.reserved_ports ${_svcj_cmd_options}"
+					_svcj_cmd_options="ip6=${_svcj_ip} allow.reserved_ports ${_svcj_cmd_options}"
 					;;
 				net_basic)
-					_svcj_cmd_options="ip4=inherit ip6=inherit allow.reserved_ports ${_svcj_cmd_options}"
+					_svcj_cmd_options="ip4=${_svcj_ip} ip6=${_svcj_ip} allow.reserved_ports ${_svcj_cmd_options}"
 					;;
 				net_raw)
 					_svcj_cmd_options="allow.raw_sockets ${_svcj_cmd_options}"
 					;;
 				net_all)
-					_svcj_cmd_options="allow.socket_af allow.raw_sockets allow.reserved_ports ip4=inherit ip6=inherit ${_svcj_cmd_options}"
+					_svcj_cmd_options="allow.socket_af allow.raw_sockets allow.reserved_ports ip4=${_svcj_ip} ip6=${_svcj_ip} ${_svcj_cmd_options}"
 					;;
 				nfsd)
 					_svcj_cmd_options="allow.nfsd enforce_statfs=1 ${_svcj_cmd_options}"

--- a/share/man/man5/rc.conf.5
+++ b/share/man/man5/rc.conf.5
@@ -269,6 +269,11 @@ If set to
 auto-jail the service with inherited filesystem and other
 jail properties depending on
 .Ao Ar name Ac Ns Va _svcj_options .
+.It Ao Ar name Ac Ns Va _svcj_ipaddrs
+.Pq Vt str
+A list of IP addresses that the service jail will be permitted to use.
+If this is not specified, the service jail will be permitted to use all
+assigned IP addresses if networking is enabled in the jail.
 .It Ao Ar name Ac Ns Va _svcj_options
 .Pq Vt str
 A list of jail properties for the service.
@@ -4969,16 +4974,26 @@ are:
 .It mlock
 Allows to lock memory pages into the physical memory.
 .It netv4
-Inherit the IPv4 address and allows to open reserved ports.
+Allows IPv4 network access and the ability to bind to reserved ports.
+If
+.Ao Ar name Ac Ns Va _svcj_ipaddrs
+is set, only the IPv4 addresses listed there will be visible to the jail,
+otherwise all assigned IPv4 addresses will be visible.
 This can not be combined with
 .Pa netv6 .
 .It netv6
-Inherit the IPv6 address and allows to open reserved ports.
+Allows IPv6 network access and the ability to bind to reserved ports.
+If
+.Ao Ar name Ac Ns Va _svcj_ipaddrs
+is set, only the IPv6 addresses listed there will be visible to the jail,
+otherwise all assigned IPv6 addresses will be visible.
 This can not be combined with
 .Pa netv4 .
 .It net_basic
-Inherits the IPv4 and IPv6 addresses and allows to open
-reserved ports.
+Equivalent to enabling both
+.Pa netv6
+and
+.Pa netv4 .
 .It net_raw
 Allow to open raw sockets.
 This option can be combined with
@@ -4986,10 +5001,12 @@ This option can be combined with
 .Pa netv6 ,
 .Pa net_basic .
 .It net_all
-Inherits the IPv4 and IPv6 addresses, allows to open reserved
-ports, allows to open raw sockets, and allows to open sockets
-of protocol stacks that have not had jail functionality added
-to them.
+Allows IPv6 and IPv4 network access as for
+.Pa netv4
+and
+.Pa netv6 ,
+allows to open raw sockets, and allows to open sockets of protocol stacks that
+have not had jail functionality added to them.
 .It nfsd
 Allows to run nfsd and affiliated daemons.
 .It sysvipc


### PR DESCRIPTION
setting ${svc}_svcj_ipaddrs to a list of IP addresses causes rc.subr to set ip6.addr and/or ip4.addr when starting the jail, restricting it to those IP addresses rather than inheriting all IP addresses.

for example:

```
inetd_enable=YES
inetd_svcj=YES
inetd_svcj_options="net_basic"
inetd_svcj_ipaddrs="::1 127.0.0.1 2001:db8::1"
```

if not specified, the default value is unchanged (inherit all addresses if networking is enabled).