### PR TITLE
ice.4: Update man page with feature documentation

### DIFF
--- a/share/man/man4/ice.4
+++ b/share/man/man4/ice.4
@@ -73,6 +73,16 @@ Intel\(rg Ethernet Connection E822\-L
 Intel\(rg Ethernet Connection E823\-C
 .It
 Intel\(rg Ethernet Connection E823\-L
+.It
+Intel\(rg Ethernet Connection E825\-C
+.It
+Intel\(rg Ethernet Connection E830\-C
+.It
+Intel\(rg Ethernet Connection E830\-CC
+.It
+Intel\(rg Ethernet Connection E830\-L
+.It
+Intel\(rg Ethernet Connection E830\-XXV
 .El
 .Pp
 For questions related to hardware requirements, refer to the documentation
@@ -182,14 +192,38 @@ See the
 .Xr iflib 4
 man page for more information on using iflib sysctl variables as tunables.
 .Bl -tag -width indent
-.It Va hw.ice.#.enable_health_events
-TBW
-.It Va hw.ice.#.debug.enable_tx_fc_filter
-TBW
-.It Va hw.ice.#.debug.enable_tx_lldp_filter
-TBW
-.It Va hw.ice.#.debug.enable_health_events
-TBW
+.It Va hw.ice.enable_health_events
+Set to 1 to enable firmware health event reporting across all devices. Enabled by default.
+.Pp
+If enabled, when the driver receives a firmware health event message, it will
+print out a description of the event to the kernel message buffer and if
+applicable, possible actions to take to remedy it.
+.It Va hw.ice.irdma
+Set to 1 to enable the RDMA client interface, required by the
+.Xr irdma 4
+driver.
+Enabled by default.
+.It Va hw.ice.rdma_max_msix
+Set the maximum number of per-device MSI-X vectors that are allocated for use by the
+.Xr irdma 4
+driver.
+Set to 64 by default.
+.It Va hw.ice.debug.enable_tx_fc_filter
+Set to 1 to enable the TX Flow Control filter across all devices. Enabled by default.
+.Pp
+If enabled, the hardware will drop any transmitted Ethertype 0x8808 control
+frames that do not originate from the hardware.
+.It Va hw.ice.debug.enable_tx_lldp_filter
+Set to 1 to enable the TX LLDP filter across all devices. Enabled by default.
+.Pp
+If enabled, the hardware will drop any transmitted Ethertype 0x88cc LLDP frames
+that do not originate from the hardware.
+This must be disabled in order to use LLDP daemon software such as
+.Xr lldpd 8 .
+.It Va hw.ice.debug.ice_tx_balance_en
+Set to 1 to allow the driver to use the 5-layer Tx Scheduler tree topology if configured by the DDP package.
+.Pp
+Enabled by default. 
 .El
 .Sh SYSCTL PROCEDURES
 .Bl -tag -width indent

--- a/share/man/man4/ice.4
+++ b/share/man/man4/ice.4
@@ -167,7 +167,7 @@ This mirroring may impact performance.
 .Pp
 To use RDMA monitoring, you may need to reserve more MSI\-X interrupts.
 Before the
-.Nm ice
+.Nm
 driver loads, configure the following tunable:
 .Bd -literal -offset indent
 dev.ice.0.iflib.use_extra_msix_vectors=4
@@ -190,7 +190,102 @@ interface naming convention is:
 <driver name><port number><modifier><modifier unit number>
 .Ed
 .Pp
-For example, ice0m0 is the first mirrored interface on ice0.
+For example,
+.Dq Li ice0m0
+is the first mirroring interface on
+.Dq Li ice0 .
+.Ss Data Center Bridging
+Data Center Bridging (DCB) is a configuration Quality of Service
+implementation in hardware.
+It uses the VLAN priority tag (802.1p) to filter traffic.
+That means that there are 8 different priorities that traffic can be filtered
+into.
+It also enables priority flow control (802.1Qbb) which can limit or eliminate
+the number of dropped packets during network stress.
+Bandwidth can be allocated to each of these priorities, which is enforced at
+the hardware level (802.1Qaz).
+.Pp
+DCB is normally configured on the network using the DCBX protocol (802.1Qaz), a
+specialization of LLDP (802.1AB). The
+.Nm
+driver supports the following mutually exclusive variants of DCBX support:
+.Bl -bullet -compact
+.It
+Firmware\-based LLDP Agent
+.It
+Software\-based LLDP Agent
+.El
+.Pp
+In firmware\-based mode, firmware intercepts all LLDP traffic and handles DCBX
+negotiation transparently for the user.
+In this mode, the adapter operates in
+.Dq willing
+DCBX mode, receiving DCB settings from the link partner (typically a
+switch).
+The local user can only query the negotiated DCB configuration.
+For information on configuring DCBX parameters on a switch, please consult the
+switch manufacturer\(aqs documentation.
+.Pp
+In software\-based mode, LLDP traffic is forwarded to the network stack and user
+space, where a software agent can handle it.
+In this mode, the adapter can operate in
+.Dq nonwilling
+DCBX mode and DCB configuration can be both queried and set locally.
+This mode requires the FW\-based LLDP Agent to be disabled.
+.Pp
+Firmware\-based mode and software\-based mode are controlled by the
+.Dq fw_lldp_agent
+sysctl.
+Refer to the Firmware Link Layer Discovery Protocol Agent section for more
+information.
+.Pp
+Link\-level flow control and priority flow control are mutually exclusive.
+The ice driver will disable link flow control when priority flow control
+is enabled on any traffic class (TC).
+It will disable priority flow control when link flow control is enabled.
+.Pp
+To enable/disable priority flow control in software\-based DCBX mode:
+.Bd -literal -offset indent
+sysctl dev.ice.<interface #>.pfc=1 (or 0 to disable)
+.Ed
+Enhanced Transmission Selection (ETS) allows you to assign bandwidth to certain
+TCs, to help ensure traffic reliability.
+To view the assigned ETS configuration, use the following:
+.Bd -literal -offset indent
+sysctl dev.ice.<interface #>.ets_min_rate
+.Ed
+To set the minimum ETS bandwidth per TC, separate the values by commas.
+All values must add up to 100.
+For example, to set all TCs to a minimum bandwidth of 10% and TC 7 to 30%,
+use the following:
+.Bd -literal -offset indent
+sysctl dev.ice.<interface #>.ets_min_rate=10,10,10,10,10,10,10,30
+.Ed
+To set the User Priority (UP) to a TC mapping for a port, separate the values
+by commas. For example, to map UP 0 and 1 to TC 0, UP 2 and 3 to TC 1, UP 4 and
+5 to TC 2, and UP 6 and 7 to TC 3, use the following:
+.Bd -literal -offset indent
+sysctl dev.ice.<interface #>.up2tc_map=0,0,1,1,2,2,3,3
+.Ed
+.Ss L3 QoS mode
+The
+.Nm
+driver supports setting DSCP\-based Layer 3 Quality of Service (L3 QoS)
+in the PF driver.
+The driver initializes in L2 QoS mode by default; L3 QoS is disabled by
+default.
+Use the following sysctl to enable or disable L3 QoS:
+.Bd -literal -offset indent
+sysctl dev.ice.<interface #>.pfc_mode=1 (or 0 to disable)
+.Ed
+If you disable L3 QoS mode, it returns to L2 QoS mode.
+.Pp
+To map a DSCP value to a traffic class, separate the values by commas. For
+example, to map DSCPs 0\-3 and DSCP 8 to DCB TCs 0\-3 and 4, respectively:
+.Bd -literal -offset indent
+sysctl dev.ice.<interface #>.dscp2tc_map.0\-7=0,1,2,3,0,0,0,0
+sysctl dev.ice.<interface #>.dscp2tc_map.8\-15=4,0,0,0,0,0,0,0
+.Ed
 .Ss Additional Utilities
 There are additional tools available from Intel to help configure and update
 the adapters covered by this driver.

--- a/share/man/man4/ice.4
+++ b/share/man/man4/ice.4
@@ -132,18 +132,14 @@ There are additional tools available from Intel to help configure and update
 the adapters covered by this driver.
 These tools can be downloaded directly from Intel at
 .Lk https://downloadcenter.intel.com ,
-by searching for their names, or by installing certain packages:
+by searching for their names:
 .Bl -bullet
 .It
-To change the behavior of the QSFP28 ports on E810-C adapters, use the
-Intel EPCT (Ethernet Port configuration tool); installed by the
-.Em sysutils/intel-epct
-package.
+To change the behavior of the QSFP28 ports on E810-C adapters, use the Intel
+.Em Ethernet Port Configuration Tool - FreeBSD .
 .It
-To update the firmware on an adapter, use the Intel Non-Volatile Memory (NVM)
-Update Utility for Intel Network Adapter 800 series; installed by the
-.Em sysutils/intel-nvmupdate-100g
-package.
+To update the firmware on an adapter, use the Intel
+.Em Non-Volatile Memory (NVM) Update Utility for Intel Ethernet Network Adapters E810 series - FreeBSD
 .El
 .Sh HARDWARE
 The

--- a/share/man/man4/ice.4
+++ b/share/man/man4/ice.4
@@ -127,6 +127,20 @@ any other PFs.
 See the
 .Em Intel(R) Ethernet Adapters and Devices User Guide
 for more details on DDP and Safe Mode.
+.Pp
+If you encounter issues with the DDP package file, you may need to download
+an updated driver or
+.Em ice_ddp
+module. See the log messages for more information.
+.Pp
+You cannot update the DDP package if any PF drivers are already loaded.
+To overwrite a package, unload all PFs and then reload the driver with the
+new package.
+.Pp
+You can only use one DDP package per driver, even if you have more than one
+device installed that uses the driver.
+.Pp
+Only the first loaded PF per device can download a package for that device.
 .Ss Additional Utilities
 There are additional tools available from Intel to help configure and update
 the adapters covered by this driver.

--- a/share/man/man4/ice.4
+++ b/share/man/man4/ice.4
@@ -114,7 +114,7 @@ The associated RDMA driver for this driver is
 .Ss Dynamic Device Personalization
 The DDP package loads during device initialization.
 The driver looks for the
-ice_ddp
+.Em ice_ddp
 module and checks that it contains a valid DDP package file.
 .Pp
 If the driver is unable to load the DDP package, the device will enter Safe
@@ -141,6 +141,56 @@ You can only use one DDP package per driver, even if you have more than one
 device installed that uses the driver.
 .Pp
 Only the first loaded PF per device can download a package for that device.
+.Ss Remote Direct Memory Access
+.sp
+Remote Direct Memory Access, or RDMA, allows a network device to transfer data
+directly to and from application memory on another system, increasing
+throughput and lowering latency in certain networking environments.
+.Pp
+The ice driver supports both the iWARP (Internet Wide Area RDMA Protocol) and
+RoCEv2 (RDMA over Converged Ethernet) protocols.
+The major difference is that iWARP performs RDMA over TCP, while RoCEv2 uses
+UDP.
+.Pp
+Devices based on the Intel(R) Ethernet 800 Series do not support RDMA when
+operating in multiport mode with more than 4 ports.
+.Pp
+For detailed installation and configuration information for RDMA, see
+.Xr irdma 4 .
+.Ss RDMA Monitoring
+For debugging/testing purposes, you can use sysctl to set up a mirroring
+interface on a port.
+The interface can receive mirrored RDMA traffic for packet
+analysis tools like
+.Xr tcpdump 1 .
+This mirroring may impact performance.
+.Pp
+To use RDMA monitoring, you may need to reserve more MSI\-X interrupts.
+Before the
+.Nm ice
+driver loads, configure the following tunable:
+.Bd -literal -offset indent
+dev.ice.0.iflib.use_extra_msix_vectors=4
+.Ed
+.Pp
+You may need to adjust the number of extra MSI\-X interrupt vectors.
+.Pp
+To create/delete the interface:
+.Bd -literal -offset indent
+sysctl dev.ice.0.create_interface=1
+sysctl dev.ice.0.delete_interface=1
+.Ed
+.Pp
+The mirrored interface receives both LAN and RDMA traffic. Additional
+filters can be configured in tcpdump.
+.Pp
+To differentiate the mirrored interface from the primary interface, the network
+interface naming convention is:
+.Bd -literal -offset indent
+<driver name><port number><modifier><modifier unit number>
+.Ed
+.Pp
+For example, ice0m0 is the first mirrored interface on ice0.
 .Ss Additional Utilities
 There are additional tools available from Intel to help configure and update
 the adapters covered by this driver.

--- a/share/man/man4/ice.4
+++ b/share/man/man4/ice.4
@@ -111,6 +111,22 @@ The associated Virtual Function (VF) driver for this driver is
 .Pp
 The associated RDMA driver for this driver is
 .Xr irdma 4 .
+.Ss Dynamic Device Personalization
+The DDP package loads during device initialization.
+The driver looks for the
+ice_ddp
+module and checks that it contains a valid DDP package file.
+.Pp
+If the driver is unable to load the DDP package, the device will enter Safe
+Mode.
+Safe Mode disables advanced and performance features and supports only
+basic traffic and minimal functionality, such as updating the NVM or
+downloading a new driver or DDP package.
+Safe Mode only applies to the affected physical function and does not impact
+any other PFs.
+See the
+.Em Intel(R) Ethernet Adapters and Devices User Guide
+for more details on DDP and Safe Mode.
 .Ss Additional Utilities
 There are additional tools available from Intel to help configure and update
 the adapters covered by this driver.

--- a/share/man/man4/ice.4
+++ b/share/man/man4/ice.4
@@ -105,6 +105,12 @@ be set and unset.
 .Pp
 For more information on configuring this device, see
 .Xr ifconfig 8 .
+.Pp
+The associated Virtual Function (VF) driver for this driver is
+.Xr iavf 4 .
+.Pp
+The associated RDMA driver for this driver is
+.Xr irdma 4 .
 .Ss Additional Utilities
 There are additional tools available from Intel to help configure and update
 the adapters covered by this driver.

--- a/sys/conf/files.amd64
+++ b/sys/conf/files.amd64
@@ -191,6 +191,10 @@ dev/ice/irdma_di_if.m		optional	ice pci \
 	compile-with "${NORMAL_M} -I$S/dev/ice"
 dev/ice/ice_ddp_common.c	optional	ice pci \
 	compile-with "${NORMAL_C} -I$S/dev/ice"
+dev/ice/ice_iov.c	optional	ice pci pci_iov \
+	compile-with "${NORMAL_C} -I$S/dev/ice"
+dev/ice/ice_vf_mbx.c	optional	ice pci pci_iov \
+	compile-with "${NORMAL_C} -I$S/dev/ice"
 ice_ddp.c			optional ice_ddp	\
 	compile-with	"${AWK} -f $S/tools/fw_stub.awk ice_ddp.fw:ice_ddp:0x01032900 -mice_ddp -c${.TARGET}"	\
 	no-ctfconvert no-implicit-rule before-depend local	\

--- a/sys/dev/ice/ice_features.h
+++ b/sys/dev/ice/ice_features.h
@@ -91,7 +91,9 @@ enum feat_list {
 static inline void
 ice_disable_unsupported_features(ice_bitmap_t __unused *bitmap)
 {
+#ifndef PCI_IOV
 	ice_clear_bit(ICE_FEATURE_SRIOV, bitmap);
+#endif
 #ifndef DEV_NETMAP
 	ice_clear_bit(ICE_FEATURE_NETMAP, bitmap);
 #endif

--- a/sys/dev/ice/ice_iflib.h
+++ b/sys/dev/ice/ice_iflib.h
@@ -139,6 +139,9 @@ struct ice_irq_vector {
  * @tc: traffic class queue belongs to
  * @q_handle: qidx in tc; used in TXQ enable functions
  *
+ * ice_iov.c requires the following parameters (when PCI_IOV is defined):
+ * @itr_idx: ITR index to use for this queue
+ *
  * Other parameters may be iflib driver specific
  */
 struct ice_tx_queue {
@@ -153,6 +156,9 @@ struct ice_tx_queue {
 	u32			me;
 	u16			q_handle;
 	u8			tc;
+#ifdef PCI_IOV
+	u8			itr_idx;
+#endif
 
 	/* descriptor writeback status */
 	qidx_t			*tx_rsq;
@@ -175,6 +181,9 @@ struct ice_tx_queue {
  * @stats: queue statistics
  * @tc: traffic class queue belongs to
  *
+ * ice_iov.c requires the following parameters (when PCI_IOV is defined):
+ * @itr_idx: ITR index to use for this queue
+ *
  * Other parameters may be iflib driver specific
  */
 struct ice_rx_queue {
@@ -187,6 +196,9 @@ struct ice_rx_queue {
 	struct ice_irq_vector		*irqv;
 	u32				me;
 	u8				tc;
+#ifdef PCI_IOV
+	u8				itr_idx;
+#endif
 
 	struct if_irq			que_irq;
 };
@@ -332,6 +344,10 @@ struct ice_softc {
 	ice_declare_bitmap(feat_cap, ICE_FEATURE_COUNT);
 	ice_declare_bitmap(feat_en, ICE_FEATURE_COUNT);
 
+#ifdef PCI_IOV
+	struct ice_vf *vfs;
+	u16 num_vfs;
+#endif
 	struct ice_resmgr os_imgr;
 	/* For mirror interface */
 	struct ice_mirr_if *mirr_if;

--- a/sys/dev/ice/ice_iov.c
+++ b/sys/dev/ice/ice_iov.c
@@ -1242,7 +1242,7 @@ ice_vc_cfg_irq_map_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
 
 	vvm = vimi->vecmap;
 	/* Save off information from message */
-	for (int i = 0; i < vimi->num_vectors - 1; i++, vvm++) {
+	for (int i = 0; i < vimi->num_vectors; i++, vvm++) {
 		struct ice_tx_queue *txq;
 		struct ice_rx_queue *rxq;
 		int bit;
@@ -1305,12 +1305,14 @@ ice_vc_cfg_irq_map_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
 
 	/* Write to T/RQCTL registers to actually map vectors to queues */
 	for (int i = 0; i < vf->vsi->num_rx_queues; i++)
-		ice_configure_rxq_interrupt(hw, vsi->rx_qmap[i],
-		    vsi->rx_queues[i].irqv->me, vsi->rx_queues[i].itr_idx);
+		if (vsi->rx_queues[i].irqv != NULL)
+			ice_configure_rxq_interrupt(hw, vsi->rx_qmap[i],
+			    vsi->rx_queues[i].irqv->me, vsi->rx_queues[i].itr_idx);
 
 	for (int i = 0; i < vf->vsi->num_tx_queues; i++)
-		ice_configure_txq_interrupt(hw, vsi->tx_qmap[i],
-		    vsi->tx_queues[i].irqv->me, vsi->tx_queues[i].itr_idx);
+		if (vsi->tx_queues[i].irqv != NULL)
+			ice_configure_txq_interrupt(hw, vsi->tx_qmap[i],
+			    vsi->tx_queues[i].irqv->me, vsi->tx_queues[i].itr_idx);
 
 	ice_flush(hw);
 

--- a/sys/dev/ice/ice_iov.c
+++ b/sys/dev/ice/ice_iov.c
@@ -631,6 +631,9 @@ ice_vc_get_vf_res_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
 
 		if (vf_caps & VIRTCHNL_VF_CAP_ADV_LINK_SPEED)
 			vf_res->vf_cap_flags |= VIRTCHNL_VF_CAP_ADV_LINK_SPEED;
+
+		if (vf_caps & VIRTCHNL_VF_OFFLOAD_WB_ON_ITR)
+                        vf_res->vf_cap_flags |= VIRTCHNL_VF_OFFLOAD_WB_ON_ITR;
 	}
 
 	vf_res->vsi_res[0].vsi_id = vf->vsi->idx;

--- a/sys/dev/ice/ice_iov.c
+++ b/sys/dev/ice/ice_iov.c
@@ -1,0 +1,1732 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*  Copyright (c) 2025, Intel Corporation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of the Intel Corporation nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file ice_iov.c
+ * @brief Virtualization support functions
+ *
+ * Contains functions for enabling and managing PCIe virtual function devices,
+ * including enabling new VFs, and managing VFs over the virtchnl interface.
+ */
+
+#include "ice_iov.h"
+
+static struct ice_vf *ice_iov_get_vf(struct ice_softc *sc, int vf_num);
+static void ice_iov_ready_vf(struct ice_softc *sc, struct ice_vf *vf);
+static void ice_reset_vf(struct ice_softc *sc, struct ice_vf *vf);
+static void ice_iov_setup_intr_mapping(struct ice_softc *sc, struct ice_vf *vf);
+
+static void ice_vc_version_msg(struct ice_softc *sc, struct ice_vf *vf,
+			       u8 *msg_buf);
+static void ice_vc_get_vf_res_msg(struct ice_softc *sc, struct ice_vf *vf,
+				  u8 *msg_buf);
+static void ice_vc_add_eth_addr_msg(struct ice_softc *sc, struct ice_vf *vf,
+				    u8 *msg_buf);
+static void ice_vc_del_eth_addr_msg(struct ice_softc *sc, struct ice_vf *vf,
+				    u8 *msg_buf);
+static bool ice_vc_isvalid_ring_len(u16 ring_len);
+static void ice_vc_cfg_vsi_qs_msg(struct ice_softc *sc, struct ice_vf *vf,
+				  u8 *msg_buf);
+static void ice_vc_cfg_rss_key_msg(struct ice_softc *sc, struct ice_vf *vf,
+				   u8 *msg_buf);
+static void ice_vc_set_rss_hena_msg(struct ice_softc *sc, struct ice_vf *vf,
+				    u8 *msg_buf);
+static void ice_vc_enable_queues_msg(struct ice_softc *sc, struct ice_vf *vf,
+				     u8 *msg_buf);
+static void ice_vc_notify_vf_link_state(struct ice_softc *sc, struct ice_vf *vf);
+static void ice_vc_disable_queues_msg(struct ice_softc *sc, struct ice_vf *vf,
+				      u8 *msg_buf);
+static void ice_vc_cfg_irq_map_msg(struct ice_softc *sc, struct ice_vf *vf,
+				   u8 *msg_buf);
+static void ice_vc_get_stats_msg(struct ice_softc *sc, struct ice_vf *vf,
+				 u8 *msg_buf);
+static void ice_eth_stats_to_virtchnl_eth_stats(struct ice_eth_stats *istats,
+     struct virtchnl_eth_stats *vstats);
+static void ice_vc_cfg_rss_lut_msg(struct ice_softc *sc, struct ice_vf *vf,
+				   u8 *msg_buf);
+static void ice_vc_cfg_promisc_mode_msg(struct ice_softc *sc, struct ice_vf *vf,
+				        u8 *msg_buf);
+static void ice_vc_add_vlan_msg(struct ice_softc *sc, struct ice_vf *vf,
+				u8 *msg_buf);
+static void ice_vc_del_vlan_msg(struct ice_softc *sc, struct ice_vf *vf,
+				u8 *msg_buf);
+static enum virtchnl_status_code ice_iov_err_to_virt_err(int ice_err);
+static int ice_vf_validate_mac(struct ice_vf *vf, const uint8_t *addr);
+
+/**
+ * ice_iov_attach - Initialize SR-IOV PF host support
+ * @sc: device softc structure
+ *
+ * Initialize SR-IOV PF host support at the end of the driver attach process.
+ *
+ * @pre Must be called from sleepable context (calls malloc() w/ M_WAITOK)
+ *
+ * @returns 0 if successful, or
+ * - ENOMEM if there is no memory for the PF/VF schemas or iov device
+ * - ENXIO if the device isn't PCI-E or doesn't support the same SR-IOV
+ *   version as the kernel
+ * - ENOENT if the device doesn't have the SR-IOV capability
+ */
+int
+ice_iov_attach(struct ice_softc *sc)
+{
+	device_t dev = sc->dev;
+	nvlist_t *pf_schema, *vf_schema;
+	int error;
+
+	pf_schema = pci_iov_schema_alloc_node();
+	vf_schema = pci_iov_schema_alloc_node();
+
+	pci_iov_schema_add_unicast_mac(vf_schema, "mac-addr", 0, NULL);
+	pci_iov_schema_add_bool(vf_schema, "mac-anti-spoof",
+	    IOV_SCHEMA_HASDEFAULT, TRUE);
+	pci_iov_schema_add_bool(vf_schema, "allow-set-mac",
+	    IOV_SCHEMA_HASDEFAULT, FALSE);
+	pci_iov_schema_add_bool(vf_schema, "allow-promisc",
+	    IOV_SCHEMA_HASDEFAULT, FALSE);
+	pci_iov_schema_add_uint16(vf_schema, "num-queues",
+	    IOV_SCHEMA_HASDEFAULT, ICE_DEFAULT_VF_QUEUES);
+	pci_iov_schema_add_uint16(vf_schema, "mirror-src-vsi",
+	    IOV_SCHEMA_HASDEFAULT, ICE_INVALID_MIRROR_VSI);
+
+	error = pci_iov_attach(dev, pf_schema, vf_schema);
+	if (error != 0) {
+		device_printf(dev,
+		    "pci_iov_attach failed (error=%s)\n",
+		    ice_err_str(error));
+		ice_clear_bit(ICE_FEATURE_SRIOV, sc->feat_en);
+	} else
+		ice_set_bit(ICE_FEATURE_SRIOV, sc->feat_en);
+
+	return (error);
+}
+
+/**
+ * ice_iov_detach - Teardown SR-IOV PF host support
+ * @sc: device softc structure
+ *
+ * Teardown SR-IOV PF host support at the start of the driver detach process.
+ *
+ * @returns 0 if successful or IOV support hasn't been setup, or
+ * - EBUSY if VFs still exist
+ */
+int
+ice_iov_detach(struct ice_softc *sc)
+{
+	device_t dev = sc->dev;
+	int error;
+
+	error = pci_iov_detach(dev);
+	if (error != 0) {
+		device_printf(dev,
+		    "pci_iov_detach failed (error=%s)\n",
+		    ice_err_str(error));
+	}
+
+	return (error);
+}
+
+/**
+ * ice_iov_init - Called by the OS before the first VF is created.
+ * @sc: device softc structure
+ * @num_vfs: number of VFs to setup resources for
+ * @params: configuration parameters for the PF
+ *
+ * @returns 0 if successful or an error code on failure
+ */
+int
+ice_iov_init(struct ice_softc *sc, uint16_t num_vfs, const nvlist_t *params __unused)
+{
+	/* Allocate array of VFs, for tracking */
+	sc->vfs = (struct ice_vf *)malloc(sizeof(struct ice_vf) * num_vfs, M_ICE, M_NOWAIT |
+	    M_ZERO);
+	if (sc->vfs == NULL)
+		return (ENOMEM);
+
+	/* Initialize each VF with basic information */
+	for (int i = 0; i < num_vfs; i++)
+		sc->vfs[i].vf_num = i;
+
+	/* Save off number of configured VFs */
+	sc->num_vfs = num_vfs;
+
+	return (0);
+}
+
+/**
+ * ice_iov_get_vf - Get pointer to VF at given index
+ * @sc: device softc structure
+ * @vf_num: Index of VF to retrieve
+ *
+ * @remark will throw an assertion if vf_num is not in the
+ * range of allocated VFs
+ *
+ * @returns a pointer to the VF structure at the given index
+ */
+static struct ice_vf *
+ice_iov_get_vf(struct ice_softc *sc, int vf_num)
+{
+	MPASS(vf_num < sc->num_vfs);
+
+	return &sc->vfs[vf_num];
+}
+
+/**
+ * ice_iov_add_vf - Called by the OS for each VF to create
+ * @sc: device softc structure
+ * @vfnum: index of VF to configure
+ * @params: configuration parameters for the VF
+ *
+ * @returns 0 if successful or an error code on failure
+ */
+int
+ice_iov_add_vf(struct ice_softc *sc, uint16_t vfnum, const nvlist_t *params)
+{
+	struct ice_tx_queue *txq;
+	struct ice_rx_queue *rxq;
+	device_t dev = sc->dev;
+	struct ice_vsi *vsi;
+	struct ice_vf *vf;
+	int vf_num_queues;
+	const void *mac;
+	size_t size;
+	int error;
+	int i;
+
+	vf = ice_iov_get_vf(sc, vfnum);
+	vf->vf_flags = VF_FLAG_ENABLED;
+
+	/* This VF needs at least one VSI */
+	vsi = ice_alloc_vsi(sc, ICE_VSI_VF);
+	if (vsi == NULL)
+		return (ENOMEM);
+	vf->vsi = vsi;
+	vsi->vf_num = vfnum;
+
+	vf_num_queues = nvlist_get_number(params, "num-queues");
+	/* Validate and clamp value if invalid */
+	if (vf_num_queues < 1 || vf_num_queues > ICE_MAX_SCATTERED_QUEUES)
+		device_printf(dev, "Invalid num-queues (%d) for VF %d\n",
+		    vf_num_queues, vf->vf_num);
+	if (vf_num_queues < 1) {
+		device_printf(dev, "Setting VF %d num-queues to 1\n", vf->vf_num);
+		vf_num_queues = 1;
+	} else if (vf_num_queues > ICE_MAX_SCATTERED_QUEUES) {
+		device_printf(dev, "Setting VF %d num-queues to %d\n",
+		    vf->vf_num, ICE_MAX_SCATTERED_QUEUES);
+		vf_num_queues = ICE_MAX_SCATTERED_QUEUES;
+	}
+	vsi->qmap_type = ICE_RESMGR_ALLOC_SCATTERED;
+
+	/* Reserve VF queue allocation from PF queues */
+	ice_alloc_vsi_qmap(vsi, vf_num_queues, vf_num_queues);
+	vsi->num_tx_queues = vsi->num_rx_queues = vf_num_queues;
+
+	/* Assign Tx queues from PF space */
+	error = ice_resmgr_assign_scattered(&sc->tx_qmgr, vsi->tx_qmap,
+					     vsi->num_tx_queues);
+	if (error) {
+		device_printf(sc->dev, "Unable to assign VF Tx queues: %s\n",
+			      ice_err_str(error));
+		goto release_vsi;
+	}
+
+	/* Assign Rx queues from PF space */
+	error = ice_resmgr_assign_scattered(&sc->rx_qmgr, vsi->rx_qmap,
+					     vsi->num_rx_queues);
+	if (error) {
+		device_printf(sc->dev, "Unable to assign VF Rx queues: %s\n",
+			      ice_err_str(error));
+		goto release_vsi;
+	}
+
+	vsi->max_frame_size = ICE_MAX_FRAME_SIZE;
+
+	/* Allocate queue structure memory */
+	vsi->tx_queues = (struct ice_tx_queue *)
+	    malloc(sizeof(struct ice_tx_queue) * vsi->num_tx_queues, M_ICE,
+		   M_NOWAIT | M_ZERO);
+	if (!vsi->tx_queues) {
+		device_printf(sc->dev, "VF-%d: Unable to allocate Tx queue memory\n",
+			      vfnum);
+		error = ENOMEM;
+		goto release_vsi;
+	}
+	for (i = 0, txq = vsi->tx_queues; i < vsi->num_tx_queues; i++, txq++) {
+		txq->me = i;
+		txq->vsi = vsi;
+	}
+
+	/* Allocate queue structure memory */
+	vsi->rx_queues = (struct ice_rx_queue *)
+	    malloc(sizeof(struct ice_rx_queue) * vsi->num_rx_queues, M_ICE,
+		   M_NOWAIT | M_ZERO);
+	if (!vsi->rx_queues) {
+		device_printf(sc->dev, "VF-%d: Unable to allocate Rx queue memory\n",
+			      vfnum);
+		error = ENOMEM;
+		goto free_txqs;
+	}
+	for (i = 0, rxq = vsi->rx_queues; i < vsi->num_rx_queues; i++, rxq++) {
+		rxq->me = i;
+		rxq->vsi = vsi;
+	}
+
+	/* Allocate space to store the IRQ vector data */
+	vf->num_irq_vectors = vf_num_queues + 1;
+	vf->tx_irqvs = (struct ice_irq_vector *)
+	    malloc(sizeof(struct ice_irq_vector) * (vf->num_irq_vectors),
+		   M_ICE, M_NOWAIT);
+	if (!vf->tx_irqvs) {
+		device_printf(sc->dev,
+			      "Unable to allocate TX irqv memory for VF-%d's %d vectors\n",
+			      vfnum, vf->num_irq_vectors);
+		error = ENOMEM;
+		goto free_rxqs;
+	}
+	vf->rx_irqvs = (struct ice_irq_vector *)
+	    malloc(sizeof(struct ice_irq_vector) * (vf->num_irq_vectors),
+		   M_ICE, M_NOWAIT);
+	if (!vf->rx_irqvs) {
+		device_printf(sc->dev,
+			      "Unable to allocate RX irqv memory for VF-%d's %d vectors\n",
+			      vfnum, vf->num_irq_vectors);
+		error = ENOMEM;
+		goto free_txirqvs;
+	}
+
+	/* Assign VF interrupts from PF space */
+	if (!(vf->vf_imap =
+	      (u16 *)malloc(sizeof(u16) * vf->num_irq_vectors,
+	      M_ICE, M_NOWAIT))) {
+		device_printf(dev, "Unable to allocate VF-%d imap memory\n", vfnum);
+		error = ENOMEM;
+		goto free_rxirqvs;
+	}
+	error = ice_resmgr_assign_contiguous(&sc->dev_imgr, vf->vf_imap, vf->num_irq_vectors);
+	if (error) {
+		device_printf(dev, "Unable to assign VF-%d interrupt mapping: %s\n",
+			      vfnum, ice_err_str(error));
+		goto free_imap;
+	}
+
+	if (nvlist_exists_binary(params, "mac-addr")) {
+		mac = nvlist_get_binary(params, "mac-addr", &size);
+		bcopy(mac, vf->mac, ETHER_ADDR_LEN);
+
+		if (nvlist_get_bool(params, "allow-set-mac"))
+			vf->vf_flags |= VF_FLAG_SET_MAC_CAP;
+	} else
+		/*
+		 * If the administrator has not specified a MAC address then
+		 * we must allow the VF to choose one.
+		 */
+		vf->vf_flags |= VF_FLAG_SET_MAC_CAP;
+
+	if (nvlist_get_bool(params, "mac-anti-spoof"))
+		vf->vf_flags |= VF_FLAG_MAC_ANTI_SPOOF;
+
+	if (nvlist_get_bool(params, "allow-promisc"))
+		vf->vf_flags |= VF_FLAG_PROMISC_CAP;
+
+	vsi->mirror_src_vsi = nvlist_get_number(params, "mirror-src-vsi");
+
+	vf->vf_flags |= VF_FLAG_VLAN_CAP;
+
+	/* Create and setup VSI in HW */
+	error = ice_initialize_vsi(vsi);
+	if (error) {
+		device_printf(sc->dev, "Unable to initialize VF %d VSI: %s\n",
+			      vfnum, ice_err_str(error));
+		goto release_imap;
+	}
+
+	ice_iov_ready_vf(sc, vf);
+
+	return (0);
+
+release_imap:
+	ice_resmgr_release_map(&sc->dev_imgr, vf->vf_imap,
+			       vf->num_irq_vectors);
+free_imap:
+	free(vf->vf_imap, M_ICE);
+	vf->vf_imap = NULL;
+free_rxirqvs:
+	free(vf->rx_irqvs, M_ICE);
+	vf->rx_irqvs = NULL;
+free_txirqvs:
+	free(vf->tx_irqvs, M_ICE);
+	vf->tx_irqvs = NULL;
+free_rxqs:
+	free(vsi->rx_queues, M_ICE);
+	vsi->rx_queues = NULL;
+free_txqs:
+	free(vsi->tx_queues, M_ICE);
+	vsi->tx_queues = NULL;
+release_vsi:
+	ice_release_vsi(vsi);
+	vf->vsi = NULL;
+	return (error);
+}
+
+/**
+ * ice_iov_uninit - Called by the OS when VFs are destroyed
+ * @sc: device softc structure
+ */
+void
+ice_iov_uninit(struct ice_softc *sc)
+{
+	struct ice_vf *vf;
+	struct ice_vsi *vsi;
+
+	/* Release per-VF resources */
+	for (int i = 0; i < sc->num_vfs; i++) {
+		vf = &sc->vfs[i];
+		vsi = vf->vsi;
+
+		/* Free VF interrupt reservation */
+		if (vf->vf_imap) {
+			free(vf->vf_imap, M_ICE);
+			vf->vf_imap = NULL;
+		}
+
+		/* Free queue interrupt mapping trackers */
+		if (vf->tx_irqvs) {
+			free(vf->tx_irqvs, M_ICE);
+			vf->tx_irqvs = NULL;
+		}
+		if (vf->rx_irqvs) {
+			free(vf->rx_irqvs, M_ICE);
+			vf->rx_irqvs = NULL;
+		}
+
+		if (!vsi)
+			continue;
+
+		/* Free VSI queues */
+		if (vsi->tx_queues) {
+			free(vsi->tx_queues, M_ICE);
+			vsi->tx_queues = NULL;
+		}
+		if (vsi->rx_queues) {
+			free(vsi->rx_queues, M_ICE);
+			vsi->rx_queues = NULL;
+		}
+
+		ice_release_vsi(vsi);
+		vf->vsi = NULL;
+	}
+
+	/* Release memory used for VF tracking */
+	if (sc->vfs) {
+		free(sc->vfs, M_ICE);
+		sc->vfs = NULL;
+	}
+	sc->num_vfs = 0;
+}
+
+/**
+ * ice_iov_ready_vf - Setup VF interrupts and mark it as ready
+ * @sc: device softc structure
+ * @vf: driver's VF structure for the VF to update
+ *
+ * Clears VF reset triggering bit, sets up the PF<->VF interrupt
+ * mapping and marks the VF as active in the HW so that the VF
+ * driver can use it.
+ */
+static void
+ice_iov_ready_vf(struct ice_softc *sc, struct ice_vf *vf)
+{
+	struct ice_hw *hw = &sc->hw;
+	u32 reg;
+
+	/* Clear the triggering bit */
+	reg = rd32(hw, VPGEN_VFRTRIG(vf->vf_num));
+	reg &= ~VPGEN_VFRTRIG_VFSWR_M;
+	wr32(hw, VPGEN_VFRTRIG(vf->vf_num), reg);
+
+	/* Setup VF interrupt allocation and mapping */
+	ice_iov_setup_intr_mapping(sc, vf);
+
+	/* Indicate to the VF that reset is done */
+	wr32(hw, VFGEN_RSTAT(vf->vf_num), VIRTCHNL_VFR_VFACTIVE);
+
+	ice_flush(hw);
+}
+
+/**
+ * ice_reset_vf - Perform a hardware reset (VFR) on a VF
+ * @sc: device softc structure
+ * @vf: driver's VF structure for VF to be reset
+ *
+ * Performs a VFR for the given VF. This function busy waits until the
+ * reset completes in the HW, notifies the VF that the reset is done
+ * by setting a bit in a HW register, then returns.
+ *
+ * @remark This also sets up the PF<->VF interrupt mapping and allocations in
+ * the hardware after the hardware reset is finished, via
+ * ice_iov_setup_intr_mapping()
+ */
+static void
+ice_reset_vf(struct ice_softc *sc, struct ice_vf *vf)
+{
+	u16 global_vf_num, reg_idx, bit_idx;
+	struct ice_hw *hw = &sc->hw;
+	int status;
+	u32 reg;
+	int i;
+
+	global_vf_num = vf->vf_num + hw->func_caps.vf_base_id;
+
+	reg = rd32(hw, VPGEN_VFRTRIG(vf->vf_num));
+	reg |= VPGEN_VFRTRIG_VFSWR_M;
+	wr32(hw, VPGEN_VFRTRIG(vf->vf_num), reg);
+
+	/* clear the VFLR bit for the VF in a GLGEN_VFLRSTAT register */
+	reg_idx = (global_vf_num) / 32;
+	bit_idx = (global_vf_num) % 32;
+	wr32(hw, GLGEN_VFLRSTAT(reg_idx), BIT(bit_idx));
+	ice_flush(hw);
+
+	/* Wait until there are no pending PCI transactions */
+	wr32(hw, PF_PCI_CIAA,
+	     ICE_PCIE_DEV_STATUS | (global_vf_num << PF_PCI_CIAA_VF_NUM_S));
+
+	for (i = 0; i < ICE_PCI_CIAD_WAIT_COUNT; i++) {
+		reg = rd32(hw, PF_PCI_CIAD);
+		if (!(reg & PCIEM_STA_TRANSACTION_PND))
+			break;
+
+		DELAY(ICE_PCI_CIAD_WAIT_DELAY_US);
+	}
+	if (i == ICE_PCI_CIAD_WAIT_COUNT)
+		device_printf(sc->dev,
+			"VF-%d PCI transactions stuck\n", vf->vf_num);
+
+	/* Disable TX queues, which is required during VF reset */
+	status = ice_dis_vsi_txq(hw->port_info, vf->vsi->idx, 0, 0, NULL, NULL,
+			NULL, ICE_VF_RESET, vf->vf_num, NULL);
+	if (status)
+		device_printf(sc->dev,
+			      "%s: Failed to disable LAN Tx queues: err %s aq_err %s\n",
+			      __func__, ice_status_str(status),
+			      ice_aq_str(hw->adminq.sq_last_status));
+
+	/* Then check for the VF reset to finish in HW */
+	for (i = 0; i < ICE_VPGEN_VFRSTAT_WAIT_COUNT; i++) {
+		reg = rd32(hw, VPGEN_VFRSTAT(vf->vf_num));
+		if ((reg & VPGEN_VFRSTAT_VFRD_M))
+			break;
+
+		DELAY(ICE_VPGEN_VFRSTAT_WAIT_DELAY_US);
+	}
+	if (i == ICE_VPGEN_VFRSTAT_WAIT_COUNT)
+		device_printf(sc->dev,
+			"VF-%d Reset is stuck\n", vf->vf_num);
+
+	ice_iov_ready_vf(sc, vf);
+}
+
+/**
+ * ice_vc_get_vf_res_msg - Handle VIRTCHNL_OP_GET_VF_RESOURCES msg from VF
+ * @sc: device private structure
+ * @vf: VF tracking structure
+ * @msg_buf: raw message buffer from the VF
+ *
+ * Receives a message from the VF listing its supported capabilities, and
+ * replies to the VF with information about what resources the PF has
+ * allocated for the VF.
+ *
+ * @remark This always replies to the VF with a success status; it does not
+ * fail. It's up to the VF driver to reject or complain about the PF's response.
+ */
+static void
+ice_vc_get_vf_res_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_vf_resource *vf_res;
+	u16 vf_res_len;
+	u32 vf_caps;
+
+	/* XXX: Only support one VSI per VF, so this size doesn't need adjusting */
+	vf_res_len = sizeof(struct virtchnl_vf_resource);
+	vf_res = (struct virtchnl_vf_resource *)malloc(vf_res_len, M_ICE, M_WAITOK | M_ZERO);
+
+	vf_res->num_vsis = 1;
+	vf_res->num_queue_pairs = vf->vsi->num_tx_queues;
+	vf_res->max_vectors = vf_res->num_queue_pairs + 1;
+
+	vf_res->rss_key_size = ICE_GET_SET_RSS_KEY_EXTEND_KEY_SIZE;
+	vf_res->rss_lut_size = ICE_VSIQF_HLUT_ARRAY_SIZE;
+	vf_res->max_mtu = 0;
+
+	vf_res->vf_cap_flags = VF_BASE_MODE_OFFLOADS;
+	if (msg_buf != NULL) {
+		vf_caps = *((u32 *)(msg_buf));
+
+		if (vf_caps & VIRTCHNL_VF_CAP_ADV_LINK_SPEED)
+			vf_res->vf_cap_flags |= VIRTCHNL_VF_CAP_ADV_LINK_SPEED;
+	}
+
+	vf_res->vsi_res[0].vsi_id = vf->vsi->idx;
+	vf_res->vsi_res[0].num_queue_pairs = vf->vsi->num_tx_queues;
+	vf_res->vsi_res[0].vsi_type = VIRTCHNL_VSI_SRIOV;
+	vf_res->vsi_res[0].qset_handle = 0;
+
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_GET_VF_RESOURCES,
+	    VIRTCHNL_STATUS_SUCCESS, (u8 *)vf_res, vf_res_len, NULL);
+
+	free(vf_res, M_ICE);
+}
+
+/**
+ * ice_vc_version_msg - Handle VIRTCHNL_OP_VERSION msg from VF
+ * @sc: device private structure
+ * @vf: VF tracking structure
+ * @msg_buf: raw message buffer from the VF
+ *
+ * Receives a version message from the VF, and responds to the VF with
+ * the version number that the PF will use.
+ *
+ * @remark This always replies to the VF with a success status; it does not
+ * fail.
+ */
+static void
+ice_vc_version_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct virtchnl_version_info *recv_vf_version;
+	struct ice_hw *hw = &sc->hw;
+	device_t dev = sc->dev;
+
+	recv_vf_version = (struct virtchnl_version_info *)msg_buf;
+
+	/* VFs running the 1.0 API expect to get 1.0 back */
+	if (VF_IS_V10(recv_vf_version)) {
+		vf->version.major = 1;
+		vf->version.minor = VIRTCHNL_VERSION_MINOR_NO_VF_CAPS;
+	} else {
+		vf->version.major = VIRTCHNL_VERSION_MAJOR;
+		vf->version.minor = VIRTCHNL_VERSION_MINOR;
+
+		if ((recv_vf_version->major != VIRTCHNL_VERSION_MAJOR) ||
+		    (recv_vf_version->minor != VIRTCHNL_VERSION_MINOR))
+		    device_printf(dev,
+		        "%s: VF-%d requested version (%d.%d) differs from PF version (%d.%d)\n",
+			__func__, vf->vf_num,
+			recv_vf_version->major, recv_vf_version->minor,
+			VIRTCHNL_VERSION_MAJOR, VIRTCHNL_VERSION_MINOR);
+	}
+
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_VERSION,
+	    VIRTCHNL_STATUS_SUCCESS, (u8 *)&vf->version, sizeof(vf->version),
+	    NULL);
+}
+
+/**
+ * ice_vf_validate_mac - Validate MAC address before adding it
+ * @vf: VF tracking structure
+ * @addr: MAC address to validate
+ *
+ * Validate a MAC address before adding it to a VF during the handling
+ * of a VIRTCHNL_OP_ADD_ETH_ADDR operation. Notably, this also checks if
+ * the VF is allowed to set its own arbitrary MAC addresses.
+ *
+ * Returns 0 if MAC address is valid for the given vf
+ */
+static int
+ice_vf_validate_mac(struct ice_vf *vf, const uint8_t *addr)
+{
+
+	if (ETHER_IS_ZERO(addr) || ETHER_IS_BROADCAST(addr))
+		return (EINVAL);
+
+	/*
+	 * If the VF is not allowed to change its MAC address, don't let it
+	 * set a MAC filter for an address that is not a multicast address and
+	 * is not its assigned MAC.
+	 */
+	if (!(vf->vf_flags & VF_FLAG_SET_MAC_CAP) &&
+	    !(ETHER_IS_MULTICAST(addr) || !bcmp(addr, vf->mac, ETHER_ADDR_LEN)))
+		return (EPERM);
+
+	return (0);
+}
+
+/**
+ * ice_vc_add_eth_addr_msg - Handle VIRTCHNL_OP_ADD_ETH_ADDR msg from VF
+ * @sc: device private structure
+ * @vf: VF tracking structure
+ * @msg_buf: raw message buffer from the VF
+ *
+ * Receives a list of MAC addresses from the VF and adds those addresses
+ * to the VSI's filter list.
+ */
+static void
+ice_vc_add_eth_addr_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct virtchnl_ether_addr_list *addr_list;
+	struct ice_hw *hw = &sc->hw;
+	int error = 0;
+
+	addr_list = (struct virtchnl_ether_addr_list *)msg_buf;
+
+	for (int i = 0; i < addr_list->num_elements; i++) {
+		u8 *addr = addr_list->list[i].addr;
+
+		/* The type flag is currently ignored; every MAC address is
+		 * treated as the LEGACY type
+		 */
+
+		error = ice_vf_validate_mac(vf, addr);
+		if (error == EPERM) {
+			device_printf(sc->dev,
+			    "%s: VF-%d: Not permitted to add MAC addr for VSI %d\n",
+			    __func__, vf->vf_num, vf->vsi->idx);
+			v_status = VIRTCHNL_STATUS_ERR_PARAM;
+			continue;
+		} else if (error) {
+			device_printf(sc->dev,
+			    "%s: VF-%d: Did not add invalid MAC addr for VSI %d\n",
+			    __func__, vf->vf_num, vf->vsi->idx);
+			v_status = VIRTCHNL_STATUS_ERR_PARAM;
+			continue;
+		}
+
+		error = ice_add_vsi_mac_filter(vf->vsi, addr);
+		if (error) {
+			device_printf(sc->dev,
+			    "%s: VF-%d: Error adding MAC addr for VSI %d\n",
+			    __func__, vf->vf_num, vf->vsi->idx);
+			v_status = VIRTCHNL_STATUS_ERR_PARAM;
+			goto done;
+		}
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_ADD_ETH_ADDR,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_del_eth_addr_msg - Handle VIRTCHNL_OP_DEL_ETH_ADDR msg from VF
+ * @sc: device private structure
+ * @vf: VF tracking structure
+ * @msg_buf: raw message buffer from the VF
+ *
+ * Receives a list of MAC addresses from the VF and removes those addresses
+ * from the VSI's filter list.
+ */
+static void
+ice_vc_del_eth_addr_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct virtchnl_ether_addr_list *addr_list;
+	struct ice_hw *hw = &sc->hw;
+	int error = 0;
+
+	addr_list = (struct virtchnl_ether_addr_list *)msg_buf;
+
+	for (int i = 0; i < addr_list->num_elements; i++) {
+		error = ice_remove_vsi_mac_filter(vf->vsi, addr_list->list[i].addr);
+		if (error) {
+			device_printf(sc->dev,
+			    "%s: VF-%d: Error removing MAC addr for VSI %d\n",
+			    __func__, vf->vf_num, vf->vsi->idx);
+			v_status = VIRTCHNL_STATUS_ERR_PARAM;
+			goto done;
+		}
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_DEL_ETH_ADDR,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_add_vlan_msg - Handle VIRTCHNL_OP_ADD_VLAN msg from VF
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ *
+ * Adds the VLANs in msg_buf to the VF's VLAN filter list.
+ */
+static void
+ice_vc_add_vlan_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_vlan_filter_list *vlan_list;
+	int status = 0;
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct ice_vsi *vsi = vf->vsi;
+
+	vlan_list = (struct virtchnl_vlan_filter_list *)msg_buf;
+
+	if (vlan_list->vsi_id != vsi->idx) {
+		device_printf(sc->dev,
+			      "VF-%d: Message has invalid VSI ID (expected %d, got %d)\n",
+			      vf->vf_num, vsi->idx, vlan_list->vsi_id);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	status = ice_add_vlan_hw_filters(vsi, vlan_list->vlan_id,
+					vlan_list->num_elements);
+	if (status) {
+		device_printf(sc->dev,
+			      "VF-%d: Failure adding VLANs to VSI %d, err %s aq_err %s\n",
+			      vf->vf_num, vsi->idx, ice_status_str(status),
+			      ice_aq_str(sc->hw.adminq.sq_last_status));
+		v_status = ice_iov_err_to_virt_err(status);
+		goto done;
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_ADD_VLAN,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_del_vlan_msg - Handle VIRTCHNL_OP_DEL_VLAN msg from VF
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ *
+ * Removes the VLANs in msg_buf from the VF's VLAN filter list.
+ */
+static void
+ice_vc_del_vlan_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_vlan_filter_list *vlan_list;
+	int status = 0;
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct ice_vsi *vsi = vf->vsi;
+
+	vlan_list = (struct virtchnl_vlan_filter_list *)msg_buf;
+
+	if (vlan_list->vsi_id != vsi->idx) {
+		device_printf(sc->dev,
+			      "VF-%d: Message has invalid VSI ID (expected %d, got %d)\n",
+			      vf->vf_num, vsi->idx, vlan_list->vsi_id);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	status = ice_remove_vlan_hw_filters(vsi, vlan_list->vlan_id,
+					vlan_list->num_elements);
+	if (status) {
+		device_printf(sc->dev,
+			      "VF-%d: Failure deleting VLANs from VSI %d, err %s aq_err %s\n",
+			      vf->vf_num, vsi->idx, ice_status_str(status),
+			      ice_aq_str(sc->hw.adminq.sq_last_status));
+		v_status = ice_iov_err_to_virt_err(status);
+		goto done;
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_DEL_VLAN,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_validate_ring_len - Check to see if a descriptor ring length is valid
+ * @ring_len: length of ring
+ *
+ * Check whether a ring size value is valid.
+ *
+ * @returns true if given ring size is valid
+ */
+static bool
+ice_vc_isvalid_ring_len(u16 ring_len)
+{
+	return (ring_len >= ICE_MIN_DESC_COUNT &&
+		ring_len <= ICE_MAX_DESC_COUNT &&
+		!(ring_len % ICE_DESC_COUNT_INCR));
+}
+
+/**
+ * ice_vc_cfg_vsi_qs_msg - Handle VIRTCHNL_OP_CONFIG_VSI_QUEUES msg from VF
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ */
+static void
+ice_vc_cfg_vsi_qs_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	device_t dev = sc->dev;
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_vsi_queue_config_info *vqci;
+	struct virtchnl_queue_pair_info *vqpi;
+	enum virtchnl_status_code status = VIRTCHNL_STATUS_SUCCESS;
+	struct ice_vsi *vsi = vf->vsi;
+	int error = 0;
+
+	vqci = (struct virtchnl_vsi_queue_config_info *)msg_buf;
+
+	if (vqci->num_queue_pairs > vf->vsi->num_tx_queues &&
+	    vqci->num_queue_pairs > vf->vsi->num_rx_queues) {
+		status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	vqpi = vqci->qpair;
+	for (int i = 0; i < vqci->num_queue_pairs; i++, vqpi++) {
+		struct ice_tx_queue *txq;
+		struct ice_rx_queue *rxq;
+
+		/* Initial parameter validation */
+		if (vqpi->txq.vsi_id != vf->vsi->idx ||
+		    vqpi->rxq.vsi_id != vf->vsi->idx ||
+		    vqpi->txq.queue_id != vqpi->rxq.queue_id ||
+		    vqpi->txq.headwb_enabled ||
+		    vqpi->rxq.splithdr_enabled ||
+		    vqpi->rxq.crc_disable ||
+		    !(ice_vc_isvalid_ring_len(vqpi->txq.ring_len)) ||
+		    !(ice_vc_isvalid_ring_len(vqpi->rxq.ring_len))) {
+			status = VIRTCHNL_STATUS_ERR_PARAM;
+			goto done;
+		}
+
+		/* Copy parameters into VF's queue/VSI structs */
+		txq = &vsi->tx_queues[vqpi->txq.queue_id];
+
+		txq->desc_count = vqpi->txq.ring_len;
+		txq->tx_paddr = vqpi->txq.dma_ring_addr;
+		txq->q_handle = vqpi->txq.queue_id;
+		txq->tc = 0;
+
+		rxq = &vsi->rx_queues[vqpi->rxq.queue_id];
+
+		rxq->desc_count = vqpi->rxq.ring_len;
+		rxq->rx_paddr = vqpi->rxq.dma_ring_addr;
+		vsi->mbuf_sz = vqpi->rxq.databuffer_size;
+	}
+
+	/* Configure TX queues in HW */
+	error = ice_cfg_vsi_for_tx(vsi);
+	if (error) {
+		device_printf(dev,
+			      "VF-%d: Unable to configure VSI for Tx: %s\n",
+			      vf->vf_num, ice_err_str(error));
+		status = VIRTCHNL_STATUS_ERR_ADMIN_QUEUE_ERROR;
+		goto done;
+	}
+
+	/* Configure RX queues in HW */
+	error = ice_cfg_vsi_for_rx(vsi);
+	if (error) {
+		device_printf(dev,
+			      "VF-%d: Unable to configure VSI for Rx: %s\n",
+			      vf->vf_num, ice_err_str(error));
+		status = VIRTCHNL_STATUS_ERR_ADMIN_QUEUE_ERROR;
+		ice_vsi_disable_tx(vsi);
+		goto done;
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_CONFIG_VSI_QUEUES,
+	    status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_cfg_rss_key_msg - Handle VIRTCHNL_OP_CONFIG_RSS_KEY msg from VF
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ *
+ * Sets the RSS key for the given VF, using the contents of msg_buf.
+ */
+static void
+ice_vc_cfg_rss_key_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct ice_aqc_get_set_rss_keys keydata =
+	    { .standard_rss_key = {0}, .extended_hash_key = {0} };
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_rss_key *vrk;
+	int status = 0;
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct ice_vsi *vsi = vf->vsi;
+
+	vrk = (struct virtchnl_rss_key *)msg_buf;
+
+	if (vrk->vsi_id != vsi->idx) {
+		device_printf(sc->dev,
+		    "VF-%d: Message has invalid VSI ID (expected %d, got %d)\n",
+		    vf->vf_num, vsi->idx, vrk->vsi_id);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	if ((vrk->key_len >
+	   (ICE_AQC_GET_SET_RSS_KEY_DATA_RSS_KEY_SIZE +
+	    ICE_AQC_GET_SET_RSS_KEY_DATA_HASH_KEY_SIZE)) ||
+	    vrk->key_len == 0) {
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	memcpy(&keydata, vrk->key, vrk->key_len);
+
+	status = ice_aq_set_rss_key(hw, vsi->idx, &keydata);
+	if (status) {
+		device_printf(sc->dev,
+			      "ice_aq_set_rss_key status %s, error %s\n",
+			      ice_status_str(status), ice_aq_str(hw->adminq.sq_last_status));
+		v_status = ice_iov_err_to_virt_err(status);
+		goto done;
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_CONFIG_RSS_KEY,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_cfg_rss_lut_msg - Handle VIRTCHNL_OP_CONFIG_RSS_LUT msg from VF
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ *
+ * Adds the LUT from the VF in msg_buf to the PF via an admin queue call.
+ */
+static void
+ice_vc_cfg_rss_lut_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_rss_lut *vrl;
+	int status = 0;
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct ice_aq_get_set_rss_lut_params lut_params = {};
+	struct ice_vsi *vsi = vf->vsi;
+
+	vrl = (struct virtchnl_rss_lut *)msg_buf;
+
+	if (vrl->vsi_id != vsi->idx) {
+		device_printf(sc->dev,
+		    "VF-%d: Message has invalid VSI ID (expected %d, got %d)\n",
+		    vf->vf_num, vsi->idx, vrl->vsi_id);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	if (vrl->lut_entries > ICE_VSIQF_HLUT_ARRAY_SIZE) {
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	lut_params.vsi_handle = vsi->idx;
+	lut_params.lut_size = vsi->rss_table_size;
+	lut_params.lut_type = vsi->rss_lut_type;
+	lut_params.lut = vrl->lut;
+	lut_params.global_lut_id = 0;
+
+	status = ice_aq_set_rss_lut(hw, &lut_params);
+	if (status) {
+		device_printf(sc->dev,
+			      "VF-%d: Cannot set RSS lut, err %s aq_err %s\n",
+			      vf->vf_num, ice_status_str(status),
+			      ice_aq_str(hw->adminq.sq_last_status));
+		v_status = ice_iov_err_to_virt_err(status);
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_CONFIG_RSS_LUT,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_set_rss_hena_msg - Handle VIRTCHNL_OP_SET_RSS_HENA msg from VF
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ *
+ * Adds the VF's hena (hash enable) bits as flow types to the PF's RSS flow
+ * type list.
+ */
+static void
+ice_vc_set_rss_hena_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_rss_hena *vrh;
+	int status = 0;
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct ice_vsi *vsi = vf->vsi;
+
+	vrh = (struct virtchnl_rss_hena *)msg_buf;
+
+	status = ice_add_avf_rss_cfg(hw, vsi->idx, vrh->hena);
+	if (status) {
+		device_printf(sc->dev,
+			      "ice_add_avf_rss_cfg status %s, error %s\n",
+			      ice_status_str(status),
+			      ice_aq_str(hw->adminq.sq_last_status));
+		v_status = ice_iov_err_to_virt_err(status);
+	}
+
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_SET_RSS_HENA,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_enable_queues_msg - Handle VIRTCHNL_OP_ENABLE_QUEUES msg from VF
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ *
+ * Enables VF queues selected in msg_buf for Tx/Rx traffic.
+ *
+ * @remark Only actually operates on Rx queues; Tx queues are enabled in
+ * CONFIG_VSI_QUEUES message handler.
+ */
+static void
+ice_vc_enable_queues_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_queue_select *vqs;
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct ice_vsi *vsi = vf->vsi;
+	int bit, error = 0;
+
+	vqs = (struct virtchnl_queue_select *)msg_buf;
+
+	if (vqs->vsi_id != vsi->idx) {
+		device_printf(sc->dev,
+		    "%s: VF-%d: Message has invalid VSI ID (expected %d, got %d)\n",
+		    __func__, vf->vf_num, vsi->idx, vqs->vsi_id);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	if (!vqs->rx_queues && !vqs->tx_queues) {
+		device_printf(sc->dev,
+		    "%s: VF-%d: message queue masks are empty\n",
+		    __func__, vf->vf_num);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	/* Validate rx_queue mask */
+	bit = fls(vqs->rx_queues);
+	if (bit > vsi->num_rx_queues) {
+		device_printf(sc->dev,
+		    "%s: VF-%d: message's rx_queues map (0x%08x) has invalid bit set (%d)\n",
+		    __func__, vf->vf_num, vqs->rx_queues, bit);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	/* Tx ring enable is handled in an earlier message. */
+	for_each_set_bit(bit, &vqs->rx_queues, 32) {
+		error = ice_control_rx_queue(vsi, bit, true);
+		if (error) {
+			device_printf(sc->dev,
+				      "Unable to enable Rx ring %d for receive: %s\n",
+				      bit, ice_err_str(error));
+			v_status = VIRTCHNL_STATUS_ERR_PARAM;
+			goto done;
+		}
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_ENABLE_QUEUES,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_disable_queues_msg - Handle VIRTCHNL_OP_DISABLE_QUEUES msg
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ *
+ * Disables all VF queues for the VF's VSI.
+ *
+ * @remark Unlike the ENABLE_QUEUES handler, this operates on both
+ * Tx and Rx queues
+ */
+static void
+ice_vc_disable_queues_msg(struct ice_softc *sc, struct ice_vf *vf,
+			  u8 *msg_buf __unused)
+{
+	struct ice_hw *hw = &sc->hw;
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct ice_vsi *vsi = vf->vsi;
+	int error = 0;
+
+	error = ice_control_all_rx_queues(vsi, false);
+	if (error) {
+		device_printf(sc->dev,
+			      "Unable to disable Rx rings for transmit: %s\n",
+			      ice_err_str(error));
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	error = ice_vsi_disable_tx(vsi);
+	if (error) {
+		/* Already prints an error message */
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_DISABLE_QUEUES,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_cfg_irq_map_msg - Handle VIRTCHNL_OP_CFG_IRQ_MAP msg from VF
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ *
+ * Configures the interrupt vectors described in the message in msg_buf. The
+ * VF needs to send this message during init, so that queues can be allowed
+ * to generate interrupts.
+ */
+static void
+ice_vc_cfg_irq_map_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+#define ICE_VIRTCHNL_QUEUE_MAP_SIZE	16
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_irq_map_info *vimi;
+	struct virtchnl_vector_map *vvm;
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	struct ice_vsi *vsi = vf->vsi;
+	u16 vector;
+
+	vimi = (struct virtchnl_irq_map_info *)msg_buf;
+
+	if (vimi->num_vectors > vf->num_irq_vectors) {
+		device_printf(sc->dev,
+		    "%s: VF-%d: message has more vectors (%d) than configured for VF (%d)\n",
+		    __func__, vf->vf_num, vimi->num_vectors, vf->num_irq_vectors);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	vvm = vimi->vecmap;
+	/* Save off information from message */
+	for (int i = 0; i < vimi->num_vectors - 1; i++, vvm++) {
+		struct ice_tx_queue *txq;
+		struct ice_rx_queue *rxq;
+		int bit;
+
+		if (vvm->vsi_id != vf->vsi->idx) {
+			device_printf(sc->dev,
+			    "%s: VF-%d: message's VSI ID (%d) does not match VF's (%d) for vector %d\n",
+			    __func__, vf->vf_num, vvm->vsi_id, vf->vsi->idx, i);
+			v_status = VIRTCHNL_STATUS_ERR_PARAM;
+			goto done;
+		}
+
+		/* vvm->vector_id is relative to VF space */
+		vector = vvm->vector_id;
+
+		if (vector >= vf->num_irq_vectors) {
+			device_printf(sc->dev,
+			    "%s: VF-%d: message's vector ID (%d) is greater than VF's max ID (%d)\n",
+			    __func__, vf->vf_num, vector, vf->num_irq_vectors - 1);
+			v_status = VIRTCHNL_STATUS_ERR_PARAM;
+			goto done;
+		}
+
+		/* The Misc/Admin Queue vector doesn't need mapping */
+		if (vector == 0)
+			continue;
+
+		/* coverity[address_of] */
+		for_each_set_bit(bit, &vvm->txq_map, ICE_VIRTCHNL_QUEUE_MAP_SIZE) {
+			if (bit >= vsi->num_tx_queues) {
+				device_printf(sc->dev,
+				    "%s: VF-%d: txq map has invalid bit set\n",
+				    __func__, vf->vf_num);
+				v_status = VIRTCHNL_STATUS_ERR_PARAM;
+				goto done;
+			}
+
+			vf->tx_irqvs[vector].me = vector;
+
+			txq = &vsi->tx_queues[bit];
+			txq->irqv = &vf->tx_irqvs[vector];
+			txq->itr_idx = vvm->txitr_idx;
+		}
+		/* coverity[address_of] */
+		for_each_set_bit(bit, &vvm->rxq_map, ICE_VIRTCHNL_QUEUE_MAP_SIZE) {
+			if (bit >= vsi->num_rx_queues) {
+				device_printf(sc->dev,
+				    "%s: VF-%d: rxq map has invalid bit set\n",
+				    __func__, vf->vf_num);
+				v_status = VIRTCHNL_STATUS_ERR_PARAM;
+				goto done;
+			}
+			vf->rx_irqvs[vector].me = vector;
+
+			rxq = &vsi->rx_queues[bit];
+			rxq->irqv = &vf->rx_irqvs[vector];
+			rxq->itr_idx = vvm->rxitr_idx;
+		}
+	}
+
+	/* Write to T/RQCTL registers to actually map vectors to queues */
+	for (int i = 0; i < vf->vsi->num_rx_queues; i++)
+		ice_configure_rxq_interrupt(hw, vsi->rx_qmap[i],
+		    vsi->rx_queues[i].irqv->me, vsi->rx_queues[i].itr_idx);
+
+	for (int i = 0; i < vf->vsi->num_tx_queues; i++)
+		ice_configure_txq_interrupt(hw, vsi->tx_qmap[i],
+		    vsi->tx_queues[i].irqv->me, vsi->tx_queues[i].itr_idx);
+
+	ice_flush(hw);
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_CONFIG_IRQ_MAP,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_eth_stats_to_virtchnl_eth_stats - Convert stats for virtchnl
+ * @istats: VSI stats from HW to convert
+ * @vstats: stats struct to copy to
+ *
+ * This function copies all known stats in struct virtchnl_eth_stats from the
+ * input struct ice_eth_stats to an output struct virtchnl_eth_stats.
+ *
+ * @remark These two structure types currently have the same definition up to
+ * the size of struct virtchnl_eth_stats (on FreeBSD), but that could change
+ * in the future.
+ */
+static void
+ice_eth_stats_to_virtchnl_eth_stats(struct ice_eth_stats *istats,
+				    struct virtchnl_eth_stats *vstats)
+{
+	vstats->rx_bytes = istats->rx_bytes;
+	vstats->rx_unicast = istats->rx_unicast;
+	vstats->rx_multicast = istats->rx_multicast;
+	vstats->rx_broadcast = istats->rx_broadcast;
+	vstats->rx_discards = istats->rx_discards;
+	vstats->rx_unknown_protocol = istats->rx_unknown_protocol;
+	vstats->tx_bytes = istats->tx_bytes;
+	vstats->tx_unicast = istats->tx_unicast;
+	vstats->tx_multicast = istats->tx_multicast;
+	vstats->tx_broadcast = istats->tx_broadcast;
+	vstats->tx_discards = istats->tx_discards;
+	vstats->tx_errors = istats->tx_errors;
+}
+
+/**
+ * ice_vc_get_stats_msg - Handle VIRTCHNL_OP_GET_STATS msg
+ * @sc: device private structure
+ * @vf: VF tracking structure
+ * @msg_buf: raw message buffer from the VF
+ *
+ * Updates the VF's VSI stats and sends those stats back to the VF.
+ */
+static void
+ice_vc_get_stats_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct virtchnl_queue_select *vqs;
+	struct virtchnl_eth_stats stats;
+	struct ice_vsi *vsi = vf->vsi;
+	struct ice_hw *hw = &sc->hw;
+
+	vqs = (struct virtchnl_queue_select *)msg_buf;
+
+	if (vqs->vsi_id != vsi->idx) {
+		device_printf(sc->dev,
+		    "%s: VF-%d: message has invalid VSI ID %d (VF has VSI ID %d)\n",
+		    __func__, vf->vf_num, vqs->vsi_id, vsi->idx);
+		ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_GET_STATS,
+		    VIRTCHNL_STATUS_ERR_PARAM, NULL, 0, NULL);
+	}
+
+	ice_update_vsi_hw_stats(vf->vsi);
+	ice_eth_stats_to_virtchnl_eth_stats(&vsi->hw_stats.cur, &stats);
+
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_GET_STATS,
+	    VIRTCHNL_STATUS_SUCCESS, (u8 *)&stats,
+	    sizeof(struct virtchnl_eth_stats), NULL);
+}
+
+/**
+ * ice_vc_cfg_promisc_mode_msg - Handle VIRTCHNL_OP_CONFIG_PROMISCUOUS_MODE
+ * @sc: PF's softc structure
+ * @vf: VF tracking structure
+ * @msg_buf: message buffer from VF
+ *
+ * Configures the promiscuous modes for the given VSI in msg_buf.
+ */
+static void
+ice_vc_cfg_promisc_mode_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
+{
+	struct ice_hw *hw = &sc->hw;
+	struct virtchnl_promisc_info *vpi;
+	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
+	int status = 0;
+	struct ice_vsi *vsi = vf->vsi;
+	ice_declare_bitmap(old_promisc_mask, ICE_PROMISC_MAX);
+	ice_declare_bitmap(req_promisc_mask, ICE_PROMISC_MAX);
+	ice_declare_bitmap(clear_promisc_mask, ICE_PROMISC_MAX);
+	ice_declare_bitmap(set_promisc_mask, ICE_PROMISC_MAX);
+	ice_declare_bitmap(old_req_xor_mask, ICE_PROMISC_MAX);
+	u16 vid;
+
+	vpi = (struct virtchnl_promisc_info *)msg_buf;
+
+	/* Check to see if VF has permission to configure promiscuous mode */
+	if (!(vf->vf_flags & VF_FLAG_PROMISC_CAP)) {
+		device_printf(sc->dev,
+			      "VF-%d: attempted to configure promiscuous mode\n",
+			      vf->vf_num);
+		/* Don't reply to VF with an error */
+		goto done;
+	}
+
+	if (vpi->vsi_id != vsi->idx) {
+		device_printf(sc->dev,
+			      "VF-%d: Message has invalid VSI ID (expected %d, got %d)\n",
+			      vf->vf_num, vsi->idx, vpi->vsi_id);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+	}
+
+	if (vpi->flags & ~ICE_VIRTCHNL_VALID_PROMISC_FLAGS) {
+		device_printf(sc->dev,
+			      "VF-%d: Message has invalid promiscuous flags set (valid 0x%02x, got 0x%02x)\n",
+			      vf->vf_num, ICE_VIRTCHNL_VALID_PROMISC_FLAGS,
+			      vpi->flags);
+		v_status = VIRTCHNL_STATUS_ERR_PARAM;
+		goto done;
+
+	}
+
+	ice_zero_bitmap(req_promisc_mask, ICE_PROMISC_MAX);
+	/* Convert virtchnl flags to ice AQ promiscuous mode flags */
+	if (vpi->flags & FLAG_VF_UNICAST_PROMISC) {
+		ice_set_bit(ICE_PROMISC_UCAST_TX, req_promisc_mask);
+		ice_set_bit(ICE_PROMISC_UCAST_RX, req_promisc_mask);
+	}
+	if (vpi->flags & FLAG_VF_MULTICAST_PROMISC) {
+		ice_set_bit(ICE_PROMISC_MCAST_TX, req_promisc_mask);
+		ice_set_bit(ICE_PROMISC_MCAST_RX, req_promisc_mask);
+	}
+
+	status = ice_get_vsi_promisc(hw, vsi->idx, old_promisc_mask, &vid);
+	if (status) {
+		device_printf(sc->dev,
+			      "VF-%d: Failed to get promiscuous mode mask for VSI %d, err %s aq_err %s\n",
+			      vf->vf_num, vsi->idx,
+			      ice_status_str(status),
+			      ice_aq_str(hw->adminq.sq_last_status));
+		v_status = ice_iov_err_to_virt_err(status);
+		goto done;
+	}
+
+	/* Figure out what got added and what got removed */
+	ice_zero_bitmap(old_req_xor_mask, ICE_PROMISC_MAX);
+	ice_xor_bitmap(old_req_xor_mask, old_promisc_mask, req_promisc_mask, ICE_PROMISC_MAX);
+	ice_and_bitmap(clear_promisc_mask, old_req_xor_mask, old_promisc_mask, ICE_PROMISC_MAX);
+	ice_and_bitmap(set_promisc_mask, old_req_xor_mask, req_promisc_mask, ICE_PROMISC_MAX);
+
+	if (ice_is_any_bit_set(clear_promisc_mask, ICE_PROMISC_MAX)) {
+		status = ice_clear_vsi_promisc(hw, vsi->idx,
+					       clear_promisc_mask, 0);
+		if (status) {
+			device_printf(sc->dev,
+				      "VF-%d: Failed to clear promiscuous mode for VSI %d, err %s aq_err %s\n",
+				      vf->vf_num, vsi->idx,
+				      ice_status_str(status),
+				      ice_aq_str(hw->adminq.sq_last_status));
+			v_status = ice_iov_err_to_virt_err(status);
+			goto done;
+		}
+	}
+
+	if (ice_is_any_bit_set(set_promisc_mask, ICE_PROMISC_MAX)) {
+		status = ice_set_vsi_promisc(hw, vsi->idx, set_promisc_mask, 0);
+		if (status) {
+			device_printf(sc->dev,
+				      "VF-%d: Failed to set promiscuous mode for VSI %d, err %s aq_err %s\n",
+				      vf->vf_num, vsi->idx,
+				      ice_status_str(status),
+				      ice_aq_str(hw->adminq.sq_last_status));
+			v_status = ice_iov_err_to_virt_err(status);
+			goto done;
+		}
+	}
+
+done:
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_CONFIG_PROMISCUOUS_MODE,
+	    v_status, NULL, 0, NULL);
+}
+
+/**
+ * ice_vc_notify_all_vfs_link_state - Notify all VFs of PF link state
+ * @sc: device private structure
+ *
+ * Sends a message to all VFs about the status of the PF's link
+ * state. For more details, @see ice_vc_notify_vf_link_state.
+ */
+void
+ice_vc_notify_all_vfs_link_state(struct ice_softc *sc)
+{
+	for (int i = 0; i < sc->num_vfs; i++)
+		ice_vc_notify_vf_link_state(sc, &sc->vfs[i]);
+}
+
+/**
+ * ice_vc_notify_vf_link_state - Notify VF of PF link state
+ * @sc: device private structure
+ * @vf: VF tracking structure
+ *
+ * Sends an event message to the specified VF with information about
+ * the current link state from the PF's port. This includes whether
+ * link is up or down, and the link speed in 100Mbps units.
+ */
+static void
+ice_vc_notify_vf_link_state(struct ice_softc *sc, struct ice_vf *vf)
+{
+	struct virtchnl_pf_event event = {};
+	struct ice_hw *hw = &sc->hw;
+
+	event.event = VIRTCHNL_EVENT_LINK_CHANGE;
+	event.severity = PF_EVENT_SEVERITY_INFO;
+	event.event_data.link_event_adv.link_status = sc->link_up;
+	event.event_data.link_event_adv.link_speed =
+		(u32)ice_conv_link_speed_to_virtchnl(true,
+		    hw->port_info->phy.link_info.link_speed);
+
+	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_EVENT,
+	    VIRTCHNL_STATUS_SUCCESS, (u8 *)&event, sizeof(event), NULL);
+}
+
+/**
+ * ice_vc_handle_vf_msg - Handle a message from a VF
+ * @sc: device private structure
+ * @event: event received from the HW MBX queue
+ *
+ * Called whenever an event is received from a VF on the HW mailbox queue.
+ * Responsible for handling these messages as well as responding to the
+ * VF afterwards, depending on the received message type.
+ */
+void
+ice_vc_handle_vf_msg(struct ice_softc *sc, struct ice_rq_event_info *event)
+{
+	struct ice_hw *hw = &sc->hw;
+	device_t dev = sc->dev;
+	struct ice_vf *vf;
+	int err = 0;
+
+	u32 v_opcode = event->desc.cookie_high;
+	u16 v_id = event->desc.retval;
+	u8 *msg = event->msg_buf;
+	u16 msglen = event->msg_len;
+
+	if (v_id >= sc->num_vfs) {
+		device_printf(dev, "%s: Received msg from invalid VF-%d: opcode %d, len %d\n",
+		    __func__, v_id, v_opcode, msglen);
+		return;
+	}
+
+	vf = &sc->vfs[v_id];
+
+	/* Perform basic checks on the msg */
+	err = virtchnl_vc_validate_vf_msg(&vf->version, v_opcode, msg, msglen);
+	if (err) {
+		device_printf(dev, "%s: Received invalid msg from VF-%d: opcode %d, len %d, error %d\n",
+		    __func__, vf->vf_num, v_opcode, msglen, err);
+		ice_aq_send_msg_to_vf(hw, v_id, v_opcode, VIRTCHNL_STATUS_ERR_PARAM, NULL, 0, NULL);
+		return;
+	}
+
+	switch (v_opcode) {
+	case VIRTCHNL_OP_VERSION:
+		ice_vc_version_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_RESET_VF:
+		ice_reset_vf(sc, vf);
+		break;
+	case VIRTCHNL_OP_GET_VF_RESOURCES:
+		ice_vc_get_vf_res_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_ADD_ETH_ADDR:
+		ice_vc_add_eth_addr_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_DEL_ETH_ADDR:
+		ice_vc_del_eth_addr_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_ADD_VLAN:
+		ice_vc_add_vlan_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_DEL_VLAN:
+		ice_vc_del_vlan_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_CONFIG_VSI_QUEUES:
+		ice_vc_cfg_vsi_qs_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_CONFIG_RSS_KEY:
+		ice_vc_cfg_rss_key_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_CONFIG_RSS_LUT:
+		ice_vc_cfg_rss_lut_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_SET_RSS_HENA:
+		ice_vc_set_rss_hena_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_ENABLE_QUEUES:
+		ice_vc_enable_queues_msg(sc, vf, msg);
+		ice_vc_notify_vf_link_state(sc, vf);
+		break;
+	case VIRTCHNL_OP_DISABLE_QUEUES:
+		ice_vc_disable_queues_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_CONFIG_IRQ_MAP:
+		ice_vc_cfg_irq_map_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_GET_STATS:
+		ice_vc_get_stats_msg(sc, vf, msg);
+		break;
+	case VIRTCHNL_OP_CONFIG_PROMISCUOUS_MODE:
+		ice_vc_cfg_promisc_mode_msg(sc, vf, msg);
+		break;
+	default:
+		device_printf(dev, "%s: Received unknown msg from VF-%d: opcode %d, len %d\n",
+		    __func__, vf->vf_num, v_opcode, msglen);
+		ice_aq_send_msg_to_vf(hw, v_id, v_opcode,
+		    VIRTCHNL_STATUS_ERR_NOT_SUPPORTED, NULL, 0, NULL);
+		break;
+	}
+}
+
+/**
+ * ice_iov_setup_intr_mapping - Setup interrupt config for a VF
+ * @sc: device softc structure
+ * @vf: driver's VF structure for VF to be configured
+ *
+ * Before a VF can be used, and after a VF reset, the PF must configure
+ * the VF's interrupt allocation registers. This includes allocating
+ * interrupts from the PF's interrupt pool to the VF using the
+ * VPINT_ALLOC(_PCI) registers, and setting up a mapping from PF vectors
+ * to VF vectors in GLINT_VECT2FUNC.
+ *
+ * As well, this sets up queue allocation registers and maps the mailbox
+ * interrupt for the VF.
+ */
+static void
+ice_iov_setup_intr_mapping(struct ice_softc *sc, struct ice_vf *vf)
+{
+	struct ice_hw *hw = &sc->hw;
+	struct ice_vsi *vsi = vf->vsi;
+	u16 v;
+
+	/* Calculate indices for register ops below */
+	u16 vf_first_irq_idx = vf->vf_imap[0];
+	u16 vf_last_irq_idx = (vf_first_irq_idx + vf->num_irq_vectors) - 1;
+	u16 abs_vf_first_irq_idx = hw->func_caps.common_cap.msix_vector_first_id +
+	    vf_first_irq_idx;
+	u16 abs_vf_last_irq_idx = (abs_vf_first_irq_idx + vf->num_irq_vectors) - 1;
+	u16 abs_vf_num = vf->vf_num + hw->func_caps.vf_base_id;
+
+	/* Map out VF interrupt allocation in global device space. Both
+	 * VPINT_ALLOC and VPINT_ALLOC_PCI use the same values.
+	 */
+	wr32(hw, VPINT_ALLOC(vf->vf_num),
+	    (((abs_vf_first_irq_idx << VPINT_ALLOC_FIRST_S) & VPINT_ALLOC_FIRST_M) |
+	    ((abs_vf_last_irq_idx << VPINT_ALLOC_LAST_S) & VPINT_ALLOC_LAST_M) |
+	    VPINT_ALLOC_VALID_M));
+	wr32(hw, VPINT_ALLOC_PCI(vf->vf_num),
+	    (((abs_vf_first_irq_idx << VPINT_ALLOC_PCI_FIRST_S) & VPINT_ALLOC_PCI_FIRST_M) |
+	    ((abs_vf_last_irq_idx << VPINT_ALLOC_PCI_LAST_S) & VPINT_ALLOC_PCI_LAST_M) |
+	    VPINT_ALLOC_PCI_VALID_M));
+
+	/* Create inverse mapping of vectors to PF/VF combinations */
+	for (v = vf_first_irq_idx; v <= vf_last_irq_idx; v++)
+	{
+		wr32(hw, GLINT_VECT2FUNC(v),
+		    (((abs_vf_num << GLINT_VECT2FUNC_VF_NUM_S) & GLINT_VECT2FUNC_VF_NUM_M) |
+		     ((hw->pf_id << GLINT_VECT2FUNC_PF_NUM_S) & GLINT_VECT2FUNC_PF_NUM_M)));
+	}
+
+	/* Map mailbox interrupt to MSI-X index 0. Disable ITR for it, too. */
+	wr32(hw, VPINT_MBX_CTL(abs_vf_num),
+	    ((0 << VPINT_MBX_CTL_MSIX_INDX_S) & VPINT_MBX_CTL_MSIX_INDX_M) |
+	    ((0x3 << VPINT_MBX_CTL_ITR_INDX_S) & VPINT_MBX_CTL_ITR_INDX_M) |
+	    VPINT_MBX_CTL_CAUSE_ENA_M);
+
+	/* Mark the TX queue mapping registers as valid */
+	wr32(hw, VPLAN_TXQ_MAPENA(vf->vf_num), VPLAN_TXQ_MAPENA_TX_ENA_M);
+
+	/* Indicate to HW that VF has scattered queue allocation */
+	wr32(hw, VPLAN_TX_QBASE(vf->vf_num), VPLAN_TX_QBASE_VFQTABLE_ENA_M);
+	for (int i = 0; i < vsi->num_tx_queues; i++) {
+		wr32(hw, VPLAN_TX_QTABLE(i, vf->vf_num),
+		    (vsi->tx_qmap[i] << VPLAN_TX_QTABLE_QINDEX_S) & VPLAN_TX_QTABLE_QINDEX_M);
+	}
+
+	/* Mark the RX queue mapping registers as valid */
+	wr32(hw, VPLAN_RXQ_MAPENA(vf->vf_num), VPLAN_RXQ_MAPENA_RX_ENA_M);
+	wr32(hw, VPLAN_RX_QBASE(vf->vf_num), VPLAN_RX_QBASE_VFQTABLE_ENA_M);
+	for (int i = 0; i < vsi->num_rx_queues; i++) {
+		wr32(hw, VPLAN_RX_QTABLE(i, vf->vf_num),
+		    (vsi->rx_qmap[i] << VPLAN_RX_QTABLE_QINDEX_S) & VPLAN_RX_QTABLE_QINDEX_M);
+	}
+}
+
+/**
+ * ice_err_to_virt err - translate ice errors into virtchnl errors
+ * @ice_err: status returned from ice function
+ */
+static enum virtchnl_status_code
+ice_iov_err_to_virt_err(int ice_err)
+{
+	switch (ice_err) {
+	case 0:
+		return VIRTCHNL_STATUS_SUCCESS;
+	case ICE_ERR_BAD_PTR:
+	case ICE_ERR_INVAL_SIZE:
+	case ICE_ERR_DEVICE_NOT_SUPPORTED:
+	case ICE_ERR_PARAM:
+	case ICE_ERR_CFG:
+		return VIRTCHNL_STATUS_ERR_PARAM;
+	case ICE_ERR_NO_MEMORY:
+		return VIRTCHNL_STATUS_ERR_NO_MEMORY;
+	case ICE_ERR_NOT_READY:
+	case ICE_ERR_RESET_FAILED:
+	case ICE_ERR_FW_API_VER:
+	case ICE_ERR_AQ_ERROR:
+	case ICE_ERR_AQ_TIMEOUT:
+	case ICE_ERR_AQ_FULL:
+	case ICE_ERR_AQ_NO_WORK:
+	case ICE_ERR_AQ_EMPTY:
+		return VIRTCHNL_STATUS_ERR_ADMIN_QUEUE_ERROR;
+	default:
+		return VIRTCHNL_STATUS_ERR_NOT_SUPPORTED;
+	}
+}

--- a/sys/dev/ice/ice_iov.c
+++ b/sys/dev/ice/ice_iov.c
@@ -369,6 +369,14 @@ ice_iov_add_vf(struct ice_softc *sc, uint16_t vfnum, const nvlist_t *params)
 		goto release_imap;
 	}
 
+	/* Add the broadcast address */
+	error = ice_add_vsi_mac_filter(vsi, broadcastaddr);
+	if (error) {
+		device_printf(sc->dev, "Unable to add broadcast filter VF %d VSI: %s\n",
+			      vfnum, ice_err_str(error));
+		goto release_imap;
+	}
+
 	ice_iov_ready_vf(sc, vf);
 
 	return (0);

--- a/sys/dev/ice/ice_iov.c
+++ b/sys/dev/ice/ice_iov.c
@@ -1142,17 +1142,34 @@ ice_vc_set_rss_hena_msg(struct ice_softc *sc, struct ice_vf *vf, u8 *msg_buf)
 	enum virtchnl_status_code v_status = VIRTCHNL_STATUS_SUCCESS;
 	struct ice_vsi *vsi = vf->vsi;
 
+	MPASS(vsi != NULL);
+
 	vrh = (struct virtchnl_rss_hena *)msg_buf;
 
-	status = ice_add_avf_rss_cfg(hw, vsi->idx, vrh->hena);
-	if (status) {
-		device_printf(sc->dev,
-			      "ice_add_avf_rss_cfg status %s, error %s\n",
-			      ice_status_str(status),
-			      ice_aq_str(hw->adminq.sq_last_status));
-		v_status = ice_iov_err_to_virt_err(status);
+	/*
+	 * Remove existing configuration to make sure only requested
+	 * config is applied and allow VFs to disable RSS completly.
+	 */
+	status = ice_rem_vsi_rss_cfg(hw, vsi->idx);
+	if (vrh->hena) {
+		/*
+		 * Problem with removing config is not fatal, when new one
+		 * is requested. Warn about it but try to apply new config
+		 * anyway.
+		 */
+		if (status)
+			device_printf(sc->dev,
+			    "ice_rem_vsi_rss_cfg status %s, error %s\n",
+			    ice_status_str(status),
+			    ice_aq_str(hw->adminq.sq_last_status));
+		status = ice_add_avf_rss_cfg(hw, vsi->idx, vrh->hena);
+		if (status)
+			device_printf(sc->dev,
+			    "ice_add_avf_rss_cfg status %s, error %s\n",
+			    ice_status_str(status),
+			    ice_aq_str(hw->adminq.sq_last_status));
 	}
-
+	v_status = ice_iov_err_to_virt_err(status);
 	ice_aq_send_msg_to_vf(hw, vf->vf_num, VIRTCHNL_OP_SET_RSS_HENA,
 	    v_status, NULL, 0, NULL);
 }

--- a/sys/dev/ice/ice_iov.h
+++ b/sys/dev/ice/ice_iov.h
@@ -85,6 +85,11 @@ struct ice_vf {
 	u16 vf_num;
 	struct virtchnl_version_info version;
 
+	u16 mac_filter_limit;
+	u16 mac_filter_cnt;
+	u16 vlan_limit;
+	u16 vlan_cnt;
+
 	u16 num_irq_vectors;
 	u16 *vf_imap;
 	struct ice_irq_vector *tx_irqvs;
@@ -100,6 +105,9 @@ struct ice_vf {
 
 #define ICE_VIRTCHNL_VALID_PROMISC_FLAGS	(FLAG_VF_UNICAST_PROMISC | \
 						 FLAG_VF_MULTICAST_PROMISC)
+
+#define ICE_DEFAULT_VF_VLAN_LIMIT			64
+#define ICE_DEFAULT_VF_FILTER_LIMIT			16
 
 int ice_iov_attach(struct ice_softc *sc);
 int ice_iov_detach(struct ice_softc *sc);

--- a/sys/dev/ice/ice_iov.h
+++ b/sys/dev/ice/ice_iov.h
@@ -108,6 +108,8 @@ int ice_iov_init(struct ice_softc *sc, uint16_t num_vfs, const nvlist_t *params)
 int ice_iov_add_vf(struct ice_softc *sc, uint16_t vfnum, const nvlist_t *params);
 void ice_iov_uninit(struct ice_softc *sc);
 
+void ice_iov_handle_vflr(struct ice_softc *sc);
+
 void ice_vc_handle_vf_msg(struct ice_softc *sc, struct ice_rq_event_info *event);
 void ice_vc_notify_all_vfs_link_state(struct ice_softc *sc);
 

--- a/sys/dev/ice/ice_iov.h
+++ b/sys/dev/ice/ice_iov.h
@@ -1,0 +1,115 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*  Copyright (c) 2025, Intel Corporation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of the Intel Corporation nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file ice_iov.h
+ * @brief header for IOV functionality
+ *
+ * This header includes definitions used to implement device Virtual Functions
+ * for the ice driver.
+ */
+
+#ifndef _ICE_IOV_H_
+#define _ICE_IOV_H_
+
+#include <sys/types.h>
+#include <sys/bus.h>
+#include <sys/nv.h>
+#include <sys/iov_schema.h>
+#include <sys/param.h>
+#include <dev/pci/pcivar.h>
+#include <dev/pci/pcireg.h>
+
+#include <dev/pci/pci_iov.h>
+
+#include "ice_iflib.h"
+#include "ice_vf_mbx.h"
+
+/**
+ * @enum ice_vf_flags
+ * @brief VF state flags
+ *
+ * Used to indicate the status of a PF's VF, as well as indicating what each VF
+ * is capabile of. Intended to be modified only using atomic operations, so
+ * they can be read and modified in places that aren't locked.
+ *
+ * Used in struct ice_vf's vf_flags field.
+ */
+enum ice_vf_flags {
+	VF_FLAG_ENABLED			= BIT(0),
+	VF_FLAG_SET_MAC_CAP		= BIT(1),
+	VF_FLAG_VLAN_CAP		= BIT(2),
+	VF_FLAG_PROMISC_CAP		= BIT(3),
+	VF_FLAG_MAC_ANTI_SPOOF		= BIT(4),
+};
+
+/**
+ * @struct ice_vf
+ * @brief PF's VF software context
+ *
+ * Represents the state and options for a VF spawned from a PF.
+ */
+struct ice_vf {
+	struct ice_vsi *vsi;
+	u32 vf_flags;
+
+	u8 mac[ETHER_ADDR_LEN];
+	u16 vf_num;
+	struct virtchnl_version_info version;
+
+	u16 num_irq_vectors;
+	u16 *vf_imap;
+	struct ice_irq_vector *tx_irqvs;
+	struct ice_irq_vector *rx_irqvs;
+};
+
+#define ICE_PCIE_DEV_STATUS			0xAA
+
+#define ICE_PCI_CIAD_WAIT_COUNT			100
+#define ICE_PCI_CIAD_WAIT_DELAY_US		1
+#define ICE_VPGEN_VFRSTAT_WAIT_COUNT		100
+#define ICE_VPGEN_VFRSTAT_WAIT_DELAY_US		20
+
+#define ICE_VIRTCHNL_VALID_PROMISC_FLAGS	(FLAG_VF_UNICAST_PROMISC | \
+						 FLAG_VF_MULTICAST_PROMISC)
+
+int ice_iov_attach(struct ice_softc *sc);
+int ice_iov_detach(struct ice_softc *sc);
+
+int ice_iov_init(struct ice_softc *sc, uint16_t num_vfs, const nvlist_t *params);
+int ice_iov_add_vf(struct ice_softc *sc, uint16_t vfnum, const nvlist_t *params);
+void ice_iov_uninit(struct ice_softc *sc);
+
+void ice_vc_handle_vf_msg(struct ice_softc *sc, struct ice_rq_event_info *event);
+void ice_vc_notify_all_vfs_link_state(struct ice_softc *sc);
+
+#endif /* _ICE_IOV_H_ */
+

--- a/sys/dev/ice/ice_lib.c
+++ b/sys/dev/ice/ice_lib.c
@@ -1675,6 +1675,10 @@ ice_cfg_vsi_for_tx(struct ice_vsi *vsi)
 		struct ice_tlan_ctx tlan_ctx = { 0 };
 		struct ice_tx_queue *txq = &vsi->tx_queues[i];
 
+		/* Last configured queue */
+		if (txq->desc_count == 0)
+			break;
+
 		pf_q = vsi->tx_qmap[txq->me];
 		qg->txqs[0].txq_id = htole16(pf_q);
 
@@ -1803,6 +1807,10 @@ ice_cfg_vsi_for_rx(struct ice_vsi *vsi)
 
 	for (i = 0; i < vsi->num_rx_queues; i++) {
 		MPASS(vsi->mbuf_sz > 0);
+		/* Last configured queue */
+		if (vsi->rx_queues[i].desc_count == 0)
+			break;
+
 		err = ice_setup_rx_ctx(&vsi->rx_queues[i]);
 		if (err)
 			return err;

--- a/sys/dev/ice/ice_lib.h
+++ b/sys/dev/ice/ice_lib.h
@@ -611,6 +611,10 @@ struct ice_vsi {
 	u16 mirror_src_vsi;
 	u16 rule_mir_ingress;
 	u16 rule_mir_egress;
+
+#ifdef PCI_IOV
+	u8 vf_num;		/* Index of owning VF, if applicable */
+#endif
 };
 
 /**

--- a/sys/dev/ice/ice_vf_mbx.c
+++ b/sys/dev/ice/ice_vf_mbx.c
@@ -1,0 +1,471 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*  Copyright (c) 2025, Intel Corporation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of the Intel Corporation nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ice_common.h"
+#include "ice_hw_autogen.h"
+#include "ice_vf_mbx.h"
+
+/**
+ * ice_aq_send_msg_to_vf
+ * @hw: pointer to the hardware structure
+ * @vfid: VF ID to send msg
+ * @v_opcode: opcodes for VF-PF communication
+ * @v_retval: return error code
+ * @msg: pointer to the msg buffer
+ * @msglen: msg length
+ * @cd: pointer to command details
+ *
+ * Send message to VF driver (0x0802) using mailbox
+ * queue and asynchronously sending message via
+ * ice_sq_send_cmd() function
+ */
+int
+ice_aq_send_msg_to_vf(struct ice_hw *hw, u16 vfid, u32 v_opcode, u32 v_retval,
+		      u8 *msg, u16 msglen, struct ice_sq_cd *cd)
+{
+	struct ice_aqc_pf_vf_msg *cmd;
+	struct ice_aq_desc desc;
+
+	ice_fill_dflt_direct_cmd_desc(&desc, ice_mbx_opc_send_msg_to_vf);
+
+	cmd = &desc.params.virt;
+	cmd->id = CPU_TO_LE32(vfid);
+
+	desc.cookie_high = CPU_TO_LE32(v_opcode);
+	desc.cookie_low = CPU_TO_LE32(v_retval);
+
+	if (msglen)
+		desc.flags |= CPU_TO_LE16(ICE_AQ_FLAG_RD);
+
+	return ice_sq_send_cmd(hw, &hw->mailboxq, &desc, msg, msglen, cd);
+}
+
+/**
+ * ice_aq_send_msg_to_pf
+ * @hw: pointer to the hardware structure
+ * @v_opcode: opcodes for VF-PF communication
+ * @v_retval: return error code
+ * @msg: pointer to the msg buffer
+ * @msglen: msg length
+ * @cd: pointer to command details
+ *
+ * Send message to PF driver using mailbox queue. By default, this
+ * message is sent asynchronously, i.e. ice_sq_send_cmd()
+ * does not wait for completion before returning.
+ */
+int
+ice_aq_send_msg_to_pf(struct ice_hw *hw, enum virtchnl_ops v_opcode,
+		      int v_retval, u8 *msg, u16 msglen,
+		      struct ice_sq_cd *cd)
+{
+	struct ice_aq_desc desc;
+
+	ice_fill_dflt_direct_cmd_desc(&desc, ice_mbx_opc_send_msg_to_pf);
+	desc.cookie_high = CPU_TO_LE32(v_opcode);
+	desc.cookie_low = CPU_TO_LE32(v_retval);
+
+	if (msglen)
+		desc.flags |= CPU_TO_LE16(ICE_AQ_FLAG_RD);
+
+	return ice_sq_send_cmd(hw, &hw->mailboxq, &desc, msg, msglen, cd);
+}
+
+static const u32 ice_legacy_aq_to_vc_speed[] = {
+	VIRTCHNL_LINK_SPEED_100MB,	/* BIT(0) */
+	VIRTCHNL_LINK_SPEED_100MB,
+	VIRTCHNL_LINK_SPEED_1GB,
+	VIRTCHNL_LINK_SPEED_1GB,
+	VIRTCHNL_LINK_SPEED_1GB,
+	VIRTCHNL_LINK_SPEED_10GB,
+	VIRTCHNL_LINK_SPEED_20GB,
+	VIRTCHNL_LINK_SPEED_25GB,
+	VIRTCHNL_LINK_SPEED_40GB,
+	VIRTCHNL_LINK_SPEED_40GB,
+	VIRTCHNL_LINK_SPEED_40GB,
+};
+
+/**
+ * ice_conv_link_speed_to_virtchnl
+ * @adv_link_support: determines the format of the returned link speed
+ * @link_speed: variable containing the link_speed to be converted
+ *
+ * Convert link speed supported by HW to link speed supported by virtchnl.
+ * If adv_link_support is true, then return link speed in Mbps. Else return
+ * link speed as a VIRTCHNL_LINK_SPEED_* casted to a u32. Note that the caller
+ * needs to cast back to an enum virtchnl_link_speed in the case where
+ * adv_link_support is false, but when adv_link_support is true the caller can
+ * expect the speed in Mbps.
+ */
+u32 ice_conv_link_speed_to_virtchnl(bool adv_link_support, u16 link_speed)
+{
+	/* convert a BIT() value into an array index */
+	u16 index = (u16)(ice_fls(link_speed) - 1);
+
+	if (adv_link_support)
+		return ice_get_link_speed(index);
+	else if (index < ARRAY_SIZE(ice_legacy_aq_to_vc_speed))
+		/* Virtchnl speeds are not defined for every speed supported in
+		 * the hardware. To maintain compatibility with older AVF
+		 * drivers, while reporting the speed the new speed values are
+		 * resolved to the closest known virtchnl speeds
+		 */
+		return ice_legacy_aq_to_vc_speed[index];
+
+	return VIRTCHNL_LINK_SPEED_UNKNOWN;
+}
+
+/* The mailbox overflow detection algorithm helps to check if there
+ * is a possibility of a malicious VF transmitting too many MBX messages to the
+ * PF.
+ * 1. The mailbox snapshot structure, ice_mbx_snapshot, is initialized during
+ * driver initialization in ice_init_hw() using ice_mbx_init_snapshot().
+ * The struct ice_mbx_snapshot helps to track and traverse a static window of
+ * messages within the mailbox queue while looking for a malicious VF.
+ *
+ * 2. When the caller starts processing its mailbox queue in response to an
+ * interrupt, the structure ice_mbx_snapshot is expected to be cleared before
+ * the algorithm can be run for the first time for that interrupt. This
+ * requires calling ice_mbx_reset_snapshot() as well as calling
+ * ice_mbx_reset_vf_info() for each VF tracking structure.
+ *
+ * 3. For every message read by the caller from the MBX Queue, the caller must
+ * call the detection algorithm's entry function ice_mbx_vf_state_handler().
+ * Before every call to ice_mbx_vf_state_handler() the struct ice_mbx_data is
+ * filled as it is required to be passed to the algorithm.
+ *
+ * 4. Every time a message is read from the MBX queue, a tracking structure
+ * for the VF must be passed to the state handler. The boolean output
+ * report_malvf from ice_mbx_vf_state_handler() serves as an indicator to the
+ * caller whether it must report this VF as malicious or not.
+ *
+ * 5. When a VF is identified to be malicious, the caller can send a message
+ * to the system administrator.
+ *
+ * 6. The PF is responsible for maintaining the struct ice_mbx_vf_info
+ * structure for each VF. The PF should clear the VF tracking structure if the
+ * VF is reset. When a VF is shut down and brought back up, we will then
+ * assume that the new VF is not malicious and may report it again if we
+ * detect it again.
+ *
+ * 7. The function ice_mbx_reset_snapshot() is called to reset the information
+ * in ice_mbx_snapshot for every new mailbox interrupt handled.
+ */
+#define ICE_RQ_DATA_MASK(rq_data) ((rq_data) & PF_MBX_ARQH_ARQH_M)
+/* Using the highest value for an unsigned 16-bit value 0xFFFF to indicate that
+ * the max messages check must be ignored in the algorithm
+ */
+#define ICE_IGNORE_MAX_MSG_CNT	0xFFFF
+
+/**
+ * ice_mbx_reset_snapshot - Initialize mailbox snapshot structure
+ * @snap: pointer to the mailbox snapshot
+ */
+static void ice_mbx_reset_snapshot(struct ice_mbx_snapshot *snap)
+{
+	struct ice_mbx_vf_info *vf_info;
+
+	/* Clear mbx_buf in the mailbox snaphot structure and setting the
+	 * mailbox snapshot state to a new capture.
+	 */
+	ice_memset(&snap->mbx_buf, 0, sizeof(snap->mbx_buf), ICE_NONDMA_MEM);
+	snap->mbx_buf.state = ICE_MAL_VF_DETECT_STATE_NEW_SNAPSHOT;
+
+	/* Reset message counts for all VFs to zero */
+	LIST_FOR_EACH_ENTRY(vf_info, &snap->mbx_vf, ice_mbx_vf_info, list_entry)
+		vf_info->msg_count = 0;
+}
+
+/**
+ * ice_mbx_traverse - Pass through mailbox snapshot
+ * @hw: pointer to the HW struct
+ * @new_state: new algorithm state
+ *
+ * Traversing the mailbox static snapshot without checking
+ * for malicious VFs.
+ */
+static void
+ice_mbx_traverse(struct ice_hw *hw,
+		 enum ice_mbx_snapshot_state *new_state)
+{
+	struct ice_mbx_snap_buffer_data *snap_buf;
+	u32 num_iterations;
+
+	snap_buf = &hw->mbx_snapshot.mbx_buf;
+
+	/* As mailbox buffer is circular, applying a mask
+	 * on the incremented iteration count.
+	 */
+	num_iterations = ICE_RQ_DATA_MASK(++snap_buf->num_iterations);
+
+	/* Checking either of the below conditions to exit snapshot traversal:
+	 * Condition-1: If the number of iterations in the mailbox is equal to
+	 * the mailbox head which would indicate that we have reached the end
+	 * of the static snapshot.
+	 * Condition-2: If the maximum messages serviced in the mailbox for a
+	 * given interrupt is the highest possible value then there is no need
+	 * to check if the number of messages processed is equal to it. If not
+	 * check if the number of messages processed is greater than or equal
+	 * to the maximum number of mailbox entries serviced in current work item.
+	 */
+	if (num_iterations == snap_buf->head ||
+	    (snap_buf->max_num_msgs_mbx < ICE_IGNORE_MAX_MSG_CNT &&
+	     ++snap_buf->num_msg_proc >= snap_buf->max_num_msgs_mbx))
+		*new_state = ICE_MAL_VF_DETECT_STATE_NEW_SNAPSHOT;
+}
+
+/**
+ * ice_mbx_detect_malvf - Detect malicious VF in snapshot
+ * @hw: pointer to the HW struct
+ * @vf_info: mailbox tracking structure for a VF
+ * @new_state: new algorithm state
+ * @is_malvf: boolean output to indicate if VF is malicious
+ *
+ * This function tracks the number of asynchronous messages
+ * sent per VF and marks the VF as malicious if it exceeds
+ * the permissible number of messages to send.
+ */
+static int
+ice_mbx_detect_malvf(struct ice_hw *hw, struct ice_mbx_vf_info *vf_info,
+		     enum ice_mbx_snapshot_state *new_state,
+		     bool *is_malvf)
+{
+	/* increment the message count for this VF */
+	vf_info->msg_count++;
+
+	if (vf_info->msg_count >= ICE_ASYNC_VF_MSG_THRESHOLD)
+		*is_malvf = true;
+
+	/* continue to iterate through the mailbox snapshot */
+	ice_mbx_traverse(hw, new_state);
+
+	return 0;
+}
+
+/**
+ * ice_e830_mbx_vf_dec_trig - Decrements the VF mailbox queue counter
+ * @hw: pointer to the HW struct
+ * @event: pointer to the control queue receive event
+ *
+ * This function triggers to decrement the counter
+ * MBX_VF_IN_FLIGHT_MSGS_AT_PF_CNT when the driver replenishes
+ * the buffers at the PF mailbox queue.
+ */
+void ice_e830_mbx_vf_dec_trig(struct ice_hw *hw,
+			      struct ice_rq_event_info *event)
+{
+	u16 vfid = LE16_TO_CPU(event->desc.retval);
+
+	wr32(hw, E830_MBX_VF_DEC_TRIG(vfid), 1);
+}
+
+/**
+ * ice_mbx_vf_clear_cnt_e830 - Clear the VF mailbox queue count
+ * @hw: pointer to the HW struct
+ * @vf_id: VF ID in the PF space
+ *
+ * This function clears the counter MBX_VF_IN_FLIGHT_MSGS_AT_PF_CNT, and should
+ * be called when a VF is created and on VF reset.
+ */
+void ice_mbx_vf_clear_cnt_e830(struct ice_hw *hw, u16 vf_id)
+{
+	u32 reg = rd32(hw, E830_MBX_VF_IN_FLIGHT_MSGS_AT_PF_CNT(vf_id));
+
+	wr32(hw, E830_MBX_VF_DEC_TRIG(vf_id), reg);
+}
+
+/**
+ * ice_mbx_vf_state_handler - Handle states of the overflow algorithm
+ * @hw: pointer to the HW struct
+ * @mbx_data: pointer to structure containing mailbox data
+ * @vf_info: mailbox tracking structure for the VF in question
+ * @report_malvf: boolean output to indicate whether VF should be reported
+ *
+ * The function serves as an entry point for the malicious VF
+ * detection algorithm by handling the different states and state
+ * transitions of the algorithm:
+ * New snapshot: This state is entered when creating a new static
+ * snapshot. The data from any previous mailbox snapshot is
+ * cleared and a new capture of the mailbox head and tail is
+ * logged. This will be the new static snapshot to detect
+ * asynchronous messages sent by VFs. On capturing the snapshot
+ * and depending on whether the number of pending messages in that
+ * snapshot exceed the watermark value, the state machine enters
+ * traverse or detect states.
+ * Traverse: If pending message count is below watermark then iterate
+ * through the snapshot without any action on VF.
+ * Detect: If pending message count exceeds watermark traverse
+ * the static snapshot and look for a malicious VF.
+ */
+int
+ice_mbx_vf_state_handler(struct ice_hw *hw, struct ice_mbx_data *mbx_data,
+			 struct ice_mbx_vf_info *vf_info, bool *report_malvf)
+{
+	struct ice_mbx_snapshot *snap = &hw->mbx_snapshot;
+	struct ice_mbx_snap_buffer_data *snap_buf;
+	struct ice_ctl_q_info *cq = &hw->mailboxq;
+	enum ice_mbx_snapshot_state new_state;
+	int status = 0;
+	bool is_malvf = false;
+
+	if (!report_malvf || !mbx_data || !vf_info)
+		return ICE_ERR_BAD_PTR;
+
+	*report_malvf = false;
+
+	/* When entering the mailbox state machine assume that the VF
+	 * is not malicious until detected.
+	 */
+	 /* Checking if max messages allowed to be processed while servicing current
+	  * interrupt is not less than the defined AVF message threshold.
+	  */
+	if (mbx_data->max_num_msgs_mbx <= ICE_ASYNC_VF_MSG_THRESHOLD)
+		return ICE_ERR_INVAL_SIZE;
+
+	/* The watermark value should not be lesser than the threshold limit
+	 * set for the number of asynchronous messages a VF can send to mailbox
+	 * nor should it be greater than the maximum number of messages in the
+	 * mailbox serviced in current interrupt.
+	 */
+	if (mbx_data->async_watermark_val < ICE_ASYNC_VF_MSG_THRESHOLD ||
+	    mbx_data->async_watermark_val > mbx_data->max_num_msgs_mbx)
+		return ICE_ERR_PARAM;
+
+	new_state = ICE_MAL_VF_DETECT_STATE_INVALID;
+	snap_buf = &snap->mbx_buf;
+
+	switch (snap_buf->state) {
+	case ICE_MAL_VF_DETECT_STATE_NEW_SNAPSHOT:
+		/* Clear any previously held data in mailbox snapshot structure. */
+		ice_mbx_reset_snapshot(snap);
+
+		/* Collect the pending ARQ count, number of messages processed and
+		 * the maximum number of messages allowed to be processed from the
+		 * Mailbox for current interrupt.
+		 */
+		snap_buf->num_pending_arq = mbx_data->num_pending_arq;
+		snap_buf->num_msg_proc = mbx_data->num_msg_proc;
+		snap_buf->max_num_msgs_mbx = mbx_data->max_num_msgs_mbx;
+
+		/* Capture a new static snapshot of the mailbox by logging the
+		 * head and tail of snapshot and set num_iterations to the tail
+		 * value to mark the start of the iteration through the snapshot.
+		 */
+		snap_buf->head = ICE_RQ_DATA_MASK(cq->rq.next_to_clean +
+						  mbx_data->num_pending_arq);
+		snap_buf->tail = ICE_RQ_DATA_MASK(cq->rq.next_to_clean - 1);
+		snap_buf->num_iterations = snap_buf->tail;
+
+		/* Pending ARQ messages returned by ice_clean_rq_elem
+		 * is the difference between the head and tail of the
+		 * mailbox queue. Comparing this value against the watermark
+		 * helps to check if we potentially have malicious VFs.
+		 */
+		if (snap_buf->num_pending_arq >=
+		    mbx_data->async_watermark_val) {
+			new_state = ICE_MAL_VF_DETECT_STATE_DETECT;
+			status = ice_mbx_detect_malvf(hw, vf_info, &new_state, &is_malvf);
+		} else {
+			new_state = ICE_MAL_VF_DETECT_STATE_TRAVERSE;
+			ice_mbx_traverse(hw, &new_state);
+		}
+		break;
+
+	case ICE_MAL_VF_DETECT_STATE_TRAVERSE:
+		new_state = ICE_MAL_VF_DETECT_STATE_TRAVERSE;
+		ice_mbx_traverse(hw, &new_state);
+		break;
+
+	case ICE_MAL_VF_DETECT_STATE_DETECT:
+		new_state = ICE_MAL_VF_DETECT_STATE_DETECT;
+		status = ice_mbx_detect_malvf(hw, vf_info, &new_state, &is_malvf);
+		break;
+
+	default:
+		new_state = ICE_MAL_VF_DETECT_STATE_INVALID;
+		status = ICE_ERR_CFG;
+	}
+
+	snap_buf->state = new_state;
+
+	/* Only report VFs as malicious the first time we detect it */
+	if (is_malvf && !vf_info->malicious) {
+		vf_info->malicious = 1;
+		*report_malvf = true;
+	}
+
+	return status;
+}
+
+/**
+ * ice_mbx_clear_malvf - Clear VF mailbox info
+ * @vf_info: the mailbox tracking structure for a VF
+ *
+ * In case of a VF reset, this function shall be called to clear the VF's
+ * current mailbox tracking state.
+ */
+void ice_mbx_clear_malvf(struct ice_mbx_vf_info *vf_info)
+{
+	vf_info->malicious = 0;
+	vf_info->msg_count = 0;
+}
+
+/**
+ * ice_mbx_init_vf_info - Initialize a new VF mailbox tracking info
+ * @hw: pointer to the hardware structure
+ * @vf_info: the mailbox tracking info structure for a VF
+ *
+ * Initialize a VF mailbox tracking info structure and insert it into the
+ * snapshot list.
+ *
+ * If you remove the VF, you must also delete the associated VF info structure
+ * from the linked list.
+ */
+void ice_mbx_init_vf_info(struct ice_hw *hw, struct ice_mbx_vf_info *vf_info)
+{
+	struct ice_mbx_snapshot *snap = &hw->mbx_snapshot;
+
+	ice_mbx_clear_malvf(vf_info);
+	LIST_ADD(&vf_info->list_entry, &snap->mbx_vf);
+}
+
+/**
+ * ice_mbx_init_snapshot - Initialize mailbox snapshot data
+ * @hw: pointer to the hardware structure
+ *
+ * Clear the mailbox snapshot structure and initialize the VF mailbox list.
+ */
+void ice_mbx_init_snapshot(struct ice_hw *hw)
+{
+	struct ice_mbx_snapshot *snap = &hw->mbx_snapshot;
+
+	INIT_LIST_HEAD(&snap->mbx_vf);
+	ice_mbx_reset_snapshot(snap);
+}

--- a/sys/dev/ice/ice_vf_mbx.h
+++ b/sys/dev/ice/ice_vf_mbx.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*  Copyright (c) 2025, Intel Corporation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of the Intel Corporation nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _ICE_VF_MBX_H_
+#define _ICE_VF_MBX_H_
+
+#include "ice_type.h"
+#include "ice_controlq.h"
+
+/* Defining the mailbox message threshold as 63 asynchronous
+ * pending messages. Normal VF functionality does not require
+ * sending more than 63 asynchronous pending message.
+ */
+
+ /* Threshold value should be used to initialize
+  * MBX_VF_IN_FLIGHT_MSGS_AT_PF_CNT register.
+  */
+#define ICE_ASYNC_VF_MSG_THRESHOLD	63
+
+int
+ice_aq_send_msg_to_pf(struct ice_hw *hw, enum virtchnl_ops v_opcode,
+		      int v_retval, u8 *msg, u16 msglen,
+		      struct ice_sq_cd *cd);
+int
+ice_aq_send_msg_to_vf(struct ice_hw *hw, u16 vfid, u32 v_opcode, u32 v_retval,
+		      u8 *msg, u16 msglen, struct ice_sq_cd *cd);
+
+u32 ice_conv_link_speed_to_virtchnl(bool adv_link_support, u16 link_speed);
+
+void ice_e830_mbx_vf_dec_trig(struct ice_hw *hw,
+			      struct ice_rq_event_info *event);
+void ice_mbx_vf_clear_cnt_e830(struct ice_hw *hw, u16 vf_id);
+int
+ice_mbx_vf_state_handler(struct ice_hw *hw, struct ice_mbx_data *mbx_data,
+			 struct ice_mbx_vf_info *vf_info, bool *report_malvf);
+void ice_mbx_clear_malvf(struct ice_mbx_vf_info *vf_info);
+void ice_mbx_init_vf_info(struct ice_hw *hw, struct ice_mbx_vf_info *vf_info);
+void ice_mbx_init_snapshot(struct ice_hw *hw);
+#endif /* _ICE_VF_MBX_H_ */

--- a/sys/modules/ice/Makefile
+++ b/sys/modules/ice/Makefile
@@ -13,6 +13,7 @@ SRCS    += opt_inet.h opt_inet6.h opt_rss.h opt_iflib.h
 SRCS    += ice_lib.c ice_osdep.c ice_resmgr.c ice_strings.c
 SRCS    += ice_iflib_recovery_txrx.c ice_iflib_txrx.c if_ice_iflib.c
 SRCS	+= ice_fw_logging.c ice_ddp_common.c
+SRCS.PCI_IOV += pci_iov_if.h ice_iov.c ice_vf_mbx.c
 
 # RDMA Client interface
 # TODO: Is this the right way to compile this?


### PR DESCRIPTION
This is eventually supposed to document the functionality from #1573, but for now it contains information ported from the out-of-tree driver's man pages in order to bring the current man page up to date with features that are already in the upstream driver.