### PR TITLE
style.9: relax "return (value)" requirement for C++

### DIFF
--- a/share/man/man9/style.9
+++ b/share/man/man9/style.9
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd February 18, 2025
+.Dd March 27, 2025
 .Dt STYLE 9
 .Os
 .Sh NAME
@@ -766,7 +766,8 @@ to any pointer type.
 .Pp
 Values in
 .Ic return
-statements should be enclosed in parentheses.
+statements should be enclosed in parentheses where possible.
+For example, parentheses cannot be used if the value is a C++ braced-init-list.
 .Pp
 Use
 .Xr err 3


### PR DESCRIPTION
consider the following C++ code:

```
	struct S { int a, b; };
	S f() { return {1, 2}; }
```

according to style(9), the return statement should be formatted as:

```
	return ({1, 2});
```

however, this is not valid C++ code and will not compile.

add an exception to style(9) to cover this case.

---

i am aware there's no C++ code in the kernel, but it's often said that userland code should also conform to style(9).