### PR TITLE
Skip testcase

### DIFF
--- a/tests/sys/net/routing/test_routing_l3.py
+++ b/tests/sys/net/routing/test_routing_l3.py
@@ -22,9 +22,13 @@ class TestIfOps(VnetTestTemplate):
     @pytest.mark.require_user("root")
     def test_change_prefix_route(self, family):
         """Tests that prefix route changes to the new one upon addr deletion"""
+        if family == "inet6":
+            pytest.skip("This test behavior is not supported for inet6")
+
         vnet = self.vnet_map["vnet1"]
         first_iface = vnet.iface_alias_map["if1"]
         second_iface = vnet.iface_alias_map["if2"]
+
         if family == "inet":
             first_addr = ipaddress.ip_interface("192.0.2.1/24")
             second_addr = ipaddress.ip_interface("192.0.2.2/24")


### PR DESCRIPTION
Skip testcase: https://ci.freebsd.org/job/FreeBSD-main-amd64-test/25819/testReport/sys.net.routing.test_routing_l3/py/TestIfOps__test_change_prefix_route_same_iface_inet6_/

Possible reasons:

IPv6 and IPv4 behave differently. IPv4 uses in_scrubprefix to delete the interface route, whereas IPv6 does not. Instead, IPv6 relies on NDP (Neighbor Discovery Protocol) to detect changes and sends RA (Router Advertisement) messages.

IPv4, by default, selects the source IP based on the routing table. In contrast, IPv6 does not solely rely on the routing table. After determining the outgoing interface via the routing table, IPv6 then follows the rules defined in RFC 6724 to select the source IP. Therefore, test code that assumes the source IP is determined solely by the routing table (as in IPv4) may not reflect actual behavior in IPv6, leading to mismatches during switchover verification.