### PR TITLE
stand/lua manuals: Describe better

### DIFF
--- a/stand/lua/cli.lua.8
+++ b/stand/lua/cli.lua.8
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd July 24, 2021
+.Dd March 29, 2025
 .Dt CLI.LUA 8
 .Os
 .Sh NAME
 .Nm cli.lua
-.Nd FreeBSD Lua CLI module
+.Nd bootloader command line interpreter module
 .Sh DESCRIPTION
 .Nm
 contains the main functionality required to add new CLI commands, which can be

--- a/stand/lua/color.lua.8
+++ b/stand/lua/color.lua.8
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 19, 2018
+.Dd March 29, 2025
 .Dt COLOR.LUA 8
 .Os
 .Sh NAME
 .Nm color.lua
-.Nd FreeBSD color module
+.Nd bootloader color module
 .Sh DESCRIPTION
 .Nm
 contains functionality for working with colors.

--- a/stand/lua/config.lua.8
+++ b/stand/lua/config.lua.8
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 17, 2020
+.Dd March 29, 2025
 .Dt CONFIG.LUA 8
 .Os
 .Sh NAME
 .Nm config.lua
-.Nd FreeBSD config module
+.Nd bootloader configuration module
 .Sh DESCRIPTION
 .Nm
 contains configuration and module loading functionality.

--- a/stand/lua/core.lua.8
+++ b/stand/lua/core.lua.8
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 8, 2023
+.Dd March 29, 2025
 .Dt CORE.LUA 8
 .Os
 .Sh NAME
 .Nm core.lua
-.Nd FreeBSD core module
+.Nd bootloader core module
 .Sh DESCRIPTION
 .Nm
 contains core functionality that does not have a more fitting module.

--- a/stand/lua/drawer.lua.8
+++ b/stand/lua/drawer.lua.8
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 19, 2018
+.Dd March 29, 2025
 .Dt DRAWER.LUA 8
 .Os
 .Sh NAME
 .Nm drawer.lua
-.Nd FreeBSD menu/screen drawer module
+.Nd bootloader menu/screen drawer module
 .Sh DESCRIPTION
 .Nm
 contains functionality for drawing and manipulating the menu, logo, and brand

--- a/stand/lua/gfx.lua.8
+++ b/stand/lua/gfx.lua.8
@@ -3,12 +3,12 @@
 .\"
 .\" SPDX-License-Identifier: BSD-2-Clause
 .\"
-.Dd February 6, 2024
+.Dd March 29, 2025
 .Dt GFX.LUA 8
 .Os
 .Sh NAME
 .Nm gfx.lua
-.Nd Fx Lua gfx module
+.Nd bootloader graphics module
 .Sh DESCRIPTION
 The built-in graphics related Lua bindings for the
 .Fx

--- a/stand/lua/hook.lua.8
+++ b/stand/lua/hook.lua.8
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 28, 2020
+.Dd March 29, 2025
 .Dt HOOK.LUA 8
 .Os
 .Sh NAME
 .Nm hook.lua
-.Nd FreeBSD hook module
+.Nd bootloader hook module
 .Sh DESCRIPTION
 .Nm
 contains functionality for defining hook types and attaching hooks.

--- a/stand/lua/loader.conf.lua.5
+++ b/stand/lua/loader.conf.lua.5
@@ -29,7 +29,7 @@
 .Os
 .Sh NAME
 .Nm loader.conf.lua
-.Nd Lua-based system bootstrap configuration file
+.Nd system bootstrap Lua configuration information
 .Sh DESCRIPTION
 When the lua-based
 .Xr loader 8

--- a/stand/lua/loader.lua.8
+++ b/stand/lua/loader.lua.8
@@ -3,12 +3,12 @@
 .\"
 .\" SPDX-License-Identifier: BSD-2-Clause
 .\"
-.Dd February 6, 2024
+.Dd March 29, 2025
 .Dt LOADER.LUA 8
 .Os
 .Sh NAME
 .Nm loader.lua
-.Nd Fx Lua loader module
+.Nd bootloader Lua binding module
 .Sh DESCRIPTION
 The built-in Lua bindings for the
 .Fx

--- a/stand/lua/menu.lua.8
+++ b/stand/lua/menu.lua.8
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd March 31, 2021
+.Dd March 29, 2025
 .Dt MENU.LUA 8
 .Os
 .Sh NAME
 .Nm menu.lua
-.Nd FreeBSD dynamic menu boot module
+.Nd bootloader dynamic menu module
 .Sh DESCRIPTION
 .Nm
 contains the main functionality required to build a dynamic menu system.

--- a/stand/lua/password.lua.8
+++ b/stand/lua/password.lua.8
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 19, 2018
+.Dd March 29, 2025
 .Dt PASSWORD.LUA 8
 .Os
 .Sh NAME
 .Nm password.lua
-.Nd FreeBSD password module
+.Nd bootloader password module
 .Sh DESCRIPTION
 .Nm
 contains functionality for prompting for and checking passwords.

--- a/stand/lua/screen.lua.8
+++ b/stand/lua/screen.lua.8
@@ -24,12 +24,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 19, 2018
+.Dd March 29, 2025
 .Dt SCREEN.LUA 8
 .Os
 .Sh NAME
 .Nm screen.lua
-.Nd FreeBSD screen manipulation module
+.Nd bootloader screen manipulation module
 .Sh DESCRIPTION
 .Nm
 contains functionality for manipulating the screen.


### PR DESCRIPTION
Reword document descriptions to increase clarity for boot or loader searches, as well as the FreeBSD search term which we've been scoping to system topic overview manuals. Previously, the boot loader module manuals were getting pulled into search results for FreeBSD, but not for boot or loader.

MFC after:	3 days

@bsdimp @kevans91  @mhorne  @sergio-carlavilla