### PR TITLE
style.mdoc.5: Improve description compatability

### DIFF
--- a/share/man/man5/style.mdoc.5
+++ b/share/man/man5/style.mdoc.5
@@ -29,10 +29,7 @@
 .Os
 .Sh NAME
 .Nm style.mdoc
-.Nd
-.Fx
-.Xr mdoc 7
-manual page style guide
+.Nd FreeBSD manual page style guide
 .Sh DESCRIPTION
 This file specifies the preferred style for manual pages in the
 .Fx


### PR DESCRIPTION
Not all manual tooling supports name document description child macros, namely apropos. It is normally correct to use these macros, but don't use them in Nd for maximum compatibility.

MFC after:		3 days

@0mp @mhorne @sergio-carlavilla