### PR TITLE
pfctl.8: fix typo in reference to rc.conf variable

### DIFF
--- a/sbin/pfctl/pfctl.8
+++ b/sbin/pfctl/pfctl.8
@@ -82,7 +82,7 @@ Translation rules are described in
 .Xr pf.conf 5 .
 .Pp
 When the variable
-.Va pf
+.Va pf_enable
 is set to
 .Dv YES
 in


### PR DESCRIPTION
The `pfctl(8)` manpage refers to a `pf` variable in `rc.conf(5)` when it should be `pf_enable`.