### PR TITLE
Fix issue: ktrace_test:ktrace__cap_sockaddr

### DIFF
--- a/tests/sys/kern/ktrace_test.c
+++ b/tests/sys/kern/ktrace_test.c
@@ -397,7 +397,7 @@ ATF_TC_BODY(ktrace__cap_sockaddr, tc)
 		 * violation.
 		 */
 		CHILD_REQUIRE(sendto(sfd, NULL, 0, 0,
-		    (const struct sockaddr *)&addr, sizeof(addr)) != -1);
+		    (const struct sockaddr *)&addr, sizeof(addr)) == -1);
 		exit(0);
 	}
 


### PR DESCRIPTION
https://ci.freebsd.org/job/FreeBSD-main-amd64-test/26177/testReport/sys.kern/ktrace_test/ktrace__cap_sockaddr/

From the following POC program, we can figure out that the result of function `sendto` are supposed to be -1 when it violates capability to send data to forbidden addresses.

I guess this is because the behavior has been changed, the syscalls wouldn't fail due to capability violations before.
 
What do you think?

```
#include <sys/types.h>
#include <sys/socket.h>
#include <sys/capsicum.h>
#include <netinet/in.h>
#include <arpa/inet.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <err.h>

int main(void) {
    int sock;
    struct sockaddr_in bind_addr, forbidden_addr;
    ssize_t ret;

    sock = socket(AF_INET, SOCK_DGRAM, 0);
    if (sock < 0)
        err(1, "socket");

    memset(&bind_addr, 0, sizeof(bind_addr));
    bind_addr.sin_family = AF_INET;
    bind_addr.sin_port = htons(5000);
    inet_pton(AF_INET, "127.0.0.1", &bind_addr.sin_addr);

    if (bind(sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0)
        err(1, "bind");

    memset(&forbidden_addr, 0, sizeof(forbidden_addr));
    forbidden_addr.sin_family = AF_INET;
    forbidden_addr.sin_port = htons(9999);
    inet_pton(AF_INET, "127.0.0.1", &forbidden_addr.sin_addr);

    if (cap_enter() < 0)
        err(1, "cap_enter");

    ret = sendto(sock, "test", 4, 0, (struct sockaddr *)&forbidden_addr, sizeof(forbidden_addr));
    if (ret < 0) {
        perror("sendto");
    } else {
        printf("sendto returned %zd\n", ret);
    }

    return 0;
}
```
