### PR TITLE
bridge(4): allow a member's native vlan id to be configured

### DIFF
--- a/sbin/ifconfig/ifbridge.c
+++ b/sbin/ifconfig/ifbridge.c
@@ -211,6 +211,8 @@ bridge_status(if_ctx *ctx)
 			else
 				printf(" <unknown state %d>", state);
 		}
+		if (member->ifbr_pvid != 0)
+			printf(" pvid %u", (unsigned)member->ifbr_pvid);
 		printf("\n");
 	}
 
@@ -577,6 +579,24 @@ setbridge_ifpathcost(if_ctx *ctx, const char *ifn, const char *cost)
 }
 
 static void
+setbridge_ifpvid(if_ctx *ctx, const char *ifn, const char *vlanid)
+{
+	struct ifbreq req;
+	u_long val;
+
+	memset(&req, 0, sizeof(req));
+
+	if (get_val(vlanid, &val) < 0)
+		errx(1, "invalid value: %s", vlanid);
+
+	strlcpy(req.ifbr_ifsname, ifn, sizeof(req.ifbr_ifsname));
+	req.ifbr_pvid = val;
+
+	if (do_cmd(ctx, BRDGSIFPVID, &req, sizeof(req), 1) < 0)
+		err(1, "BRDGSIFPVID %s", vlanid);
+}
+
+static void
 setbridge_ifmaxaddr(if_ctx *ctx, const char *ifn, const char *arg)
 {
 	struct ifbreq req;
@@ -659,6 +679,7 @@ static struct cmd bridge_cmds[] = {
 	DEF_CMD_ARG2("ifpriority",	setbridge_ifpriority),
 	DEF_CMD_ARG2("ifpathcost",	setbridge_ifpathcost),
 	DEF_CMD_ARG2("ifmaxaddr",	setbridge_ifmaxaddr),
+	DEF_CMD_ARG2("ifpvid",		setbridge_ifpvid),
 	DEF_CMD_ARG("timeout",		setbridge_timeout),
 	DEF_CMD_ARG("private",		setbridge_private),
 	DEF_CMD_ARG("-private",		unsetbridge_private),

--- a/sbin/ifconfig/ifconfig.8
+++ b/sbin/ifconfig/ifconfig.8
@@ -28,7 +28,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 6, 2024
+.Dd April 2, 2025
 .Dt IFCONFIG 8
 .Os
 .Sh NAME
@@ -2696,6 +2696,11 @@ Set the maximum number of hosts allowed from an interface, packets with unknown
 source addresses are dropped until an existing host cache entry expires or is
 removed.
 Set to 0 to disable.
+.It Cm ifpvid Ar interface Ar vlan-id
+Set the Port VLAN ID (PVID, sometimes called native VLAN ID) for this
+interface.
+Incoming frames which do not have an 802.1Q VLAN tag will inherit the
+PVID from the interface on which they were received.
 .El
 .Ss Link Aggregation and Link Failover Parameters
 The following parameters are specific to lagg interfaces:

--- a/share/man/man4/bridge.4
+++ b/share/man/man4/bridge.4
@@ -36,7 +36,7 @@
 .\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd April 10, 2024
+.Dd April 2, 2025
 .Dt IF_BRIDGE 4
 .Os
 .Sh NAME
@@ -50,8 +50,8 @@ kernel configuration file:
 .Cd "device if_bridge"
 .Ed
 .Pp
-Alternatively, to load the driver as a
-module at boot time, place the following lines in
+Alternatively, to load the driver as a module at boot time, place the
+following lines in
 .Xr loader.conf 5 :
 .Bd -literal -offset indent
 if_bridge_load="YES"
@@ -60,18 +60,18 @@ bridgestp_load="YES"
 .Sh DESCRIPTION
 The
 .Nm
-driver creates a logical link between two or more IEEE 802 networks
-that use the same (or
+driver creates a logical link between two or more IEEE 802 networks that
+use the same (or
 .Dq "similar enough" )
 framing format.
-For example, it is possible to bridge Ethernet and 802.11 networks together,
-but it is not possible to bridge Ethernet and Token Ring together.
+For example, it is possible to bridge Ethernet and 802.11 networks
+together, but it is not possible to bridge Ethernet and Token Ring
+together.
 .Pp
 Each
 .Nm
 interface is created at runtime using interface cloning.
-This is
-most easily done with the
+This is most easily done with the
 .Xr ifconfig 8
 .Cm create
 command or using the
@@ -81,8 +81,8 @@ variable in
 .Pp
 The
 .Nm
-interface randomly chooses a link (MAC) address in the range reserved for
-locally administered addresses when it is created.
+interface randomly chooses a link (MAC) address in the range reserved
+for locally administered addresses when it is created.
 This address is guaranteed to be unique
 .Em only
 across all
@@ -112,12 +112,13 @@ by default.
 A bridge can be used to provide several services, such as a simple
 802.11-to-Ethernet bridge for wireless hosts, or traffic isolation.
 .Pp
-A bridge works like a switch, forwarding traffic from one interface
-to another.
-Multicast and broadcast packets are always forwarded to all
-interfaces that are part of the bridge.
-For unicast traffic, the bridge learns which MAC addresses are associated
-with which interfaces and will forward the traffic selectively.
+A bridge works like a switch, forwarding traffic from one interface to
+another.
+Multicast and broadcast packets are always forwarded to all interfaces
+that are part of the bridge.
+For unicast traffic, the bridge learns which MAC addresses are
+associated with which interfaces and will forward the traffic
+selectively.
 .Pp
 By default the bridge logs MAC address port flapping to
 .Xr syslog 3 .
@@ -128,8 +129,8 @@ variable
 to
 .Li 0 .
 .Pp
-All the bridged member interfaces need to be up
-in order to pass network traffic.
+All the bridged member interfaces need to be up in order to pass network
+traffic.
 These can be enabled using
 .Xr ifconfig 8
 or
@@ -137,15 +138,18 @@ or
 in
 .Xr rc.conf 5 .
 .Pp
-The MTU of the first member interface to be added is used as the bridge MTU.
+The MTU of the first member interface to be added is used as the bridge
+MTU.
 All additional members will have their MTU changed to match.
-If the MTU of a bridge is changed after its creation, the MTU of all member
-interfaces is also changed to match.
+If the MTU of a bridge is changed after its creation, the MTU of all
+member interfaces is also changed to match.
 .Pp
-The TOE, TSO, TXCSUM and TXCSUM6 capabilities on all interfaces added to the
-bridge are disabled if any of the interfaces do not support/enable them.
+The TOE, TSO, TXCSUM and TXCSUM6 capabilities on all interfaces added to
+the bridge are disabled if any of the interfaces do not support/enable
+them.
 The LRO capability is always disabled.
-All the capabilities are restored when the interface is removed from the bridge.
+All the capabilities are restored when the interface is removed from the
+bridge.
 Changing capabilities at run-time may cause NIC reinit and a link flap.
 .Pp
 The bridge supports
@@ -153,11 +157,12 @@ The bridge supports
 where the packets are discarded after
 .Xr bpf 4
 processing, and are not processed or forwarded further.
-This can be used to multiplex the input of two or more interfaces into a single
+This can be used to multiplex the input of two or more interfaces into a
+single
 .Xr bpf 4
 stream.
-This is useful for reconstructing the traffic for network taps
-that transmit the RX/TX signals out through two separate interfaces.
+This is useful for reconstructing the traffic for network taps that
+transmit the RX/TX signals out through two separate interfaces.
 .Sh IPV6 SUPPORT
 .Nm
 supports the
@@ -176,8 +181,8 @@ However, the
 .Li AF_INET6
 address family has a concept of scope zone.
 Bridging multiple interfaces changes the zone configuration because
-multiple links are merged to each other and form a new single link
-while the member interfaces still work individually.
+multiple links are merged to each other and form a new single link while
+the member interfaces still work individually.
 This means each member interface still has a separate link-local scope
 zone and the
 .Nm
@@ -188,16 +193,16 @@ This situation is clearly against the description
 in Section 5,
 RFC 4007.
 Although it works in most cases,
-it can cause some counterintuitive or undesirable behavior in some
-edge cases when both, the
+it can cause some counterintuitive or undesirable behavior in some edge
+cases when both the
 .Nm
-interface and one of the member interfaces, have an IPv6 address
+interface and one of the member interfaces have an IPv6 address
 and applications use both of them.
 .Pp
 To prevent this situation,
 .Nm
-checks whether a link-local scoped IPv6 address is configured on
-a member interface to be added and the
+checks whether a link-local scoped IPv6 address is configured on a
+member interface to be added and the
 .Nm
 interface.
 When the
@@ -232,14 +237,14 @@ driver implements the Rapid Spanning Tree Protocol (RSTP or 802.1w) with
 backwards compatibility with the legacy Spanning Tree Protocol (STP).
 Spanning Tree is used to detect and remove loops in a network topology.
 .Pp
-RSTP provides faster spanning tree convergence than legacy STP, the protocol
-will exchange information with neighbouring switches to quickly transition to
-forwarding without creating loops.
+RSTP provides faster spanning tree convergence than legacy STP, the
+protocol will exchange information with neighbouring switches to quickly
+transition to forwarding without creating loops.
 .Pp
-The code will default to RSTP mode but will downgrade any port connected to a
-legacy STP network so is fully backward compatible.
-A bridge can be forced to operate in STP mode without rapid state transitions
-via the
+The code will default to RSTP mode but will downgrade any port connected
+to a legacy STP network so is fully backward compatible.
+A bridge can be forced to operate in STP mode without rapid state
+transitions via the
 .Va proto
 command in
 .Xr ifconfig 8 .
@@ -250,13 +255,38 @@ by setting the
 .Va net.link.bridge.log_stp
 node using
 .Xr sysctl 8 .
+.Sh VLAN SUPPORT
+The
+.Nm
+driver has limited support for virtual LANs (VLANs).
+An incoming packet with an 802.1Q tag will be assigned to the
+appropriate VLAN.
+An interface's Port VLAN ID (PVID, sometimes called native VLAN ID) may
+be configured using the
+.Xr ifconfig 8
+.Cm ifpvid
+option; incoming packets with no 802.1Q tag (or where the VLAN ID in the
+tag is zero) will be assigned to the interface's PVID.
+.Pp
+An interface without a PVID configured will receive frames for all
+VLANs.
+An interface with a PVID configured will only receive frames for its
+configured PVID.
+In either case, if the incoming frame has an 802.1Q tag, the tag will be
+preserved in the output frame; if not, no tag will be added to the
+output frame.
+.Pp
+There is no support for adding or removing 802.1Q tags on outgoing
+frames, and for interfaces without a PVID configured, there is no way to
+restrict which VLANs the interface can send or receive frames for.
 .Sh PACKET FILTERING
-Packet filtering can be used with any firewall package that hooks in via the
+Packet filtering can be used with any firewall package that hooks in via
+the
 .Xr pfil 9
 framework.
 When filtering is enabled, bridged packets will pass through the filter
-inbound on the originating interface, on the bridge interface and outbound on
-the appropriate interfaces.
+inbound on the originating interface, on the bridge interface and
+outbound on the appropriate interfaces.
 Either stage can be disabled.
 The filtering behavior can be controlled using
 .Xr sysctl 8 :
@@ -279,14 +309,14 @@ to disable it.
 .It Va net.link.bridge.pfil_bridge
 Set to
 .Li 1
-to enable filtering on the bridge interface, set
-to
+to enable filtering on the bridge interface, set to
 .Li 0
 to disable it.
 .It Va net.link.bridge.pfil_local_phys
 Set to
 .Li 1
-to additionally filter on the physical interface for locally destined packets.
+to additionally filter on the physical interface for locally destined
+packets.
 Set to
 .Li 0
 to disable this feature.
@@ -307,8 +337,8 @@ is enabled,
 .Va pfil_bridge
 and
 .Va pfil_member
-will be disabled so that IPFW
-is not run twice; these can be re-enabled if desired.
+will be disabled so that IPFW is not run twice; these can be re-enabled
+if desired.
 .It Va net.link.bridge.ipfw_arp
 Set to
 .Li 1
@@ -328,38 +358,34 @@ that are not IP nor IPv6 packets are not forwarded when
 is enabled.
 IPFW can filter Ethernet types using
 .Cm mac-type
-so all packets are passed to
-the filter for processing.
+so all packets are passed to the filter for processing.
 .Pp
-The packets originating from the bridging host will be seen by
-the filter on the interface that is looked up in the routing
-table.
+The packets originating from the bridging host will be seen by the
+filter on the interface that is looked up in the routing table.
 .Pp
-The packets destined to the bridging host will be seen by the filter
-on the interface with the MAC address equal to the packet's destination
+The packets destined to the bridging host will be seen by the filter on
+the interface with the MAC address equal to the packet's destination
 MAC.
-There are situations when some of the bridge members are sharing
-the same MAC address (for example the
+There are situations when some of the bridge members are sharing the
+same MAC address (for example the
 .Xr vlan 4
-interfaces: they are currently sharing the
-MAC address of the parent physical interface).
-It is not possible to distinguish between these interfaces using
-their MAC address, excluding the case when the packet's destination
-MAC address is equal to the MAC address of the interface on which
-the packet was entered to the system.
-In this case the filter will see the incoming packet on this
-interface.
+interfaces: they are currently sharing the MAC address of the parent
+physical interface).
+It is not possible to distinguish between these interfaces using their
+MAC address, excluding the case when the packet's destination MAC
+address is equal to the MAC address of the interface on which the packet
+was entered to the system.
+In this case the filter will see the incoming packet on this interface.
 In all other cases the interface seen by the packet filter is chosen
-from the list of bridge members with the same MAC address and the
-result strongly depends on the member addition sequence and the
-actual implementation of
+from the list of bridge members with the same MAC address and the result
+strongly depends on the member addition sequence and the actual
+implementation of
 .Nm .
 It is not recommended to rely on the order chosen by the current
 .Nm
 implementation since it may change in the future.
 .Pp
-The previous paragraph is best illustrated with the following
-pictures.
+The previous paragraph is best illustrated with the following pictures.
 Let
 .Bl -bullet
 .It
@@ -376,8 +402,8 @@ MAC address is
 there are possibly other bridge members with the same MAC address
 .Nm xx:xx:xx:xx:xx:xx ,
 .It
-the bridge has more than one interface that are sharing the
-same MAC address
+the bridge has more than one interface that are sharing the same MAC
+address
 .Nm yy:yy:yy:yy:yy:yy ;
 we will call them
 .Nm vlanY1 ,
@@ -391,28 +417,28 @@ is equal to
 .Nm xx:xx:xx:xx:xx:xx
 the filter will see the packet on interface
 .Nm ifX
-no matter if there are any other bridge members carrying the same
-MAC address.
+no matter if there are any other bridge members carrying the same MAC
+address.
 But if the MAC address
 .Nm nn:nn:nn:nn:nn:nn
 is equal to
 .Nm yy:yy:yy:yy:yy:yy
 then the interface that will be seen by the filter is one of the
 .Nm vlanYn .
-It is not possible to predict the name of the actual interface
-without the knowledge of the system state and the
+It is not possible to predict the name of the actual interface without
+the knowledge of the system state and the
 .Nm
 implementation details.
 .Pp
-This problem arises for any bridge members that are sharing the same
-MAC address, not only to the
+This problem arises for any bridge members that are sharing the same MAC
+address, not only to the
 .Xr vlan 4
 ones: they were taken just as an example of such a situation.
-So if one wants to filter the locally destined packets based on
-their interface name, one should be aware of this implication.
+So if one wants to filter the locally destined packets based on their
+interface name, one should be aware of this implication.
 The described situation will appear at least on the filtering bridges
-that are doing IP-forwarding; in some of such cases it is better
-to assign the IP address only to the
+that are doing IP-forwarding; in some of such cases it is better to
+assign the IP address only to the
 .Nm
 interface and not to the bridge members.
 Enabling
@@ -428,18 +454,19 @@ member interface will be received by the netmap application.
 .Pp
 When the
 .Xr netmap 4
-application transmits a packet to the host stack via the bridge interface,
+application transmits a packet to the host stack via the bridge
+interface,
 .Nm
 receive it and attempts to determine its
 .Ql source
-interface by looking up the source MAC address in the interface's learning
-tables.
-Packets for which no matching source interface is found are dropped and the
-input error counter is incremented.
+interface by looking up the source MAC address in the interface's
+learning tables.
+Packets for which no matching source interface is found are dropped and
+the input error counter is incremented.
 If a matching source interface is found,
 .Nm
-treats the packet as though it was received from the corresponding interface
-and handles it normally without passing the packet back to
+treats the packet as though it was received from the corresponding
+interface and handles it normally without passing the packet back to
 .Xr netmap 4 .
 .Sh EXAMPLES
 The following when placed in the file
@@ -452,8 +479,8 @@ and
 .Dq Li fxp0
 to the bridge, and then enable packet forwarding.
 Such a configuration could be used to implement a simple
-802.11-to-Ethernet bridge (assuming the 802.11 interface is
-in ad-hoc mode).
+802.11-to-Ethernet bridge (assuming the 802.11 interface is in ad-hoc
+mode).
 .Bd -literal -offset indent
 cloned_interfaces="bridge0"
 ifconfig_bridge0="addm wlan0 addm fxp0 up"
@@ -469,8 +496,8 @@ ifconfig_fxp0="up"
 .Ed
 .Pp
 Consider a system with two 4-port Ethernet boards.
-The following will cause a bridge consisting of all 8 ports with
-Rapid Spanning Tree enabled to be created:
+The following will cause a bridge consisting of all 8 ports with Rapid
+Spanning Tree enabled to be created:
 .Bd -literal -offset indent
 ifconfig bridge0 create
 ifconfig bridge0 \e
@@ -485,10 +512,10 @@ ifconfig bridge0 \e
     up
 .Ed
 .Pp
-The bridge can be used as a regular host interface at the same time as bridging
-between its member ports.
-In this example, the bridge connects em0 and em1, and will receive its IP
-address through DHCP:
+The bridge can be used as a regular host interface at the same time as
+bridging between its member ports.
+In this example, the bridge connects em0 and em1, and will receive its
+IP address through DHCP:
 .Bd -literal -offset indent
 cloned_interfaces="bridge0"
 ifconfig_bridge0="addm em0 addm em1 DHCP"
@@ -503,8 +530,8 @@ This can be combined with
 to provide an encrypted connection.
 Create a
 .Xr gif 4
-interface and set the local and remote IP addresses for the
-tunnel, these are reversed on the remote bridge.
+interface and set the local and remote IP addresses for the tunnel,
+these are reversed on the remote bridge.
 .Bd -literal -offset indent
 ifconfig gif0 create
 ifconfig gif0 tunnel 1.2.3.4 5.6.7.8 up
@@ -529,8 +556,8 @@ The
 .Nm bridge
 driver was originally written by
 .An Jason L. Wright Aq Mt jason@thought.net
-as part of an undergraduate independent study at the University of
-North Carolina at Greensboro.
+as part of an undergraduate independent study at the University of North
+Carolina at Greensboro.
 .Pp
 This version of the
 .Nm
@@ -543,5 +570,5 @@ Rapid Spanning Tree Protocol (RSTP) support was added by
 The
 .Nm
 driver currently supports only Ethernet and Ethernet-like (e.g., 802.11)
-network devices, which can be configured with the same MTU size as the bridge
-device.
+network devices, which can be configured with the same MTU size as the
+bridge device.

--- a/sys/net/ethernet.h
+++ b/sys/net/ethernet.h
@@ -81,6 +81,11 @@ struct ether_addr {
 	  (addr)[3] | (addr)[4] | (addr)[5]) == 0x00)
 
 /*
+ * This is the type of the VLAN ID inside the tag, not the tag itself.
+ */
+typedef uint16_t ether_vlanid_t;
+
+/*
  * 802.1q Virtual LAN header.
  */
 struct ether_vlan_header {

--- a/sys/net/if_bridge.c
+++ b/sys/net/if_bridge.c
@@ -1852,7 +1852,7 @@ bridge_ioctl_sifpvid(struct bridge_softc *sc, void *arg)
 	if (bif == NULL)
 		return (ENOENT);
 
-	if (req->ifbr_pvid >= 4096)
+	if (req->ifbr_pvid > DOT1Q_VID_MAX)
 		return (EINVAL);
 
 	bif->bif_pvid = req->ifbr_pvid;

--- a/sys/net/if_bridgevar.h
+++ b/sys/net/if_bridgevar.h
@@ -122,6 +122,7 @@
 #define	BRDGSPROTO		28	/* set protocol (ifbrparam) */
 #define	BRDGSTXHC		29	/* set tx hold count (ifbrparam) */
 #define	BRDGSIFAMAX		30	/* set max interface addrs (ifbreq) */
+#define	BRDGSIFPVID		31	/* set if PVID */
 
 /*
  * Generic bridge control request.
@@ -139,7 +140,8 @@ struct ifbreq {
 	uint32_t	ifbr_addrcnt;		/* member if addr number */
 	uint32_t	ifbr_addrmax;		/* member if addr max */
 	uint32_t	ifbr_addrexceeded;	/* member if addr violations */
-	uint8_t		pad[32];
+	ether_vlanid_t	ifbr_pvid;		/* member if PVID */
+	uint8_t		pad[30];
 };
 
 /* BRDGGIFFLAGS, BRDGSIFFLAGS */

--- a/sys/net/if_bridgevar.h
+++ b/sys/net/if_bridgevar.h
@@ -190,7 +190,7 @@ struct ifbareq {
 	unsigned long	ifba_expire;		/* address expire time */
 	uint8_t		ifba_flags;		/* address flags */
 	uint8_t		ifba_dst[ETHER_ADDR_LEN];/* destination address */
-	uint16_t	ifba_vlan;		/* vlan id */
+	ether_vlanid_t	ifba_vlan;		/* vlan id */
 };
 
 #define	IFBAF_TYPEMASK	0x03	/* address type mask */

--- a/sys/net/if_vlan.c
+++ b/sys/net/if_vlan.c
@@ -1273,7 +1273,7 @@ vlan_clone_create_nl(struct if_clone *ifc, char *name, size_t len,
 	error = nl_parse_nested(lattrs->ifla_idata, &vlan_parser, npt, &attrs);
 	if (error != 0)
 		return (error);
-	if (attrs.vlan_id > 4095) {
+	if (attrs.vlan_id > DOT1Q_VID_MAX) {
 		nlmsg_report_err_msg(npt, "Invalid VID: %d", attrs.vlan_id);
 		return (EINVAL);
 	}

--- a/sys/net/if_vlan_var.h
+++ b/sys/net/if_vlan_var.h
@@ -130,6 +130,8 @@ struct	vlanreq {
 #define	DOT1Q_VID_DEF_PVID	0x1
 #define	DOT1Q_VID_DEF_SR_PVID	0x2
 #define	DOT1Q_VID_RSVD_IMPL	0xfff
+#define	DOT1Q_VID_MIN		1	/* minimum valid vlan id */
+#define	DOT1Q_VID_MAX		4095	/* maximum valid vlan id */
 
 /*
  * 802.1q full tag. Proto and vid are stored in host byte order.

--- a/tests/sys/net/if_bridge_test.sh
+++ b/tests/sys/net/if_bridge_test.sh
@@ -703,6 +703,82 @@ many_bridge_members_cleanup()
 	vnet_cleanup
 }
 
+atf_test_case "vlan_pvid" "cleanup"
+vlan_pvid_head()
+{
+	atf_set descr 'bridge with two ports with pvid set'
+	atf_set require.user root
+}
+
+vlan_pvid_body()
+{
+	vnet_init
+	vnet_init_bridge
+
+	epone=$(vnet_mkepair)
+	eptwo=$(vnet_mkepair)
+
+	vnet_mkjail one ${epone}b
+	vnet_mkjail two ${eptwo}b
+
+	jexec one ifconfig ${epone}b 192.0.2.1/24 up
+	jexec two ifconfig ${eptwo}b 192.0.2.2/24 up
+
+	bridge=$(vnet_mkbridge)
+
+	ifconfig ${bridge} up
+	ifconfig ${epone}a up
+	ifconfig ${eptwo}a up
+	ifconfig ${bridge} addm ${epone}a ifpvid ${epone}a 20
+	ifconfig ${bridge} addm ${eptwo}a ifpvid ${eptwo}a 20
+
+	atf_check -s exit:0 -o ignore jexec one ping -c 3 -t 1 192.0.2.2
+	atf_check -s exit:0 -o ignore jexec two ping -c 3 -t 1 192.0.2.1
+}
+
+vlan_pvid_cleanup()
+{
+	vnet_cleanup
+}
+
+atf_test_case "vlan_pvid_filtered" "cleanup"
+vlan_pvid_filtered_head()
+{
+	atf_set descr 'bridge with two ports with different pvids'
+	atf_set require.user root
+}
+
+vlan_pvid_filtered_body()
+{
+	vnet_init
+	vnet_init_bridge
+
+	epone=$(vnet_mkepair)
+	eptwo=$(vnet_mkepair)
+
+	vnet_mkjail one ${epone}b
+	vnet_mkjail two ${eptwo}b
+
+	jexec one ifconfig ${epone}b 192.0.2.1/24 up
+	jexec two ifconfig ${eptwo}b 192.0.2.2/24 up
+
+	bridge=$(vnet_mkbridge)
+
+	ifconfig ${bridge} up
+	ifconfig ${epone}a up
+	ifconfig ${eptwo}a up
+	ifconfig ${bridge} addm ${epone}a ifpvid ${epone}a 20
+	ifconfig ${bridge} addm ${eptwo}a ifpvid ${eptwo}a 30
+
+	atf_check -s exit:2 -o ignore jexec one ping -c 3 -t 1 192.0.2.2
+	atf_check -s exit:2 -o ignore jexec two ping -c 3 -t 1 192.0.2.1
+}
+
+vlan_pvid_filtered_cleanup()
+{
+	vnet_cleanup
+}
+
 atf_init_test_cases()
 {
 	atf_add_test_case "bridge_transmit_ipv4_unicast"
@@ -718,4 +794,6 @@ atf_init_test_cases()
 	atf_add_test_case "mtu"
 	atf_add_test_case "vlan"
 	atf_add_test_case "many_bridge_members"
+	atf_add_test_case "vlan_pvid"
+	atf_add_test_case "vlan_pvid_filtered"
 }


### PR DESCRIPTION
* add support for a new ifconfig option, `ifpvid <interface> <vlanid>`, which can be used to set the native vlan ID on a bridge member.
* in bridge(4), filter outgoing frames so that they are only sent to interfaces whose native vlan ID is the same as the frame's VLAN ID
* if the interface's VLAN ID is zero (the default) it receives all frames, for backward compatibility.

this is NOT "vlan filtering" (in the Linux sense) and it's not proper access/trunk port support for bridge(4).  however, it's a necessary step to enable proper VLAN support in bridge in the future, and in the mean time, it's a useful self-contained feature.

this change is 100% backward compatible, since if an interface has no VLAN ID configured, it will receive all frames, just like it did before.

i've used `uint32_t` for VLAN ID in bridge(4) so we can support VXLANs in the future, but i haven't changed the userland ABI to avoid breaking the ABI for no reason (yet).