### PR TITLE
timeout(1): Sync from DragonFly BSD

### DIFF
--- a/bin/timeout/timeout.1
+++ b/bin/timeout/timeout.1
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 2, 2025
+.Dd April 3, 2025
 .Dt TIMEOUT 1
 .Os
 .Sh NAME
@@ -64,6 +64,14 @@ zero, signifies no limit.
 Therefore, a signal is never sent if
 .Ar duration
 is 0.
+.Pp
+The signal dispositions inherited by the
+.Ar command
+are the same as the dispositions that
+.Nm
+inherited, except for the signal that will be sent upon timeout,
+which is reset to take the default action and should terminate
+the process.
 .Pp
 The options are as follows:
 .Bl -tag -width indent

--- a/bin/timeout/timeout.1
+++ b/bin/timeout/timeout.1
@@ -1,6 +1,7 @@
 .\" SPDX-License-Identifier: BSD-2-Clause
 .\"
 .\" Copyright (c) 2014 Baptiste Daroussin <bapt@FreeBSD.org>
+.\" Copyright (c) 2025 Aaron LI <aly@aaronly.me>
 .\" All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -101,6 +102,9 @@ The options are as follows:
 Only time out the
 .Ar command
 itself, but do not propagate signals to its descendants.
+See the
+.Sx IMPLEMENTATION NOTES
+section for more details.
 .It Fl k Ar time , Fl -kill-after Ar time
 Send a
 .Dv SIGKILL
@@ -145,6 +149,30 @@ hours
 .It Cm d
 days
 .El
+.Sh IMPLEMENTATION NOTES
+If the
+.Fl -foreground
+option is not specified,
+.Nm
+runs as the reaper (see also
+.Xr procctl 2 )
+of the
+.Ar command
+and its descendants, and will wait for all the descendants to terminate.
+This behavior might cause surprises if there are descendants running
+in the background, because they will ignore
+.Dv SIGINT
+and
+.Dv SIGQUIT
+signals.
+For example, the following command that sends a
+.Dv SIGTERM
+signal will complete in 2 seconds:
+.Dl $ timeout -s TERM 2 sh -c 'sleep 4 & sleep 5'
+However, this command that sends a
+.Dv SIGINT
+signal will complete in 4 seconds:
+.Dl $ timeout -s INT 2 sh -c 'sleep 4 & sleep 5'
 .Sh EXIT STATUS
 If the time limit was reached and the
 .Fl -preserve-status
@@ -247,9 +275,9 @@ The
 command first appeared in
 .Fx 10.3 .
 .Pp
-The
+The initial
 .Fx
-work is compatible with GNU
+work was compatible with GNU
 .Nm
 by
 .An Padraig Brady ,
@@ -258,6 +286,7 @@ The
 .Nm
 utility first appeared in GNU Coreutils 7.0.
 .Sh AUTHORS
-.An Baptiste Daroussin Aq Mt bapt@FreeBSD.org
-and
+.An Baptiste Daroussin Aq Mt bapt@FreeBSD.org ,
 .An Vsevolod Stakhov Aq Mt vsevolod@FreeBSD.org
+and
+.An Aaron LI Aq Mt aly@aaronly.me

--- a/bin/timeout/timeout.1
+++ b/bin/timeout/timeout.1
@@ -32,11 +32,11 @@
 .Nd run a command with a time limit
 .Sh SYNOPSIS
 .Nm
+.Op Fl f | Fl -foreground
 .Op Fl k Ar time | Fl -kill-after Ar time
+.Op Fl p | Fl -preserve-status
 .Op Fl s Ar signal | Fl -signal Ar signal
 .Op Fl v | Fl -verbose
-.Op Fl -foreground
-.Op Fl -preserve-status
 .Ar duration
 .Ar command
 .Op Ar arg ...
@@ -67,7 +67,7 @@ is 0.
 .Pp
 The options are as follows:
 .Bl -tag -width indent
-.It Fl -foreground
+.It Fl f , Fl -foreground
 Only time out the
 .Ar command
 itself, but do not propagate signals to its descendants.
@@ -79,7 +79,7 @@ signal if
 is still running after
 .Ar time
 since the first signal was sent.
-.It Fl -preserve-status
+.It Fl p , Fl -preserve-status
 Always exit with the same status as
 .Ar command ,
 even if the timeout was reached.

--- a/bin/timeout/timeout.1
+++ b/bin/timeout/timeout.1
@@ -73,6 +73,28 @@ inherited, except for the signal that will be sent upon timeout,
 which is reset to take the default action and should terminate
 the process.
 .Pp
+If
+.Nm
+receives the
+.Dv SIGALRM
+signal, it will behave as if the time limit has been reached
+and send the specified signal to
+.Ar command .
+For any other signals delivered to
+.Nm ,
+it will propagate them to
+.Ar command ,
+with the exception of
+.Dv SIGKILL
+and
+.Dv SIGSTOP .
+If you want to prevent the
+.Ar command
+from being timed out, send
+.Dv SIGKILL
+to
+.Nm .
+.Pp
 The options are as follows:
 .Bl -tag -width indent
 .It Fl f , Fl -foreground

--- a/bin/timeout/timeout.1
+++ b/bin/timeout/timeout.1
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 4, 2025
+.Dd April 2, 2025
 .Dt TIMEOUT 1
 .Os
 .Sh NAME
@@ -33,36 +33,44 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl k Ar time | Fl -kill-after Ar time
-.Op Fl s Ar sig | Fl -signal Ar sig
+.Op Fl s Ar signal | Fl -signal Ar signal
 .Op Fl v | Fl -verbose
 .Op Fl -foreground
 .Op Fl -preserve-status
 .Ar duration
 .Ar command
-.Op Ar args ...
+.Op Ar arg ...
 .Sh DESCRIPTION
-.Nm
+.Nm Timeout
 starts the
 .Ar command
 with its
-.Ar args .
+.Ar arg
+list.
 If the
 .Ar command
 is still running after
 .Ar duration ,
-it is killed.
-By default,
+it is killed by sending the
+.Ar signal ,
+or
 .Dv SIGTERM
-is sent.
+if the
+.Fl s
+option is unspecified.
 The special
 .Ar duration ,
 zero, signifies no limit.
-Therefore a signal is never sent if
+Therefore, a signal is never sent if
 .Ar duration
 is 0.
 .Pp
 The options are as follows:
 .Bl -tag -width indent
+.It Fl -foreground
+Only time out the
+.Ar command
+itself, but do not propagate signals to its descendants.
 .It Fl k Ar time , Fl -kill-after Ar time
 Send a
 .Dv SIGKILL
@@ -70,32 +78,29 @@ signal if
 .Ar command
 is still running after
 .Ar time
-after the first signal was sent.
-.It Fl s Ar sig , Fl -signal Ar sig
+since the first signal was sent.
+.It Fl -preserve-status
+Always exit with the same status as
+.Ar command ,
+even if the timeout was reached.
+.It Fl s Ar signal , Fl -signal Ar signal
 Specify the signal to send on timeout.
 By default,
 .Dv SIGTERM
 is sent.
 .It Fl v , Fl -verbose
 Show information to stderr about any signal sent on timeout.
-.It Fl -foreground
-Do not propagate timeout to the children of
-.Ar command .
-.It Fl -preserve-status
-Exit with the same status as
-.Ar command ,
-even if it times out and is killed.
 .El
-.Sh DURATION FORMAT
+.Ss Duration Format
 The
 .Ar duration
 and
 .Ar time
 are non-negative integer or real (decimal) numbers, with an optional
-unit-specifying suffix.
+suffix specifying the unit.
 Values without an explicit unit are interpreted as seconds.
 .Pp
-Supported unit symbols are:
+Supported unit suffixes are:
 .Bl -tag -offset indent -width indent -compact
 .It Cm s
 seconds
@@ -152,9 +157,9 @@ $ echo $?
 Run
 .Xr sleep 1
 for 4 seconds and terminate process after 2 seconds.
-124 is returned since no
+The exit status is 124 since
 .Fl -preserve-status
-is used:
+is not used:
 .Bd -literal -offset indent
 $ timeout 2 sleep 4
 $ echo $?
@@ -162,8 +167,8 @@ $ echo $?
 .Ed
 .Pp
 Same as above but preserving status.
-Exit status is 128 + signal number (15 for
-.Va SIGTERM ) :
+The exit status is 128 + signal number (15 for
+.Dv SIGTERM ) :
 .Bd -literal -offset indent
 $ timeout --preserve-status 2 sleep 4
 $ echo $?
@@ -171,9 +176,9 @@ $ echo $?
 .Ed
 .Pp
 Same as above but sending
-.Va SIGALRM
+.Dv SIGALRM
 (signal number 14) instead of
-.Va SIGTERM :
+.Dv SIGTERM :
 .Bd -literal -offset indent
 $ timeout --preserve-status -s SIGALRM 2 sleep 4
 $ echo $?
@@ -186,9 +191,9 @@ the PDF version of the
 .Fx
 Handbook.
 Send a
-.Va SIGTERM
+.Dv SIGTERM
 signal after 1 minute and send a
-.Va SIGKILL
+.Dv SIGKILL
 signal 5 seconds later if the process refuses to stop:
 .Bd -literal -offset indent
 $ timeout -k 5s 1m fetch \\
@@ -202,7 +207,7 @@ $ timeout -k 5s 1m fetch \\
 .Sh STANDARDS
 The
 .Nm
-utility is compliant with the
+utility is expected to conform to the
 .St -p1003.1-2024
 specification.
 .Sh HISTORY

--- a/bin/timeout/timeout.1
+++ b/bin/timeout/timeout.1
@@ -146,37 +146,33 @@ hours
 days
 .El
 .Sh EXIT STATUS
-If the timeout was not reached, the exit status of
-.Ar command
-is returned.
-.Pp
-If the timeout was reached and
+If the time limit was reached and the
 .Fl -preserve-status
-is set, the exit status of
+option is not specified, the exit status is 124.
+Otherwise,
+.Nm
+exits with the same exit status as the
+.Ar command .
+For example,
+.Nm
+will terminate itself with the same signal if the
 .Ar command
-is returned.
-If
-.Fl -preserve-status
-is not set, an exit status of 124 is returned.
+is terminated by a signal.
 .Pp
-If an invalid parameter is passed to
-.Fl s
-or
-.Fl k ,
-the exit status returned is 125.
-.Pp
-If
+If an error occurred, the following exit values are returned:
+.Bl -tag -offset indent with indent -compact
+.It 125
+An error other than the two described below occurred.
+For example, an invalid duration or signal was specified.
+.It 126
+The
 .Ar command
-is an otherwise invalid program, the exit status returned is 126.
-.Pp
-If
+was found but could not be executed.
+.It 127
+The
 .Ar command
-refers to a non-existing program, the exit status returned is 127.
-.Pp
-If
-.Ar command
-exits after receiving a signal, the exit status returned is the signal number
-plus 128.
+could not be found.
+.El
 .Sh EXAMPLES
 Run
 .Xr sleep 1
@@ -202,7 +198,8 @@ $ echo $?
 .Pp
 Same as above but preserving status.
 The exit status is 128 + signal number (15 for
-.Dv SIGTERM ) :
+.Dv SIGTERM )
+for most shells:
 .Bd -literal -offset indent
 $ timeout --preserve-status 2 sleep 4
 $ echo $?

--- a/bin/timeout/timeout.1
+++ b/bin/timeout/timeout.1
@@ -89,7 +89,11 @@ By default,
 .Dv SIGTERM
 is sent.
 .It Fl v , Fl -verbose
-Show information to stderr about any signal sent on timeout.
+Show information to
+.Xr stderr 4
+about timeouts, signals to be sent, and the
+.Ar command
+exits.
 .El
 .Ss Duration Format
 The

--- a/bin/timeout/timeout.c
+++ b/bin/timeout/timeout.c
@@ -344,6 +344,19 @@ main(int argc, char **argv)
 				} else if (cpid == pid) {
 					pstat = status;
 					child_done = true;
+					logv("child terminated: pid=%d, "
+					     "exit=%d, signal=%d",
+					     (int)pid, WEXITSTATUS(status),
+					     WTERMSIG(status));
+				} else {
+					/*
+					 * Collect grandchildren zombies.
+					 * Only effective if we're a reaper.
+					 */
+					logv("collected zombie: pid=%d, "
+					     "exit=%d, signal=%d",
+					     (int)cpid, WEXITSTATUS(status),
+					     WTERMSIG(status));
 				}
 			}
 			if (child_done) {
@@ -361,9 +374,12 @@ main(int argc, char **argv)
 				sig = killsig;
 				sig_alrm = 0;
 				timedout = true;
+				logv("time limit reached or received SIGALRM");
 			} else {
 				sig = sig_term;
 				sig_term = 0;
+				logv("received terminating signal %s(%d)",
+				     sys_signame[sig], sig);
 			}
 
 			send_sig(pid, sig, foreground);

--- a/bin/timeout/timeout.c
+++ b/bin/timeout/timeout.c
@@ -68,19 +68,19 @@ static double
 parse_duration(const char *duration)
 {
 	double ret;
-	char *end;
+	char *suffix;
 
-	ret = strtod(duration, &end);
-	if (ret == 0 && end == duration)
-		errx(EXIT_INVALID, "invalid duration");
+	ret = strtod(duration, &suffix);
+	if (suffix == duration)
+		errx(EXIT_INVALID, "duration is not a number");
 
-	if (end == NULL || *end == '\0')
+	if (*suffix == '\0')
 		return (ret);
 
-	if (end != NULL && *(end + 1) != '\0')
-		errx(EXIT_INVALID, "invalid duration");
+	if (suffix[1] != '\0')
+		errx(EXIT_INVALID, "duration unit suffix too long");
 
-	switch (*end) {
+	switch (*suffix) {
 	case 's':
 		break;
 	case 'm':
@@ -93,11 +93,11 @@ parse_duration(const char *duration)
 		ret *= 60 * 60 * 24;
 		break;
 	default:
-		errx(EXIT_INVALID, "invalid duration");
+		errx(EXIT_INVALID, "duration unit suffix invalid");
 	}
 
 	if (ret < 0 || ret >= 100000000UL)
-		errx(EXIT_INVALID, "invalid duration");
+		errx(EXIT_INVALID, "duration out of range");
 
 	return (ret);
 }

--- a/bin/timeout/timeout.c
+++ b/bin/timeout/timeout.c
@@ -45,10 +45,10 @@
 #define EXIT_CMD_ERROR 126
 #define EXIT_CMD_NOENT 127
 
-static sig_atomic_t sig_chld = 0;
-static sig_atomic_t sig_term = 0;
-static sig_atomic_t sig_alrm = 0;
-static sig_atomic_t sig_ign = 0;
+static volatile sig_atomic_t sig_chld = 0;
+static volatile sig_atomic_t sig_term = 0;
+static volatile sig_atomic_t sig_alrm = 0;
+static volatile sig_atomic_t sig_ign = 0;
 static const char *command = NULL;
 static bool verbose = false;
 

--- a/bin/timeout/timeout.c
+++ b/bin/timeout/timeout.c
@@ -49,7 +49,6 @@
 static volatile sig_atomic_t sig_chld = 0;
 static volatile sig_atomic_t sig_term = 0;
 static volatile sig_atomic_t sig_alrm = 0;
-static volatile sig_atomic_t sig_ign = 0;
 static const char *command = NULL;
 static bool verbose = false;
 
@@ -138,11 +137,6 @@ parse_signal(const char *str)
 static void
 sig_handler(int signo)
 {
-	if (sig_ign != 0 && signo == sig_ign) {
-		sig_ign = 0;
-		return;
-	}
-
 	switch (signo) {
 	case SIGINT:
 	case SIGHUP:
@@ -377,17 +371,9 @@ main(int argc, char **argv)
 			if (do_second_kill) {
 				set_interval(second_kill);
 				do_second_kill = false;
-				sig_ign = killsig;
 				killsig = SIGKILL;
-			} else {
-				break;
 			}
 		}
-	}
-
-	while (!child_done && wait(&pstat) == -1) {
-		if (errno != EINTR)
-			err(EXIT_FAILURE, "wait()");
 	}
 
 	if (!foreground)

--- a/bin/timeout/timeout.c
+++ b/bin/timeout/timeout.c
@@ -56,8 +56,8 @@ static void __dead2
 usage(void)
 {
 	fprintf(stderr,
-		"Usage: %s [--foreground] [-k time | --kill-after time]"
-		" [--preserve-status] [-s signal | --signal signal] "
+		"Usage: %s [-f | --foreground] [-k time | --kill-after time]"
+		" [-p | --preserve-status] [-s signal | --signal signal] "
 		" [-v | --verbose] <duration> <command> [arg ...]\n",
 		getprogname());
 	exit(EXIT_FAILURE);
@@ -175,13 +175,14 @@ int
 main(int argc, char **argv)
 {
 	int ch, status, sig;
-	int foreground, preserve;
 	int pstat = 0;
 	int killsig = SIGTERM;
 	size_t i;
 	pid_t pid, cpid;
 	double first_kill;
-	double second_kill;
+	double second_kill = 0;
+	bool foreground = false;
+	bool preserve = false;
 	bool timedout = false;
 	bool do_second_kill = false;
 	bool child_done = false;
@@ -198,24 +199,28 @@ main(int argc, char **argv)
 		SIGQUIT,
 	};
 
-	foreground = preserve = 0;
-	second_kill = 0;
-
+	const char optstr[] = "+fhk:ps:v";
 	const struct option longopts[] = {
-		{ "foreground",      no_argument,       &foreground,  1  },
-		{ "help",            no_argument,       NULL,        'h' },
-		{ "kill-after",      required_argument, NULL,        'k' },
-		{ "preserve-status", no_argument,       &preserve,    1  },
-		{ "signal",          required_argument, NULL,        's' },
-		{ "verbose",         no_argument,       NULL,        'v' },
-		{ NULL,              0,                 NULL,         0  },
+		{ "foreground",      no_argument,       NULL, 'f' },
+		{ "help",            no_argument,       NULL, 'h' },
+		{ "kill-after",      required_argument, NULL, 'k' },
+		{ "preserve-status", no_argument,       NULL, 'p' },
+		{ "signal",          required_argument, NULL, 's' },
+		{ "verbose",         no_argument,       NULL, 'v' },
+		{ NULL,              0,                 NULL,  0  },
 	};
 
-	while ((ch = getopt_long(argc, argv, "+k:s:vh", longopts, NULL)) != -1) {
+	while ((ch = getopt_long(argc, argv, optstr, longopts, NULL)) != -1) {
 		switch (ch) {
+		case 'f':
+			foreground = true;
+			break;
 		case 'k':
 			do_second_kill = true;
 			second_kill = parse_duration(optarg);
+			break;
+		case 'p':
+			preserve = true;
 			break;
 		case 's':
 			killsig = parse_signal(optarg);

--- a/bin/timeout/timeout.c
+++ b/bin/timeout/timeout.c
@@ -1,6 +1,7 @@
 /*-
  * Copyright (c) 2014 Baptiste Daroussin <bapt@FreeBSD.org>
  * Copyright (c) 2014 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2025 Aaron LI <aly@aaronly.me>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,8 +48,10 @@
 #define EXIT_CMD_NOENT	127
 
 static volatile sig_atomic_t sig_chld = 0;
-static volatile sig_atomic_t sig_term = 0;
 static volatile sig_atomic_t sig_alrm = 0;
+static volatile sig_atomic_t sig_term = 0; /* signal to terminate children */
+static volatile sig_atomic_t sig_other = 0; /* signal to propagate */
+static int killsig = SIGTERM; /* signal to kill children */
 static const char *command = NULL;
 static bool verbose = false;
 
@@ -137,18 +140,45 @@ parse_signal(const char *str)
 static void
 sig_handler(int signo)
 {
-	switch (signo) {
-	case SIGINT:
-	case SIGHUP:
-	case SIGQUIT:
-	case SIGTERM:
+	if (signo == killsig) {
 		sig_term = signo;
-		break;
+		return;
+	}
+
+	switch (signo) {
 	case SIGCHLD:
 		sig_chld = 1;
 		break;
 	case SIGALRM:
 		sig_alrm = 1;
+		break;
+	case SIGHUP:
+	case SIGINT:
+	case SIGQUIT:
+	case SIGILL:
+	case SIGTRAP:
+	case SIGABRT:
+	case SIGEMT:
+	case SIGFPE:
+	case SIGBUS:
+	case SIGSEGV:
+	case SIGSYS:
+	case SIGPIPE:
+	case SIGTERM:
+	case SIGXCPU:
+	case SIGXFSZ:
+	case SIGVTALRM:
+	case SIGPROF:
+	case SIGUSR1:
+	case SIGUSR2:
+		/*
+		 * Signals with default action to terminate the process.
+		 * See the sigaction(2) man page.
+		 */
+		sig_term = signo;
+		break;
+	default:
+		sig_other = signo;
 		break;
 	}
 }
@@ -214,8 +244,6 @@ main(int argc, char **argv)
 {
 	int ch, status, sig;
 	int pstat = 0;
-	int killsig = SIGTERM;
-	size_t i;
 	pid_t pid, cpid;
 	double first_kill;
 	double second_kill = 0;
@@ -225,17 +253,8 @@ main(int argc, char **argv)
 	bool do_second_kill = false;
 	bool child_done = false;
 	sigset_t zeromask, allmask, oldmask;
-	struct sigaction signals;
+	struct sigaction sa;
 	struct procctl_reaper_status info;
-	int signums[] = {
-		-1,
-		SIGTERM,
-		SIGINT,
-		SIGHUP,
-		SIGCHLD,
-		SIGALRM,
-		SIGQUIT,
-	};
 
 	const char optstr[] = "+fhk:ps:v";
 	const struct option longopts[] = {
@@ -316,22 +335,17 @@ main(int argc, char **argv)
 
 	/* parent continues here */
 
-	memset(&signals, 0, sizeof(signals));
-	sigemptyset(&signals.sa_mask);
-
-	if (killsig != SIGKILL && killsig != SIGSTOP)
-		signums[0] = killsig;
-
-	for (i = 0; i < sizeof(signums) / sizeof(signums[0]); i++)
-		sigaddset(&signals.sa_mask, signums[i]);
-
-	signals.sa_handler = sig_handler;
-	signals.sa_flags = SA_RESTART;
-
-	for (i = 0; i < sizeof(signums) / sizeof(signums[0]); i++) {
-		if (signums[i] > 0 &&
-		    sigaction(signums[i], &signals, NULL) == -1)
-			err(EXIT_FAILURE, "sigaction()");
+	/* Catch all signals in order to propagate them. */
+	memset(&sa, 0, sizeof(sa));
+	sigfillset(&sa.sa_mask);
+	sa.sa_handler = sig_handler;
+	sa.sa_flags = SA_RESTART;
+	for (sig = 1; sig < sys_nsig; sig++) {
+		if (sig == SIGKILL || sig == SIGSTOP || sig == SIGCONT ||
+		    sig == SIGTTIN || sig == SIGTTOU)
+			continue;
+		if (sigaction(sig, &sa, NULL) == -1)
+			err(EXIT_FAILURE, "sigaction(%d)", sig);
 	}
 
 	/* Don't stop if background child needs TTY */
@@ -399,6 +413,14 @@ main(int argc, char **argv)
 				do_second_kill = false;
 				killsig = SIGKILL;
 			}
+
+		} else if (sig_other) {
+			/* Propagate any other signals. */
+			sig = sig_other;
+			sig_other = 0;
+			logv("received signal %s(%d)", sys_signame[sig], sig);
+
+			send_sig(pid, sig, foreground);
 		}
 	}
 

--- a/bin/timeout/timeout.c
+++ b/bin/timeout/timeout.c
@@ -178,7 +178,7 @@ main(int argc, char **argv)
 {
 	int ch;
 	int foreground, preserve;
-	int error, pstat, status;
+	int pstat, status;
 	int killsig = SIGTERM;
 	size_t i;
 	pid_t pid, cpid;
@@ -280,13 +280,9 @@ main(int argc, char **argv)
 		signal(SIGTTIN, SIG_DFL);
 		signal(SIGTTOU, SIG_DFL);
 
-		error = execvp(argv[0], argv);
-		if (error == -1) {
-			if (errno == ENOENT)
-				err(EXIT_CMD_NOENT, "exec(%s)", argv[0]);
-			else
-				err(EXIT_CMD_ERROR, "exec(%s)", argv[0]);
-		}
+		execvp(argv[0], argv);
+		warn("exec(%s)", argv[0]);
+		_exit(errno == ENOENT ? EXIT_CMD_NOENT : EXIT_CMD_ERROR);
 	}
 
 	if (sigprocmask(SIG_BLOCK, &signals.sa_mask, NULL) == -1)


### PR DESCRIPTION
The timeout(1) utility in DragonFly BSD has recently been updated and improved to conform to the [POSIX.1-2024 Standard](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/timeout.html).  Sync the changes over.

@bapt 