### PR TITLE
Remove testcase sys.netinet.fibs_test.same_ip_multiple_ifaces_fib0.

### DIFF
--- a/tests/sys/netinet/fibs_test.sh
+++ b/tests/sys/netinet/fibs_test.sh
@@ -297,45 +297,6 @@ default_route_with_multiple_fibs_on_same_subnet_inet6_cleanup()
 	cleanup_ifaces
 }
 
-
-# Regression test for PR kern/189089
-# Create two tap interfaces and assign them both the same IP address but with
-# different netmasks, and both on the default FIB.  Then remove one's IP
-# address.  Hopefully the machine won't panic.
-atf_test_case same_ip_multiple_ifaces_fib0 cleanup
-same_ip_multiple_ifaces_fib0_head()
-{
-	atf_set "descr" "Can remove an IPv4 alias from an interface when the same IPv4 is also assigned to another interface."
-	atf_set "require.user" "root"
-}
-same_ip_multiple_ifaces_fib0_body()
-{
-	ADDR="192.0.2.2"
-	MASK0="24"
-	MASK1="32"
-
-	# Unlike most of the tests in this file, this is applicable regardless
-	# of net.add_addr_allfibs
-
-	# Setup the interfaces, then remove one alias.  It should not panic.
-	setup_tap 0 inet ${ADDR} ${MASK0}
-	TAP0=${TAP}
-	setup_tap 0 inet ${ADDR} ${MASK1}
-	TAP1=${TAP}
-	ifconfig ${TAP1} -alias ${ADDR}
-
-	# Do it again, in the opposite order.  It should not panic.
-	setup_tap 0 inet ${ADDR} ${MASK0}
-	TAP0=${TAP}
-	setup_tap 0 inet ${ADDR} ${MASK1}
-	TAP1=${TAP}
-	ifconfig ${TAP0} -alias ${ADDR}
-}
-same_ip_multiple_ifaces_fib0_cleanup()
-{
-	cleanup_ifaces
-}
-
 # Regression test for PR kern/189088
 # Test that removing an IP address works even if the same IP is assigned to a
 # different interface, on a different FIB.  Tests the same code that whose
@@ -715,7 +676,6 @@ atf_init_test_cases()
 	atf_add_test_case loopback_and_network_routes_on_nondefault_fib_inet6
 	atf_add_test_case default_route_with_multiple_fibs_on_same_subnet
 	atf_add_test_case default_route_with_multiple_fibs_on_same_subnet_inet6
-	atf_add_test_case same_ip_multiple_ifaces_fib0
 	atf_add_test_case same_ip_multiple_ifaces
 	atf_add_test_case same_ip_multiple_ifaces_inet6
 	atf_add_test_case slaac_on_nondefault_fib6


### PR DESCRIPTION
https://ci.freebsd.org/job/FreeBSD-main-amd64-test/26201/testReport/sys.netinet/fibs_test/same_ip_multiple_ifaces_fib0/

The original test behavior: Create two tap interfaces and assign them both the same IP address with different netmasks on the default FIB, and then remove one's IP. Test if the machine panic or not.

However, it is not allowed to assign same ip address to two interfaces with different netmasks.

https://github.com/freebsd/freebsd-src/pull/1631