### PR TITLE
bridge: define VLANTAGOF correctly

### DIFF
--- a/sys/net/if_bridge.c
+++ b/sys/net/if_bridge.c
@@ -419,7 +419,7 @@ static void	bridge_linkcheck(struct bridge_softc *sc);
  * to indicate untagged frames.
  */
 #define	VLANTAGOF(_m)	\
-    (_m->m_flags & M_VLANTAG) ? EVL_VLANOFTAG(_m->m_pkthdr.ether_vtag) : DOT1Q_VID_NULL
+    ((_m->m_flags & M_VLANTAG) ? EVL_VLANOFTAG(_m->m_pkthdr.ether_vtag) : DOT1Q_VID_NULL)
 
 static struct bstp_cb_ops bridge_ops = {
 	.bcb_state = bridge_state_change,


### PR DESCRIPTION
to avoid strange precedence errors, enclose the macro body in parentheses.  this fixes constructs like: if (VLANTAGOF(m) == i)