### PR TITLE
netstat(1): add description for option -o and -O.

### DIFF
--- a/usr.bin/netstat/netstat.1
+++ b/usr.bin/netstat/netstat.1
@@ -191,6 +191,10 @@ and the third count is the maximum number of queued connections.
 Do not resolve numeric addresses and port numbers to names.
 See
 .Sx GENERAL OPTIONS .
+.It Fl o
+Print nexthop (nhops) information associated with routing entries.
+.It Fl O
+Print nexthop groups (nhgrp) information associated with routing entries.
 .It Fl P
 Display the log ID for each socket.
 .It Fl R


### PR DESCRIPTION
They are added in 
- https://github.com/freebsd/freebsd-src/commit/fedeb08b6a58e708e1153224d37ad26bdc1062a2
- https://github.com/freebsd/freebsd-src/commit/a666325282eaed4b044459d121f339b2d6d0224b

However, these options are not introduced in the manual.