### PR TITLE
in6_control_ioctl: correctly report errors from SIOCAIFADDR_IN6

### DIFF
--- a/sys/netinet6/in6.c
+++ b/sys/netinet6/in6.c
@@ -587,7 +587,7 @@ in6_control_ioctl(u_long cmd, void *data,
 #endif
 		error = in6_addifaddr(ifp, ifra, ia);
 		ia = NULL;
-		break;
+		goto out;
 
 	case SIOCDIFADDR_IN6:
 		in6_purgeifaddr(ia);

--- a/tests/sys/netinet6/Makefile
+++ b/tests/sys/netinet6/Makefile
@@ -14,7 +14,8 @@ ATF_TESTS_SH=		exthdr \
 			lpm6 \
 			fibs6 \
 			ndp \
-			proxy_ndp
+			proxy_ndp \
+			addr6
 
 TEST_METADATA.divert+=	execenv="jail"		\
 			execenv_jail_params="vnet allow.raw_sockets"
@@ -32,6 +33,8 @@ TEST_METADATA.proxy_ndp+= execenv="jail"		\
 TEST_METADATA.redirect+= execenv="jail"		\
 			execenv_jail_params="vnet allow.raw_sockets"
 TEST_METADATA.scapyi386+= execenv="jail"		\
+			execenv_jail_params="vnet allow.raw_sockets"
+TEST_METADATA.addr6+= execenv="jail"		\
 			execenv_jail_params="vnet allow.raw_sockets"
 
 ${PACKAGE}FILES+=	exthdr.py \

--- a/tests/sys/netinet6/addr6.sh
+++ b/tests/sys/netinet6/addr6.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env atf-sh
+#-
+# SPDX-License-Identifier: ISC
+#
+# Copyright (c) 2025 Lexi Winter.
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+. $(atf_get_srcdir)/../common/vnet.subr
+
+atf_test_case "addr6_invalid_addr" "cleanup"
+addr6_invalid_addr_head()
+{
+	atf_set descr "adding an invalid IPv6 address returns an error"
+	atf_set require.user root
+}
+
+addr6_invalid_addr_body()
+{
+	vnet_init
+
+	ep=$(vnet_mkepair)
+	atf_check -s exit:0 ifconfig ${ep}a inet6 2001:db8::1/128
+	atf_check -s exit:1 -e ignore ifconfig ${ep}a inet6 2001:db8::1/127 alias
+}
+
+addr6_invalid_addr_cleanup()
+{
+	vnet_cleanup
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case "addr6_invalid_addr"
+}


### PR DESCRIPTION
we have to use 'goto out' here rather than 'break' because otherwise error is set to 0, which means the error is not propagated back to the caller.