### PR TITLE
Fix typo in the test causing errors in sys.netinet6.redirect.valid_redirect.

### DIFF
--- a/tests/sys/netinet6/redirect.py
+++ b/tests/sys/netinet6/redirect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -
 # SPDX-License-Identifier: BSD-2-Clause
 #

--- a/tests/sys/netinet6/redirect.sh
+++ b/tests/sys/netinet6/redirect.sh
@@ -39,10 +39,6 @@ valid_redirect_head() {
 
 valid_redirect_body() {
 
-	if [ "$(atf_config_get ci false)" = "true" ]; then
-		atf_skip "https://bugs.freebsd.org/247729"
-	fi
-
 	ids=65533
 	id=`printf "%x" ${ids}`
 	if [ $$ -gt 65535 ]; then
@@ -89,7 +85,7 @@ valid_redirect_body() {
 	while [ `ifconfig ${epair}a inet6 | grep -c tentative` != "0" ]; do
 		sleep 0.1
 	done
-	while [ `jexec ${jname}b ifconfig ${epair}b inet6 | grep -c tentative` != "0" ]; do
+	while [ `jexec ${jname} ifconfig ${epair}b inet6 | grep -c tentative` != "0" ]; do
 		sleep 0.1
 	done
 


### PR DESCRIPTION
Bug: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=247729
CI: https://ci.freebsd.org/job/FreeBSD-main-amd64-test/26219/testReport/sys.netinet6/redirect/valid_redirect/

I think it is a typo.

However, this is not the original bug. The original bug was fixed somehow.