### PR TITLE
packages: add a new iputils package for ping and traceroute

### DIFF
--- a/release/packages/Makefile.package
+++ b/release/packages/Makefile.package
@@ -91,6 +91,9 @@ hyperv-tools_COMMENT=	Microsoft HyperV Utilities
 hyperv-tools_DESC=	Microsoft HyperV Utilities
 inetd_COMMENT=		Internet super-server
 inetd_DESC=		Internet super-server
+iputils_COMMENT=	IP utilities
+iputils_DESC=		Contains non-essential IP utilities: ping, ping6, \
+traceroute and traceroute6.
 jail_COMMENT= 		Jail Utilities
 jail_DESC= 		Jail Utilities
 jail-debug_DESCR= 	Debugging Symbols

--- a/release/packages/generate-ucl.sh
+++ b/release/packages/generate-ucl.sh
@@ -43,6 +43,10 @@ main() {
 		periodic)
 			pkgdeps="cron"
 			;;
+		rc)
+			# because rc.d/netwait requires ping
+			pkgdeps="iputils"
+			;;
 
 		# -dev packages that have no corresponding non-dev package
 		# as a dependency.

--- a/sbin/ping/Makefile
+++ b/sbin/ping/Makefile
@@ -1,6 +1,6 @@
 .include <src.opts.mk>
 
-PACKAGE=runtime
+PACKAGE=iputils
 PROG=	ping
 SRCS=	main.c
 MAN=	ping.8

--- a/usr.sbin/traceroute/Makefile
+++ b/usr.sbin/traceroute/Makefile
@@ -1,6 +1,6 @@
 .include <src.opts.mk>
 
-PACKAGE=	runtime
+PACKAGE=	iputils
 PROG=	traceroute
 MAN=	traceroute.8
 SRCS=	as.c traceroute.c ifaddrlist.c findsaddr-udp.c

--- a/usr.sbin/traceroute6/Makefile
+++ b/usr.sbin/traceroute6/Makefile
@@ -17,7 +17,7 @@
 TRACEROUTE_DISTDIR?= ${SRCTOP}/usr.sbin/traceroute
 .PATH: ${TRACEROUTE_DISTDIR}
 
-PACKAGE=	runtime
+PACKAGE=	iputils
 PROG=	traceroute6
 MAN=	traceroute6.8
 SRCS=	as.c traceroute6.c


### PR DESCRIPTION
this moves them out of runtime, where they definitely don't belong. since both ping and traceroute are setuid, there is a (minor) security benefit to putting them in their own package so minimal systems don't need to install them.