### PR TITLE
traceroute: add tests

### DIFF
--- a/etc/mtree/BSD.tests.dist
+++ b/etc/mtree/BSD.tests.dist
@@ -1273,6 +1273,8 @@
         ..
         syslogd
         ..
+        traceroute
+        ..
     ..
 ..
 

--- a/usr.sbin/traceroute/Makefile
+++ b/usr.sbin/traceroute/Makefile
@@ -7,6 +7,9 @@ SRCS=	as.c traceroute.c ifaddrlist.c findsaddr-udp.c
 BINOWN=	root
 BINMODE=4555
 
+HAS_TESTS=
+SUBDIR.${MK_TESTS}+= tests
+
 .if !defined(TRACEROUTE_NO_IPSEC)
 CFLAGS+= -DIPSEC
 .endif

--- a/usr.sbin/traceroute/tests/Makefile
+++ b/usr.sbin/traceroute/tests/Makefile
@@ -1,0 +1,7 @@
+ATF_TESTS_SH+=	traceroute_test
+
+# Allow tests to run in parallel in their own jails
+TEST_METADATA+=	execenv="jail"
+TEST_METADATA+=	execenv_jail_params="vnet allow.raw_sockets"
+
+.include <bsd.test.mk>

--- a/usr.sbin/traceroute/tests/traceroute_test.sh
+++ b/usr.sbin/traceroute/tests/traceroute_test.sh
@@ -439,7 +439,7 @@ ipv4_srcaddr_cleanup()
 atf_test_case "ipv4_srcinterface" "cleanup"
 ipv4_srcinterface_head()
 {
-	atf_set descr "IPv4 traceroute with explicit source address"
+	atf_set descr "IPv4 traceroute with explicit source interface"
 	atf_set require.user root
 }
 

--- a/usr.sbin/traceroute/tests/traceroute_test.sh
+++ b/usr.sbin/traceroute/tests/traceroute_test.sh
@@ -125,9 +125,8 @@ start_tcpdump()
 		interface="${epsrc}b"
 	fi
 
-	dir="$(pwd)"
-	jexec trrtr daemon -p "${dir}/tcpdump.pid" \
-	    tcpdump --immediate-mode -w "${dir}/traceroute.pcap" -nv \
+	jexec trrtr daemon -p "${PWD}/tcpdump.pid" \
+	    tcpdump --immediate-mode -w "${PWD}/traceroute.pcap" -nv \
 	    -i $interface
 
 	# Give tcpdump time to start
@@ -137,14 +136,14 @@ start_tcpdump()
 stop_tcpdump()
 {
 	# Sleep to give tcpdump a chance to finish flushing
-	jexec trrtr kill -USR2 $(cat "${dir}/tcpdump.pid")
+	jexec trrtr kill -USR2 $(cat "${PWD}/tcpdump.pid")
 	sleep 1
-	jexec trrtr kill $(cat "${dir}/tcpdump.pid")
+	jexec trrtr kill $(cat "${PWD}/tcpdump.pid")
 
 	# Format the packet capture and merge continued lines (starting with
 	# whitespace) into a single line; this makes it easier to match in
 	# atf_check.  Append a blank line since the N command exits on EOF.
-	(tcpdump -nv -r "${dir}/traceroute.pcap"; echo) | \
+	(tcpdump -nv -r "${PWD}/traceroute.pcap"; echo) | \
 	    sed -E -e :a -e N -e 's/\n +/ /' -e ta -e P -e D \
 	    > tcpdump.output
 }

--- a/usr.sbin/traceroute/tests/traceroute_test.sh
+++ b/usr.sbin/traceroute/tests/traceroute_test.sh
@@ -658,6 +658,42 @@ ipv4_udplite_cleanup()
 }
 
 ##
+# test: ipv4_iptos
+#
+
+atf_test_case "ipv4_iptos" "cleanup"
+ipv4_iptos_head()
+{
+	atf_set descr "IPv4 traceroute with explicit ToS"
+	atf_set require.user root
+}
+
+ipv4_iptos_body()
+{
+	setup_network
+
+	start_tcpdump
+
+	atf_check -s exit:0					\
+	    -e match:"^traceroute to ${LINK_TRDST_TRDST}"	\
+	    -o match:"^ 1  ${LINK_TRSRC_TRRTR}"			\
+	    -o match:"^ 2  ${LINK_TRDST_TRDST}"			\
+	    -o not-match:"^ 3"					\
+	    jexec trsrc traceroute $TR_FLAGS -t 4 ${LINK_TRDST_TRDST}
+
+	stop_tcpdump
+	atf_check -s exit:0 -e ignore 				\
+	    -o match:"IP \\(tos 0x4, ttl 1, .*, proto UDP .*\\).* ${LINK_TRSRC_TRSRC}.[0-9]+ > ${LINK_TRDST_TRDST}.33435: UDP" \
+	    -o match:"IP \\(tos 0x4, ttl 2, .*, proto UDP .*\\).* ${LINK_TRSRC_TRSRC}.[0-9]+ > ${LINK_TRDST_TRDST}.33436: UDP" \
+	    cat tcpdump.output
+}
+
+ipv4_iptos_cleanup()
+{
+	vnet_cleanup
+}
+
+##
 # test case declarations
 
 atf_init_test_cases()
@@ -676,4 +712,5 @@ atf_init_test_cases()
 	atf_add_test_case ipv4_firsthop
 	atf_add_test_case ipv4_nprobes
 	atf_add_test_case ipv4_baseport
+	atf_add_test_case ipv4_iptos
 }


### PR DESCRIPTION
three basic tests for usr.sbin/traceroute:
- traceroute between two hosts
- ICMP traceroute between two hosts
- traceroute between two hosts with an explicit source address (-s)

to run the tests, we create three jails: one for the source host, one for the destination host, and one to route packets betweem them.  this ensures we're actually testing traceroute across a routed network and not just sending probe packets to a directly connected host.

no tests for traceroute6 are in this commit since the traceroute6 merge into traceroute is in progress.