### PR TITLE
traceroute.8: improve the documentation of -P

### DIFF
--- a/usr.sbin/traceroute/traceroute.8
+++ b/usr.sbin/traceroute/traceroute.8
@@ -15,7 +15,7 @@
 .\"
 .\"	$Id: traceroute.8,v 1.19 2000/09/21 08:44:19 leres Exp $
 .\"
-.Dd November 17, 2023
+.Dd April 11, 2025
 .Dt TRACEROUTE 8
 .Os
 .Sh NAME
@@ -136,10 +136,62 @@ to terminate the route tracing).
 If something is listening on a port in the default range, this option can be
 used to pick an unused port range.
 .It Fl P Ar proto
-Send packets of specified IP protocol.
-The currently supported protocols
-are: UDP, UDP-Lite, TCP, SCTP, GRE and ICMP.
-Other protocols may also be specified (either by name or by number), though
+Use packets of specified IP protocol when sending probes.
+The
+.Ar proto
+argument may be one of the following:
+.Bl -tag -width Ar udplite
+.It Ar udp
+Use
+.Xr udp 4
+packets.
+This is the default.
+.It Ar icmp
+Use
+.Xr icmp 4
+.Dq echo request
+packets.
+.It Ar udplite
+Use
+.Xr udplite 4
+packets.
+.It Ar tcp
+Use
+.Xr tcp 4
+.Dq SYN
+packets.
+This will cause a successful traceroute to end with no response (i.e., a
+.Dq *
+response) since
+.Nm
+does not know how to detect the RST or SYN+ACK response from the
+destination host.
+.It Ar sctp
+Use
+.Xr sctp 4
+packets.
+The
+.Ar packetlen
+argument must be a multiple of 4.
+SCTP probes will be constructed as SCTP
+.Dq INIT
+chunks, unless the packet length is too small, in which case the probes
+will be SCTP
+.Dq SHUTDOWN-ACK
+chunks followed by zero or one
+.Dq PAD
+chunks.
+.It Ar gre
+Use
+.Xr gre 4
+packets.
+The GRE packets will be constructed as if they contain a PPTP
+(Point-to-Point Tunneling Protocol) payload.
+.El
+.Pp
+Other protocols may also be specified, either by number or by name (see
+.Xr protocols 5 ) ,
+though
 .Nm
 does not implement any special knowledge of their packet formats.
 This option is useful for determining which router along a path may be blocking


### PR DESCRIPTION
1. -P didn't say what the argument is supposed to be; in the case of udplite(4), "-Pudp-lite" is not valid, one must use "-Pudplite".
2. be more explicit about what sort of packets we generate, particularly for -Psctp and -Pgre.

---

cc @jlduran, @concussious 