### PR TITLE
mac_portacl: do not reject unspecific family directly.

### DIFF
--- a/sys/security/mac_portacl/mac_portacl.c
+++ b/sys/security/mac_portacl/mac_portacl.c
@@ -452,7 +452,7 @@ socket_check_bind(struct ucred *cred, struct socket *so,
 		return (0);
 
 	/* Reject addresses we don't understand; fail closed. */
-	if (sa->sa_family != AF_INET && sa->sa_family != AF_INET6)
+	if (sa->sa_family != AF_UNSPEC && sa->sa_family != AF_INET && sa->sa_family != AF_INET6)
 		return (EINVAL);
 
 	family = so->so_proto->pr_domain->dom_family;

--- a/tests/sys/mac/portacl/Makefile
+++ b/tests/sys/mac/portacl/Makefile
@@ -1,9 +1,11 @@
 PACKAGE=	tests
 
 TESTSDIR=	${TESTSBASE}/sys/mac/portacl
+BINDIR= 	${TESTSDIR}
 
 ${PACKAGE}FILES+=	misc.sh
 
+PROGS+=   bind
 TAP_TESTS_SH+=	nobody_test
 TAP_TESTS_SH+=	root_test
 

--- a/tests/sys/mac/portacl/bind.c
+++ b/tests/sys/mac/portacl/bind.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+int main(int argc, char *argv[]) {
+    if (argc < 5) {
+        fprintf(stderr, "Usage: %s family host protocol port\n", argv[0]);
+        return 1;
+    }
+    int family = atoi(argv[1]);
+    const char *host = argv[2];
+    const char *protocol = argv[3];
+    const char *port = argv[4];
+    int sock_type;
+    if (strcmp(protocol, "tcp") == 0)
+        sock_type = SOCK_STREAM;
+    else if (strcmp(protocol, "udp") == 0)
+        sock_type = SOCK_DGRAM;
+    else {
+        fprintf(stderr, "Unsupported protocol: %s\n", protocol);
+        return 1;
+    }
+    struct addrinfo hints, *res;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = family;
+    hints.ai_socktype = sock_type;
+    hints.ai_flags = AI_PASSIVE;
+    int err = getaddrinfo(host, port, &hints, &res);
+    if (err != 0) {
+        fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(err));
+        return 1;
+    }
+    int sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (sock < 0) {
+        freeaddrinfo(res);
+        return 1;
+    }
+    int opt = 1;
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    if (bind(sock, res->ai_addr, res->ai_addrlen) < 0) {
+        if (errno == EACCES || errno == EPERM)
+            printf("bind_error: permission denied.\n");
+        else
+            printf("bind error: %s\n", strerror(errno));
+        close(sock);
+        freeaddrinfo(res);
+        return 1;
+    }
+    printf("ok\n");
+    close(sock);
+    freeaddrinfo(res);
+    return 0;
+}
+

--- a/tests/sys/netinet/socket_afinet.c
+++ b/tests/sys/netinet/socket_afinet.c
@@ -57,9 +57,6 @@ ATF_TC_BODY(socket_afinet_bind_zero, tc)
 	int sd, rc;
 	struct sockaddr_in sin;
 
-	if (atf_tc_get_config_var_as_bool_wd(tc, "ci", false))
-		atf_tc_skip("doesn't work when mac_portacl(4) loaded (https://bugs.freebsd.org/238781)");
-
 	sd = socket(PF_INET, SOCK_DGRAM, 0);
 	ATF_CHECK(sd >= 0);
 


### PR DESCRIPTION
It could fix the following bug:

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=238781

I also add tests for it (based on existing tests).