### PR TITLE
netlink/test_snl: turn off the NETLINK_EXT_ACK flag during the test.

### DIFF
--- a/tests/sys/netlink/test_snl.c
+++ b/tests/sys/netlink/test_snl.c
@@ -60,11 +60,11 @@ ATF_TC_BODY(snl_parse_errmsg_capped, tc)
 	if (!snl_init(&ss, NETLINK_ROUTE))
 		atf_tc_fail("snl_init() failed");
 
-	atf_tc_skip("does not work");
-
 	int optval = 1;
 	ATF_CHECK(setsockopt(ss.fd, SOL_NETLINK, NETLINK_CAP_ACK, &optval, sizeof(optval)) == 0);
 
+	optval = 0;
+	ATF_CHECK(setsockopt(ss.fd, SOL_NETLINK, NETLINK_EXT_ACK, &optval, sizeof(optval)) == 0);
 	snl_init_writer(&ss, &nw);
 
 	struct nlmsghdr *hdr = snl_create_msg_request(&nw, 255);


### PR DESCRIPTION
This test was disabled due to the extra 32-byte data in the `rx_hdr->nlmsg_len`.

It's not we expected, that should be `sizeof(struct nlmsghdr) + sizeof(struct nlmsgerr)`.

However, that's because the NETLINK_EXT_ACK is enabled, if we disable it, the length will be correct.

https://github.com/freebsd/freebsd-src/commit/04dacd5691fb3de5fddd0868836c5a7ff9888370