### PR TITLE
Add POSIX psiginfo(3) call

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -115,6 +115,7 @@ int	siginterrupt(int, int);
 #endif
 
 #if __POSIX_VISIBLE >= 200809
+void	psiginfo(const siginfo_t *, const char *);
 void	psignal(int, const char *);
 #endif
 

--- a/lib/libc/gen/Makefile.inc
+++ b/lib/libc/gen/Makefile.inc
@@ -465,7 +465,8 @@ MLINKS+=posix_spawn.3 posix_spawnp.3 \
 	posix_spawnattr_getsigdefault.3 posix_spawnattr_setsigdefault.3 \
 	posix_spawnattr_getsigmask.3 posix_spawnattr_setsigmask.3 \
 	posix_spawnattr_init.3 posix_spawnattr_destroy.3
-MLINKS+=psignal.3 strsignal.3 \
+MLINKS+=psignal.3 psiginfo.3 \
+	psignal.3 strsignal.3 \
 	psignal.3 sys_siglist.3 \
 	psignal.3 sys_signame.3
 MLINKS+=pwcache.3 gid_from_group.3 \

--- a/lib/libc/gen/Symbol.map
+++ b/lib/libc/gen/Symbol.map
@@ -458,6 +458,7 @@ FBSD_1.8 {
 	aio_read2;
 	aio_write2;
 	execvpe;
+	psiginfo;
 	rtld_get_var;
 	rtld_set_var;
 };

--- a/lib/libc/gen/psignal.3
+++ b/lib/libc/gen/psignal.3
@@ -25,11 +25,12 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd May 30, 2016
+.Dd Apr 16, 2025
 .Dt PSIGNAL 3
 .Os
 .Sh NAME
 .Nm psignal ,
+.Nm psiginfo ,
 .Nm strsignal ,
 .Nm sys_siglist ,
 .Nm sys_signame
@@ -40,6 +41,8 @@
 .In signal.h
 .Ft void
 .Fn psignal "int sig" "const char *s"
+.Ft void
+.Fn psiginfo "const siginfo_t *si" "const char *s"
 .Vt extern const char * const sys_siglist[] ;
 .Vt extern const char * const sys_signame[] ;
 .In string.h
@@ -79,6 +82,16 @@ the string
 .Dq "Unknown signal"
 is produced.
 .Pp
+The
+.Fn psiginfo
+function is similar to
+.Fn psignal ,
+except that the signal number information is taken from the
+.Fa si
+argument which is a
+.Vt siginfo_t
+structure.
+.Pp
 The message strings can be accessed directly
 through the external array
 .Va sys_siglist ,
@@ -104,3 +117,10 @@ The
 .Fn psignal
 function appeared in
 .Bx 4.2 .
+The
+.Fn psiginfo
+function appeared in
+.Fx 15.0 ,
+.Nx 6.0 ,
+and
+.Dx 4.1 .

--- a/lib/libc/gen/psignal.c
+++ b/lib/libc/gen/psignal.c
@@ -55,3 +55,9 @@ psignal(int sig, const char *s)
 	(void)_write(STDERR_FILENO, c, strlen(c));
 	(void)_write(STDERR_FILENO, "\n", 1);
 }
+
+void
+psiginfo(const siginfo_t *si, const char *s)
+{
+	psignal(si->si_signo, s);
+}


### PR DESCRIPTION
Add POSIX psiginfo(3) call.

Fixes https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=286133

For now, use the same implementation used by NetBSD & DragonflyBSD.

References:
- https://pubs.opengroup.org/onlinepubs/9699919799/functions/psiginfo.html
- https://github.com/NetBSD/src/blob/trunk/lib/libc/gen/psignal.c
- https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/lib/libc/gen/psignal.c