### PR TITLE
gpio: misc fixes for acpi_gpiobus & gpioaei

### DIFF
--- a/sys/dev/gpio/acpi_gpiobus.c
+++ b/sys/dev/gpio/acpi_gpiobus.c
@@ -357,7 +357,7 @@ acpi_gpiobus_attach(device_t dev)
 	    &ctx);
 
 	if (ACPI_FAILURE(status))
-		device_printf(dev, "Failed to enumerate GPIO resources\n");
+		device_printf(dev, "Failed to enumerate AEI resources\n");
 
 	return (0);
 }

--- a/sys/dev/gpio/acpi_gpiobus.c
+++ b/sys/dev/gpio/acpi_gpiobus.c
@@ -203,7 +203,8 @@ acpi_gpiobus_enumerate_aei(ACPI_RESOURCE *res, void *context)
 	device_set_ivars(child, devi);
 
 	for (int i = 0; i < devi->gpiobus.npins; i++) {
-		if (GPIOBUS_PIN_SETFLAGS(bus, child, 0, devi->flags)) {
+		if (GPIOBUS_PIN_SETFLAGS(bus, child, 0, devi->flags &
+		    ~GPIO_INTR_MASK)) {
 			device_delete_child(bus, child);
 			return (AE_OK);
 		}

--- a/sys/dev/gpio/acpi_gpiobus.c
+++ b/sys/dev/gpio/acpi_gpiobus.c
@@ -380,23 +380,6 @@ acpi_gpiobus_detach(device_t dev)
 	return (gpiobus_detach(dev));
 }
 
-int
-gpio_pin_get_by_acpi_index(device_t consumer, uint32_t idx,
-    gpio_pin_t *out_pin)
-{
-	struct acpi_gpiobus_ivar *devi;
-	int rv;
-
-	rv = gpio_pin_get_by_child_index(consumer, idx, out_pin);
-	if (rv != 0)
-		return (rv);
-
-	devi = device_get_ivars(consumer);
-	(*out_pin)->flags = devi->flags;
-
-	return (0);
-}
-
 static int
 acpi_gpiobus_read_ivar(device_t dev, device_t child, int which, uintptr_t *result)
 {
@@ -405,6 +388,9 @@ acpi_gpiobus_read_ivar(device_t dev, device_t child, int which, uintptr_t *resul
 	switch (which) {
 	case ACPI_GPIOBUS_IVAR_HANDLE:
 		*result = (uintptr_t)devi->dev_handle;
+		break;
+	case ACPI_GPIOBUS_IVAR_FLAGS:
+		*result = (uintptr_t)devi->flags;
 		break;
 	default:
 		return (gpiobus_read_ivar(dev, child, which, result));

--- a/sys/dev/gpio/acpi_gpiobusvar.h
+++ b/sys/dev/gpio/acpi_gpiobusvar.h
@@ -34,16 +34,15 @@
 
 enum acpi_gpiobus_ivars {
 	ACPI_GPIOBUS_IVAR_HANDLE	= 10600,
+	ACPI_GPIOBUS_IVAR_FLAGS,
 };
 
 #define ACPI_GPIOBUS_ACCESSOR(var, ivar, type)			\
 	__BUS_ACCESSOR(acpi_gpiobus, var, ACPI_GPIOBUS, ivar, type)
 
 ACPI_GPIOBUS_ACCESSOR(handle,	HANDLE,		ACPI_HANDLE)
+ACPI_GPIOBUS_ACCESSOR(flags,	FLAGS,		uint32_t)
 
 #undef ACPI_GPIOBUS_ACCESSOR
-
-int gpio_pin_get_by_acpi_index(device_t consumer, uint32_t idx,
-    gpio_pin_t *out_pin);
 
 #endif	/* __ACPI_GPIOBUS_H__ */

--- a/sys/dev/gpio/gpioaei.c
+++ b/sys/dev/gpio/gpioaei.c
@@ -120,8 +120,9 @@ gpio_aei_attach(device_t dev)
 		device_printf(dev, "Cannot allocate an IRQ\n");
 		return (ENOTSUP);
 	}
-	err = bus_setup_intr(dev, sc->intr_res, INTR_TYPE_MISC | INTR_MPSAFE,
-	    NULL, gpio_aei_intr, sc, &sc->intr_cookie);
+	err = bus_setup_intr(dev, sc->intr_res, INTR_TYPE_MISC | INTR_MPSAFE |
+	    INTR_EXCL | INTR_SLEEPABLE, NULL, gpio_aei_intr, sc,
+	    &sc->intr_cookie);
 	if (err != 0) {
 		device_printf(dev, "Cannot set up IRQ\n");
 		bus_release_resource(dev, SYS_RES_IRQ, sc->intr_rid,

--- a/sys/dev/gpio/gpioaei.c
+++ b/sys/dev/gpio/gpioaei.c
@@ -79,6 +79,7 @@ gpio_aei_attach(device_t dev)
 {
 	struct gpio_aei_softc * sc = device_get_softc(dev);
 	gpio_pin_t pin;
+	uint32_t flags;
 	ACPI_HANDLE handle;
 	int err;
 
@@ -87,17 +88,19 @@ gpio_aei_attach(device_t dev)
 
 	/* Store parameters needed by gpio_aei_intr. */
 	handle = acpi_gpiobus_get_handle(dev);
-	if (gpio_pin_get_by_acpi_index(dev, 0, &pin) != 0) {
+	if (gpio_pin_get_by_child_index(dev, 0, &pin) != 0) {
 		device_printf(dev, "Unable to get the input pin\n");
 		return (ENXIO);
 	}
 
 	sc->type = ACPI_AEI_TYPE_UNKNOWN;
 	sc->pin = pin->pin;
+
+	flags = acpi_gpiobus_get_flags(dev);
 	if (pin->pin <= 255) {
 		char objname[5];	/* "_EXX" or "_LXX" */
 		sprintf(objname, "_%c%02X",
-		    (pin->flags & GPIO_INTR_EDGE_MASK) ? 'E' : 'L', pin->pin);
+		    (flags & GPIO_INTR_EDGE_MASK) ? 'E' : 'L', pin->pin);
 		if (ACPI_SUCCESS(AcpiGetHandle(handle, objname, &sc->handle)))
 			sc->type = ACPI_AEI_TYPE_ELX;
 	}
@@ -113,7 +116,7 @@ gpio_aei_attach(device_t dev)
 
 	/* Set up the interrupt. */
 	if ((sc->intr_res = gpio_alloc_intr_resource(dev, &sc->intr_rid,
-	    RF_ACTIVE, pin, pin->flags & GPIO_INTR_MASK)) == NULL) {
+	    RF_ACTIVE, pin, flags & GPIO_INTR_MASK)) == NULL) {
 		device_printf(dev, "Cannot allocate an IRQ\n");
 		return (ENOTSUP);
 	}


### PR DESCRIPTION
Some misc fixes for acpi_gpiobus and gpioaei

About getting the pin flags via an accessor instead of `pin->flags`:
We shouldn't be putting pin flags from acpi_gpiobus into `pin->flags` since the rest of the gpiobus code expects it to contain FDT flags. e.g `gpio_pin_is_active` checks for `GPIO_ACTIVE_LOW`, an FDT-specific flag. If we want to mirror this with ACPI, we would have to: 1. Put the ACPI-specific flags there (currently we convert the ACPI flags to the ones in `sys/gpio.h`). 2. Add a way for gpiobus to differentiate between ACPI and FDT pins.