### PR TITLE
vtnet: Option to force vtnet to compile the multiqueue capable driver, even if ALTQ is enabled

### DIFF
--- a/sys/conf/NOTES
+++ b/sys/conf/NOTES
@@ -2424,6 +2424,7 @@ device		virtio_gpu	# VirtIO GPU device
 device		virtio_random	# VirtIO Entropy device
 device		virtio_scmi	# VirtIO SCMI device
 device		virtio_scsi	# VirtIO SCSI device
+options 	VTNET_NO_ALTQ	# Force VTNET to be Multiqueue capable instead of ALTQ capable
 
 #####################################################################
 # HID support

--- a/sys/conf/options
+++ b/sys/conf/options
@@ -680,6 +680,9 @@ UVSCOM_INTR_INTERVAL	opt_uvscom.h
 RTWN_DEBUG		opt_rtwn.h
 RTWN_WITHOUT_UCODE	opt_rtwn.h
 
+# options for VTNET (VirtIO Networking) Driver
+VTNET_NO_ALTQ		opt_global.h
+
 # Embedded system options
 INIT_PATH
 

--- a/sys/dev/virtio/network/if_vtnetvar.h
+++ b/sys/dev/virtio/network/if_vtnetvar.h
@@ -29,7 +29,7 @@
 #ifndef _IF_VTNETVAR_H
 #define _IF_VTNETVAR_H
 
-#ifdef ALTQ
+#if defined(ALTQ) && !defined(VTNET_NO_ALTQ)
 #define	VTNET_LEGACY_TX
 #endif
 

--- a/sys/dev/virtio/network/if_vtnetvar.h
+++ b/sys/dev/virtio/network/if_vtnetvar.h
@@ -374,7 +374,7 @@ CTASSERT(((VTNET_TX_SEGS_MAX - 1) * MCLBYTES) >= VTNET_MAX_MTU);
  */
 #define VTNET_DEFAULT_BUFRING_SIZE	4096
 
-#define VTNET_CORE_MTX(_sc)		&(_sc)->vtnet_mtx
+#define VTNET_CORE_MTX(_sc)		(&(_sc)->vtnet_mtx)
 #define VTNET_CORE_LOCK(_sc)		mtx_lock(VTNET_CORE_MTX((_sc)))
 #define VTNET_CORE_UNLOCK(_sc)		mtx_unlock(VTNET_CORE_MTX((_sc)))
 #define VTNET_CORE_LOCK_DESTROY(_sc)	mtx_destroy(VTNET_CORE_MTX((_sc)))


### PR DESCRIPTION
The Problem is that when compiling the FreeBSD Kernel with ALTQ, it forces the VTNET driver to compile a non-multiqueue capable driver. But i need a kernel with ALTQ enabled, and a multiqueue capable VTNET driver. 

So i added a check, so that when building the kernel `-DVTNET_NO_ALTQ` can be specified, to get the VTNET driver, that is multiqueue capable, instead of the ALTQ capable driver,