### PR TITLE
cross-build: Don't provide strchrnul on macOS 15.4+.

### DIFF
--- a/tools/build/cross-build/include/mac/string.h
+++ b/tools/build/cross-build/include/mac/string.h
@@ -38,9 +38,12 @@
 #include_next <string.h>
 
 /*
- * strchrnul is not provided by macOS and the strchrnul.c implementation
- * can not be compiled on macOS so just provide it inline here
+ * strchrnul is provided by macOS 15.4 and later.  However, there is
+ * no good way to detect the current host version at compile time, so
+ * provide an inline definition under an alternate name.
  */
+#define	strchrnul(p, ch)	__freebsd_strchrnul(p, ch)
+
 static inline char *
 strchrnul(const char *p, int ch)
 {


### PR DESCRIPTION
macOS added a native strchrnul in 15.4.

Reported by:	kib