### PR TITLE
bin/cat: add test for reading data from stdin

### DIFF
--- a/bin/cat/tests/Makefile
+++ b/bin/cat/tests/Makefile
@@ -12,6 +12,7 @@ ${PACKAGE}FILES+=		d_s_output.in
 ${PACKAGE}FILES+=		d_s_output.out
 ${PACKAGE}FILES+=		d_vt_output.in
 ${PACKAGE}FILES+=		d_vt_output.out
+${PACKAGE}FILES+=		stdin_test.out
 
 .include <netbsd-tests.test.mk>
 

--- a/contrib/netbsd-tests/bin/cat/stdin_test.out
+++ b/contrib/netbsd-tests/bin/cat/stdin_test.out
@@ -1,0 +1,1 @@
+This is nothing but a cat test.

--- a/contrib/netbsd-tests/bin/cat/t_cat.sh
+++ b/contrib/netbsd-tests/bin/cat/t_cat.sh
@@ -112,6 +112,20 @@ vt_output_body() {
 }
 # End FreeBSD
 
+# Begin FreeBSD
+atf_test_case stdin_test
+stdin_test_head() {
+	atf_set "descr" "Test that cat(1) receives data from stdin " \
+			"and outputs."
+}
+
+stdin_test_body() {
+	echo "This is nothing but a cat test." | \
+		atf_check -s ignore -o file:$(atf_get_srcdir)/stdin_test.out \
+		cat
+}
+# End FreeBSD
+
 atf_init_test_cases()
 {
 	atf_add_test_case align
@@ -124,5 +138,6 @@ atf_init_test_cases()
 	atf_add_test_case s_output
 	atf_add_test_case e_output
 	atf_add_test_case vt_output
+	atf_add_test_case stdin_test
 # End FreeBSD
 }


### PR DESCRIPTION
I was working on testing FreeBSD component on MacOS, and the tested component is bin/cat.

I found that the cat program binary generated on MacOS are unable to read from stdin, however, which could pass all the tests.

Therefore, I hope I can add a test for testing stdin reading.