### PR TITLE
radxa: support dtb for radxa zero3e, zero3w

### DIFF
--- a/sys/modules/dtb/rockchip/Makefile
+++ b/sys/modules/dtb/rockchip/Makefile
@@ -19,7 +19,9 @@ DTS=	\
 	rockchip/rk3399-firefly.dts \
 	rockchip/rk3399-rockpro64.dts \
 	rockchip/rk3566-quartz64-a.dts \
-	rockchip/rk3568-nanopi-r5s.dts
+	rockchip/rk3568-nanopi-r5s.dts \
+	rockchip/rk3566-radxa-zero-3e.dts \
+	rockchip/rk3566-radxa-zero-3w.dts
 
 DTSO=	rk3328-analog-sound.dtso \
 	rk3328-i2c0.dtso \


### PR DESCRIPTION
I am testing radxa zero3e on FreeBSD.