### PR TITLE
Make a space between the password prompt

### DIFF
--- a/usr.bin/login/login.c
+++ b/usr.bin/login/login.c
@@ -95,7 +95,7 @@ static void		 usage(void);
 #define	DEFAULT_BACKOFF		3
 #define	DEFAULT_RETRIES		10
 #define	DEFAULT_PROMPT		"login: "
-#define	DEFAULT_PASSWD_PROMPT	"Password:"
+#define	DEFAULT_PASSWD_PROMPT	"Password: "
 #define	TERM_UNKNOWN		"su"
 #define	DEFAULT_WARN		(2L * 7L * 86400L)	/* Two weeks */
 #define	NO_SLEEP_EXIT		0


### PR DESCRIPTION
So i made it sync a bit better with the login prompt so basically the expected changes are:
password:(no space) -> password: (with space)
