### PR TITLE
riscv: add Sifive p550/p650 identification

### DIFF
--- a/sys/riscv/include/cpu.h
+++ b/sys/riscv/include/cpu.h
@@ -80,6 +80,7 @@
 
 /* SiFive marchid values */
 #define	MARCHID_SIFIVE_U7	MARCHID_COMMERCIAL(7)
+#define	MARCHID_SIFIVE_P5	MARCHID_COMMERCIAL(8)
 
 /*
  * MMU virtual-addressing modes. Support for each level implies the previous,

--- a/sys/riscv/riscv/identcpu.c
+++ b/sys/riscv/riscv/identcpu.c
@@ -114,6 +114,7 @@ static const struct marchid_entry global_marchids[] = {
 
 static const struct marchid_entry sifive_marchids[] = {
 	{ MARCHID_SIFIVE_U7,	"6/7/P200/X200-Series Processor" },
+	{ MARCHID_SIFIVE_P5,	"P550/P650 Processor" },
 	MARCHID_END
 };
 


### PR DESCRIPTION
Tested on P550/Linux Hosted QEMU(KVM)

```
VT: init without driver.                                
SBI: Kernel-based Virtual Machine 394825                
SBI Specification Version: 1.0                          
CPU 0  : Vendor=SiFive Core=P550/P650 Processor (Hart 0)
  marchid=0x8000000000000008, mimpid=0x6220425          
  MMU: 0x1<Sv39>                                        
  ISA: 0x112d<Atomic,Compressed,Double,Float,Mult/Div>  
  S-mode Extensions: 0                                  
```