### PR TITLE
ath: fix all -wunused-but-set-variable warnings

### DIFF
--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -231,7 +231,7 @@ ZFS_RPC_C=	${CC} -c ${ZFS_CFLAGS} -DHAVE_RPC_TYPES ${WERROR} ${.IMPSRC}
 ZFS_S=		${CC} -c ${ZFS_ASM_CFLAGS} ${WERROR} ${.IMPSRC}
 
 # ATH driver
-ATH_CFLAGS=	-I${SRCTOP}/sys/dev/ath ${NO_WUNUSED_BUT_SET_VARIABLE}
+ATH_CFLAGS=	-I${SRCTOP}/sys/dev/ath
 ATH_C=		${CC} -c ${CFLAGS} ${WERROR} ${ATH_CFLAGS} ${.IMPSRC}
 
 # Special flags for managing the compat compiles for DTrace

--- a/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_eeprom.c
+++ b/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_eeprom.c
@@ -1717,7 +1717,7 @@ HAL_BOOL ar9300_ant_ctrl_apply(struct ath_hal *ah, HAL_BOOL is_2ghz)
     if ( AR_SREV_POSEIDON(ah) && (ahp->ah_lna_div_use_bt_ant_enable == TRUE) ) {
         value &= ~AR_SWITCH_TABLE_COM2_ALL;
         value |= ah->ah_config.ath_hal_ant_ctrl_comm2g_switch_enable;
-	HALDEBUG(ah, HAL_DEBUG_RESET, "%s: com2=0x%08x\n", __func__, value)
+	HALDEBUG(ah, HAL_DEBUG_RESET, "%s: com2=0x%08x\n", __func__, value);
     }
 #endif  /* ATH_ANT_DIV_COMB */
     OS_REG_RMW_FIELD(ah, AR_PHY_SWITCH_COM_2, AR_SWITCH_TABLE_COM2_ALL, value);
@@ -1848,7 +1848,7 @@ HAL_BOOL ar9300_ant_ctrl_apply(struct ath_hal *ah, HAL_BOOL is_2ghz)
              * This will not affect HB125 LNA diversity feature.
              */
 	     HALDEBUG(ah, HAL_DEBUG_RESET, "%s: com2=0x%08x\n", __func__,
-	         ah->ah_config.ath_hal_ant_ctrl_comm2g_switch_enable)
+	         ah->ah_config.ath_hal_ant_ctrl_comm2g_switch_enable);
             OS_REG_RMW_FIELD(ah, AR_PHY_SWITCH_COM_2, AR_SWITCH_TABLE_COM2_ALL, 
                 ah->ah_config.ath_hal_ant_ctrl_comm2g_switch_enable);
             break;
@@ -2561,9 +2561,7 @@ ar9300_eeprom_set_power_per_rate_table(
     u_int8_t ctl_num;
     u_int16_t twice_min_edge_power;
     u_int16_t twice_max_edge_power = AR9300_MAX_RATE_POWER;
-#ifdef	AH_DEBUG
     HAL_CHANNEL_INTERNAL *ichan = ath_hal_checkchannel(ah, chan);
-#endif
 
     if (chainmask)
         tx_chainmask = chainmask;

--- a/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_paprd.c
+++ b/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_paprd.c
@@ -1857,9 +1857,7 @@ void ar9300_populate_paprd_single_table(struct ath_hal *ah,
     struct ieee80211_channel *chan, int chain_num)
 {
     int i, j, bad_read = 0;
-#ifdef	AH_DEBUG
     HAL_CHANNEL_INTERNAL *ichan = ath_hal_checkchannel(ah, chan);
-#endif
     u_int32_t *paprd_table_val = &AH9300(ah)->pa_table[chain_num][0];
     u_int32_t small_signal_gain = AH9300(ah)->small_signal_gain[chain_num];
     u_int32_t reg = 0;

--- a/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_phy.c
+++ b/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_phy.c
@@ -848,7 +848,6 @@ ar9300_init_rate_txpower_stbc(struct ath_hal *ah, const HAL_RATE_TABLE *rt,
     struct ath_hal_9300 *ahp = AH9300(ah);
     int i;
     int16_t twice_array_gain, stbc_power = 0;
-    u_int8_t mcs_index = 0;
 
     /* Upper Limit with STBC */
     switch (chainmask) {
@@ -900,7 +899,6 @@ ar9300_init_rate_txpower_stbc(struct ath_hal *ah, const HAL_RATE_TABLE *rt,
                      __func__, chainmask);
             break;
         }
-        mcs_index++;
     }
 
     for (i = rt_ds_offset; i < rt_ds_offset + AR9300_NUM_HT_DS_RATES; i++) {
@@ -924,7 +922,6 @@ ar9300_init_rate_txpower_stbc(struct ath_hal *ah, const HAL_RATE_TABLE *rt,
                      __func__, chainmask);
             break;
         }
-        mcs_index++;
     }
 
     for (i = rt_ts_offset; i < rt_ts_offset + AR9300_NUM_HT_TS_RATES; i++) {
@@ -944,7 +941,6 @@ ar9300_init_rate_txpower_stbc(struct ath_hal *ah, const HAL_RATE_TABLE *rt,
                      __func__, chainmask);
             break;
         }
-        mcs_index++;
     }
 
     return;

--- a/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_power.c
+++ b/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_power.c
@@ -653,14 +653,12 @@ HAL_BOOL
 ar9300_set_power_mode(struct ath_hal *ah, HAL_POWER_MODE mode, int set_chip)
 {
     struct ath_hal_9300 *ahp = AH9300(ah);
-#if defined(AH_DEBUG) || defined(AH_PRINT_FILTER)
     static const char* modes[] = {
         "AWAKE",
         "FULL-SLEEP",
         "NETWORK SLEEP",
         "UNDEFINED"
     };
-#endif
     int status = AH_TRUE;
 
     HALDEBUG(ah, HAL_DEBUG_POWER_MGMT, "%s: %s -> %s (%s)\n", __func__,

--- a/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_reset.c
+++ b/sys/contrib/dev/ath/ath_hal/ar9300/ar9300_reset.c
@@ -1046,8 +1046,6 @@ ar9300_spur_mitigate_ofdm(struct ath_hal *ah, struct ieee80211_channel *chan)
     int i;
     int mode;
     u_int8_t* spur_chans_ptr;
-    struct ath_hal_9300 *ahp;
-    ahp = AH9300(ah);
     HAL_CHANNEL_INTERNAL *ichan = ath_hal_checkchannel(ah, chan);
 
     if (IS_CHAN_5GHZ(ichan)) {
@@ -3425,14 +3423,12 @@ ar9300_run_init_cals(struct ath_hal *ah, int init_cal_count)
     HAL_CHANNEL_INTERNAL ichan; /* bogus */
     HAL_BOOL is_cal_done;
     HAL_CAL_LIST *curr_cal;
-    const HAL_PERCAL_DATA *cal_data;
     int i;
 
     curr_cal = ahp->ah_cal_list_curr;
     if (curr_cal == AH_NULL) {
         return AH_FALSE;
     }
-    cal_data = curr_cal->cal_data;
     ichan.calValid = 0;
 
     for (i = 0; i < init_cal_count; i++) {

--- a/sys/dev/ath/ath_hal/ah_eeprom_v3.c
+++ b/sys/dev/ath/ath_hal/ah_eeprom_v3.c
@@ -181,7 +181,6 @@ eepromExpandPower5112(struct ath_hal *ah,
 	EEPROM_POWER_EXPN_5112 *pPowerExpn)
 {
 	int ii, jj, kk;
-	int16_t maxPower_t4;
 	EXPN_DATA_PER_XPD_5112 *pExpnXPD;
 	/* ptr to array of info held per channel */
 	const EEPROM_DATA_PER_CHANNEL_5112 *pCalCh;
@@ -218,7 +217,6 @@ eepromExpandPower5112(struct ath_hal *ah,
 			pCalCh->channelValue;
 		pPowerExpn->pDataPerChannel[ii].maxPower_t4 =
 			pCalCh->maxPower_t4;
-		maxPower_t4 = pPowerExpn->pDataPerChannel[ii].maxPower_t4;
 
 		for (jj = 0; jj < NUM_XPD_PER_CHANNEL; jj++)
 			pPowerExpn->pDataPerChannel[ii].pDataPerXPD[jj].numPcdacs = 0;

--- a/sys/dev/ath/ath_hal/ah_internal.h
+++ b/sys/dev/ath/ath_hal/ah_internal.h
@@ -653,7 +653,7 @@ extern	int ath_hal_debug;	/* Global debug flags */
 extern	void DO_HALDEBUG(struct ath_hal *ah, u_int mask, const char* fmt, ...)
 	__printflike(3,4);
 #else
-#define HALDEBUG(_ah, __m, ...)
+#define HALDEBUG(_ah, __m, ...) (void)(sizeof((__VA_ARGS__), 0))
 #endif /* AH_DEBUG */
 
 /*

--- a/sys/dev/ath/ath_hal/ar5210/ar5210_power.c
+++ b/sys/dev/ath/ath_hal/ar5210/ar5210_power.c
@@ -93,14 +93,12 @@ ar5210SetPowerModeSleep(struct ath_hal *ah, int setChip)
 HAL_BOOL
 ar5210SetPowerMode(struct ath_hal *ah, HAL_POWER_MODE mode, int setChip)
 {
-#ifdef AH_DEBUG
 	static const char* modes[] = {
 		"AWAKE",
 		"FULL-SLEEP",
 		"NETWORK SLEEP",
 		"UNDEFINED"
 	};
-#endif
 	int status = AH_TRUE;
 
 	HALDEBUG(ah, HAL_DEBUG_POWER, "%s: %s -> %s (%s)\n", __func__,

--- a/sys/dev/ath/ath_hal/ar5211/ar5211_power.c
+++ b/sys/dev/ath/ath_hal/ar5211/ar5211_power.c
@@ -95,14 +95,12 @@ ar5211SetPowerModeNetworkSleep(struct ath_hal *ah, int setChip)
 HAL_BOOL
 ar5211SetPowerMode(struct ath_hal *ah, HAL_POWER_MODE mode, int setChip)
 {
-#ifdef AH_DEBUG
 	static const char* modes[] = {
 		"AWAKE",
 		"FULL-SLEEP",
 		"NETWORK SLEEP",
 		"UNDEFINED"
 	};
-#endif
 	int status = AH_TRUE;
 
 	HALDEBUG(ah, HAL_DEBUG_POWER, "%s: %s -> %s (%s)\n", __func__,

--- a/sys/dev/ath/ath_hal/ar5212/ar2413.c
+++ b/sys/dev/ath/ath_hal/ar5212/ar2413.c
@@ -292,13 +292,12 @@ ar2413FillVpdTable(uint32_t pdGainIdx, int16_t Pmin, int16_t  Pmax,
 		   const int16_t *pwrList, const uint16_t *VpdList,
 		   uint16_t numIntercepts, uint16_t retVpdList[][64])
 {
-	uint16_t ii, jj, kk;
+	uint16_t ii, kk;
 	int16_t currPwr = (int16_t)(2*Pmin);
 	/* since Pmin is pwr*2 and pwrList is 4*pwr */
 	uint32_t  idxL, idxR;
 
 	ii = 0;
-	jj = 0;
 
 	if (numIntercepts < 2)
 		return AH_FALSE;

--- a/sys/dev/ath/ath_hal/ar5212/ar2425.c
+++ b/sys/dev/ath/ath_hal/ar5212/ar2425.c
@@ -294,13 +294,12 @@ ar2425FillVpdTable(uint32_t pdGainIdx, int16_t Pmin, int16_t  Pmax,
 		   uint16_t numIntercepts,
 		   uint16_t retVpdList[][64])
 {
-	uint16_t ii, jj, kk;
+	uint16_t ii, kk;
 	int16_t currPwr = (int16_t)(2*Pmin);
 	/* since Pmin is pwr*2 and pwrList is 4*pwr */
 	uint32_t  idxL, idxR;
 
 	ii = 0;
-	jj = 0;
 
 	if (numIntercepts < 2)
 		return AH_FALSE;

--- a/sys/dev/ath/ath_hal/ar5212/ar5212_power.c
+++ b/sys/dev/ath/ath_hal/ar5212/ar5212_power.c
@@ -119,14 +119,12 @@ ar5212SetPowerModeNetworkSleep(struct ath_hal *ah, int setChip)
 HAL_BOOL
 ar5212SetPowerMode(struct ath_hal *ah, HAL_POWER_MODE mode, int setChip)
 {
-#ifdef AH_DEBUG
 	static const char* modes[] = {
 		"AWAKE",
 		"FULL-SLEEP",
 		"NETWORK SLEEP",
 		"UNDEFINED"
 	};
-#endif
 	int status = AH_TRUE;
 
 	HALDEBUG(ah, HAL_DEBUG_POWER, "%s: %s -> %s (%s)\n", __func__,

--- a/sys/dev/ath/ath_hal/ar5212/ar5212_reset.c
+++ b/sys/dev/ath/ath_hal/ar5212/ar5212_reset.c
@@ -732,12 +732,11 @@ ar5212ChannelChange(struct ath_hal *ah, const struct ieee80211_channel *chan)
 	uint32_t   data, synthDelay, qnum;
 	uint16_t   rfXpdGain[MAX_NUM_PDGAINS_PER_CHANNEL];
 	HAL_BOOL    txStopped = AH_TRUE;
-	HAL_CHANNEL_INTERNAL *ichan;
 
 	/*
 	 * Map public channel to private.
 	 */
-	ichan = ath_hal_checkchannel(ah, chan);
+	(void)ath_hal_checkchannel(ah, chan);
 
 	/* TX must be stopped or RF Bus grant will not work */
 	for (qnum = 0; qnum < AH_PRIVATE(ah)->ah_caps.halTotalQueues; qnum++) {

--- a/sys/dev/ath/ath_hal/ar5212/ar5413.c
+++ b/sys/dev/ath/ath_hal/ar5212/ar5413.c
@@ -335,13 +335,12 @@ ar5413FillVpdTable(uint32_t pdGainIdx, int16_t Pmin, int16_t  Pmax,
 		   uint16_t numIntercepts,
 		   uint16_t retVpdList[][64])
 {
-	uint16_t ii, jj, kk;
+	uint16_t ii, kk;
 	int16_t currPwr = (int16_t)(2*Pmin);
 	/* since Pmin is pwr*2 and pwrList is 4*pwr */
 	uint32_t  idxL, idxR;
 
 	ii = 0;
-	jj = 0;
 
 	if (numIntercepts < 2)
 		return AH_FALSE;

--- a/sys/dev/ath/ath_hal/ar5416/ar5416_beacon.c
+++ b/sys/dev/ath/ath_hal/ar5416/ar5416_beacon.c
@@ -150,7 +150,7 @@ ar5416ResetStaBeaconTimers(struct ath_hal *ah)
 void
 ar5416SetStaBeaconTimers(struct ath_hal *ah, const HAL_BEACON_STATE *bs)
 {
-	uint32_t nextTbtt, nextdtim,beaconintval, dtimperiod;
+	uint32_t nextTbtt, beaconintval, dtimperiod;
 
 	HALASSERT(bs->bs_intval != 0);
 
@@ -245,7 +245,6 @@ ar5416SetStaBeaconTimers(struct ath_hal *ah, const HAL_BEACON_STATE *bs)
 		nextTbtt = bs->bs_nextdtim;
 	else
 		nextTbtt = bs->bs_nexttbtt;
-	nextdtim = bs->bs_nextdtim;
 
 	OS_REG_WRITE(ah, AR_NEXT_DTIM,
 		TU_TO_USEC(bs->bs_nextdtim - SLEEP_SLOP));

--- a/sys/dev/ath/ath_hal/ar5416/ar5416_power.c
+++ b/sys/dev/ath/ath_hal/ar5416/ar5416_power.c
@@ -124,14 +124,12 @@ ar5416SetPowerModeNetworkSleep(struct ath_hal *ah, int setChip)
 HAL_BOOL
 ar5416SetPowerMode(struct ath_hal *ah, HAL_POWER_MODE mode, int setChip)
 {
-#ifdef AH_DEBUG
 	static const char* modes[] = {
 		"AWAKE",
 		"FULL-SLEEP",
 		"NETWORK SLEEP",
 		"UNDEFINED"
 	};
-#endif
 	int status = AH_TRUE;
 
 #if 0

--- a/sys/dev/ath/ath_hal/ar5416/ar5416_reset.c
+++ b/sys/dev/ath/ath_hal/ar5416/ar5416_reset.c
@@ -2354,7 +2354,6 @@ ar5416SetPowerCalTable(struct ath_hal *ah, struct ar5416eeprom *pEepData,
     int16_t  tMinCalPower;
     uint16_t numXpdGain, xpdMask;
     uint16_t xpdGainValues[AR5416_NUM_PD_GAINS];
-    uint32_t regChainOffset;
 
     OS_MEMZERO(xpdGainValues, sizeof(xpdGainValues));
     
@@ -2381,8 +2380,6 @@ ar5416SetPowerCalTable(struct ath_hal *ah, struct ar5416eeprom *pEepData,
     ar5416WriteDetectorGainBiases(ah, numXpdGain, xpdGainValues);
 
     for (i = 0; i < AR5416_MAX_CHAINS; i++) {
-	regChainOffset = ar5416GetRegChainOffset(ah, i);
-
         if (pEepData->baseEepHeader.txMask & (1 << i)) {
             if (IEEE80211_IS_CHAN_2GHZ(chan)) {
                 pRawDataset = pEepData->calPierData2G[i];

--- a/sys/dev/ath/ath_hal/ar9002/ar9280_attach.c
+++ b/sys/dev/ath/ath_hal/ar9002/ar9280_attach.c
@@ -491,7 +491,7 @@ ar9280DisablePCIE(struct ath_hal *ah)
 static void
 ar9280WriteIni(struct ath_hal *ah, const struct ieee80211_channel *chan)
 {
-	u_int modesIndex, freqIndex;
+	u_int modesIndex;
 	int regWrites = 0;
 	int i;
 	const HAL_INI_ARRAY *ia;
@@ -499,7 +499,6 @@ ar9280WriteIni(struct ath_hal *ah, const struct ieee80211_channel *chan)
 	/* Setup the indices for the next set of register array writes */
 	/* XXX Ignore 11n dynamic mode on the AR5416 for the moment */
 	if (IEEE80211_IS_CHAN_2GHZ(chan)) {
-		freqIndex = 2;
 		if (IEEE80211_IS_CHAN_HT40(chan))
 			modesIndex = 3;
 		else if (IEEE80211_IS_CHAN_108G(chan))
@@ -507,7 +506,6 @@ ar9280WriteIni(struct ath_hal *ah, const struct ieee80211_channel *chan)
 		else
 			modesIndex = 4;
 	} else {
-		freqIndex = 1;
 		if (IEEE80211_IS_CHAN_HT40(chan) ||
 		    IEEE80211_IS_CHAN_TURBO(chan))
 			modesIndex = 2;

--- a/sys/dev/ath/ath_hal/ar9002/ar9280_olc.c
+++ b/sys/dev/ath/ath_hal/ar9002/ar9280_olc.c
@@ -290,7 +290,6 @@ ar9280SetPowerCalTable(struct ath_hal *ah, struct ar5416eeprom *pEepData,
 	int16_t  tMinCalPower;
 	uint16_t numXpdGain, xpdMask;
 	uint16_t xpdGainValues[AR5416_NUM_PD_GAINS];
-	uint32_t regChainOffset;
 	int8_t pwr_table_offset;
 
 	OS_MEMZERO(xpdGainValues, sizeof(xpdGainValues));
@@ -338,7 +337,6 @@ ar9280SetPowerCalTable(struct ath_hal *ah, struct ar5416eeprom *pEepData,
 	ar5416WriteDetectorGainBiases(ah, numXpdGain, xpdGainValues);
 
 	for (i = 0; i < AR5416_MAX_CHAINS; i++) {
-		regChainOffset = ar5416GetRegChainOffset(ah, i);
 		if (pEepData->baseEepHeader.txMask & (1 << i)) {
 			uint16_t diff;
 

--- a/sys/dev/ath/ath_hal/ar9002/ar9285_attach.c
+++ b/sys/dev/ath/ath_hal/ar9002/ar9285_attach.c
@@ -488,12 +488,11 @@ ar9285DisablePCIE(struct ath_hal *ah)
 static void
 ar9285WriteIni(struct ath_hal *ah, const struct ieee80211_channel *chan)
 {
-	u_int modesIndex, freqIndex;
+	u_int modesIndex;
 	int regWrites = 0;
 
 	/* Setup the indices for the next set of register array writes */
 	/* XXX Ignore 11n dynamic mode on the AR5416 for the moment */
-	freqIndex = 2;
 	if (IEEE80211_IS_CHAN_HT40(chan))
 		modesIndex = 3;
 	else if (IEEE80211_IS_CHAN_108G(chan))

--- a/sys/dev/ath/ath_hal/ar9002/ar9285_reset.c
+++ b/sys/dev/ath/ath_hal/ar9002/ar9285_reset.c
@@ -573,7 +573,6 @@ ar9285SetPowerCalTable(struct ath_hal *ah, struct ar5416eeprom_4k *pEepData,
     int16_t  tMinCalPower;
     uint16_t numXpdGain, xpdMask;
     uint16_t xpdGainValues[4];	/* v4k eeprom has 2; the other two stay 0 */
-    uint32_t regChainOffset;
 
     OS_MEMZERO(xpdGainValues, sizeof(xpdGainValues));
     
@@ -605,7 +604,6 @@ ar9285SetPowerCalTable(struct ath_hal *ah, struct ar5416eeprom_4k *pEepData,
     ar5416WriteDetectorGainBiases(ah, numXpdGain, xpdGainValues);
 
     for (i = 0; i < AR5416_MAX_CHAINS; i++) {
-	regChainOffset = ar5416GetRegChainOffset(ah, i);
         if (pEepData->baseEepHeader.txMask & (1 << i)) {
             pRawDataset = pEepData->calPierData2G[i];
 

--- a/sys/dev/ath/ath_hal/ar9002/ar9287_attach.c
+++ b/sys/dev/ath/ath_hal/ar9002/ar9287_attach.c
@@ -387,13 +387,12 @@ ar9287DisablePCIE(struct ath_hal *ah)
 static void
 ar9287WriteIni(struct ath_hal *ah, const struct ieee80211_channel *chan)
 {
-	u_int modesIndex, freqIndex;
+	u_int modesIndex;
 	int regWrites = 0;
 
 	/* Setup the indices for the next set of register array writes */
 	/* XXX Ignore 11n dynamic mode on the AR5416 for the moment */
 	if (IEEE80211_IS_CHAN_2GHZ(chan)) {
-		freqIndex = 2;
 		if (IEEE80211_IS_CHAN_HT40(chan))
 			modesIndex = 3;
 		else if (IEEE80211_IS_CHAN_108G(chan))
@@ -401,7 +400,6 @@ ar9287WriteIni(struct ath_hal *ah, const struct ieee80211_channel *chan)
 		else
 			modesIndex = 4;
 	} else {
-		freqIndex = 1;
 		if (IEEE80211_IS_CHAN_HT40(chan) ||
 		    IEEE80211_IS_CHAN_TURBO(chan))
 			modesIndex = 2;

--- a/sys/dev/ath/ath_hal/ar9002/ar9287_reset.c
+++ b/sys/dev/ath/ath_hal/ar9002/ar9287_reset.c
@@ -47,22 +47,18 @@ ar9287SetPowerCalTable(struct ath_hal *ah,
 {
 	struct cal_data_op_loop_ar9287 *pRawDatasetOpenLoop;
 	uint8_t *pCalBChans = NULL;
-	uint16_t pdGainOverlap_t2;
 	uint16_t numPiers = 0, i;
 	uint16_t numXpdGain, xpdMask;
 	uint16_t xpdGainValues[AR5416_NUM_PD_GAINS] = {0, 0, 0, 0};
-	uint32_t regChainOffset;
 	HAL_EEPROM_9287 *ee = AH_PRIVATE(ah)->ah_eeprom;
 	struct ar9287_eeprom *pEepData = &ee->ee_base;
 
 	xpdMask = pEepData->modalHeader.xpdGain;
 
-	if ((pEepData->baseEepHeader.version & AR9287_EEP_VER_MINOR_MASK) >=
-	    AR9287_EEP_MINOR_VER_2)
-		pdGainOverlap_t2 = pEepData->modalHeader.pdGainOverlap;
-	else
-		pdGainOverlap_t2 = (uint16_t)(MS(OS_REG_READ(ah, AR_PHY_TPCRG5),
-					    AR_PHY_TPCRG5_PD_GAIN_OVERLAP));
+	if ((pEepData->baseEepHeader.version & AR9287_EEP_VER_MINOR_MASK) <
+	    AR9287_EEP_MINOR_VER_2) {
+		(void)(MS(OS_REG_READ(ah, AR_PHY_TPCRG5), AR_PHY_TPCRG5_PD_GAIN_OVERLAP));
+	}
 
 	/* Note: Kiwi should only be 2ghz.. */
 	if (IEEE80211_IS_CHAN_2GHZ(chan)) {
@@ -94,8 +90,6 @@ ar9287SetPowerCalTable(struct ath_hal *ah,
 		      xpdGainValues[2]);
 
 	for (i = 0; i < AR9287_MAX_CHAINS; i++) {
-		regChainOffset = i * 0x1000;
-
 		if (pEepData->baseEepHeader.txMask & (1 << i)) {
 			int8_t txPower;
 			pRawDatasetOpenLoop =

--- a/sys/dev/ath/ath_rate/sample/sample.h
+++ b/sys/dev/ath/ath_rate/sample/sample.h
@@ -199,7 +199,6 @@ static unsigned calc_usecs_unicast_packet(struct ath_softc *sc,
 	}
 
 	if (rts || cts) {
-		int ctsrate;
 		int ctsduration = 0;
 
 		/* NB: this is intentionally not a runtime check */
@@ -207,7 +206,6 @@ static unsigned calc_usecs_unicast_packet(struct ath_softc *sc,
 		    ("bogus cix %d, max %u, mode %u\n", cix, rt->rateCount,
 		     sc->sc_curmode));
 
-		ctsrate = rt->info[cix].rateCode | rt->info[cix].shortPreamble;
 		if (rts)		/* SIFS + CTS */
 			ctsduration += rt->info[cix].spAckDuration;
 

--- a/sys/dev/ath/if_ath.c
+++ b/sys/dev/ath/if_ath.c
@@ -5008,15 +5008,15 @@ ath_tx_draintxq(struct ath_softc *sc, struct ath_txq *txq)
 {
 #ifdef ATH_DEBUG
 	struct ath_hal *ah = sc->sc_ah;
+	u_int ix = 0;
 #endif
 	struct ath_buf *bf;
-	u_int ix;
 
 	/*
 	 * NB: this assumes output has been stopped and
 	 *     we do not need to block ath_tx_proc
 	 */
-	for (ix = 0;; ix++) {
+	while (1) {
 		ATH_TXQ_LOCK(txq);
 		bf = ath_tx_draintxq_get_one(sc, txq);
 		if (bf == NULL) {
@@ -5041,7 +5041,7 @@ ath_tx_draintxq(struct ath_softc *sc, struct ath_txq *txq)
 				    bf->bf_lastds,
 				    &bf->bf_status.ds_txstat) == HAL_OK);
 			}
-			ath_printtxbuf(sc, bf, txq->axq_qnum, ix, status);
+			ath_printtxbuf(sc, bf, txq->axq_qnum, ix++, status);
 			ieee80211_dump_pkt(ic, mtod(bf->bf_m, const uint8_t *),
 			    bf->bf_m->m_len, 0, -1);
 		}

--- a/sys/dev/ath/if_ath_debug.h
+++ b/sys/dev/ath/if_ath_debug.h
@@ -110,12 +110,10 @@ extern	void ath_printtxbuf(struct ath_softc *, const struct ath_buf *bf,
 extern	void ath_printtxstatbuf(struct ath_softc *sc, const struct ath_buf *bf,
 	const uint32_t *ds, u_int qnum, u_int ix, int done);
 #else	/* ATH_DEBUG */
-#define	ATH_KTR(_sc, _km, _kf, ...)	do { } while (0)
+#define	ATH_KTR(_sc, _km, _kf, ...) (void)(sizeof((__VA_ARGS__), 0))
 
 #define	IFF_DUMPPKTS(sc, m)	(0)
-#define	DPRINTF(sc, m, fmt, ...) do {				\
-	(void) sc;						\
-} while (0)
+#define	DPRINTF(sc, m, ...) (void)(sizeof((__VA_ARGS__), 0))
 #define	KEYPRINTF(sc, k, ix, mac) do {				\
 	(void) sc;						\
 } while (0)

--- a/sys/dev/ath/if_ath_lna_div.c
+++ b/sys/dev/ath/if_ath_lna_div.c
@@ -710,27 +710,11 @@ ath_lna_rx_comb_scan(struct ath_softc *sc, struct ath_rx_status *rs,
 	int curr_main_set, curr_bias;
 	int main_rssi = rs->rs_rssi_ctl[0];
 	int alt_rssi = rs->rs_rssi_ctl[1];
-	int rx_ant_conf, main_ant_conf, alt_ant_conf;
+	int rx_ant_conf, main_ant_conf;
 	HAL_BOOL short_scan = AH_FALSE;
 
 	rx_ant_conf = (rs->rs_rssi_ctl[2] >> 4) & ATH_ANT_RX_MASK;
 	main_ant_conf = (rs->rs_rssi_ctl[2] >> 2) & ATH_ANT_RX_MASK;
-	alt_ant_conf = (rs->rs_rssi_ctl[2] >> 0) & ATH_ANT_RX_MASK;
-
-#if 0
-	DPRINTF(sc, ATH_DEBUG_DIVERSITY,
-	    "%s: RSSI %d/%d, conf %x/%x, rxconf %x, LNA: %d; ANT: %d; "
-	    "FastDiv: %d\n",
-	    __func__,
-	    main_rssi,
-	    alt_rssi,
-	    main_ant_conf,
-	    alt_ant_conf,
-	    rx_ant_conf,
-	    !!(rs->rs_rssi_ctl[2] & 0x80),
-	    !!(rs->rs_rssi_ctl[2] & 0x40),
-	    !!(rs->rs_rssi_ext[2] & 0x40));
-#endif
 
 	/*
 	 * If LNA diversity combining isn't enabled, don't run this.

--- a/sys/dev/ath/if_ath_rx_edma.c
+++ b/sys/dev/ath/if_ath_rx_edma.c
@@ -413,13 +413,11 @@ ath_edma_recv_proc_queue(struct ath_softc *sc, HAL_RX_QUEUE qtype,
 	struct ath_rx_status *rs;
 	struct ath_desc *ds;
 	struct ath_buf *bf;
-	struct mbuf *m;
 	struct ath_hal *ah = sc->sc_ah;
-	uint64_t tsf;
 	uint16_t nf;
 	int npkts = 0;
 
-	tsf = ath_hal_gettsf64(ah);
+	(void)ath_hal_gettsf64(ah);
 	nf = ath_hal_getchannoise(ah, sc->sc_curchan);
 	sc->sc_stats.ast_rx_noise = nf;
 
@@ -451,7 +449,6 @@ ath_edma_recv_proc_queue(struct ath_softc *sc, HAL_RX_QUEUE qtype,
 			    qtype);
 			break;
 		}
-		m = bf->bf_m;
 		ds = bf->bf_desc;
 
 		/*
@@ -677,24 +674,12 @@ ath_edma_rxbuf_init(struct ath_softc *sc, struct ath_buf *bf)
 
 	struct mbuf *m;
 	int error;
-	int len;
 
 	ATH_RX_LOCK_ASSERT(sc);
 
 	m = m_getm(NULL, sc->sc_edma_bufsize, M_NOWAIT, MT_DATA);
 	if (! m)
 		return (ENOBUFS);		/* XXX ?*/
-
-	/* XXX warn/enforce alignment */
-
-	len = m->m_ext.ext_size;
-#if 0
-	device_printf(sc->sc_dev, "%s: called: m=%p, size=%d, mtod=%p\n",
-	    __func__,
-	    m,
-	    len,
-	    mtod(m, char *));
-#endif
 
 	m->m_pkthdr.len = m->m_len = m->m_ext.ext_size;
 

--- a/sys/dev/ath/if_ath_tx_edma.c
+++ b/sys/dev/ath/if_ath_tx_edma.c
@@ -799,7 +799,6 @@ ath_edma_tx_processq(struct ath_softc *sc, int dosched)
 	struct ath_txq *txq;
 	struct ath_buf *bf;
 	struct ieee80211_node *ni;
-	int nacked = 0;
 	int idx;
 	int i;
 
@@ -1005,7 +1004,6 @@ ath_edma_tx_processq(struct ath_softc *sc, int dosched)
 		/* XXX duplicate from ath_tx_processq */
 		if (ni != NULL && ts.ts_status == 0 &&
 		    ((bf->bf_state.bfs_txflags & HAL_TXDESC_NOACK) == 0)) {
-			nacked++;
 			sc->sc_stats.ast_tx_rssi = ts.ts_rssi;
 			ATH_RSSI_LPF(sc->sc_halstats.ns_avgtxrssi,
 			    ts.ts_rssi);


### PR DESCRIPTION
Patch set attached in the following manner:

[PATCH 1/8] ath: fix DEBUG print varargs macros to handle unused parameters
  This clears out a lot of unused-but-set warnings cleanly while avoiding the `#ifdef DEBUG` pattern

[PATCH 2..6/8]
  These are non-trivial changes that need a closer review to ensure no breaking changes.

[PATCH 7/8] ath_hal: fix all remaining trivial -wunused-but-set-variable warnings
  These are all the remaining (trivial) changes.

[PATCH 8/8] build: ath: re-enable -wunused-but-set-variable in ATH_C
  Once all warnings are cleaned up, the ${NO_WUNUSED_BUT_SET_VARIABLE} can be removed safely.