### PR TITLE
ig4(4): Add Raptor Lake PCI ID

### DIFF
--- a/sys/dev/ichiic/ig4_pci.c
+++ b/sys/dev/ichiic/ig4_pci.c
@@ -168,6 +168,12 @@ static int ig4iic_pci_detach(device_t dev);
 #define PCI_CHIP_ALDERLAKE_M_I2C_3	0x54eb8086
 #define PCI_CHIP_ALDERLAKE_M_I2C_4	0x54c58086
 #define PCI_CHIP_ALDERLAKE_M_I2C_5	0x54c68086
+#define PCI_CHIP_RAPTORLAKE_S_I2C_0	0x7a4c8086
+#define PCI_CHIP_RAPTORLAKE_S_I2C_1	0x7a4d8086
+#define PCI_CHIP_RAPTORLAKE_S_I2C_2	0x7a4e8086
+#define PCI_CHIP_RAPTORLAKE_S_I2C_3	0x7a4f8086
+#define PCI_CHIP_RAPTORLAKE_S_I2C_4	0x7a7c8086
+#define PCI_CHIP_RAPTORLAKE_S_I2C_5	0x7a7d8086
 #define PCI_CHIP_METEORLAKE_M_I2C_0	0x7e788086
 #define PCI_CHIP_METEORLAKE_M_I2C_1	0x7e798086
 #define PCI_CHIP_METEORLAKE_M_I2C_2	0x7e508086
@@ -286,6 +292,12 @@ static struct ig4iic_pci_device ig4iic_pci_devices[] = {
 	{ PCI_CHIP_ALDERLAKE_M_I2C_3, "Intel Alder Lake-M I2C Controller-3", IG4_TIGERLAKE},
 	{ PCI_CHIP_ALDERLAKE_M_I2C_4, "Intel Alder Lake-M I2C Controller-4", IG4_TIGERLAKE},
 	{ PCI_CHIP_ALDERLAKE_M_I2C_5, "Intel Alder Lake-M I2C Controller-5", IG4_TIGERLAKE},
+	{ PCI_CHIP_RAPTORLAKE_S_I2C_0, "Intel Raptor Lake-S I2C Controller-0", IG4_TIGERLAKE},
+	{ PCI_CHIP_RAPTORLAKE_S_I2C_1, "Intel Raptor Lake-S I2C Controller-1", IG4_TIGERLAKE},
+	{ PCI_CHIP_RAPTORLAKE_S_I2C_2, "Intel Raptor Lake-S I2C Controller-2", IG4_TIGERLAKE},
+	{ PCI_CHIP_RAPTORLAKE_S_I2C_3, "Intel Raptor Lake-S I2C Controller-3", IG4_TIGERLAKE},
+	{ PCI_CHIP_RAPTORLAKE_S_I2C_4, "Intel Raptor Lake-S I2C Controller-4", IG4_TIGERLAKE},
+	{ PCI_CHIP_RAPTORLAKE_S_I2C_5, "Intel Raptor Lake-S I2C Controller-5", IG4_TIGERLAKE},
 	{ PCI_CHIP_METEORLAKE_M_I2C_0, "Intel Meteor Lake-M I2C Controller-0", IG4_TIGERLAKE},
 	{ PCI_CHIP_METEORLAKE_M_I2C_1, "Intel Meteor Lake-M I2C Controller-1", IG4_TIGERLAKE},
 	{ PCI_CHIP_METEORLAKE_M_I2C_2, "Intel Meteor Lake-M I2C Controller-2", IG4_TIGERLAKE},


### PR DESCRIPTION
Add the PCI ID for Raptor Lake's I2C controller.  Tested on Razer Blade 16 (2023) with I2C touchpad.

```
ig4iic0: <Intel Raptor Lake-M I2C Controller-0> at device 21.0 on pci0
ig4iic0: Using MSI
iicbus11: <Philips I2C bus (ACPI-hinted)> on ig4iic0
iic11: <I2C generic I/O> on iicbus11
iichid0: <ELAN0406:00 04F3:3297 I2C HID device> at addr 0x15 on iicbus11
iichid0: Using sampling mode
hidbus0: <HID bus> on iichid0
```

```
ig4iic0@pci0:0:21:0:    class=0x0c8000 rev=0x11 hdr=0x00 vendor=0x8086 device=0x7a4c subvendor=0x1a58 subdevice=0x3
006
    vendor     = 'Intel Corporation'
    device     = 'Raptor Lake Serial IO I2C Host Controller'
    class      = serial bus
```