### PR TITLE
vtnet(4): Add Tunable to deactivate ALTQ support

### DIFF
--- a/share/man/man4/vtnet.4
+++ b/share/man/man4/vtnet.4
@@ -91,6 +91,9 @@ The number of queue pairs used is the lesser of the maximum supported by the
 driver and the hypervisor, the number of CPUs present in the guest, and this
 tunable if not zero.
 The default value is 0.
+.It Va hw.vtnet.altq_disable
+This tunable disables ALTQ support, allowing the use of multiqueue instead. This option applies to all interfaces.
+The default value is 0
 .El
 .Sh SEE ALSO
 .Xr arp 4 ,

--- a/sys/dev/virtio/network/if_vtnet.c
+++ b/sys/dev/virtio/network/if_vtnet.c
@@ -309,6 +309,19 @@ static int vtnet_lro_mbufq_depth = 0;
 SYSCTL_UINT(_hw_vtnet, OID_AUTO, lro_mbufq_depth, CTLFLAG_RDTUN,
     &vtnet_lro_mbufq_depth, 0, "Depth of software LRO mbuf queue");
 
+/* Deactivate ALTQ Support */
+static int vtnet_altq_disable = 0;
+SYSCTL_INT(_hw_vtnet, OID_AUTO, altq_disable, CTLFLAG_RDTUN,
+    &vtnet_altq_disable, 0, "Disables ALTQ Support");
+
+/*
+ * For the driver to be considered as having altq enabled,
+ * it must be compiled with an ALTQ capable kernel,
+ * and the tunable hw.vtnet.altq_disable must be zero
+ */
+#define VTNET_ALTQ_ENABLED (VTNET_ALTQ_CAPABLE && (!vtnet_altq_disable))
+
+
 static uma_zone_t vtnet_tx_header_zone;
 
 static struct virtio_feature_desc vtnet_feature_desc[] = {

--- a/sys/dev/virtio/network/if_vtnet.c
+++ b/sys/dev/virtio/network/if_vtnet.c
@@ -657,7 +657,7 @@ vtnet_negotiate_features(struct vtnet_softc *sc)
 
 		mtu = virtio_read_dev_config_2(dev,
 		    offsetof(struct virtio_net_config, mtu));
-		if (mtu < VTNET_MIN_MTU /* || mtu > VTNET_MAX_MTU */) {
+		if (mtu < VTNET_MIN_MTU) {
 			device_printf(dev, "Invalid MTU value: %d. "
 			    "MTU feature disabled.\n", mtu);
 			features &= ~VIRTIO_NET_F_MTU;
@@ -1037,19 +1037,19 @@ vtnet_alloc_virtqueues(struct vtnet_softc *sc)
 		    "%s-rx%d", device_get_nameunit(dev), rxq->vtnrx_id);
 
 		txq = &sc->vtnet_txqs[i];
-		VQ_ALLOC_INFO_INIT(&info[idx+1], sc->vtnet_tx_nsegs,
+		VQ_ALLOC_INFO_INIT(&info[idx + 1], sc->vtnet_tx_nsegs,
 		    vtnet_tx_vq_intr, txq, &txq->vtntx_vq,
 		    "%s-tx%d", device_get_nameunit(dev), txq->vtntx_id);
 	}
 
 	/* These queues will not be used so allocate the minimum resources. */
-	for (/**/; i < sc->vtnet_max_vq_pairs; i++, idx += 2) {
+	for (; i < sc->vtnet_max_vq_pairs; i++, idx += 2) {
 		rxq = &sc->vtnet_rxqs[i];
 		VQ_ALLOC_INFO_INIT(&info[idx], 0, NULL, rxq, &rxq->vtnrx_vq,
 		    "%s-rx%d", device_get_nameunit(dev), rxq->vtnrx_id);
 
 		txq = &sc->vtnet_txqs[i];
-		VQ_ALLOC_INFO_INIT(&info[idx+1], 0, NULL, txq, &txq->vtntx_vq,
+		VQ_ALLOC_INFO_INIT(&info[idx + 1], 0, NULL, txq, &txq->vtntx_vq,
 		    "%s-tx%d", device_get_nameunit(dev), txq->vtntx_id);
 	}
 

--- a/sys/dev/virtio/network/if_vtnetvar.h
+++ b/sys/dev/virtio/network/if_vtnetvar.h
@@ -114,18 +114,14 @@ struct vtnet_txq {
 	struct vtnet_softc	*vtntx_sc;
 	struct virtqueue	*vtntx_vq;
 	struct sglist		*vtntx_sg;
-#ifndef VTNET_LEGACY_TX
 	struct buf_ring		*vtntx_br;
-#endif
 	int			 vtntx_id;
 	int			 vtntx_watchdog;
 	int			 vtntx_intr_threshold;
 	struct vtnet_txq_stats	 vtntx_stats;
 	struct taskqueue	*vtntx_tq;
 	struct task		 vtntx_intrtask;
-#ifndef VTNET_LEGACY_TX
 	struct task		 vtntx_defrtask;
-#endif
 #ifdef DEV_NETMAP
 	struct virtio_net_hdr_mrg_rxbuf vtntx_shrhdr;
 #endif  /* DEV_NETMAP */

--- a/sys/dev/virtio/network/if_vtnetvar.h
+++ b/sys/dev/virtio/network/if_vtnetvar.h
@@ -29,8 +29,10 @@
 #ifndef _IF_VTNETVAR_H
 #define _IF_VTNETVAR_H
 
+#define VTNET_ALTQ_CAPABLE (0)
 #ifdef ALTQ
-#define	VTNET_LEGACY_TX
+#undef VTNET_ALTQ_CAPABLE
+#define	VTNET_ALTQ_CAPABLE (1)
 #endif
 
 struct vtnet_softc;

--- a/sys/dev/virtio/network/if_vtnetvar.h
+++ b/sys/dev/virtio/network/if_vtnetvar.h
@@ -374,7 +374,7 @@ CTASSERT(((VTNET_TX_SEGS_MAX - 1) * MCLBYTES) >= VTNET_MAX_MTU);
  */
 #define VTNET_DEFAULT_BUFRING_SIZE	4096
 
-#define VTNET_CORE_MTX(_sc)		&(_sc)->vtnet_mtx
+#define VTNET_CORE_MTX(_sc)		(&(_sc)->vtnet_mtx)
 #define VTNET_CORE_LOCK(_sc)		mtx_lock(VTNET_CORE_MTX((_sc)))
 #define VTNET_CORE_UNLOCK(_sc)		mtx_unlock(VTNET_CORE_MTX((_sc)))
 #define VTNET_CORE_LOCK_DESTROY(_sc)	mtx_destroy(VTNET_CORE_MTX((_sc)))


### PR DESCRIPTION
This adds a new tunable for the VirtIO Networking driver (VTNET), called `hw.vtnet.altq_disable`. Which deactivates ALTQ support, so that Multiqueue can be used instead. It does this be changing all compiletime checks, that use the preprocessor, into runtime checks, which depend on the tunable.

If the kernel is compiled without ALTQ included this should have no effect. And if the kernel is compiled with ALTQ, it can npw be deactivated using the tunable as described above.

I tested this on a freebsd vm running under KVM. With ALTQ disabled multiple queues can be used and ALTQ Rules get rejected by pfctl. With ALTQ not disabled, multiqueue cant be used, but pfctl accepts ALTQ Rules.