### PR TITLE
fusefs: Upgrade FUSE protocol to version 7.33.

### DIFF
--- a/tests/sys/fs/fusefs/xattr.cc
+++ b/tests/sys/fs/fusefs/xattr.cc
@@ -110,6 +110,8 @@ void expect_setxattr(uint64_t ino, const char *attr, const char *value,
 			const char *v = a + strlen(a) + 1;
 			return (in.header.opcode == FUSE_SETXATTR &&
 				in.header.nodeid == ino &&
+				in.body.setxattr.size == (strlen(value) + 1) &&
+				in.body.setxattr.setxattr_flags == 0 &&
 				0 == strcmp(attr, a) &&
 				0 == strcmp(value, v));
 		}, Eq(true)),
@@ -117,6 +119,33 @@ void expect_setxattr(uint64_t ino, const char *attr, const char *value,
 	).WillOnce(Invoke(r));
 }
 
+};
+
+class Xattr_7_32:public FuseTest {
+public:
+virtual void SetUp()
+{
+	m_kernel_minor_version = 32;
+	FuseTest::SetUp();
+}
+
+void expect_setxattr_7_32(uint64_t ino, const char *attr, const char *value,
+	ProcessMockerT r)
+{
+	EXPECT_CALL(*m_mock, process(
+		ResultOf([=](auto in) {
+			const char *a = (const char *)in.body.bytes +
+				FUSE_COMPAT_SETXATTR_IN_SIZE;
+			const char *v = a + strlen(a) + 1;
+			return (in.header.opcode == FUSE_SETXATTR &&
+				in.header.nodeid == ino &&
+				in.body.setxattr.size == (strlen(value) + 1) &&
+				0 == strcmp(attr, a) &&
+				0 == strcmp(value, v));
+		}, Eq(true)),
+		_)
+	).WillOnce(Invoke(r));
+}
 };
 
 class Getxattr: public Xattr {};
@@ -153,6 +182,7 @@ void TearDown() {
 
 class Removexattr: public Xattr {};
 class Setxattr: public Xattr {};
+class Setxattr_7_32:public Xattr_7_32 {};
 class RofsXattr: public Xattr {
 public:
 virtual void SetUp() {
@@ -728,6 +758,7 @@ TEST_F(Removexattr, system)
 		<< strerror(errno);
 }
 
+
 /*
  * If the filesystem returns ENOSYS, then it will be treated as a permanent
  * failure and all future VOP_SETEXTATTR calls will fail with EOPNOTSUPP
@@ -811,6 +842,23 @@ TEST_F(Setxattr, system)
 	expect_setxattr(ino, "system.foo", value, ReturnErrno(0));
 
 	r = extattr_set_file(FULLPATH, ns, "foo", (const void*)value,
+		value_len);
+	ASSERT_EQ(value_len, r) << strerror(errno);
+}
+
+
+TEST_F(Setxattr_7_32, ok)
+{
+	uint64_t ino = 42;
+	const char value[] = "whatever";
+	ssize_t value_len = strlen(value) + 1;
+	int ns = EXTATTR_NAMESPACE_USER;
+	ssize_t r;
+
+	expect_lookup(RELPATH, ino, S_IFREG | 0644, 0, 1);
+	expect_setxattr_7_32(ino, "user.foo", value, ReturnErrno(0));
+
+	r = extattr_set_file(FULLPATH, ns, "foo", (const void *)value,
 		value_len);
 	ASSERT_EQ(value_len, r) << strerror(errno);
 }


### PR DESCRIPTION
This commit upgrades the FUSE API to protocol 7.33, it doesn't implement any of protocol 7.33's new features, setxattr is tested for binary compatibility with protocol version 7.32.