### PR TITLE
Fix incorrect version introduced in manual pages

### DIFF
--- a/lib/libc/gen/psignal.3
+++ b/lib/libc/gen/psignal.3
@@ -120,7 +120,7 @@ function appeared in
 The
 .Fn psiginfo
 function appeared in
-.Fx 15.0 ,
+.Fx 14.3 ,
 .Nx 6.0 ,
 and
 .Dx 4.1 .

--- a/lib/libc/gen/rtld_get_var.3
+++ b/lib/libc/gen/rtld_get_var.3
@@ -103,4 +103,4 @@ is unknown.
 The
 .Nm
 function first appeared in
-.Fx 15.0 .
+.Fx 14.3 .

--- a/lib/libsys/getsockopt.2
+++ b/lib/libsys/getsockopt.2
@@ -679,7 +679,7 @@ The
 option originated in
 .Ox 4.9
 and first appeared in
-.Fx 15.0 .
+.Fx 14.3 .
 The
 .Fx
 implementation aims to be source-compatible.

--- a/lib/libsys/setcred.2
+++ b/lib/libsys/setcred.2
@@ -248,7 +248,7 @@ does not.
 The
 .Fn setcred
 system call appeared in
-.Fx 15.0 .
+.Fx 14.3 .
 .Pp
 Traditionally in UNIX, all credential changes beyond shuffles of effective, real
 and saved IDs have been done by setuid binaries that successively call multiple


### PR DESCRIPTION
Several manual pages for releng/14.3 incorrectly claim that features were first introduced in FreeBSD 15.0.

I discovered these by running:

```
  git checkout origin/releng/14.3
  git grep -F '.Fx 15.0'
```

I suggest whoever commits these changes also merges them to the `stable/14` and `releng/14.3` branches.