### PR TITLE
tcp(4): the default congestion algorithm changed

### DIFF
--- a/share/man/man4/tcp.4
+++ b/share/man/man4/tcp.4
@@ -447,7 +447,7 @@ and the reverse source route is used in responding.
 The default congestion control algorithm for
 .Tn TCP
 is
-.Xr cc_newreno 4 .
+.Xr cc_cubic 4 .
 Other congestion control algorithms can be made available using the
 .Xr mod_cc 4
 framework.


### PR DESCRIPTION
cc_cubic(4) replaced cc_newreno(4) as the default in FreeBSD 14 with commit bb1d472d79f7.