### PR TITLE
fr.kbd and fr.acc.kbd: Added alias to tilde on french layouts for consistency

### DIFF
--- a/share/vt/keymaps/fr.acc.kbd
+++ b/share/vt/keymaps/fr.acc.kbd
@@ -43,7 +43,7 @@
   038   'l'    'L'    ff     ff     'l'    'L'    ff     ff      C
   039   'm'    'M'    cr     cr     'm'    'M'    cr     cr      C
   040   0xf9   '%'    nul    nul    '''    '@'    nul    nul     O
-  041   0xb2   nop    nop    nop    '|'    '|'    nop    nop     O
+  041   0xb2   '~'    nop    nop    '|'    '|'    nop    nop     O
   042   lshift lshift lshift lshift lshift lshift lshift lshift  O
   043   '*'    0xb5   nop    nop    '#'    '~'    nop    nop     O
   044   'w'    'W'    etb    etb    'w'    'W'    sub    sub     C

--- a/share/vt/keymaps/fr.kbd
+++ b/share/vt/keymaps/fr.kbd
@@ -43,7 +43,7 @@
   038   'l'    'L'    ff     ff     'l'    'L'    ff     ff      C
   039   'm'    'M'    cr     cr     'm'    'M'    cr     cr      C
   040   0xf9   '%'    nul    nul    '''    '@'    nul    nul     O
-  041   0xb2   nop    nop    nop    '|'    '|'    nop    nop     O
+  041   0xb2   '~'    nop    nop    '|'    '|'    nop    nop     O
   042   lshift lshift lshift lshift lshift lshift lshift lshift  O
   043   '*'    0xb5   nop    nop    '#'    '~'    nop    nop     O
   044   'w'    'W'    etb    etb    'w'    'W'    sub    sub     C


### PR DESCRIPTION
While not specified by the AZERTY standard employed by the `fr.kbd` and `fr.acc.kbd` layouts, the keycode `041 | shift` (Shift-²) is assigned to the tilde/home symbol on Xorg, the Linux TTY, and all popular wayland compositors; it is much easier to type than the standard way of writing a tilde with AZERTY.

The only context that I know of where this is not the case is the FreeBSD TTY, this addition aims to improve the quality-of-life to the french-typing FreeBSD experience.