### PR TITLE
fsck_msdosfs: reduce the scope of dentry deletion when dirent flags is ATTR_VOLUME

### DIFF
--- a/sbin/fsck_msdosfs/dir.c
+++ b/sbin/fsck_msdosfs/dir.c
@@ -769,7 +769,7 @@ readDosDirSection(struct fat_descriptor *fat, struct dosDirEntry *dir)
 				if (vallfn || invlfn) {
 					mod |= removede(fat,
 							invlfn ? invlfn : vallfn, p,
-							invlfn ? invcl : valcl, -1, 0,
+							invlfn ? invcl : valcl, cl, cl,
 							fullpath(dir), 2);
 					vallfn = NULL;
 					invlfn = NULL;


### PR DESCRIPTION
fsck_msdosfs: reduce the scope of dentry deletion when dirent flags is ATTR_VOLUME

When dentry flag is ATTR_VOLUME because of 1 bit flip(from 0x10 to 0x18), removede function will delete all dentry from invalid dentry postion, so some normal dentries will be deleted in the same cluster.Unfortunately, these normal directories and files will not be visible to the user after wo do fsck_msdos