### PR TITLE
Update atomic.h, 64 bit compare exchange on ARM 32

### DIFF
--- a/sys/arm/include/atomic.h
+++ b/sys/arm/include/atomic.h
@@ -213,7 +213,7 @@ ATOMIC_ACQ_REL_LONG(clear)
 	    "   teqeq    %R[tmp], %R[cmp]                     \n"  \
 	    "   ittee    ne                                   \n"  \
 	    "   movne    %[ret], #0                           \n"  \
-	    "   strdne   %[cmp], [%[oldv]]                    \n"  \
+	    "   strdne   %[tmp], [%[oldv]]                    \n"  \
 	    "   strexdeq %[ret], %Q[newv], %R[newv], [%[ptr]] \n"  \
 	    "   eorseq   %[ret], #1                           \n"  \
 	    "   beq      1b                                   \n"  \


### PR DESCRIPTION
Hello everyone.

Forgive me if I am not following the rules. This is a quick fix, and I like to stay private. 

Assembly code pertaining to ARM 32bit processors acting on 64bit wide data in what amounts to a compare and exchange operation has an apparent bug where the current value in memory that is returned to the caller is the same suspected current value that was passed by the caller even when the exchange fails.

Please be warned that this apparent bug was caught by code analysis, not testing.