### PR TITLE
Add support for POSIX O_CLOFORK

### DIFF
--- a/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/oclo.c
+++ b/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/oclo.c
@@ -1,0 +1,1310 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Oxide Computer Company
+ */
+
+/*
+ * Verify the behavior of the various O_CLOFORK and O_CLOEXEC variants. In
+ * particular getting this via:
+ *
+ *  - open(2): O_CLOFORK/O_CLOEXEC
+ *  - fcntl(2): F_SETFD FD_CLOFORK/FD_CLOEXEC
+ *  - fcntl(2): F_DUPFD_CLOFORK/F_DUPFD_CLOEXEC
+ *  - fcntl(2): F_DUP2FD_CLOFORK/F_DUP2FD_CLOEXEC
+ *  - dup2(3C)
+ *  - dup3(3C): argument translation
+ *  - pipe2(2)
+ *  - socket(2): SOCK_CLOEXEC/SOCK_CLOFORK
+ *  - accept(2): flags on the listen socket aren't inherited on accept
+ *  - socketpair(3SOCKET)
+ *  - accept4(2): SOCK_CLOEXEC/SOCK_CLOFORK
+ *  - recvmsg(2): SCM_RIGHTS MSG_CMSG_CLOFORK/MSG_CMSG_CLOEXEC
+ *
+ * The test is designed such that we have an array of functions that are used to
+ * create file descriptors with different rules. This is found in the
+ * oclo_create array. Each file descriptor that is created is then registered
+ * with information about what is expected about it. A given creation function
+ * can create more than one file descriptor; however, our expectation is that
+ * every file descriptor is accounted for (ignoring stdin, stdout, and stderr).
+ *
+ * We pass a record of each file descriptor that was recorded to a verification
+ * program that will verify everything is correctly honored after an exec. Note
+ * that O_CLOFORK is cleared after exec. The original specification in POSIX has
+ * it being retained; however, this issue was raised after the spec was
+ * published as folks went to implement it and we have ended up following along
+ * with the divergence of other implementations.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <err.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/sysmacros.h>
+#include <sys/fork.h>
+#include <wait.h>
+#include <errno.h>
+#include <string.h>
+#include <limits.h>
+#include <libgen.h>
+#include <sys/socket.h>
+
+/*
+ * Verification program name.
+ */
+#define	OCLO_VERIFY	"ocloexec_verify"
+
+/*
+ * This structure represents a table of ways we expect to create file
+ * descriptors that should have the resulting flags set when done. The table is
+ * ordered and subsequent iterations are allowed to assume that the ones that
+ * have gone ahead of them have run and are therefore allowed to access them.
+ * The create function is expected to return the created fd.
+ */
+typedef struct clo_create clo_create_t;
+struct clo_create {
+	const char *clo_desc;
+	int clo_flags;
+	void (*clo_func)(const clo_create_t *);
+};
+
+/*
+ * This is our run-time data. We expect all file descriptors to be registered by
+ * our calling functions through oclo_record().
+ */
+typedef struct clo_rtdata {
+	const clo_create_t *crt_data;
+	size_t crt_idx;
+	int crt_fd;
+	int crt_flags;
+	const char *crt_desc;
+} clo_rtdata_t;
+
+static clo_rtdata_t *oclo_rtdata;
+size_t oclo_rtdata_nents = 0;
+size_t oclo_rtdata_next = 0;
+static int oclo_nextfd = STDERR_FILENO + 1;
+
+static bool
+oclo_flags_match(const clo_rtdata_t *rt, bool child)
+{
+	const char *pass = child ? "post-fork" : "pre-fork";
+	bool fail = child && (rt->crt_flags & FD_CLOFORK) != 0;
+	int flags = fcntl(rt->crt_fd, F_GETFD, NULL);
+
+	if (flags < 0) {
+		int e = errno;
+
+		if (fail) {
+			if (e == EBADF) {
+				(void) printf("TEST PASSED: %s (%s): fd %d: "
+				    "correctly closed\n",
+				    rt->crt_data->clo_desc, pass, rt->crt_fd);
+				return (true);
+			}
+
+			warn("TEST FAILED: %s (%s): fd %d: expected fcntl to "
+			    "fail with EBADF, but found %s",
+			    rt->crt_data->clo_desc, pass, rt->crt_fd,
+			    strerrorname_np(e));
+			return (false);
+		}
+
+		warnx("TEST FAILED: %s (%s): fd %d: fcntl(F_GETFD) "
+		    "unexpectedly failed", rt->crt_data->clo_desc, pass,
+		    rt->crt_fd);
+		return (false);
+	}
+
+	if (fail) {
+		warnx("TEST FAILED: %s (%s): fd %d: received flags %d, but "
+		    "expected to fail based on flags %d",
+		    rt->crt_data->clo_desc, pass, rt->crt_fd, flags,
+		    rt->crt_fd);
+		return (false);
+	}
+
+	if (flags != rt->crt_flags) {
+		warnx("TEST FAILED: %s (%s): fd %d: discovered flags 0x%x do "
+		    "not match expected flags 0x%x", rt->crt_data->clo_desc,
+		    pass, rt->crt_fd, flags, rt->crt_fd);
+		return (false);
+	}
+
+	(void) printf("TEST PASSED: %s (%s): fd %d discovered flags match "
+	    "(0x%x)\n", rt->crt_data->clo_desc, pass, rt->crt_fd, flags);
+	return (true);
+}
+
+
+static void
+oclo_record(const clo_create_t *c, int fd, int exp_flags, const char *desc)
+{
+	if (oclo_rtdata_next == oclo_rtdata_nents) {
+		size_t newrt = oclo_rtdata_nents + 8;
+		clo_rtdata_t *rt;
+		rt = recallocarray(oclo_rtdata, oclo_rtdata_nents, newrt,
+		    sizeof (clo_rtdata_t));
+		if (rt == NULL) {
+			err(EXIT_FAILURE, "TEST_FAILED: internal error "
+			    "expanding fd records to %zu entries", newrt);
+		}
+
+		oclo_rtdata_nents = newrt;
+		oclo_rtdata = rt;
+	}
+
+	if (fd != oclo_nextfd) {
+		errx(EXIT_FAILURE, "TEST FAILED: internal test error: expected "
+		    "to record next fd %d, given %d", oclo_nextfd, fd);
+	}
+
+	oclo_rtdata[oclo_rtdata_next].crt_data = c;
+	oclo_rtdata[oclo_rtdata_next].crt_fd = fd;
+	oclo_rtdata[oclo_rtdata_next].crt_flags = exp_flags;
+	oclo_rtdata[oclo_rtdata_next].crt_desc = desc;
+
+	/*
+	 * Matching errors at this phase are fatal as it means we screwed up the
+	 * program pretty badly.
+	 */
+	if (!oclo_flags_match(&oclo_rtdata[oclo_rtdata_next], false)) {
+		exit(EXIT_FAILURE);
+	}
+
+	oclo_rtdata_next++;
+	oclo_nextfd++;
+}
+
+static int
+oclo_file(const clo_create_t *c)
+{
+	int flags = O_RDWR, fd;
+
+	if ((c->clo_flags & FD_CLOEXEC) != 0)
+		flags |= O_CLOEXEC;
+	if ((c->clo_flags & FD_CLOFORK) != 0)
+		flags |= O_CLOFORK;
+	fd = open("/dev/null", flags);
+	if (fd < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to open /dev/null",
+		    c->clo_desc);
+	}
+
+	return (fd);
+}
+
+static void
+oclo_open(const clo_create_t *c)
+{
+	oclo_record(c, oclo_file(c), c->clo_flags, NULL);
+}
+
+static void
+oclo_setfd_common(const clo_create_t *c, int targ_flags)
+{
+	int fd = oclo_file(c);
+	if (fcntl(fd, F_SETFD, targ_flags) < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: F_SETFD failed to set "
+		    "flags to %d", c->clo_desc, targ_flags);
+	}
+
+	oclo_record(c, fd, targ_flags, NULL);
+}
+
+static void
+oclo_setfd_none(const clo_create_t *c)
+{
+	oclo_setfd_common(c, 0);
+}
+
+static void
+oclo_setfd_exec(const clo_create_t *c)
+{
+	oclo_setfd_common(c, FD_CLOEXEC);
+}
+
+static void
+oclo_setfd_fork(const clo_create_t *c)
+{
+	oclo_setfd_common(c, FD_CLOFORK);
+}
+
+static void
+oclo_setfd_both(const clo_create_t *c)
+{
+	oclo_setfd_common(c, FD_CLOFORK | FD_CLOEXEC);
+}
+
+/*
+ * Open an fd with flags in a certain form and then use one of the F_DUPFD or
+ * F_DUP2FD variants and ensure that flags are properly propagated as expected.
+ */
+static void
+oclo_fdup_common(const clo_create_t *c, int targ_flags, int cmd)
+{
+	int dup, fd;
+
+	fd = oclo_file(c);
+	oclo_record(c, fd, c->clo_flags, "base");
+	switch (cmd) {
+	case F_DUPFD:
+	case F_DUPFD_CLOEXEC:
+	case F_DUPFD_CLOFORK:
+		dup = fcntl(fd, cmd, fd);
+		break;
+	case F_DUP2FD:
+	case F_DUP2FD_CLOEXEC:
+	case F_DUP2FD_CLOFORK:
+		dup = fcntl(fd, cmd, fd + 1);
+		break;
+	case F_DUP3FD:
+		dup = fcntl(fd, cmd, fd + 1, targ_flags);
+		break;
+	default:
+		errx(EXIT_FAILURE, "TEST FAILURE: %s: internal error: "
+		    "unexpected fcntl cmd: 0x%x", c->clo_desc, cmd);
+	}
+
+	if (dup < 0) {
+		err(EXIT_FAILURE, "TEST FAILURE: %s: failed to dup fd with "
+		    "fcntl command 0x%x", c->clo_desc, cmd);
+	}
+
+	oclo_record(c, dup, targ_flags, "dup");
+}
+
+static void
+oclo_fdupfd(const clo_create_t *c)
+{
+	oclo_fdup_common(c, 0, F_DUPFD);
+}
+
+static void
+oclo_fdupfd_fork(const clo_create_t *c)
+{
+	oclo_fdup_common(c, FD_CLOFORK, F_DUPFD_CLOFORK);
+}
+
+static void
+oclo_fdupfd_exec(const clo_create_t *c)
+{
+	oclo_fdup_common(c, FD_CLOEXEC, F_DUPFD_CLOEXEC);
+}
+
+static void
+oclo_fdup2fd(const clo_create_t *c)
+{
+	oclo_fdup_common(c, 0, F_DUP2FD);
+}
+
+static void
+oclo_fdup2fd_fork(const clo_create_t *c)
+{
+	oclo_fdup_common(c, FD_CLOFORK, F_DUP2FD_CLOFORK);
+}
+
+static void
+oclo_fdup2fd_exec(const clo_create_t *c)
+{
+	oclo_fdup_common(c, FD_CLOEXEC, F_DUP2FD_CLOEXEC);
+}
+
+static void
+oclo_fdup3fd_none(const clo_create_t *c)
+{
+	oclo_fdup_common(c, 0, F_DUP3FD);
+}
+
+static void
+oclo_fdup3fd_exec(const clo_create_t *c)
+{
+	oclo_fdup_common(c, FD_CLOEXEC, F_DUP3FD);
+}
+
+static void
+oclo_fdup3fd_fork(const clo_create_t *c)
+{
+	oclo_fdup_common(c, FD_CLOFORK, F_DUP3FD);
+}
+
+static void
+oclo_fdup3fd_both(const clo_create_t *c)
+{
+	oclo_fdup_common(c, FD_CLOEXEC | FD_CLOFORK, F_DUP3FD);
+}
+
+static void
+oclo_dup_common(const clo_create_t *c, int targ_flags, bool v3)
+{
+	int dup, fd;
+	fd = oclo_file(c);
+	oclo_record(c, fd, c->clo_flags, "base");
+	if (v3) {
+		int dflags = 0;
+		if ((targ_flags & FD_CLOEXEC) != 0)
+			dflags |= O_CLOEXEC;
+		if ((targ_flags & FD_CLOFORK) != 0)
+			dflags |= O_CLOFORK;
+		dup = dup3(fd, fd + 1, dflags);
+	} else {
+		dup = dup2(fd, fd + 1);
+	}
+
+	oclo_record(c, dup, targ_flags, "dup");
+}
+
+static void
+oclo_dup2(const clo_create_t *c)
+{
+	oclo_dup_common(c, 0, false);
+}
+
+static void
+oclo_dup3_none(const clo_create_t *c)
+{
+	oclo_dup_common(c, 0, true);
+}
+
+static void
+oclo_dup3_exec(const clo_create_t *c)
+{
+	oclo_dup_common(c, FD_CLOEXEC, true);
+}
+
+static void
+oclo_dup3_fork(const clo_create_t *c)
+{
+	oclo_dup_common(c, FD_CLOFORK, true);
+}
+
+static void
+oclo_dup3_both(const clo_create_t *c)
+{
+	oclo_dup_common(c, FD_CLOEXEC | FD_CLOFORK, true);
+}
+
+static void
+oclo_pipe(const clo_create_t *c)
+{
+	int flags = 0, fds[2];
+
+	if ((c->clo_flags & FD_CLOEXEC) != 0)
+		flags |= O_CLOEXEC;
+	if ((c->clo_flags & FD_CLOFORK) != 0)
+		flags |= O_CLOFORK;
+
+	if (pipe2(fds, flags) < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: pipe2() with flags %d "
+		    "failed", c->clo_desc, flags);
+	}
+
+	oclo_record(c, fds[0], c->clo_flags, "pipe[0]");
+	oclo_record(c, fds[1], c->clo_flags, "pipe[1]");
+}
+
+static void
+oclo_socket(const clo_create_t *c)
+{
+	int type = SOCK_DGRAM, fd;
+
+	if ((c->clo_flags & FD_CLOEXEC) != 0)
+		type |= SOCK_CLOEXEC;
+	if ((c->clo_flags & FD_CLOFORK) != 0)
+		type |= SOCK_CLOFORK;
+	fd = socket(PF_INET, type, 0);
+	if (fd < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to create socket "
+		    "with flags: 0x%x\n", c->clo_desc, c->clo_flags);
+	}
+
+	oclo_record(c, fd, c->clo_flags, NULL);
+}
+
+static void
+oclo_accept_common(const clo_create_t *c, int targ_flags, bool a4)
+{
+	int lsock, csock, asock;
+	int ltype = SOCK_STREAM, atype = 0;
+	struct sockaddr_in in;
+	socklen_t slen;
+
+	if ((c->clo_flags & FD_CLOEXEC) != 0)
+		ltype |= SOCK_CLOEXEC;
+	if ((c->clo_flags & FD_CLOFORK) != 0)
+		ltype |= SOCK_CLOFORK;
+
+	if ((targ_flags & FD_CLOEXEC) != 0)
+		atype |= SOCK_CLOEXEC;
+	if ((targ_flags & FD_CLOFORK) != 0)
+		atype |= SOCK_CLOFORK;
+
+	lsock = socket(PF_INET, ltype, 0);
+	if (lsock < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to create listen "
+		    "socket with flags: 0x%x\n", c->clo_desc, c->clo_flags);
+	}
+
+	oclo_record(c, lsock, c->clo_flags, "listen");
+	(void) memset(&in, 0, sizeof (in));
+	in.sin_family = AF_INET;
+	in.sin_port = 0;
+	in.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+	if (bind(lsock, (struct sockaddr *)&in, sizeof (in)) != 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to bind socket",
+		    c->clo_desc);
+	}
+
+	slen = sizeof (struct sockaddr_in);
+	if (getsockname(lsock, (struct sockaddr *)&in, &slen) != 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to discover bound "
+		    "socket address", c->clo_desc);
+	}
+
+	if (listen(lsock, 5) < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to listen on socket",
+		    c->clo_desc);
+	}
+
+	csock = socket(PF_INET, SOCK_STREAM, 0);
+	if (csock < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to create client "
+		    "socket", c->clo_desc);
+	}
+	oclo_record(c, csock, 0, "connect");
+
+	if (connect(csock, (struct sockaddr *)&in, sizeof (in)) != 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to connect to "
+		    "server socket", c->clo_desc);
+	}
+
+	if (a4) {
+		asock = accept4(lsock, NULL, NULL, atype);
+	} else {
+		asock = accept(lsock, NULL, NULL);
+	}
+	if (asock < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to accept client "
+		    "connection", c->clo_desc);
+	}
+	oclo_record(c, asock, targ_flags, "accept");
+}
+
+static void
+oclo_accept(const clo_create_t *c)
+{
+	oclo_accept_common(c, 0, false);
+}
+
+static void
+oclo_accept4_none(const clo_create_t *c)
+{
+	oclo_accept_common(c, 0, true);
+}
+
+static void
+oclo_accept4_fork(const clo_create_t *c)
+{
+	oclo_accept_common(c, FD_CLOFORK, true);
+}
+
+static void
+oclo_accept4_exec(const clo_create_t *c)
+{
+	oclo_accept_common(c, FD_CLOEXEC, true);
+}
+
+static void
+oclo_accept4_both(const clo_create_t *c)
+{
+	oclo_accept_common(c, FD_CLOEXEC | FD_CLOFORK, true);
+}
+
+/*
+ * Go through the process of sending ourselves a file descriptor.
+ */
+static void
+oclo_rights_common(const clo_create_t *c, int targ_flags)
+{
+	int pair[2], type = SOCK_DGRAM, sflags = 0;
+	int tosend = oclo_file(c), recvfd;
+	uint32_t data = 0x7777;
+	struct iovec iov;
+	struct msghdr msg;
+	struct cmsghdr *cm;
+
+	if ((c->clo_flags & FD_CLOEXEC) != 0)
+		type |= SOCK_CLOEXEC;
+	if ((c->clo_flags & FD_CLOFORK) != 0)
+		type |= SOCK_CLOFORK;
+
+	if (socketpair(PF_UNIX, type, 0, pair) < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to create socket "
+		    "pair", c->clo_desc);
+	}
+
+	oclo_record(c, tosend, c->clo_flags, "send fd");
+	oclo_record(c, pair[0], c->clo_flags, "pair[0]");
+	oclo_record(c, pair[1], c->clo_flags, "pair[1]");
+
+	iov.iov_base = (void *)&data;
+	iov.iov_len = sizeof (data);
+
+	(void) memset(&msg, 0, sizeof (msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_controllen = CMSG_SPACE(sizeof (int));
+
+	msg.msg_control = calloc(1, msg.msg_controllen);
+	if (msg.msg_control == NULL) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to allocate %u "
+		    "bytes for SCM_RIGHTS control message", c->clo_desc,
+		    msg.msg_controllen);
+	}
+
+	cm = CMSG_FIRSTHDR(&msg);
+	cm->cmsg_len = CMSG_LEN(sizeof (int));
+	cm->cmsg_level = SOL_SOCKET;
+	cm->cmsg_type = SCM_RIGHTS;
+	(void) memcpy(CMSG_DATA(cm), &tosend, sizeof (tosend));
+
+	if ((targ_flags & FD_CLOEXEC) != 0)
+		sflags |= MSG_CMSG_CLOEXEC;
+	if ((targ_flags & FD_CLOFORK) != 0)
+		sflags |= MSG_CMSG_CLOFORK;
+
+	if (sendmsg(pair[0], &msg, 0) < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to send fd",
+		    c->clo_desc);
+	}
+
+	data = 0;
+	if (recvmsg(pair[1], &msg, sflags) < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: %s: failed to get fd",
+		    c->clo_desc);
+	}
+
+	if (data != 0x7777) {
+		errx(EXIT_FAILURE, "TEST FAILED: %s: did not receive correct "
+		    "data: expected 0x7777, found 0x%x", c->clo_desc, data);
+	}
+
+	if (msg.msg_controllen < CMSG_SPACE(sizeof (int))) {
+		errx(EXIT_FAILURE, "TEST FAILED: %s: found insufficient "
+		    "message control length: expected at least 0x%x, found "
+		    "0x%x", c->clo_desc, CMSG_SPACE(sizeof (int)),
+		    msg.msg_controllen);
+	}
+
+	cm = CMSG_FIRSTHDR(&msg);
+	if (cm->cmsg_level != SOL_SOCKET || cm->cmsg_type != SCM_RIGHTS) {
+		errx(EXIT_FAILURE, "TEST FAILED: %s: found surprising cmsg "
+		    "0x%x/0x%x, expected 0x%x/0x%x", c->clo_desc,
+		    cm->cmsg_level, cm->cmsg_type, SOL_SOCKET, SCM_RIGHTS);
+	}
+
+	if (cm->cmsg_len != CMSG_LEN(sizeof (int))) {
+		errx(EXIT_FAILURE, "TEST FAILED: %s: found unexpected "
+		    "SCM_RIGHTS length 0x%x: expected 0x%zx", c->clo_desc,
+		    cm->cmsg_len, CMSG_LEN(sizeof (int)));
+	}
+
+	(void) memcpy(&recvfd, CMSG_DATA(cm), sizeof (recvfd));
+	oclo_record(c, recvfd, targ_flags, "SCM_RIGHTS");
+}
+
+static void
+oclo_rights_none(const clo_create_t *c)
+{
+	oclo_rights_common(c, 0);
+}
+
+static void
+oclo_rights_exec(const clo_create_t *c)
+{
+	oclo_rights_common(c, FD_CLOEXEC);
+}
+
+static void
+oclo_rights_fork(const clo_create_t *c)
+{
+	oclo_rights_common(c, FD_CLOFORK);
+}
+
+static void
+oclo_rights_both(const clo_create_t *c)
+{
+	oclo_rights_common(c, FD_CLOEXEC | FD_CLOFORK);
+}
+
+static const clo_create_t oclo_create[] = { {
+	.clo_desc = "open(2), no flags",
+	.clo_flags = 0,
+	.clo_func = oclo_open
+}, {
+	.clo_desc = "open(2), O_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_open
+}, {
+	.clo_desc = "open(2), O_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_open
+}, {
+	.clo_desc = "open(2), O_CLOEXEC|O_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_open
+}, {
+	.clo_desc = "fcntl(F_SETFD) no flags->no flags",
+	.clo_flags = 0,
+	.clo_func = oclo_setfd_none
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOFORK|O_CLOEXEC->no flags",
+	.clo_flags = O_CLOFORK | O_CLOEXEC,
+	.clo_func = oclo_setfd_none
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOEXEC->no flags",
+	.clo_flags = O_CLOEXEC,
+	.clo_func = oclo_setfd_none
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOFORK->no flags",
+	.clo_flags = O_CLOFORK,
+	.clo_func = oclo_setfd_none
+}, {
+	.clo_desc = "fcntl(F_SETFD) no flags->O_CLOEXEC",
+	.clo_flags = 0,
+	.clo_func = oclo_setfd_exec
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOFORK|O_CLOEXEC->O_CLOEXEC",
+	.clo_flags = O_CLOFORK | O_CLOEXEC,
+	.clo_func = oclo_setfd_exec
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOEXEC->O_CLOEXEC",
+	.clo_flags = O_CLOEXEC,
+	.clo_func = oclo_setfd_exec
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOFORK->O_CLOEXEC",
+	.clo_flags = O_CLOFORK,
+	.clo_func = oclo_setfd_exec
+}, {
+	.clo_desc = "fcntl(F_SETFD) no flags->O_CLOFORK",
+	.clo_flags = 0,
+	.clo_func = oclo_setfd_fork
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOFORK|O_CLOEXEC->O_CLOFORK",
+	.clo_flags = O_CLOFORK | O_CLOEXEC,
+	.clo_func = oclo_setfd_fork
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOEXEC->O_CLOFORK",
+	.clo_flags = O_CLOEXEC,
+	.clo_func = oclo_setfd_fork
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOFORK->O_CLOFORK",
+	.clo_flags = O_CLOFORK,
+	.clo_func = oclo_setfd_fork
+}, {
+	.clo_desc = "fcntl(F_SETFD) no flags->O_CLOFORK|O_CLOEXEC",
+	.clo_flags = 0,
+	.clo_func = oclo_setfd_both
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOFORK|O_CLOEXEC->O_CLOFORK|O_CLOEXEC",
+	.clo_flags = O_CLOFORK | O_CLOEXEC,
+	.clo_func = oclo_setfd_both
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOEXEC->O_CLOFORK|O_CLOEXEC",
+	.clo_flags = O_CLOEXEC,
+	.clo_func = oclo_setfd_both
+}, {
+	.clo_desc = "fcntl(F_SETFD) O_CLOFORK->O_CLOFORK|O_CLOEXEC",
+	.clo_flags = O_CLOFORK,
+	.clo_func = oclo_setfd_both
+}, {
+	.clo_desc = "fcntl(F_DUPFD) none->none",
+	.clo_flags = 0,
+	.clo_func = oclo_fdupfd
+}, {
+	.clo_desc = "fcntl(F_DUPFD) FD_CLOEXEC->none",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdupfd
+}, {
+	.clo_desc = "fcntl(F_DUPFD) FD_CLOFORK->none",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdupfd
+}, {
+	.clo_desc = "fcntl(F_DUPFD) FD_CLOEXEC|FD_CLOFORK->none",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdupfd
+}, {
+	.clo_desc = "fcntl(F_DUPFD_CLOFORK) none",
+	.clo_flags = 0,
+	.clo_func = oclo_fdupfd_fork
+}, {
+	.clo_desc = "fcntl(F_DUPFD_CLOFORK) FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdupfd_fork
+}, {
+	.clo_desc = "fcntl(F_DUPFD_CLOFORK) FD_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdupfd_fork
+}, {
+	.clo_desc = "fcntl(F_DUPFD_CLOFORK) FD_CLOEXEC|FD_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdupfd_fork
+}, {
+	.clo_desc = "fcntl(F_DUPFD_CLOEXEC) none",
+	.clo_flags = 0,
+	.clo_func = oclo_fdupfd_exec
+}, {
+	.clo_desc = "fcntl(F_DUPFD_CLOEXEC) FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdupfd_exec
+}, {
+	.clo_desc = "fcntl(F_DUPFD_CLOEXEC) FD_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdupfd_exec
+}, {
+	.clo_desc = "fcntl(F_DUPFD_CLOEXEC) FD_CLOEXEC|FD_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdupfd_exec
+}, {
+	.clo_desc = "fcntl(F_DUP2FD) none->none",
+	.clo_flags = 0,
+	.clo_func = oclo_fdup2fd
+}, {
+	.clo_desc = "fcntl(F_DUP2FD) FD_CLOEXEC->none",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdup2fd
+}, {
+	.clo_desc = "fcntl(F_DUP2FD) FD_CLOFORK->none",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdup2fd
+}, {
+	.clo_desc = "fcntl(F_DUP2FD) FD_CLOEXEC|FD_CLOFORK->none",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdup2fd
+}, {
+	.clo_desc = "fcntl(F_DUP2FD_CLOFORK) none",
+	.clo_flags = 0,
+	.clo_func = oclo_fdup2fd_fork
+}, {
+	.clo_desc = "fcntl(F_DUP2FD_CLOFORK) FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdup2fd_fork
+}, {
+	.clo_desc = "fcntl(F_DUP2FD_CLOFORK) FD_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdup2fd_fork
+}, {
+	.clo_desc = "fcntl(F_DUP2FD_CLOFORK) FD_CLOEXEC|FD_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdup2fd_fork
+}, {
+	.clo_desc = "fcntl(F_DUP2FD_CLOEXEC) none",
+	.clo_flags = 0,
+	.clo_func = oclo_fdup2fd_exec
+}, {
+	.clo_desc = "fcntl(F_DUP2FD_CLOEXEC) FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdup2fd_exec
+}, {
+	.clo_desc = "fcntl(F_DUP2FD_CLOEXEC) FD_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdup2fd_exec
+}, {
+	.clo_desc = "fcntl(F_DUP2FD_CLOEXEC) FD_CLOEXEC|FD_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdup2fd_exec
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) none->none",
+	.clo_flags = 0,
+	.clo_func = oclo_fdup3fd_none
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOEXEC->none",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdup3fd_none
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOFORK->none",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdup3fd_none
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOEXEC|FD_CLOFORK->none",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdup3fd_none
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) none->FD_CLOEXEC",
+	.clo_flags = 0,
+	.clo_func = oclo_fdup3fd_exec
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOEXEC->FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdup3fd_exec
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOFORK->FD_CLOEXEC",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdup3fd_exec
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOEXEC|FD_CLOFORK->FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdup3fd_exec
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) none->FD_CLOFORK|FD_CLOEXEC",
+	.clo_flags = 0,
+	.clo_func = oclo_fdup3fd_both
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOEXEC->FD_CLOFORK|FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdup3fd_both
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOFORK->FD_CLOFORK|FD_CLOEXEC",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdup3fd_both
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOEXEC|FD_CLOFORK->"
+	    "FD_CLOFORK|FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdup3fd_both
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) none->FD_CLOFORK",
+	.clo_flags = 0,
+	.clo_func = oclo_fdup3fd_fork
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOEXEC->FD_CLOFORK",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_fdup3fd_fork
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOFORK->FD_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_fdup3fd_fork
+}, {
+	.clo_desc = "fcntl(F_DUP3FD) FD_CLOEXEC|FD_CLOFORK->FD_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_fdup3fd_fork
+}, {
+	.clo_desc = "dup2() none->none",
+	.clo_flags = 0,
+	.clo_func = oclo_dup2
+}, {
+	.clo_desc = "dup2() FD_CLOEXEC->none",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_dup2
+}, {
+	.clo_desc = "dup2() FD_CLOFORK->none",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_dup2
+}, {
+	.clo_desc = "dup2() FD_CLOEXEC|FD_CLOFORK->none",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_dup2
+}, {
+	.clo_desc = "dup3() none->none",
+	.clo_flags = 0,
+	.clo_func = oclo_dup3_none
+}, {
+	.clo_desc = "dup3() FD_CLOEXEC->none",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_dup3_none
+}, {
+	.clo_desc = "dup3() FD_CLOFORK->none",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_dup3_none
+}, {
+	.clo_desc = "dup3() FD_CLOEXEC|FD_CLOFORK->none",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_dup3_none
+}, {
+	.clo_desc = "dup3() none->FD_CLOEXEC",
+	.clo_flags = 0,
+	.clo_func = oclo_dup3_exec
+}, {
+	.clo_desc = "dup3() FD_CLOEXEC->FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_dup3_exec
+}, {
+	.clo_desc = "dup3() FD_CLOFORK->FD_CLOEXEC",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_dup3_exec
+}, {
+	.clo_desc = "dup3() FD_CLOEXEC|FD_CLOFORK->FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_dup3_exec
+}, {
+	.clo_desc = "dup3() none->FD_CLOFORK|FD_CLOEXEC",
+	.clo_flags = 0,
+	.clo_func = oclo_dup3_both
+}, {
+	.clo_desc = "dup3() FD_CLOEXEC->FD_CLOFORK|FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_dup3_both
+}, {
+	.clo_desc = "dup3() FD_CLOFORK->FD_CLOFORK|FD_CLOEXEC",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_dup3_both
+}, {
+	.clo_desc = "dup3() FD_CLOEXEC|FD_CLOFORK->FD_CLOFORK|FD_CLOEXEC",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_dup3_both
+}, {
+	.clo_desc = "dup3() none->FD_CLOFORK",
+	.clo_flags = 0,
+	.clo_func = oclo_dup3_fork
+}, {
+	.clo_desc = "dup3() FD_CLOEXEC->FD_CLOFORK",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_dup3_fork
+}, {
+	.clo_desc = "dup3() FD_CLOFORK->FD_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_dup3_fork
+}, {
+	.clo_desc = "dup3() FD_CLOEXEC|FD_CLOFORK->FD_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_dup3_fork
+}, {
+	.clo_desc = "pipe(2), no flags",
+	.clo_flags = 0,
+	.clo_func = oclo_pipe
+}, {
+	.clo_desc = "pipe(2), O_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_pipe
+}, {
+	.clo_desc = "pipe(2), O_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_pipe
+}, {
+	.clo_desc = "pipe(2), O_CLOEXEC|O_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_pipe
+}, {
+	.clo_desc = "socket(2), no flags",
+	.clo_flags = 0,
+	.clo_func = oclo_socket
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_socket
+}, {
+	.clo_desc = "socket(2), O_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_socket
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC|O_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_socket
+}, {
+	.clo_desc = "socket(2), no flags->accept() none",
+	.clo_flags = 0,
+	.clo_func = oclo_accept
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC->accept() none",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_accept
+}, {
+	.clo_desc = "socket(2), O_CLOFORK->accept() none",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_accept
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC|O_CLOFORK->accept() none",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_accept
+}, {
+	.clo_desc = "socket(2), no flags->accept4() none",
+	.clo_flags = 0,
+	.clo_func = oclo_accept4_none
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC->accept4() none",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_accept4_none
+}, {
+	.clo_desc = "socket(2), O_CLOFORK->accept4() none",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_accept4_none
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC|O_CLOFORK->accept4() none",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_accept4_none
+}, {
+	.clo_desc = "socket(2), no flags->accept4() SOCK_CLOFORK|SOCK_CLOEXEC",
+	.clo_flags = 0,
+	.clo_func = oclo_accept4_both
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC->accept4() SOCK_CLOFORK|SOCK_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_accept4_both
+}, {
+	.clo_desc = "socket(2), O_CLOFORK->accept4() SOCK_CLOFORK|SOCK_CLOEXEC",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_accept4_both
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC|O_CLOFORK->accept4() "
+	    "SOCK_CLOFORK|SOCK_CLOEXEC",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_accept4_both
+}, {
+	.clo_desc = "socket(2), no flags->accept4() SOCK_CLOFORK",
+	.clo_flags = 0,
+	.clo_func = oclo_accept4_fork
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC->accept4() SOCK_CLOFORK",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_accept4_fork
+}, {
+	.clo_desc = "socket(2), O_CLOFORK->accept4() SOCK_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_accept4_fork
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC|O_CLOFORK->accept4() SOCK_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_accept4_fork
+}, {
+	.clo_desc = "socket(2), no flags->accept4() SOCK_CLOEXEC",
+	.clo_flags = 0,
+	.clo_func = oclo_accept4_exec
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC->accept4() SOCK_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_accept4_exec
+}, {
+	.clo_desc = "socket(2), O_CLOFORK->accept4() SOCK_CLOEXEC",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_accept4_exec
+}, {
+	.clo_desc = "socket(2), O_CLOEXEC|O_CLOFORK->accept4() SOCK_CLOEXEC",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_accept4_exec
+}, {
+	.clo_desc = "SCM_RIGHTS none->none",
+	.clo_flags = 0,
+	.clo_func = oclo_rights_none
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOFORK->none",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_rights_none
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOEXEC->none",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_rights_none
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOEXEC|FD_CLOFORK->none",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_rights_none
+}, {
+	.clo_desc = "SCM_RIGHTS none->MSG_CMSG_CLOEXEC",
+	.clo_flags = 0,
+	.clo_func = oclo_rights_exec
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOFORK->MSG_CMSG_CLOEXEC",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_rights_exec
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOEXEC->MSG_CMSG_CLOEXEC",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_rights_exec
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOEXEC|FD_CLOFORK->MSG_CMSG_CLOEXEC",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_rights_exec
+}, {
+	.clo_desc = "SCM_RIGHTS MSG_CMSG_CLOFORK->nMSG_CMSG_CLOFORK",
+	.clo_flags = 0,
+	.clo_func = oclo_rights_fork
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOFORK->MSG_CMSG_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_rights_fork
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOEXEC->MSG_CMSG_CLOFORK",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_rights_fork
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOEXEC|FD_CLOFORK->MSG_CMSG_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_rights_fork
+}, {
+	.clo_desc = "SCM_RIGHTS none->MSG_CMSG_CLOEXEC|MSG_CMSG_CLOFORK",
+	.clo_flags = 0,
+	.clo_func = oclo_rights_both
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOFORK->MSG_CMSG_CLOEXEC|MSG_CMSG_CLOFORK",
+	.clo_flags = FD_CLOFORK,
+	.clo_func = oclo_rights_both
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOEXEC->MSG_CMSG_CLOEXEC|MSG_CMSG_CLOFORK",
+	.clo_flags = FD_CLOEXEC,
+	.clo_func = oclo_rights_both
+}, {
+	.clo_desc = "SCM_RIGHTS FD_CLOEXEC|FD_CLOFORK->"
+	    "MSG_CMSG_CLOEXEC|MSG_CMSG_CLOFORK",
+	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
+	.clo_func = oclo_rights_both
+} };
+
+static bool
+oclo_verify_fork(void)
+{
+	bool ret = true;
+
+	for (size_t i = 0; i < oclo_rtdata_next; i++) {
+		if (!oclo_flags_match(&oclo_rtdata[i], true)) {
+			ret = false;
+		}
+	}
+
+	return (ret);
+}
+
+/*
+ * Here we proceed to re-open any fd that was closed due to O_CLOFORK again to
+ * make sure that the file descriptor makes it to our child verifier.
+ * Importantly, with the changes that cause O_CLOFORK to be cleared on exec, we
+ * should not see any file descriptors with the flag in the child. This allows
+ * us to confirm that this is what we expect.
+ *
+ * In addition, this serves as a test to make sure that our opening of the
+ * lowest fd is correct. While this doesn't actually use the same method as was
+ * done previously, this should get us most of the way there.
+ */
+static void
+oclo_child_reopen(void)
+{
+	for (size_t i = 0; i < oclo_rtdata_next; i++) {
+		int fd;
+		int flags = O_RDWR | O_CLOFORK;
+
+		if ((oclo_rtdata[i].crt_flags & FD_CLOFORK) == 0)
+			continue;
+
+		if ((oclo_rtdata[i].crt_flags & FD_CLOEXEC) != 0)
+			flags |= O_CLOEXEC;
+
+		fd = open("/dev/zero", flags);
+		if (fd < 0) {
+			err(EXIT_FAILURE, "TEST FAILED: failed to re-open fd "
+			    "%d with flags %d", oclo_rtdata[i].crt_fd, flags);
+		}
+
+		if (fd != oclo_rtdata[i].crt_fd) {
+			errx(EXIT_FAILURE, "TEST FAILED: re-opening fd %d "
+			    "returned fd %d: test design issue or lowest fd "
+			    "algorithm is broken", oclo_rtdata[i].crt_fd, fd);
+		}
+	}
+
+	(void) printf("TEST PASSED: successfully reopened fds post-fork");
+}
+
+/*
+ * Look for the verification program in the same directory that this program is
+ * found in. Note, that isn't the same thing as the current working directory.
+ */
+static void
+oclo_exec(void)
+{
+	ssize_t ret;
+	char dir[PATH_MAX], file[PATH_MAX];
+	char **argv;
+
+	ret = readlink("/proc/self/path/a.out", dir, sizeof (dir));
+	if (ret < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: failed to read our a.out path "
+		    "from /proc");
+	} else if (ret == 0) {
+		errx(EXIT_FAILURE, "TEST FAILED: reading /proc/self/path/a.out "
+		    "returned 0 bytes");
+	} else if (ret == sizeof (dir)) {
+		errx(EXIT_FAILURE, "TEST FAILED: Using /proc/self/path/a.out "
+		    "requires truncation");
+	}
+
+	if (snprintf(file, sizeof (file), "%s/%s", dirname(dir), OCLO_VERIFY) >=
+	    sizeof (file)) {
+		errx(EXIT_FAILURE, "TEST FAILED: cannot assemble exec path "
+		    "name: internal buffer overflow");
+	}
+
+	/* We need an extra for both the NULL terminator and the program name */
+	argv = calloc(oclo_rtdata_next + 2, sizeof (char *));
+	if (argv == NULL) {
+		err(EXIT_FAILURE, "TEST FAILED: failed to allocate exec "
+		    "argument array");
+	}
+
+	argv[0] = file;
+	for (size_t i = 0; i < oclo_rtdata_next; i++) {
+		if (asprintf(&argv[i + 1], "0x%x", oclo_rtdata[i].crt_flags) ==
+		    -1) {
+			err(EXIT_FAILURE, "TEST FAILED: failed to assemble "
+			    "exec argument %zu", i + 1);
+		}
+	}
+
+	(void) execv(file, argv);
+	warn("TEST FAILED: failed to exec verifier %s", file);
+}
+
+int
+main(void)
+{
+	int ret = EXIT_SUCCESS;
+	siginfo_t cret;
+
+	/*
+	 * Before we do anything else close all FDs that aren't standard. We
+	 * don't want anything the test suite environment may have left behind.
+	 */
+	(void) closefrom(STDERR_FILENO + 1);
+
+	/*
+	 * Treat failure during this set up phase as a hard failure. There's no
+	 * reason to continue if we can't successfully create the FDs we expect.
+	 */
+	for (size_t i = 0; i < ARRAY_SIZE(oclo_create); i++) {
+		oclo_create[i].clo_func(&oclo_create[i]);
+	}
+
+	pid_t child = forkx(FORK_NOSIGCHLD | FORK_WAITPID);
+	if (child == 0) {
+		if (!oclo_verify_fork()) {
+			ret = EXIT_FAILURE;
+		}
+
+		oclo_child_reopen();
+
+		oclo_exec();
+		ret = EXIT_FAILURE;
+		_exit(ret);
+	}
+
+	if (waitid(P_PID, child, &cret, WEXITED) < 0) {
+		err(EXIT_FAILURE, "TEST FAILED: internal test failure waiting "
+		    "for forked child to report");
+	}
+
+	if (cret.si_code != CLD_EXITED) {
+		warnx("TEST FAILED: child process did not successfully exit: "
+		    "found si_code: %d", cret.si_code);
+		ret = EXIT_FAILURE;
+	} else if (cret.si_status != 0) {
+		warnx("TEST FAILED: child process did not exit with code 0: "
+		    "found %d", cret.si_status);
+		ret = EXIT_FAILURE;
+	}
+
+	if (ret == EXIT_SUCCESS) {
+		(void) printf("All tests passed successfully\n");
+	}
+
+	return (ret);
+}

--- a/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/oclo.c
+++ b/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/oclo.c
@@ -45,21 +45,54 @@
  * with the divergence of other implementations.
  */
 
-#include <stdlib.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <err.h>
-#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <sys/sysmacros.h>
-#include <sys/fork.h>
-#include <wait.h>
-#include <errno.h>
-#include <string.h>
-#include <limits.h>
-#include <libgen.h>
+#include <sys/wait.h>
+
+#include <netinet/in.h>
 #include <sys/socket.h>
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+void *recallocarray(void *, size_t, size_t, size_t);
+
+#define strerrorname_np(e) (sys_errlist[e])
+
+/*
+ * Get pathname to avoid reading /proc/curproc/exe
+ *
+ * Taken from procstat_getpathname_sysctl()
+ */
+static int
+getpathname(pid_t pid, char *pathname, size_t maxlen)
+{
+	int error, name[4];
+	size_t len;
+
+	name[0] = CTL_KERN;
+	name[1] = KERN_PROC;
+	name[2] = KERN_PROC_PATHNAME;
+	name[3] = pid;
+	len = maxlen;
+	error = sysctl(name, nitems(name), pathname, &len, NULL, 0);
+	if (error != 0 && errno != ESRCH)
+		warn("sysctl: kern.proc.pathname: %d", pid);
+	if (len == 0)
+		pathname[0] = '\0';
+	return (error);
+}
 
 /*
  * Verification program name.
@@ -93,8 +126,8 @@ typedef struct clo_rtdata {
 } clo_rtdata_t;
 
 static clo_rtdata_t *oclo_rtdata;
-size_t oclo_rtdata_nents = 0;
-size_t oclo_rtdata_next = 0;
+static size_t oclo_rtdata_nents = 0;
+static size_t oclo_rtdata_next = 0;
 static int oclo_nextfd = STDERR_FILENO + 1;
 
 static bool
@@ -267,11 +300,13 @@ oclo_fdup_common(const clo_create_t *c, int targ_flags, int cmd)
 		break;
 	case F_DUP2FD:
 	case F_DUP2FD_CLOEXEC:
+#ifdef F_DUP2FD_CLOFORK
 	case F_DUP2FD_CLOFORK:
+#endif
 		dup = fcntl(fd, cmd, fd + 1);
 		break;
 	case F_DUP3FD:
-		dup = fcntl(fd, cmd, fd + 1, targ_flags);
+		dup = fcntl(fd, cmd | (targ_flags << F_DUP3FD_SHIFT), fd + 1);
 		break;
 	default:
 		errx(EXIT_FAILURE, "TEST FAILURE: %s: internal error: "
@@ -310,11 +345,13 @@ oclo_fdup2fd(const clo_create_t *c)
 	oclo_fdup_common(c, 0, F_DUP2FD);
 }
 
+#ifdef F_DUP2FD_CLOFORK
 static void
 oclo_fdup2fd_fork(const clo_create_t *c)
 {
 	oclo_fdup_common(c, FD_CLOFORK, F_DUP2FD_CLOFORK);
 }
+#endif
 
 static void
 oclo_fdup2fd_exec(const clo_create_t *c)
@@ -604,7 +641,7 @@ oclo_rights_common(const clo_create_t *c, int targ_flags)
 
 	if (msg.msg_controllen < CMSG_SPACE(sizeof (int))) {
 		errx(EXIT_FAILURE, "TEST FAILED: %s: found insufficient "
-		    "message control length: expected at least 0x%x, found "
+		    "message control length: expected at least 0x%lx, found "
 		    "0x%x", c->clo_desc, CMSG_SPACE(sizeof (int)),
 		    msg.msg_controllen);
 	}
@@ -795,6 +832,7 @@ static const clo_create_t oclo_create[] = { {
 	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
 	.clo_func = oclo_fdup2fd
 }, {
+#ifdef F_DUP2FD_CLOFORK
 	.clo_desc = "fcntl(F_DUP2FD_CLOFORK) none",
 	.clo_flags = 0,
 	.clo_func = oclo_fdup2fd_fork
@@ -811,6 +849,7 @@ static const clo_create_t oclo_create[] = { {
 	.clo_flags = FD_CLOEXEC | FD_CLOFORK,
 	.clo_func = oclo_fdup2fd_fork
 }, {
+#endif
 	.clo_desc = "fcntl(F_DUP2FD_CLOEXEC) none",
 	.clo_flags = 0,
 	.clo_func = oclo_fdup2fd_exec
@@ -1216,20 +1255,12 @@ oclo_exec(void)
 	char dir[PATH_MAX], file[PATH_MAX];
 	char **argv;
 
-	ret = readlink("/proc/self/path/a.out", dir, sizeof (dir));
-	if (ret < 0) {
-		err(EXIT_FAILURE, "TEST FAILED: failed to read our a.out path "
-		    "from /proc");
-	} else if (ret == 0) {
-		errx(EXIT_FAILURE, "TEST FAILED: reading /proc/self/path/a.out "
-		    "returned 0 bytes");
-	} else if (ret == sizeof (dir)) {
-		errx(EXIT_FAILURE, "TEST FAILED: Using /proc/self/path/a.out "
-		    "requires truncation");
-	}
+	ret = getpathname(getpid(), dir, sizeof(dir));
+	if (ret < 0)
+		err(EXIT_FAILURE, "TEST FAILED: failed to read executable path");
 
 	if (snprintf(file, sizeof (file), "%s/%s", dirname(dir), OCLO_VERIFY) >=
-	    sizeof (file)) {
+	    (int)sizeof (file)) {
 		errx(EXIT_FAILURE, "TEST FAILED: cannot assemble exec path "
 		    "name: internal buffer overflow");
 	}
@@ -1270,11 +1301,11 @@ main(void)
 	 * Treat failure during this set up phase as a hard failure. There's no
 	 * reason to continue if we can't successfully create the FDs we expect.
 	 */
-	for (size_t i = 0; i < ARRAY_SIZE(oclo_create); i++) {
+	for (size_t i = 0; i < nitems(oclo_create); i++) {
 		oclo_create[i].clo_func(&oclo_create[i]);
 	}
 
-	pid_t child = forkx(FORK_NOSIGCHLD | FORK_WAITPID);
+	pid_t child = fork();
 	if (child == 0) {
 		if (!oclo_verify_fork()) {
 			ret = EXIT_FAILURE;

--- a/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/oclo_errors.c
+++ b/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/oclo_errors.c
@@ -1,0 +1,193 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2024 Oxide Computer Company
+ */
+
+/*
+ * Verify that unsupported flags will properly generate errors across the
+ * functions that we know perform strict error checking. This includes:
+ *
+ *  o fcntl(..., F_DUP3FD, ...)
+ *  o dup3()
+ *  o pipe2()
+ *  o socket()
+ *  o accept4()
+ */
+
+#include <stdlib.h>
+#include <err.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/socket.h>
+
+static bool
+oclo_check(const char *desc, const char *act, int ret, int e)
+{
+	if (ret >= 0) {
+		warnx("TEST FAILED: %s: fd was %s!", desc, act);
+		return (false);
+	} else if (errno != EINVAL) {
+		int e = errno;
+		warnx("TEST FAILED: %s: failed with %s, expected "
+		    "EINVAL", desc, strerrorname_np(e));
+		return (false);
+	}
+
+	(void) printf("TEST PASSED: %s: correctly failed with EINVAL\n",
+	    desc);
+	return (true);
+}
+
+static bool
+oclo_dup3(const char *desc, int flags)
+{
+	int fd = dup3(STDERR_FILENO, 23, flags);
+	return (oclo_check(desc, "duplicated", fd, errno));
+}
+
+static bool
+oclo_dup3fd(const char *desc, int flags)
+{
+	int fd = fcntl(STDERR_FILENO, F_DUP3FD, 23, flags);
+	return (oclo_check(desc, "duplicated", fd, errno));
+}
+
+
+static bool
+oclo_pipe2(const char *desc, int flags)
+{
+	int fds[2], ret;
+
+	ret = pipe2(fds, flags);
+	return (oclo_check(desc, "piped", ret, errno));
+}
+
+static bool
+oclo_socket(const char *desc, int type)
+{
+	int fd = socket(PF_UNIX, SOCK_STREAM | type, 0);
+	return (oclo_check(desc, "created", fd, errno));
+}
+
+static bool
+oclo_accept(const char *desc, int flags)
+{
+	int sock, fd, e;
+	struct sockaddr_in in;
+
+	sock = socket(PF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	if (sock < 0) {
+		warn("TEST FAILED: %s: failed to create listen socket", desc);
+		return (false);
+	}
+
+	(void) memset(&in, 0, sizeof (in));
+	in.sin_family = AF_INET;
+	in.sin_port = 0;
+	in.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+	if (bind(sock, (struct sockaddr *)&in, sizeof (in)) != 0) {
+		warn("TEST FAILED: %s: failed to bind socket", desc);
+		(void) close(sock);
+		return (false);
+	}
+
+	if (listen(sock, 5) < 0) {
+		warn("TEST FAILED: %s: failed to listen on socket", desc);
+		(void) close(sock);
+		return (false);
+	}
+
+
+	fd = accept4(sock, NULL, NULL, flags);
+	e = errno;
+	(void) close(sock);
+	return (oclo_check(desc, "accepted", fd, e));
+}
+
+int
+main(void)
+{
+	int ret = EXIT_SUCCESS;
+
+	closefrom(STDERR_FILENO + 1);
+
+	if (!oclo_dup3("dup3(): O_RDWR", O_RDWR)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_dup3("dup3(): O_NONBLOCK|O_CLOXEC", O_NONBLOCK | O_CLOEXEC)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_dup3("dup3(): O_CLOFORK|O_WRONLY", O_CLOFORK | O_WRONLY)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_dup3fd("fcntl(FDUP3FD): 0x7777", 0x7777)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_dup3fd("fcntl(FDUP3FD): FD_CLOEXEC|FD_CLOFORK + 1",
+	    (FD_CLOEXEC | FD_CLOFORK) + 1)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_dup3fd("fcntl(FDUP3FD): INT_MAX", INT_MAX)) {
+		ret = EXIT_FAILURE;
+	}
+
+
+	if (!oclo_pipe2("pipe2(): O_RDWR", O_RDWR)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_pipe2("pipe2(): O_SYNC|O_CLOXEC", O_SYNC | O_CLOEXEC)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_pipe2("pipe2(): O_CLOFORK|O_WRONLY", O_CLOFORK | O_WRONLY)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_pipe2("pipe2(): INT32_MAX", INT32_MAX)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_socket("socket(): INT32_MAX", INT32_MAX)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_socket("socket(): 3 << 25", 3 << 25)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_accept("accept4(): INT32_MAX", INT32_MAX)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (!oclo_accept("accept4(): 3 << 25", 3 << 25)) {
+		ret = EXIT_FAILURE;
+	}
+
+	if (ret == EXIT_SUCCESS) {
+		(void) printf("All tests completed successfully\n");
+	}
+
+	return (ret);
+}

--- a/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/ocloexec_verify.c
+++ b/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/ocloexec_verify.c
@@ -1,0 +1,137 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Oxide Computer Company
+ */
+
+/*
+ * Verify that our file descriptors starting after stderr are correct based upon
+ * the series of passed in arguments from the 'oclo' program. Arguments are
+ * passed as a string that represents the flags that were originally verified
+ * pre-fork/exec via fcntl(F_GETFD). In addition, anything that was originally
+ * closed because it had FD_CLOFORK set was reopened with the same flags. This
+ * allows us to verify that the combinations worked and that FD_CLOFORK was
+ * properly cleared.
+ */
+
+#include <err.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+
+static int
+verify_fdwalk_cb(void *arg, int fd)
+{
+	int *max = arg;
+	*max = fd;
+	return (0);
+}
+
+/*
+ * Our flags may have FD_CLOFORK set in them (anything with FD_CLOEXEC Should
+ * not exist by definition). FD_CLOFORK is supposed to be cleared on exec. We
+ * still indicate which file descriptors FD_CLOFORK so we can check where it
+ * wasn't cleared.
+ */
+static bool
+verify_flags(int fd, int exp_flags)
+{
+	bool fail = (exp_flags & FD_CLOEXEC) != 0;
+	int flags = fcntl(fd, F_GETFD, NULL);
+	bool clofork = (exp_flags & FD_CLOFORK) != 0;
+	exp_flags &= ~FD_CLOFORK;
+
+	if (flags < 0) {
+		int e = errno;
+
+		if (fail) {
+			if (e == EBADF) {
+				(void) printf("TEST PASSED: post-exec fd %d: "
+				    "flags 0x%x: correctly closed\n", fd,
+				    exp_flags);
+				return (true);
+			}
+
+
+			warn("TEST FAILED: post-fork fd %d: expected fcntl to "
+			    "fail with EBADF, but found %s", fd,
+			    strerrorname_np(e));
+			return (false);
+		}
+
+		warnx("TEST FAILED: post-fork fd %d: fcntl(F_GETFD) "
+		    "unexpectedly failed with %s, expected flags %d", fd,
+		    strerrorname_np(e), exp_flags);
+		return (false);
+	}
+
+	if (fail) {
+		warnx("TEST FAILED: post-fork fd %d: received flags %d, but "
+		    "expected to fail based on flags %d", fd, flags, exp_flags);
+		return (false);
+	}
+
+	if (clofork && (flags & FD_CLOFORK) != 0) {
+		warnx("TEST FAILED: post-fork fd %d (flags %d) retained "
+		    "FD_CLOFORK, but it should have been cleared", fd, flags);
+		return (false);
+	}
+
+	if (flags != exp_flags) {
+		warnx("TEST FAILED: post-exec fd %d: discovered flags 0x%x do "
+		    "not match expected flags 0x%x", fd, flags, exp_flags);
+		return (false);
+	}
+
+	(void) printf("TEST PASSED: post-exec fd %d: flags 0x%x: successfully "
+	    "matched\n", fd, exp_flags);
+	return (true);
+}
+
+int
+main(int argc, char *argv[])
+{
+	int maxfd = STDIN_FILENO;
+	int ret = EXIT_SUCCESS;
+
+	/*
+	 * We should have one argument for each fd we found, ignoring stdin,
+	 * stdout, and stderr. argc will also have an additional entry for our
+	 * program name, which we want to skip. Note, the last fd may not exist
+	 * because it was marked for close, hence the use of '>' below.
+	 */
+	(void) fdwalk(verify_fdwalk_cb, &maxfd);
+	if (maxfd - 3 > argc - 1) {
+		errx(EXIT_FAILURE, "TEST FAILED: found more fds %d than "
+		    "arguments %d", maxfd - 3, argc - 1);
+	}
+
+	for (int i = 1; i < argc; i++) {
+		const char *errstr;
+		int targ_fd = i + STDERR_FILENO;
+		long long targ_flags = strtonumx(argv[i], 0,
+		    FD_CLOEXEC | FD_CLOFORK, &errstr, 0);
+
+		if (errstr != NULL) {
+			errx(EXIT_FAILURE, "TEST FAILED: failed to parse "
+			    "argument %d: %s is %s", i, argv[i], errstr);
+		}
+
+		if (!verify_flags(targ_fd, (int)targ_flags))
+			ret = EXIT_FAILURE;
+	}
+
+	return (ret);
+}

--- a/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/ocloexec_verify.c
+++ b/cddl/contrib/opensolaris/tests/os-tests/tests/oclo/ocloexec_verify.c
@@ -23,20 +23,36 @@
  * properly cleared.
  */
 
+#include <sys/types.h>
+#include <sys/user.h>
 #include <err.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <stdbool.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <libutil.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+
+#define strerrorname_np(e) (sys_errlist[e])
 
 static int
-verify_fdwalk_cb(void *arg, int fd)
+getmaxfd(void)
 {
-	int *max = arg;
-	*max = fd;
-	return (0);
+	struct kinfo_file *files;
+	int i, cnt, max;
+
+	if ((files = kinfo_getfile(getpid(), &cnt)) == NULL)
+		err(1, "kinfo_getfile");
+
+	max = -1;
+	for (i = 0; i < cnt; i++)
+		if (files[i].kf_fd > max)
+			max = files[i].kf_fd;
+
+	free(files);
+	return (max);
 }
 
 /*
@@ -103,7 +119,7 @@ verify_flags(int fd, int exp_flags)
 int
 main(int argc, char *argv[])
 {
-	int maxfd = STDIN_FILENO;
+	int maxfd;
 	int ret = EXIT_SUCCESS;
 
 	/*
@@ -112,24 +128,25 @@ main(int argc, char *argv[])
 	 * program name, which we want to skip. Note, the last fd may not exist
 	 * because it was marked for close, hence the use of '>' below.
 	 */
-	(void) fdwalk(verify_fdwalk_cb, &maxfd);
+	maxfd = getmaxfd();
 	if (maxfd - 3 > argc - 1) {
 		errx(EXIT_FAILURE, "TEST FAILED: found more fds %d than "
 		    "arguments %d", maxfd - 3, argc - 1);
 	}
 
 	for (int i = 1; i < argc; i++) {
-		const char *errstr;
+		char *endptr;
 		int targ_fd = i + STDERR_FILENO;
-		long long targ_flags = strtonumx(argv[i], 0,
-		    FD_CLOEXEC | FD_CLOFORK, &errstr, 0);
+		errno = 0;
+		long long val = strtoll(argv[i], &endptr, 0);
 
-		if (errstr != NULL) {
+		if (errno != 0 || *endptr != '\0' ||
+		    (val < 0 || val > (FD_CLOEXEC | FD_CLOFORK))) {
 			errx(EXIT_FAILURE, "TEST FAILED: failed to parse "
-			    "argument %d: %s is %s", i, argv[i], errstr);
+			    "argument %d: %s", i, argv[i]);
 		}
 
-		if (!verify_flags(targ_fd, (int)targ_flags))
+		if (!verify_flags(targ_fd, (int)val))
 			ret = EXIT_FAILURE;
 	}
 

--- a/lib/libc/gen/dup3.3
+++ b/lib/libc/gen/dup3.3
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 16, 2013
+.Dd May 17, 2025
 .Dt DUP3 3
 .Os
 .Sh NAME
@@ -44,6 +44,11 @@ while allowing the value of the new descriptor to be specified.
 .Pp
 The close-on-exec flag on the new file descriptor is determined by the
 .Dv O_CLOEXEC
+bit in
+.Fa flags .
+.Pp
+The close-on-fork flag on the new file descriptor is determined by the
+.Dv O_CLOFORK
 bit in
 .Fa flags .
 .Pp
@@ -91,7 +96,9 @@ argument.
 The
 .Fa flags
 argument has bits set other than
-.Dv O_CLOEXEC .
+.Dv O_CLOEXEC
+or
+.Dv O_CLOFORK .
 .El
 .Sh SEE ALSO
 .Xr accept 2 ,
@@ -112,3 +119,7 @@ The
 .Fn dup3
 function appeared in
 .Fx 10.0 .
+The
+.Dv O_CLOFORK
+flag appeared in
+.Fx 15.0 .

--- a/lib/libopenbsd/Makefile
+++ b/lib/libopenbsd/Makefile
@@ -2,7 +2,8 @@ PACKAGE=lib${LIB}
 LIB=	openbsd
 SRCS=	imsg-buffer.c \
 	imsg.c \
-	ohash.c
+	ohash.c \
+	recallocarray.c
 .if !defined(BOOTSTRAPPING)
 # Skip getdtablecount.c when bootstrapping since it doesn't compile for Linux
 # and is not used by any of the bootstrap tools

--- a/lib/libopenbsd/recallocarray.c
+++ b/lib/libopenbsd/recallocarray.c
@@ -1,0 +1,82 @@
+/*	$OpenBSD: recallocarray.c,v 1.1 2017/03/06 18:44:21 otto Exp $	*/
+/*
+ * Copyright (c) 2008, 2017 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW ((size_t)1 << (sizeof(size_t) * 4))
+
+void *recallocarray(void *, size_t, size_t, size_t);
+
+void *
+recallocarray(void *ptr, size_t oldnmemb, size_t newnmemb, size_t size)
+{
+	size_t oldsize, newsize;
+	void *newptr;
+
+	if (ptr == NULL)
+		return calloc(newnmemb, size);
+
+	if ((newnmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    newnmemb > 0 && SIZE_MAX / newnmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	newsize = newnmemb * size;
+
+	if ((oldnmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    oldnmemb > 0 && SIZE_MAX / oldnmemb < size) {
+		errno = EINVAL;
+		return NULL;
+	}
+	oldsize = oldnmemb * size;
+	
+	/*
+	 * Don't bother too much if we're shrinking just a bit,
+	 * we do not shrink for series of small steps, oh well.
+	 */
+	if (newsize <= oldsize) {
+		size_t d = oldsize - newsize;
+
+		if (d < oldsize / 2 && d < (size_t)getpagesize()) {
+			memset((char *)ptr + newsize, 0, d);
+			return ptr;
+		}
+	}
+
+	newptr = malloc(newsize);
+	if (newptr == NULL)
+		return NULL;
+
+	if (newsize > oldsize) {
+		memcpy(newptr, ptr, oldsize);
+		memset((char *)newptr + oldsize, 0, newsize - oldsize);
+	} else
+		memcpy(newptr, ptr, newsize);
+
+	explicit_bzero(ptr, oldsize);
+	free(ptr);
+
+	return newptr;
+}

--- a/lib/libsys/accept.2
+++ b/lib/libsys/accept.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd October 9, 2014
+.Dd May 17, 2025
 .Dt ACCEPT 2
 .Os
 .Sh NAME
@@ -82,6 +82,13 @@ property is cleared,
 the signal destination is cleared
 and the close-on-exec flag on the new file descriptor can be set via the
 .Dv SOCK_CLOEXEC
+flag in the
+.Fa flags
+argument.
+Similarly, the
+.Dv O_CLOFORK
+property can be set via the
+.Dv SOCK_CLOFORK
 flag in the
 .Fa flags
 argument.
@@ -234,3 +241,8 @@ The
 .Fn accept4
 system call appeared in
 .Fx 10.0 .
+.Pp
+The
+.Dv SOCK_CLOFORK
+flag appeared in
+.Fx 15.0 .

--- a/lib/libsys/closefrom.2
+++ b/lib/libsys/closefrom.2
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd March 3, 2022
+.Dd May 17, 2025
 .Dt CLOSEFROM 2
 .Os
 .Sh NAME
@@ -59,6 +59,8 @@ Supported
 .Bl -tag -width ".Dv CLOSE_RANGE_CLOEXEC"
 .It Dv CLOSE_RANGE_CLOEXEC
 Set the close-on-exec flag on descriptors in the range instead of closing them.
+.It Dv CLOSE_RANGE_CLOFORK
+Set the close-on-fork flag on descriptors in the range instead of closing them.
 .El
 .Sh RETURN VALUES
 Upon successful completion,
@@ -90,3 +92,8 @@ The
 .Fn closefrom
 function first appeared in
 .Fx 8.0 .
+.Pp
+The
+.Dv CLOSE_RANGE_CLOFORK
+flag appeared in
+.Fx 15.0 .

--- a/lib/libsys/execve.2
+++ b/lib/libsys/execve.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 26, 2022
+.Dd July 02, 2025
 .Dt EXECVE 2
 .Os
 .Sh NAME
@@ -127,7 +127,10 @@ flag is set (see
 and
 .Xr fcntl 2 ) .
 Descriptors that remain open are unaffected by
-.Fn execve .
+.Fn execve ,
+except those with the close-on-fork flag
+.Dv FD_CLOFORK
+which is cleared from all file descriptors.
 If any of the standard descriptors (0, 1, and/or 2) are closed at the
 time
 .Fn execve

--- a/lib/libsys/fcntl.2
+++ b/lib/libsys/fcntl.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 5, 2025
+.Dd June 24, 2025
 .Dt FCNTL 2
 .Os
 .Sh NAME
@@ -81,6 +81,13 @@ to remain open across
 .Xr execve 2
 system calls.
 .It
+The fork-on-exec flag
+.Dv FD_CLOFORK
+associated with the new file descriptor is cleared, so the file descriptor is
+to remain open across
+.Xr fork 2
+system calls.
+.It
 The
 .Dv FD_RESOLVE_BENEATH
 flag, described below, will be set if it was set on the original
@@ -94,6 +101,15 @@ but the
 flag associated with the new file descriptor is set, so the file descriptor
 is closed when
 .Xr execve 2
+system call executes.
+.It Dv F_DUPFD_CLOFORK
+Like
+.Dv F_DUPFD ,
+but the
+.Dv FD_CLOFORK
+flag associated with the new file descriptor is set, so the file descriptor
+is closed when
+.Xr fork 2
 system call executes.
 .It Dv F_DUP2FD
 It is functionally equivalent to
@@ -117,6 +133,11 @@ Use
 .Fn dup2
 instead of
 .Dv F_DUP2FD .
+.It Dv F_DUP3FD
+Used to implement the
+.Fn dup3
+call.
+Do not use it.
 .It Dv F_GETFD
 Get the flags associated with the file descriptor
 .Fa fd .
@@ -128,6 +149,10 @@ The file will be closed upon execution of
 .Fa ( arg
 is ignored).
 Otherwise, the file descriptor will remain open.
+.It Dv FD_CLOFORK
+The file will be closed upon execution of the
+.Fn fork
+family of system calls.
 .It Dv FD_RESOLVE_BENEATH
 All path name lookups relative to that file descriptor
 will behave as if the lookup had
@@ -153,7 +178,8 @@ descriptor to also have the flag set.
 Set flags associated with
 .Fa fd .
 The available flags are
-.Dv FD_CLOEXEC
+.Dv FD_CLOEXEC ,
+.Dv FD_CLOFORK
 and
 .Dv FD_RESOLVE_BENEATH .
 The
@@ -785,8 +811,10 @@ for the reasons as stated in
 .Sh STANDARDS
 The
 .Dv F_DUP2FD
-constant is non portable.
-It is provided for compatibility with AIX and Solaris.
+and
+.Dv F_DUP3FD
+constants are not portable.
+They are provided for compatibility with AIX and Solaris.
 .Pp
 Per
 .St -susv4 ,
@@ -811,3 +839,10 @@ The
 .Dv F_DUP2FD
 constant first appeared in
 .Fx 7.1 .
+.Pp
+The
+.Dv F_DUPFD_CLOFORK
+and
+.Dv F_DUP3FD
+flags appeared in
+.Fx 15.0 .

--- a/lib/libsys/fork.2
+++ b/lib/libsys/fork.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 5, 2021
+.Dd May 17, 2024
 .Dt FORK 2
 .Os
 .Sh NAME
@@ -68,6 +68,16 @@ by the parent.
 This descriptor copying is also used by the shell to
 establish standard input and output for newly created processes
 as well as to set up pipes.
+Any file descriptors that were marked with the close-on-fork flag,
+.Dv FD_CLOFORK
+.Po see
+.Fn fcntl 2
+and
+.Dv O_CLOFORK
+in
+.Fn open 2
+.Pc ,
+will not be present in the child process, but remain open in the parent.
 .It
 The child process' resource utilizations
 are set to 0; see

--- a/lib/libsys/open.2
+++ b/lib/libsys/open.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 3, 2025
+.Dd May 17, 2025
 .Dt OPEN 2
 .Os
 .Sh NAME
@@ -195,6 +195,9 @@ error if file is not a directory
 .It Dv O_CLOEXEC
 automatically close file on
 .Xr execve 2
+.It Dv O_CLOFORK
+automatically close file on any child process created with
+.Fn fork 2
 .It Dv O_VERIFY
 verify the contents of the file with
 .Xr mac_veriexec 4
@@ -359,6 +362,27 @@ such as device nodes.
 may be used to set
 .Dv FD_CLOEXEC
 flag for the newly returned file descriptor.
+.Pp
+.Dv O_CLOFORK
+may be used to set
+.Dv FD_CLOFORK
+flag for the newly returned file descriptor.
+The file will be closed on any child process created with
+.Fn fork 2 ,
+.Fn vfork 2
+or
+.Fn rfork 2
+with the
+.Dv RFFDG
+flag, remaining open in the parent.
+Both the
+.Dv O_CLOEXEC
+and
+.Dv O_CLOFORK
+flags can be modified with the
+.Dv F_SETFD
+.Fn fcntl 2
+command.
 .Pp
 .Dv O_VERIFY
 may be used to indicate to the kernel that the contents of the file should
@@ -846,6 +870,9 @@ function was introduced in
 appeared in 13.0.
 .Dv O_NAMEDATTR
 appeared in 15.0.
+.Dv O_CLOFORK
+appeared in
+.Fx 15.0 .
 .Sh BUGS
 The
 .Fa mode

--- a/lib/libsys/pipe.2
+++ b/lib/libsys/pipe.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 1, 2017
+.Dd May 17, 2025
 .Dt PIPE 2
 .Os
 .Sh NAME
@@ -64,6 +64,8 @@ list, defined in
 .Bl -tag -width ".Dv O_NONBLOCK"
 .It Dv O_CLOEXEC
 Set the close-on-exec flag for the new file descriptors.
+.It Dv O_CLOFORK
+Set the close-on-fork flag for the new file descriptors.
 .It Dv O_NONBLOCK
 Set the non-blocking flag for the ends of the pipe.
 .El
@@ -173,3 +175,8 @@ function became a wrapper around
 .Fn pipe2
 in
 .Fx 11.0 .
+.Pp
+The
+.Dv O_CLOFORK
+flag appeared in
+.Fx 15.0 .

--- a/lib/libsys/recv.2
+++ b/lib/libsys/recv.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd July 30, 2022
+.Dd May 17, 2025
 .Dt RECV 2
 .Os
 .Sh NAME
@@ -164,6 +164,7 @@ one or more of the values:
 .It Dv MSG_WAITALL Ta wait for full request or error
 .It Dv MSG_DONTWAIT Ta do not block
 .It Dv MSG_CMSG_CLOEXEC Ta set received fds close-on-exec
+.It Dv MSG_CMSG_CLOFORK Ta set received fds close-on-fork
 .It Dv MSG_WAITFORONE Ta do not block after receiving the first message
 (only for
 .Fn recvmmsg

--- a/lib/libsys/socket.2
+++ b/lib/libsys/socket.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 15, 2023
+.Dd May 17, 2025
 .Dt SOCKET 2
 .Os
 .Sh NAME
@@ -121,6 +121,7 @@ argument:
 .Pp
 .Bd -literal -offset indent -compact
 SOCK_CLOEXEC	Set close-on-exec on the new descriptor,
+SOCK_CLOFORK	Set close-on-fork on the new descriptor,
 SOCK_NONBLOCK	Set non-blocking mode on the new socket
 .Ed
 .Pp
@@ -331,7 +332,10 @@ argument of
 .Fn socket .
 The
 .Dv SOCK_CLOEXEC
-flag is expected to conform to the next revision of the
+and
+.Dv SOCK_CLOFORK
+flags are expected to conform to
+.St -p1003.1-2024 .
 .Tn POSIX
 standard.
 The
@@ -347,3 +351,8 @@ The
 .Fn socket
 system call appeared in
 .Bx 4.2 .
+.Pp
+The
+.Dv SOCK_CLOFORK
+flag appeared in
+.Fx 15.0 .

--- a/lib/libsys/socketpair.2
+++ b/lib/libsys/socketpair.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd February 10, 2018
+.Dd May 17, 2025
 .Dt SOCKETPAIR 2
 .Os
 .Sh NAME
@@ -56,7 +56,8 @@ and
 The two sockets are indistinguishable.
 .Pp
 The
-.Dv SOCK_CLOEXEC
+.Dv SOCK_CLOEXEC ,
+.Dv SOCK_CLOFORK
 and
 .Dv SOCK_NONBLOCK
 flags in the

--- a/lib/libsysdecode/flags.c
+++ b/lib/libsysdecode/flags.c
@@ -196,7 +196,7 @@ sysdecode_vmprot(FILE *fp, int type, int *rem)
 }
 
 static struct name_table sockflags[] = {
-	X(SOCK_CLOEXEC) X(SOCK_NONBLOCK) XEND
+	X(SOCK_CLOEXEC) X(SOCK_CLOFORK) X(SOCK_NONBLOCK) XEND
 };
 
 bool
@@ -206,16 +206,17 @@ sysdecode_socket_type(FILE *fp, int type, int *rem)
 	uintmax_t val;
 	bool printed;
 
-	str = lookup_value(socktype, type & ~(SOCK_CLOEXEC | SOCK_NONBLOCK));
+	str = lookup_value(socktype,
+	    type & ~(SOCK_CLOEXEC | SOCK_CLOFORK | SOCK_NONBLOCK));
 	if (str != NULL) {
 		fputs(str, fp);
 		*rem = 0;
 		printed = true;
 	} else {
-		*rem = type & ~(SOCK_CLOEXEC | SOCK_NONBLOCK);
+		*rem = type & ~(SOCK_CLOEXEC | SOCK_CLOFORK | SOCK_NONBLOCK);
 		printed = false;
 	}
-	val = type & (SOCK_CLOEXEC | SOCK_NONBLOCK);
+	val = type & (SOCK_CLOEXEC | SOCK_CLOFORK | SOCK_NONBLOCK);
 	print_mask_part(fp, sockflags, &val, &printed);
 	return (printed);
 }
@@ -556,7 +557,7 @@ sysdecode_nfssvc_flags(int flags)
 }
 
 static struct name_table pipe2flags[] = {
-	X(O_CLOEXEC) X(O_NONBLOCK) XEND
+	X(O_CLOEXEC) X(O_CLOFORK) X(O_NONBLOCK) XEND
 };
 
 bool
@@ -866,7 +867,7 @@ sysdecode_fcntl_cmd(int cmd)
 }
 
 static struct name_table fcntl_fd_arg[] = {
-	X(FD_CLOEXEC) X(0) XEND
+	X(FD_CLOEXEC) X(FD_CLOFORK) X(0) XEND
 };
 
 bool

--- a/lib/libsysdecode/sysdecode_fcntl_arg.3
+++ b/lib/libsysdecode/sysdecode_fcntl_arg.3
@@ -54,7 +54,8 @@ are determined by
 .It Sy Command Ta Fa arg Sy Type Ta Sy Output Format
 .It
 .It Dv F_SETFD Ta Vt int Ta
-.Dq FD_CLOEXEC
+.Dq FD_CLOEXEC ,
+.Dq FD_CLOFORK
 or the value of
 .Fa arg
 in the indicated

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -548,7 +548,7 @@ sys_pipe2(struct thread *td, struct pipe2_args *uap)
 {
 	int error, fildes[2];
 
-	if (uap->flags & ~(O_CLOEXEC | O_NONBLOCK))
+	if ((uap->flags & ~(O_CLOEXEC | O_CLOFORK | O_NONBLOCK)) != 0)
 		return (EINVAL);
 	error = kern_pipe(td, fildes, uap->flags, NULL, NULL);
 	if (error)

--- a/sys/kern/uipc_usrreq.c
+++ b/sys/kern/uipc_usrreq.c
@@ -3463,7 +3463,8 @@ unp_externalize(struct mbuf *control, struct mbuf **controlp, int flags)
 
 	UNP_LINK_UNLOCK_ASSERT();
 
-	fdflags = (flags & MSG_CMSG_CLOEXEC) ? O_CLOEXEC : 0;
+	fdflags = ((flags & MSG_CMSG_CLOEXEC) ? O_CLOEXEC : 0) |
+	    ((flags & MSG_CMSG_CLOFORK) ? O_CLOFORK : 0);
 
 	error = 0;
 	if (controlp != NULL) /* controlp == NULL => free control messages */

--- a/sys/sys/fcntl.h
+++ b/sys/sys/fcntl.h
@@ -143,6 +143,10 @@ typedef	__pid_t		pid_t;
 #define	O_NAMEDATTR	0x04000000	/* NFSv4 named attributes */
 #endif
 
+#if __POSIX_VISIBLE >= 202405
+#define	O_CLOFORK	0x08000000
+#endif
+
 /*
  * !!! DANGER !!!
  *
@@ -279,7 +283,13 @@ typedef	__pid_t		pid_t;
 #define	F_GET_SEALS	20
 #define	F_ISUNIONSTACK	21		/* Kludge for libc, don't use it. */
 #define	F_KINFO		22		/* Return kinfo_file for this fd */
+#endif	/* __BSD_VISIBLE */
 
+#if __POSIX_VISIBLE >= 202405
+#define	F_DUPFD_CLOFORK	23		/* Like F_DUPFD, but FD_CLOFORK is set */
+#endif
+
+#if __BSD_VISIBLE
 /* Seals (F_ADD_SEALS, F_GET_SEALS). */
 #define	F_SEAL_SEAL	0x0001		/* Prevent adding sealings */
 #define	F_SEAL_SHRINK	0x0002		/* May not shrink */
@@ -291,6 +301,9 @@ typedef	__pid_t		pid_t;
 #define	FD_CLOEXEC	1		/* close-on-exec flag */
 #define	FD_RESOLVE_BENEATH 2		/* all lookups relative to fd have
 					   O_RESOLVE_BENEATH semantics */
+#if __POSIX_VISIBLE >= 202405
+#define	FD_CLOFORK	4		/* close-on-fork flag */
+#endif
 
 /* record locking flags (F_GETLK, F_SETLK, F_SETLKW) */
 #define	F_RDLCK		1		/* shared or read lock */

--- a/sys/sys/fcntl.h
+++ b/sys/sys/fcntl.h
@@ -290,6 +290,10 @@ typedef	__pid_t		pid_t;
 #endif
 
 #if __BSD_VISIBLE
+#define F_DUP3FD	24		/* Used with dup3() */
+
+#define F_DUP3FD_SHIFT	16		/* Shift used for F_DUP3FD */
+
 /* Seals (F_ADD_SEALS, F_GET_SEALS). */
 #define	F_SEAL_SEAL	0x0001		/* Prevent adding sealings */
 #define	F_SEAL_SHRINK	0x0002		/* May not shrink */

--- a/sys/sys/filedesc.h
+++ b/sys/sys/filedesc.h
@@ -149,6 +149,7 @@ struct filedesc_to_leader {
  */
 #define	UF_EXCLOSE	0x01		/* auto-close on exec */
 #define	UF_RESOLVE_BENEATH 0x02		/* lookups must be beneath this dir */
+#define	UF_FOCLOSE	0x04		/* auto-close on fork */
 
 #ifdef _KERNEL
 
@@ -221,6 +222,7 @@ enum {
 
 /* Flags for kern_dup(). */
 #define	FDDUP_FLAG_CLOEXEC	0x1	/* Atomically set UF_EXCLOSE. */
+#define	FDDUP_FLAG_CLOFORK	0x2	/* Atomically set UF_FOCLOSE. */
 
 /* For backward compatibility. */
 #define	falloc(td, resultfp, resultfd, flags) \

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -479,6 +479,9 @@ struct msghdr {
 #define	MSG_MORETOCOME	 0x00100000	/* additional data pending */
 #define	MSG_TLSAPPDATA	 0x00200000	/* do not soreceive() alert rec. (TLS) */
 #endif
+#if __BSD_VISIBLE
+#define	MSG_CMSG_CLOFORK 0x00400000	/* make received fds close-on-fork */
+#endif
 
 /*
  * Header for ancillary data objects in msg_control buffer.

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -111,10 +111,11 @@ typedef	__uintptr_t	uintptr_t;
  */
 #define	SOCK_CLOEXEC	0x10000000
 #define	SOCK_NONBLOCK	0x20000000
+#define	SOCK_CLOFORK	0x40000000
 #ifdef _KERNEL
 /*
  * Flags for accept1(), kern_accept4() and solisten_dequeue, in addition
- * to SOCK_CLOEXEC and SOCK_NONBLOCK.
+ * to SOCK_CLOEXEC, SOCK_CLOFORK and SOCK_NONBLOCK.
  */
 #define ACCEPT4_INHERIT 0x1
 #define ACCEPT4_COMPAT  0x2

--- a/sys/sys/unistd.h
+++ b/sys/sys/unistd.h
@@ -210,6 +210,7 @@
  * close_range() options.
  */
 #define	CLOSE_RANGE_CLOEXEC	(1<<2)
+#define	CLOSE_RANGE_CLOFORK	(1<<3)
 
 #endif /* __BSD_VISIBLE */
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,5 @@
+.include <src.opts.mk>
+
 PACKAGE= tests
 
 TESTSDIR= ${TESTSBASE}
@@ -11,6 +13,9 @@ SUBDIR+= examples
 SUBDIR+= include
 SUBDIR+= sys
 SUBDIR+= atf_python
+.if ${MK_CDDL} != "no"
+SUBDIR+= oclo
+.endif
 
 SUBDIR_PARALLEL=
 

--- a/tests/oclo/Makefile
+++ b/tests/oclo/Makefile
@@ -1,0 +1,11 @@
+.PATH:	${SRCTOP}/cddl/contrib/opensolaris/tests/os-tests/tests/oclo
+
+TESTSDIR=	${TESTSBASE}/cddl/oclo
+
+PLAIN_TESTS_C=	oclo oclo_errors ocloexec_verify
+
+SRCS.oclo=	oclo.c
+LIBADD.oclo+=	openbsd
+LIBADD.ocloexec_verify+= util
+
+.include <bsd.test.mk>


### PR DESCRIPTION
This PR:
- Adds support for POSIX O_CLOFORK (close-on-fork) flag.
- Extends the concept to close_range()

This one looks perhaps deceptively simple to implement but it's passing all tests (hundreds of them) from a suite adapted from Illumos.

This may be useful for Golang, Rust, Swift (and other languages):
- https://github.com/golang/go/issues/22315
- https://github.com/rust-lang/rust/issues/114554
- https://github.com/swiftlang/swift-subprocess/pull/79#issuecomment-2973262771

This interface was called stupid by opinionated Linux folks and perhaps they're right, so I want an informed opinion before going any further.  I had my fun anyway.  Here are the relevant links with discussion:
- https://lore.kernel.org/lkml/20200525081626.GA16796@amd/T/#m4ef81228aba3f9524329f83a124d0322ed53f834

DONE
- [x] Add the adapted CDDL-licensed oclo tests. All 791 PASSED, 0 failed or skipped.
- [x] Support it in `dup3`
- [x] Add it in libsysdecode
- [x] Update manpages.
- [x] Fixed some instances of naive calls to `F_SETFD` found with `grep -Er 'F_SETFD, (1|FD_CLOEXEC|fcntl)' *`
- [x] Check [0001851: FD_CLOFORK should not be preserved across exec](https://www.austingroupbugs.net/view.php?id=1851)
- [x]Adapt new oclo tests from https://code.illumos.org/c/illumos-gate/+/4304

NOT NEEDED
- `"f"` in `fopen`.  It's not POSIX and not even Solaris/Illumos implement it.

NOTES
- Except for manpages, this patch applies cleanly on FreeBSD 14.3

POSIX References:
- O_CLOFORK: https://pubs.opengroup.org/onlinepubs/9799919799/functions/open.html
- FD_CLOFORK: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fcntl.h.html
- SOCK_CLOFORK: https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/basedefs/sys_socket.h.html
- dup3() with O_CLOFORK : https://pubs.opengroup.org/onlinepubs/9799919799/functions/dup.html

Illumos references:
- Oclo tests: https://github.com/illumos/illumos-gate/tree/master/usr/src/test/os-tests/tests/oclo

Fixes https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=286843

To test:

```
cd /usr/src/tests/oclo
make
sudo make install
/usr/tests/cddl/oclo/oclo
/usr/tests/cddl/oclo/oclo_errors
```