### PR TITLE
If the hostname is not set for the host, the value "Amnesiac" should be written to rc.conf

### DIFF
--- a/usr.sbin/bsdinstall/scripts/hostname
+++ b/usr.sbin/bsdinstall/scripts/hostname
@@ -111,15 +111,15 @@ HOSTNAME=$( dialog_hostname "$HOSTNAME" )
 # Store the user's choice
 #
 f_eval_catch "$pgm" echo "$ECHO_OVERWRITE" \
-    'hostname=\"$HOSTNAME\"' "$HOSTNAMEFILE"
+	'hostname=\"$HOSTNAME\"' "$HOSTNAMEFILE"
 retval=$?
 
 #
 # Activate entry if configured
 #
 if [ "$BSDINSTALL_CONFIGCURRENT" ]; then
-    f_eval_catch "$pgm" hostname "$SET_HOSTNAME" "$HOSTNAME"
-    retval=$?
+	f_eval_catch "$pgm" hostname "$SET_HOSTNAME" "$HOSTNAME"
+	retval=$?
 fi
 
 exit $retval

--- a/usr.sbin/bsdinstall/scripts/hostname
+++ b/usr.sbin/bsdinstall/scripts/hostname
@@ -103,19 +103,16 @@ HOSTNAME=$( dialog_hostname "$HOSTNAME" )
 [ $? -eq $DIALOG_CANCEL ] && exit 1
 
 #
+# Set hostname to Amnesiac if empty
+#
+[ -z "$HOSTNAME" ] && HOSTNAME="Amnesiac"
+
+#
 # Store the user's choice
 #
 f_eval_catch "$pgm" echo "$ECHO_OVERWRITE" \
-	'hostname=\"$HOSTNAME\"' "$HOSTNAMEFILE"
+    'hostname=\"$HOSTNAME\"' "$HOSTNAMEFILE"
 retval=$?
-
-#
-# Activate entry if configured
-#
-if [ "$BSDINSTALL_CONFIGCURRENT" ]; then
-	f_eval_catch "$pgm" hostname "$SET_HOSTNAME" "$HOSTNAME"
-	retval=$?
-fi
 
 exit $retval
 

--- a/usr.sbin/bsdinstall/scripts/hostname
+++ b/usr.sbin/bsdinstall/scripts/hostname
@@ -110,9 +110,16 @@ HOSTNAME=$( dialog_hostname "$HOSTNAME" )
 #
 # Store the user's choice
 #
+f_eval_catch "$pgm" echo "$ECHO_OVERWRITE" \
+    'hostname=\"$HOSTNAME\"' "$HOSTNAMEFILE"
+retval=$?
+
+#
+# Activate entry if configured
+#
 if [ "$BSDINSTALL_CONFIGCURRENT" ]; then
-	f_eval_catch "$pgm" hostname "$SET_HOSTNAME" "$HOSTNAME"
-	retval=$?
+    f_eval_catch "$pgm" hostname "$SET_HOSTNAME" "$HOSTNAME"
+    retval=$?
 fi
 
 exit $retval

--- a/usr.sbin/bsdinstall/scripts/hostname
+++ b/usr.sbin/bsdinstall/scripts/hostname
@@ -110,9 +110,10 @@ HOSTNAME=$( dialog_hostname "$HOSTNAME" )
 #
 # Store the user's choice
 #
-f_eval_catch "$pgm" echo "$ECHO_OVERWRITE" \
-    'hostname=\"$HOSTNAME\"' "$HOSTNAMEFILE"
-retval=$?
+if [ "$BSDINSTALL_CONFIGCURRENT" ]; then
+	f_eval_catch "$pgm" hostname "$SET_HOSTNAME" "$HOSTNAME"
+	retval=$?
+fi
 
 exit $retval
 


### PR DESCRIPTION
see also https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=286847

see also https://docs.freebsd.org/en/books/handbook/network/#hostname

If no hostname has been set for the host FreeBSD will assign the value Amnesiac.

This operation does not actually work because the hostname setting in `rc.conf` is `hostname=""`. As a result, all software, including the output of the `hostname` command, still shows an empty value. For Xorg, a setting like `hostname=""` will prevent the GUI from starting. If the hostname is not set for the host, the value `"Amnesiac"` should be written to `rc.conf`.

Why is the hostname empty (`hostname=""`): because the user simply pressed the Enter key at the hostname setup step during the FreeBSD installation.

Signed-off-by: ykla <yklaxds@gmail.com>