### PR TITLE
fwget: Add GPU names to pci_video_amd

### DIFF
--- a/usr.sbin/fwget/pci/pci_video_amd
+++ b/usr.sbin/fwget/pci/pci_video_amd
@@ -138,7 +138,7 @@ pci_video_amd()
 		0x742*|0x743*)
 			addpkg "gpu-firmware-amd-kmod-beige-goby"
 			;;
-		0x744c)
+		0x744c) # Navi 31
 			addpkg "gpu-firmware-amd-kmod-dcn-3-2-0"
 			addpkg "gpu-firmware-amd-kmod-gc-11-0-0"
 			addpkg "gpu-firmware-amd-kmod-psp-13-0-0"
@@ -146,21 +146,21 @@ pci_video_amd()
 			addpkg "gpu-firmware-amd-kmod-smu-13-0-0"
 			addpkg "gpu-firmware-amd-kmod-vcn-4-0-0"
 			;;
-		0x15bf)
+		0x15bf) # Phoenix1
 			addpkg "gpu-firmware-amd-kmod-gc-11-0-1"
 			addpkg "gpu-firmware-amd-kmod-psp-13-0-4"
 			addpkg "gpu-firmware-amd-kmod-dcn-3-1-4"
 			addpkg "gpu-firmware-amd-kmod-sdma-6-0-1"
 			addpkg "gpu-firmware-amd-kmod-vcn-4-0-2"
 			;;
-		0x15c8)
+		0x15c8) # Phoenix2
 			addpkg "gpu-firmware-amd-kmod-dcn-3-1-4"
 			addpkg "gpu-firmware-amd-kmod-gc-11-0-4"
 			addpkg "gpu-firmware-amd-kmod-psp-13-0-11"
 			addpkg "gpu-firmware-amd-kmod-sdma-6-0-1"
 			addpkg "gpu-firmware-amd-kmod-vcn-4-0-2"
 			;;
-		0x164e)
+		0x164e) # Raphael
 			addpkg "gpu-firmware-amd-kmod-gc-10-3-6"
 			addpkg "gpu-firmware-amd-kmod-psp-13-0-5"
 			addpkg "gpu-firmware-amd-kmod-dcn-3-1-5"


### PR DESCRIPTION
Add GPU names as comments to the latest GPU device IDs as the kernel modules are segmented now.

Names taken from:

https://devicehunt.com/view/type/pci/vendor/1002/device/744C
https://devicehunt.com/view/type/pci/vendor/1002/device/15BF
https://devicehunt.com/view/type/pci/vendor/1002/device/15C8
https://devicehunt.com/view/type/pci/vendor/1002/device/164E

More references:

https://www.techpowerup.com/gpu-specs/amd-navi-31.g998
https://www.techpowerup.com/gpu-specs/amd-phoenix.g1024
https://www.techpowerup.com/gpu-specs/amd-raphael.g1021