### PR TITLE
newsyslog: Add tests for rotating files based on size

### DIFF
--- a/usr.sbin/newsyslog/tests/legacy_test.sh
+++ b/usr.sbin/newsyslog/tests/legacy_test.sh
@@ -205,8 +205,7 @@ tmpdir_clean()
 
 run_newsyslog()
 {
-
-	newsyslog -f ../newsyslog.conf -F -r "$@"
+	newsyslog -f ../newsyslog.conf -r "$@"
 }
 
 tests_normal_rotate() {
@@ -216,10 +215,10 @@ tests_normal_rotate() {
 	dir="$2"
 
 	if [ -n "$dir" ]; then
-		newsyslog_args=" -a ${dir}"
+		newsyslog_args="-F -a ${dir}"
 		name_postfix="${ext} archive dir"
 	else
-		newsyslog_args=""
+		newsyslog_args="-F"
 		name_postfix="${ext}"
 	fi
 
@@ -294,10 +293,10 @@ tests_normal_rotate_keepn() {
 	dir="$3"
 
 	if [ -n "$dir" ]; then
-		newsyslog_args=" -a ${dir}"
+		newsyslog_args="-F -a ${dir}"
 		name_postfix="${ext} archive dir"
 	else
-		newsyslog_args=""
+		newsyslog_args="-F"
 		name_postfix="${ext}"
 	fi
 
@@ -363,10 +362,10 @@ tests_time_rotate() {
 	dir="$2"
 
 	if [ -n "$dir" ]; then
-		newsyslog_args="-t DEFAULT -a ${dir}"
+		newsyslog_args="-F -t DEFAULT -a ${dir}"
 		name_postfix="${ext} archive dir"
 	else
-		newsyslog_args="-t DEFAULT"
+		newsyslog_args="-F -t DEFAULT"
 		name_postfix="${ext}"
 	fi
 
@@ -424,10 +423,10 @@ tests_rfc5424() {
 	dir="$2"
 
 	if [ -n "$dir" ]; then
-		newsyslog_args=" -a ${dir}"
+		newsyslog_args="-F -a ${dir}"
 		name_postfix="${ext} archive dir"
 	else
-		newsyslog_args=""
+		newsyslog_args="-F"
 		name_postfix="${ext}"
 	fi
 
@@ -473,16 +472,16 @@ tests_p_flag_rotate() {
 	end
 
 	begin "rotate p flag 1 ${ext}"
-	run_newsyslog
+	run_newsyslog -F
 	ckfe $LOGFNAME
 	ckfe ${LOGFNAME}.0
 	cknt ${LOGFNAME}.0${ext}
-	run_newsyslog
+	run_newsyslog -F
 	ckfe $LOGFNAME
 	ckfe ${LOGFNAME}.0
 	cknt ${LOGFNAME}.0${ext}
 	ckfe ${LOGFNAME}.1${ext}
-	run_newsyslog
+	run_newsyslog -F
 	ckfe $LOGFNAME
 	ckfe ${LOGFNAME}.0
 	cknt ${LOGFNAME}.0${ext}
@@ -507,7 +506,7 @@ tests_normal_rotate_recompress() {
 	end
 
 	begin "rotate normal 1"
-	run_newsyslog
+	run_newsyslog -F
 	ckfe $LOGFNAME
 	ckfe ${LOGFNAME}.0${ext}
 	cknt ${LOGFNAME}.1${ext}
@@ -517,7 +516,7 @@ tests_normal_rotate_recompress() {
 	gunzip ${LOGFNAME}.0${ext}
 	ckfe ${LOGFNAME}.0
 	cknt ${LOGFNAME}.0${ext}
-	run_newsyslog
+	run_newsyslog -F
 	ckfe $LOGFNAME
 	ckfe ${LOGFNAME}.0${ext}
 	ckfe ${LOGFNAME}.1${ext}

--- a/usr.sbin/newsyslog/tests/legacy_test.sh
+++ b/usr.sbin/newsyslog/tests/legacy_test.sh
@@ -225,7 +225,7 @@ tests_normal_rotate() {
 
 	tmpdir_create
 
-	begin "create file ${name_postfix}" -newdir
+	begin "create file ${name_postfix}"
 	run_newsyslog -C
 	ckfe $LOGFNAME
 	cknt ${dir}${LOGFNAME}.0${ext}
@@ -303,7 +303,7 @@ tests_normal_rotate_keepn() {
 
 	tmpdir_create
 
-	begin "create file ${name_postfix}" -newdir
+	begin "create file ${name_postfix}"
 	run_newsyslog -C
 	ckfe $LOGFNAME
 	cknt ${dir}${LOGFNAME}.0${ext}
@@ -372,7 +372,7 @@ tests_time_rotate() {
 
 	tmpdir_create
 
-	begin "create file ${name_postfix}" -newdir
+	begin "create file ${name_postfix}"
 	run_newsyslog -C ${newsyslog_args}
 	ckfe ${LOGFNAME}
 	end
@@ -433,7 +433,7 @@ tests_rfc5424() {
 
 	tmpdir_create
 
-	begin "RFC-5424 - create file ${name_postfix}" -newdir
+	begin "RFC-5424 - create file ${name_postfix}"
 	run_newsyslog -C
 	ckfe $LOGFNAME
 	cknt ${dir}${LOGFNAME}.0${ext}


### PR DESCRIPTION
The tests for newsyslog(8) did not previously test size-based rotation, e.g., “rotate `foo.log` once it becomes larger than 8 KB.” This pull request adds a few tests for this functionality.