### PR TITLE
sed: Fix usage guidelines

### DIFF
--- a/usr.bin/sed/main.c
+++ b/usr.bin/sed/main.c
@@ -198,8 +198,8 @@ static void
 usage(void)
 {
 	(void)fprintf(stderr,
-	    "usage: %s script [-Ealnru] [-i extension] [file ...]\n"
-	    "\t%s [-Ealnu] [-i extension] [-e script] ... [-f script_file]"
+	    "usage: %s [-Ealnru] [-i extension] command [file ...]\n"
+	    "\t%s [-Ealnu] [-i extension] [-e command] ... [-f command_file]"
 	    " ... [file ...]\n", getprogname(), getprogname());
 	exit(1);
 }

--- a/usr.bin/sed/sed.1
+++ b/usr.bin/sed/sed.1
@@ -37,9 +37,9 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl Ealnru
-.Ar command
 .Op Fl I Ar extension
 .Op Fl i Ar extension
+.Ar command
 .Op Ar
 .Nm
 .Op Fl Ealnru
@@ -368,7 +368,7 @@ function or by beginning a new cycle.
 Branch to the
 .Dq \&:
 function with the specified label.
-If the label is not specified, branch to the end of the script.
+If the label is not specified, branch to the end of the command.
 .Pp
 .It [2addr]c\e
 .It text
@@ -454,7 +454,7 @@ Write the pattern space, up to the first newline character to the
 standard output.
 .Pp
 .It [1addr]q
-Branch to the end of the script and quit without starting a new cycle.
+Branch to the end of the command and quit without starting a new cycle.
 .Pp
 .It [1addr]r file
 Copy the contents of
@@ -524,7 +524,7 @@ function bearing the label if any substitutions have been made since the
 most recent reading of an input line or execution of a
 .Dq t
 function.
-If no label is specified, branch to the end of the script.
+If no label is specified, branch to the end of the command.
 .Pp
 .It [2addr]w Em file
 Append the pattern space to the


### PR DESCRIPTION
When viewing the usage guidelines of sed, whether by invoking it with an invalid argument or through viewing its manual page, it is suggested that [-i extension] or [-I extension] can or should be used after supplying a command, when in fact they can only be used before supplying a command.

Additionally, the manual pages and usage guidelines use inconsistent language by using "script" and "command" interchangeably. This change commits to using "command."