### PR TITLE
Fix full memory dumps on amd64

### DIFF
--- a/lib/libkvm/kvm_amd64.c
+++ b/lib/libkvm/kvm_amd64.c
@@ -109,8 +109,9 @@ _amd64_initvtop(kvm_t *kd)
 {
 	struct kvm_nlist nl[2];
 	amd64_physaddr_t pa;
-	kvaddr_t kernbase;
+	kvaddr_t kernbase, kernphys;
 	amd64_pml4e_t *PML4;
+	int found = 0;
 
 	kd->vmst = (struct vmstate *)_kvm_malloc(kd, sizeof(*kd->vmst));
 	if (kd->vmst == NULL) {
@@ -123,16 +124,43 @@ _amd64_initvtop(kvm_t *kd)
 		if (_kvm_read_core_phdrs(kd, &kd->vmst->phnum,
 		    &kd->vmst->phdr) == -1)
 			return (-1);
+
+		for (size_t i = 0; i < kd->vmst->phnum; i++) {
+			if (kd->vmst->phdr[i].p_type == PT_DUMP_DELTA) {
+				/* Account for the 2M hole at KERNBASE. */
+				kernphys = kd->vmst->phdr[i].p_paddr -
+				    kd->vmst->phdr[i].p_align;
+				kernbase = kd->vmst->phdr[i].p_vaddr;
+
+				found = 1;
+				break;
+			}
+		}
 	}
 
-	nl[0].n_name = "kernbase";
-	nl[1].n_name = 0;
+	if (found == 0) {
+		nl[0].n_name = "kernbase";
+		nl[1].n_name = 0;
 
-	if (kvm_nlist2(kd, nl) != 0) {
-		_kvm_err(kd, kd->program, "bad namelist - no kernbase");
-		return (-1);
+		if (kvm_nlist2(kd, nl) != 0) {
+			_kvm_err(kd, kd->program, "bad namelist - no kernbase");
+			return (-1);
+		}
+
+		nl[0].n_name = "kernphys";
+		nl[1].n_name = 0;
+
+		/* XXX
+		 * Relocatable kernels can still be loaded at 2M.
+		 */
+		if (kvm_nlist2(kd, nl) != 1) {
+			_kvm_err(kd, kd->program, "cannot determine kernphys");
+			return (-1);
+		}
+
+		kernphys = 0;
+		kernbase = nl[0].n_value;
 	}
-	kernbase = nl[0].n_value;
 
 	nl[0].n_name = "KPML4phys";
 	nl[1].n_name = 0;
@@ -141,8 +169,8 @@ _amd64_initvtop(kvm_t *kd)
 		_kvm_err(kd, kd->program, "bad namelist - no KPML4phys");
 		return (-1);
 	}
-	if (kvm_read2(kd, (nl[0].n_value - kernbase), &pa, sizeof(pa)) !=
-	    sizeof(pa)) {
+	if (kvm_read2(kd, (nl[0].n_value - kernbase + kernphys), &pa,
+	    sizeof(pa)) != sizeof(pa)) {
 		_kvm_err(kd, kd->program, "cannot read KPML4phys");
 		return (-1);
 	}

--- a/lib/libkvm/kvm_open.3
+++ b/lib/libkvm/kvm_open.3
@@ -29,7 +29,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd March 20, 2017
+.Dd June 14, 2025
 .Dt KVM_OPEN 3
 .Os
 .Sh NAME
@@ -245,7 +245,20 @@ The value passed via
 was
 .Dv NULL .
 .El
+.Sh NOTE
+Full memory dumps taken on 13.x (excluding 13.0) and 14.x amd64 kernels
+will cause both
+.Fn kvm_open
+and
+.Fn kvm_open2
+to fail since they do not provide sufficient information to figure out
+where in physical memory the kernel was loaded.
+Full memory dumps have to be explicitly enabled by setting the
+.Va debug.minidump
+.Xr sysctl 8
+to 0.
 .Sh SEE ALSO
+.Xr dumpon 8 ,
 .Xr close 2 ,
 .Xr open 2 ,
 .Xr kvm 3 ,

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -554,8 +554,8 @@ typedef struct {
 #define	PT_GNU_EH_FRAME	0x6474e550
 #define	PT_GNU_STACK	0x6474e551
 #define	PT_GNU_RELRO	0x6474e552
-#define	PT_DUMP_DELTA	0x6fb5d000	/* va->pa map for kernel dumps
-					   (currently arm). */
+#define	PT_DUMP_DELTA	0x6fb5d000	/* va->pa map for arm and amd64 kernel
+					   dumps */
 #define	PT_LOSUNW	0x6ffffffa
 #define	PT_SUNWBSS	0x6ffffffa	/* Sun Specific segment */
 #define	PT_SUNWSTACK	0x6ffffffb	/* describes the stack segment */

--- a/sys/x86/include/dump.h
+++ b/sys/x86/include/dump.h
@@ -38,7 +38,11 @@
 
 /* 20 phys_avail entry pairs correspond to 10 pa's */
 #define	DUMPSYS_MD_PA_NPAIRS	10
+#ifdef __amd64__
+#define	DUMPSYS_NUM_AUX_HDRS	1
+#else
 #define	DUMPSYS_NUM_AUX_HDRS	0
+#endif
 
 /* How often to check the dump progress bar? */
 #define	DUMPSYS_PB_CHECK_BITS	24	/* Every 16MB */
@@ -71,12 +75,16 @@ dumpsys_unmap_chunk(vm_paddr_t pa, size_t s, void *va)
 	dumpsys_gen_unmap_chunk(pa, s, va);
 }
 
+#ifdef __amd64__
+int dumpsys_write_aux_headers(struct dumperinfo *di);
+#else
 static inline int
 dumpsys_write_aux_headers(struct dumperinfo *di)
 {
 
 	return (dumpsys_gen_write_aux_headers(di));
 }
+#endif
 
 static inline int
 dumpsys(struct dumperinfo *di)


### PR DESCRIPTION
Currently, libkvm can't read full memory dumps correctly on amd64 since it assumes the kernel was loaded at 2M physical.   Fix this by adding the kernel's physical address in an auxiliary ELF section, similar to what arm does.

This seems to have been broken since 13.1 (see 8ca493ffb44691e70ae92300b8de1c1d30134ef4 and 1b33aa1f5f99e1270d526ffa5b652250ec80a7ef), so document that.

From my testing, this also stops kgdb and lldb from crashing when trying to open full memory dumps.