### PR TITLE
[PR: 269782] Add -q option to /usr/sbin/service and man page

### DIFF
--- a/usr.sbin/service/service.8
+++ b/usr.sbin/service/service.8
@@ -45,6 +45,7 @@
 .Fl r
 .Nm
 .Op Fl j Ar jail
+.Op Fl q
 .Op Fl v
 .Op Fl E Ar var=value
 .Ar script
@@ -115,6 +116,8 @@ as in
 above, but list all of the files, not just what is enabled.
 .It Fl v
 Be slightly more verbose.
+.It Fl v
+Be quiet, redirecting output to /dev/null.
 .El
 .Sh ENVIRONMENT
 When used to run rc.d scripts the

--- a/usr.sbin/service/service.sh
+++ b/usr.sbin/service/service.sh
@@ -44,7 +44,7 @@ usage () {
 	echo "-R		Stop and start enabled $local_startup services"
 	echo "-l		List all scripts in /etc/rc.d and $local_startup"
 	echo '-r		Show the results of boot time rcorder'
-	echo '-q	quiet'
+	echo '-q		quiet'
 	echo '-v		Verbose'
 	echo ''
 }


### PR DESCRIPTION
This adds a -q option to /usr/sbin/service to redirect output to /dev/null.  This is useful when doing a restart via cron or similar, or when a tool like puppet calls a restart/refresh.

Note that I opened this a few years ago under PR 269782, and was advised there to try the github workflow, and had missed that, but I've rebased the patch on the current tree.  (I do not know if I should now request that PR be closed).

Also note: I'll be at BSDCan this year and if there's an issue with the way I've submitted this, would love to speak in person and get it right.