### PR TITLE
Add missing POSIX NSIG_MAX & _SC_NSIG definitions

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -139,6 +139,7 @@
 
 #if __POSIX_VISIBLE >= 202405
 #define GETENTROPY_MAX		256
+#define NSIG_MAX		128	/* _SIG_MAXSIG from <signal.h> */
 #endif
 
 #include <sys/limits.h>

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -295,6 +295,10 @@ typedef	__useconds_t	useconds_t;
 #define	_SC_UEXTERR_MAXLEN	123 /* user */
 #endif
 
+#if __POSIX_VISIBLE >= 202405
+#define	_SC_NSIG		124
+#endif
+
 /* Extensions found in Solaris and Linux. */
 #define	_SC_PHYS_PAGES		121
 

--- a/lib/libc/gen/sysconf.c
+++ b/lib/libc/gen/sysconf.c
@@ -287,6 +287,8 @@ do_NAME_MAX:
 		mib[0] = CTL_P1003_1B;
 		mib[1] = CTL_P1003_1B_MQ_OPEN_MAX;
 		goto yesno;
+	case _SC_NSIG:
+		return (_SIG_MAXSIG);
 	case _SC_PAGESIZE:
 		return (getpagesize());
 	case _SC_RTSIG_MAX:


### PR DESCRIPTION
Add missing POSIX NSIG_MAX & _SC_NSIG definitions.

POSIX references:
- limits.h: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/limits.h.html
- signal.h: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html

Fixes https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287062