### PR TITLE
FIX: usb_msc_auto_quirk() called when UQ_MSC_IGNORE is set

### DIFF
--- a/sys/dev/usb/usb_device.c
+++ b/sys/dev/usb/usb_device.c
@@ -2068,7 +2068,8 @@ repeat_set_config:
 	    usb_test_quirk(&uaa, UQ_MSC_NO_SYNC_CACHE) == 0 &&
 	    usb_test_quirk(&uaa, UQ_MSC_NO_TEST_UNIT_READY) == 0 &&
 	    usb_test_quirk(&uaa, UQ_MSC_NO_GETMAXLUN) == 0 &&
-	    usb_test_quirk(&uaa, UQ_MSC_NO_INQUIRY) == 0) {
+	    usb_test_quirk(&uaa, UQ_MSC_NO_INQUIRY) == 0 &&
+		usb_test_quirk(&uaa, UQ_MSC_IGNORE) == 0) {
 		/*
 		 * Try to figure out if there are any MSC quirks we
 		 * should apply automatically:


### PR DESCRIPTION
usb_msc_auto_quirk() potentially crashes usb devices with a hidden storage (see bug 287333). These devices may still operate normally if usb_msc_auto_quirk() would not be called all and the hidden storage is ignored. This patch makes sure, that usb_msc_auto_quirk() is not called when the UQ_MSC_IGNORE quirk is set for a device. It shouldn't be called anyway if the hidden storage supposed to be ignored. This gives users a chance to get their devices working by using 'usbconfig add_dev_quirk_vplh <vid> <pid> <lo_rev> <hi_rev> UQ_MSC_IGNORE'.