### PR TITLE
nanobsd: Update the updatep1 script to edit the EFI device to boot from

### DIFF
--- a/tools/tools/nanobsd/Files/root/updatep1
+++ b/tools/tools/nanobsd/Files/root/updatep1
@@ -59,7 +59,7 @@ EFI=`gpart show ${NANO_DRIVE}|grep 'efi'`
 if [ $EFI != '' ] ;
 then
 	PART=`echo $EFI|awk '{ print $3 }'`
-	mount -t msdosfs /dev/${NANO_DRIVE}s$EFI /mnt
+	mount -t msdosfs /dev/${NANO_DRIVE}s$PART /mnt
 	echo 'rootdev=disk0s1a' >/mnt/EFI/FreeBSD/loader.env
 	umount /mnt
 fi


### PR DESCRIPTION
Part of the nanobsd legacy.sh change. The only fly in the ointment is that its not possible to reliably know what disk number the BIOS EFI loader "saw"; I've seen USB media come up as disk1 when there was another device (non-bootable) in the machine, yet if you look at rootdev or similar after it comes up it shows as disk0.  If this is wrong in loader.env it won't boot at all, where if the file is missing then it will boot (but not your updated code slice!)

This requires more investigation in the case where other disk media is in the unit; if you have only the boot media in then it works as expected.