### PR TITLE
Fix NULL deref segfault in bhyve's usb_mouse.c

### DIFF
--- a/usr.sbin/bhyve/usb_mouse.c
+++ b/usr.sbin/bhyve/usb_mouse.c
@@ -530,7 +530,7 @@ umouse_request(void *scarg, struct usb_data_xfer *xfer)
 			data->bdone += 2;
 		}
 
-		eshort = data->blen > 0;
+		eshort = data != NULL && data->blen > 0;
 		break;
 
 	case UREQ(UR_GET_STATUS, UT_READ_INTERFACE):
@@ -541,7 +541,7 @@ umouse_request(void *scarg, struct usb_data_xfer *xfer)
 			data->blen = len - 2;
 			data->bdone += 2;
 		}
-		eshort = data->blen > 0;
+		eshort = data != NULL && data->blen > 0;
 		break;
 
 	case UREQ(UR_SET_ADDRESS, UT_WRITE_DEVICE):
@@ -626,7 +626,7 @@ umouse_request(void *scarg, struct usb_data_xfer *xfer)
 			data->blen = len - 1;
 			data->bdone += 1;
 		}
-		eshort = data->blen > 0;
+		eshort = data != NULL && data->blen > 0;
 		break;
 
 	case UREQ(UMOUSE_GET_PROTOCOL, UT_READ_CLASS_INTERFACE):
@@ -635,7 +635,7 @@ umouse_request(void *scarg, struct usb_data_xfer *xfer)
 			data->blen = len - 1;
 			data->bdone += 1;
 		}
-		eshort = data->blen > 0;
+		eshort = data != NULL && data->blen > 0;
 		break;
 
 	case UREQ(UMOUSE_SET_REPORT, UT_WRITE_CLASS_INTERFACE):


### PR DESCRIPTION
Bugzilla link:

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=282237

> Some of the cases inside umouse_request() (usr.sbin/bhyve/usb_mouse.c) use the data component of an event, while only partially checking if it's NULL.
> 
> For example:
> ```
	case UREQ(UR_GET_STATUS, UT_READ_INTERFACE):
	case UREQ(UR_GET_STATUS, UT_READ_ENDPOINT):
		DPRINTF(("umouse: (UR_GET_STATUS, UT_READ_INTERFACE)"));
		if (data != NULL && len > 1) {
			USETW(udata, 0);
			data->blen = len - 2;
			data->bdone += 2;
		}
		eshort = data->blen > 0;
		break;
> ```
> As you can see, 'data' has a NULL check, but then 'data' is immediately deferenced anyway after the check regardless of if it's NULL or not.
> 
> There are actually four occurrences of this same bug, each in a different case in this switch block.
> 
> Cheers,
> Jack Bendtsen