### PR TITLE
tcp: Add TCP_FASTOPEN_CONNECT sockopt

### DIFF
--- a/sys/netinet/tcp.h
+++ b/sys/netinet/tcp.h
@@ -224,6 +224,7 @@ __tcp_set_flags(struct tcphdr *th, uint16_t flags)
 #define	TCP_KEEPINTVL		512	/* L,N interval between keepalives */
 #define	TCP_KEEPCNT		1024	/* L,N number of keepalives before close */
 #define	TCP_FASTOPEN		1025	/* enable TFO / was created via TFO */
+#define TCP_FASTOPEN_CONNECT	1027	/* defer connect until data; attempt TFO */
 /* unused			2048	   was TCP_PCAP_OUT */
 /* unused			4096	   was TCP_PCAP_IN */
 #define	TCP_FUNCTION_BLK	8192	/* Set the tcp function pointers to the specified stack */

--- a/sys/netinet/tcp_var.h
+++ b/sys/netinet/tcp_var.h
@@ -841,6 +841,7 @@ tcp_packets_this_ack(struct tcpcb *tp, tcp_seq ack)
 #define	TF2_PROC_SACK_PROHIBIT	0x00100000 /* Due to small MSS size do not process sack's */
 #define	TF2_IPSEC_TSO		0x00200000 /* IPSEC + TSO supported */
 #define	TF2_NO_ISS_CHECK	0x00400000 /* Don't check SEG.ACK against ISS */
+#define TF2_TFO_CONNECT		0x00800000 /* TCP Fast Open lazy-connect */
 
 /*
  * Structure to hold TCP options that are only used during segment


### PR DESCRIPTION
This option causes a subsequent connect syscall to only bind the
remote address, leaving the TCP connection initiation for a later
data-send call.  This supports applications where the transport
connect coding is a long way away from the data-send (eg. the
latter is in a TLS library) and the wish is for data-bearing
TCP Fast Open.

The option name matches that used by the Linux kernel.

For discussion:
- The implementation also does the equivalent of a TCP_FASTOPEN
  setsockopt; is this wanted or should they be separated?
  It does not support the PSK mode of TCP_FASTOPEN; is that wanted?
- The implementation diverges the "connected" socket state from
  the actual state of the TCP connection; is this acceptable
  architecturally?
- Testing: only basic kernel bootability and exercise of the feature
  has been done.  Is there a general networking testsuite?