### PR TITLE
kill: Fix support for kill -0

### DIFF
--- a/bin/kill/kill.c
+++ b/bin/kill/kill.c
@@ -99,7 +99,9 @@ main(int argc, char *argv[])
 		argc--, argv++;
 	} else if (**argv == '-' && *(*argv + 1) != '-') {
 		++*argv;
-		if (str2sig(*argv, &numsig) < 0)
+		if (strcmp(*argv, "0") == 0)
+			numsig = 0;
+		else if (str2sig(*argv, &numsig) < 0)
 			nosig(*argv);
 		argc--, argv++;
 	}


### PR DESCRIPTION
Fix issue mentioned in https://github.com/freebsd/freebsd-src/pull/1696#issuecomment-2992285544

These tests now pass:

```
bin/pwait/tests/pwait_test:basic
bin/pwait/pwait_test or_flag
```