### PR TITLE
Fixing typos in the CI tests

### DIFF
--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -173,15 +173,15 @@ ci-buildworld: .PHONY
 
 
 ci-buildkernel: ci-buildworld-${TARGET_ARCH:tl} .PHONY
-	@echo "Building kernel for ${TARGET_ARCH"}"
+	@echo "Building kernel for ${TARGET_ARCH}"
 	${IMAKE} -j${PARALLEL_JOBS} -C ${WORLDDIR} ${METAMODE} \
-		${CROSS_TOOLCHAIN_PARAM} __MAKE_CONF=${MAKECONF} SRCCONF=${SRCCONF}
+		${CROSS_TOOLCHAIN_PARAM} __MAKE_CONF=${MAKECONF} SRCCONF=${SRCCONF} \
 		${EXTRA_MAKE_FLAGS} KERNCONF=${KERNCONF} \
 		buildkernel > ${.CURDIR}/_.${TARGET_ARCH}.${.TARGET} 2>&1 || \
 		(echo "${.TARGET} failed, check _.${TARGET_ARCH}.${.TARGET} for details" ; false)
 
 ci-buildimage: ${QEMUTGT} ci-buildkernel-${TARGET_ARCH:tl} .PHONY
-	@echo "Building ci image for ${TARGET_ARCH"}"
+	@echo "Building ci image for ${TARGET_ARCH}"
 	mkdir -p ${.OBJDIR}/${.TARGET}
 	env TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} SWAPSIZE=${SWAPSIZE} \
 		QEMUSTATIC=${QEMUSTATIC} CITYPE=${CITYPE} \


### PR DESCRIPTION
CI: Fix typos

Fixes: c08f5ad160bf7 ("CI: Add full test support")
Sponsored by: The FreeBSD Foundation
Signed-off-by: Kalina Spasova <kalinasp@gmail.com>