### PR TITLE
libsa: Add isprint()

### DIFF
--- a/stand/libsa/hexdump.c
+++ b/stand/libsa/hexdump.c
@@ -61,7 +61,7 @@ hexdump(caddr_t region, size_t len)
 	for (x = 0; x < 16; x++) {
 	    if ((line + x) < (region + len)) {
 		c = *(uint8_t *)(line + x);
-		if ((c < ' ') || (c > '~'))	/* !isprint(c) */
+		if (!isprint(c))
 		    c = '.';
 		emit("%c", c);
 	    } else {

--- a/stand/libsa/stand.h
+++ b/stand/libsa/stand.h
@@ -275,6 +275,11 @@ static __inline int ispunct(int c)
 	    (c >= '[' && c <= '`') || (c >= '{' && c <= '~');
 }
 
+static __inline int isprint(int c)
+{
+	return (c >= ' ') && (c <= '~');
+}
+
 static __inline int toupper(int c)
 {
     return islower(c) ? c - 'a' + 'A' : c;


### PR DESCRIPTION

Add `isprint()` alongside other `isfoo()` functions in `libsa`.
Motivations for change:
1) Future `ACPICA` work in loader needs it.
2) `libsa/hexdump.c` already uses it.

Signed-off-by: Kayla Powell (AKA Kat) <kpowkitty@FreeBSD.org>