### PR TITLE
Improve installer UI for mirrorselect and zfsboot

### DIFF
--- a/usr.sbin/bsdinstall/scripts/mirrorselect
+++ b/usr.sbin/bsdinstall/scripts/mirrorselect
@@ -27,6 +27,7 @@
 
 BSDCFG_SHARE="/usr/share/bsdconfig"
 . $BSDCFG_SHARE/common.subr || exit 1
+f_include $BSDCFG_SHARE/dialog.subr
 
 : ${BSDDIALOG_OK=0}
 : ${BSDDIALOG_CANCEL=1}
@@ -35,61 +36,141 @@ BSDCFG_SHARE="/usr/share/bsdconfig"
 : ${BSDDIALOG_ESC=5}
 : ${BSDDIALOG_ERROR=255}
 
-exec 5>&1
-MIRROR=`bsddialog --backtitle "$OSNAME Installer" \
-    --title "Mirror Selection" --extra-button --extra-label "Other" \
-    --menu "Please select the best suitable site for you or \"other\" if you want to specify a different choice. The \"Main Site\" directs users to the nearest project managed mirror via GeoDNS (they carry the full range of possible distributions and support both IPv4 and IPv6). All other sites are known as \"Community Mirrors\"; not every site listed here carries more than the base distribution kits. Select a site!" \
-    0 0 16 \
-	http://ftp.freebsd.org		"Main Site (GeoDNS, HTTP)"\
-	ftp://ftp.freebsd.org		"Main Site (GeoDNS, FTP)"\
-	http://ftp.au.freebsd.org 	"Australia - IPv6"\
-	ftp://ftp3.au.freebsd.org 	"Australia #3"\
-	ftp://ftp.at.freebsd.org 	"Austria - IPv6"\
-	ftp://ftp2.br.freebsd.org 	"Brazil #2"\
-	ftp://ftp3.br.freebsd.org 	"Brazil #3"\
-	ftp://ftp.bg.freebsd.org 	"Bulgaria - IPv6"\
-	ftp://ftp.cz.freebsd.org 	"Czech Republic - IPv6"\
-	ftp://ftp.dk.freebsd.org 	"Denmark - IPv6"\
-	ftp://ftp.fi.freebsd.org 	"Finland"\
-	ftp://ftp.fr.freebsd.org 	"France - IPv6"\
-	ftp://ftp3.fr.freebsd.org 	"France #3"\
-	ftp://ftp6.fr.freebsd.org 	"France #6"\
-	ftp://ftp.de.freebsd.org 	"Germany - IPv6"\
-	ftp://ftp1.de.freebsd.org 	"Germany #1 - IPv6"\
-	ftp://ftp2.de.freebsd.org 	"Germany #2 - IPv6"\
-	ftp://ftp5.de.freebsd.org 	"Germany #5 - IPv6"\
-	ftp://ftp7.de.freebsd.org 	"Germany #7 - IPv6"\
-	ftp://ftp.gr.freebsd.org 	"Greece - IPv6"\
-	ftp://ftp2.gr.freebsd.org 	"Greece #2 - IPv6"\
-	ftp://ftp.jp.freebsd.org 	"Japan - IPv6"\
-	ftp://ftp2.jp.freebsd.org 	"Japan #2"\
-	ftp://ftp3.jp.freebsd.org 	"Japan #3"\
-	ftp://ftp4.jp.freebsd.org 	"Japan #4"\
-	ftp://ftp6.jp.freebsd.org 	"Japan #6 - IPv6"\
-	ftp://ftp.kr.freebsd.org 	"Korea"\
-	ftp://ftp2.kr.freebsd.org 	"Korea #2"\
-	ftp://ftp.lv.freebsd.org 	"Latvia"\
-	ftp://ftp.nl.freebsd.org 	"Netherlands - IPv6"\
-	ftp://ftp2.nl.freebsd.org 	"Netherlands #2"\
-	ftp://ftp.nz.freebsd.org 	"New Zealand"\
-	ftp://ftp.no.freebsd.org 	"Norway - IPv6"\
-	ftp://ftp.pl.freebsd.org 	"Poland - IPv6"\
-	ftp://ftp.ru.freebsd.org 	"Russia - IPv6"\
-	ftp://ftp2.ru.freebsd.org 	"Russia #2"\
-	ftp://ftp.si.freebsd.org 	"Slovenia - IPv6"\
-	ftp://ftp.za.freebsd.org 	"South Africa - IPv6"\
-	ftp://ftp2.za.freebsd.org 	"South Africa #2 - IPv6"\
-	ftp://ftp4.za.freebsd.org 	"South Africa #4"\
-	ftp://ftp.se.freebsd.org 	"Sweden - IPv6"\
-	ftp://ftp4.tw.freebsd.org 	"Taiwan #4"\
-	ftp://ftp5.tw.freebsd.org 	"Taiwan #5"\
-	ftp://ftp.uk.freebsd.org 	"UK - IPv6"\
-	ftp://ftp2.uk.freebsd.org 	"UK #2 - IPv6"\
-	ftp://ftp.ua.FreeBSD.org 	"Ukraine - IPv6"\
-	ftp://ftp5.us.freebsd.org 	"USA #5 - IPv6"\
-    2>&1 1>&5`
-MIRROR_BUTTON=$?
-exec 5>&-
+# Define regions and mirrors
+REGIONS="
+Africa
+Asia
+Europe
+North_America
+Oceania
+South_America
+"
+
+# Mirrors by region
+MIRRORS_Africa="
+ftp://ftp.za.freebsd.org 'South Africa - IPv6'
+ftp://ftp2.za.freebsd.org 'South Africa #2 - IPv6'
+ftp://ftp4.za.freebsd.org 'South Africa #4'
+"
+
+MIRRORS_Asia="
+ftp://ftp.jp.freebsd.org 'Japan - IPv6'
+ftp://ftp2.jp.freebsd.org 'Japan #2'
+ftp://ftp3.jp.freebsd.org 'Japan #3'
+ftp://ftp4.jp.freebsd.org 'Japan #4'
+ftp://ftp6.jp.freebsd.org 'Japan #6 - IPv6'
+ftp://ftp.kr.freebsd.org 'Korea'
+ftp://ftp2.kr.freebsd.org 'Korea #2'
+ftp://ftp4.tw.freebsd.org 'Taiwan #4'
+ftp://ftp5.tw.freebsd.org 'Taiwan #5'
+"
+
+MIRRORS_Europe="
+ftp://ftp.at.freebsd.org 'Austria - IPv6'
+ftp://ftp.bg.freebsd.org 'Bulgaria - IPv6'
+ftp://ftp.cz.freebsd.org 'Czech Republic - IPv6'
+ftp://ftp.dk.freebsd.org 'Denmark - IPv6'
+ftp://ftp.fi.freebsd.org 'Finland'
+ftp://ftp.fr.freebsd.org 'France - IPv6'
+ftp://ftp3.fr.freebsd.org 'France #3'
+ftp://ftp6.fr.freebsd.org 'France #6'
+ftp://ftp.de.freebsd.org 'Germany - IPv6'
+ftp://ftp1.de.freebsd.org 'Germany #1 - IPv6'
+ftp://ftp2.de.freebsd.org 'Germany #2 - IPv6'
+ftp://ftp5.de.freebsd.org 'Germany #5 - IPv6'
+ftp://ftp7.de.freebsd.org 'Germany #7 - IPv6'
+ftp://ftp.gr.freebsd.org 'Greece - IPv6'
+ftp://ftp2.gr.freebsd.org 'Greece #2 - IPv6'
+ftp://ftp.lv.freebsd.org 'Latvia'
+ftp://ftp.nl.freebsd.org 'Netherlands - IPv6'
+ftp://ftp2.nl.freebsd.org 'Netherlands #2'
+ftp://ftp.no.freebsd.org 'Norway - IPv6'
+ftp://ftp.pl.freebsd.org 'Poland - IPv6'
+ftp://ftp.ru.freebsd.org 'Russia - IPv6'
+ftp://ftp2.ru.freebsd.org 'Russia #2'
+ftp://ftp.si.freebsd.org 'Slovenia - IPv6'
+ftp://ftp.se.freebsd.org 'Sweden - IPv6'
+ftp://ftp.uk.freebsd.org 'UK - IPv6'
+ftp://ftp2.uk.freebsd.org 'UK #2 - IPv6'
+ftp://ftp.ua.FreeBSD.org 'Ukraine - IPv6'
+"
+
+MIRRORS_North_America="
+ftp://ftp5.us.freebsd.org 'USA #5 - IPv6'
+"
+
+MIRRORS_Oceania="
+http://ftp.au.freebsd.org 'Australia - IPv6'
+ftp://ftp3.au.freebsd.org 'Australia #3'
+ftp://ftp.nz.freebsd.org 'New Zealand'
+"
+
+MIRRORS_South_America="
+ftp://ftp2.br.freebsd.org 'Brazil #2'
+ftp://ftp3.br.freebsd.org 'Brazil #3'
+"
+
+# Main Site options
+MAIN_SITE_OPTIONS="
+http://ftp.freebsd.org 'Main Site (GeoDNS, HTTP)'
+ftp://ftp.freebsd.org 'Main Site (GeoDNS, FTP)'
+"
+
+while true; do
+	exec 5>&1
+	REGION_CHOICE=$(echo $MAIN_SITE_OPTIONS $REGIONS | xargs -o bsddialog \
+	    --backtitle "$OSNAME Installer" \
+	    --title "Mirror Selection - Region" --extra-button --extra-label "Other" \
+	    --menu "Please select a region or a main site option. The \"Main Site\" directs users to the nearest project managed mirror via GeoDNS. \"Other\" allows you to specify a custom URL." \
+	    0 0 16 \
+	    2>&1 1>&5)
+	MIRROR_BUTTON=$?
+	exec 5>&-
+
+	if [ $MIRROR_BUTTON -eq $BSDDIALOG_CANCEL ] || [ $MIRROR_BUTTON -eq $BSDDIALOG_ESC ]; then
+		exit 1
+	fi
+
+	if [ $MIRROR_BUTTON -eq $BSDDIALOG_EXTRA ]; then
+		# Handle "Other" option
+		exec 5>&1
+		BSDINSTALL_DISTSITE_BASE=$(bsddialog --backtitle "$OSNAME Installer" \
+		    --title "Mirror Selection" \
+		    --inputbox "Please enter the URL to an alternate $OSNAME mirror (without the /pub/FreeBSD/... path):" \
+		    0 74 "" 2>&1 1>&5)
+		INPUT_BOX_EXIT_CODE=$?
+		exec 5>&-
+		if [ $INPUT_BOX_EXIT_CODE -eq $BSDDIALOG_OK ]; then
+			MIRROR="$BSDINSTALL_DISTSITE_BASE"
+			break
+		else
+			continue # Go back to region selection
+		fi
+	elif echo "$MAIN_SITE_OPTIONS" | grep -q "$REGION_CHOICE"; then
+		MIRROR="$REGION_CHOICE"
+		break
+	else
+		# Display mirrors for the selected region
+		CURRENT_MIRRORS_VAR="MIRRORS_$REGION_CHOICE"
+		CURRENT_MIRRORS=$(eval echo "\$$CURRENT_MIRRORS_VAR")
+
+		exec 5>&1
+		MIRROR_CHOICE=$(echo "$CURRENT_MIRRORS" | xargs -o bsddialog \
+		    --backtitle "$OSNAME Installer" \
+		    --title "Mirror Selection - $REGION_CHOICE" \
+		    --menu "Please select a mirror for $REGION_CHOICE:" \
+		    0 0 16 \
+		    2>&1 1>&5)
+		MIRROR_BUTTON=$?
+		exec 5>&-
+
+		if [ $MIRROR_BUTTON -eq $BSDDIALOG_OK ]; then
+			MIRROR="$MIRROR_CHOICE"
+			break
+		fi
+		# If cancelled, loop back to region selection
+	fi
+done
 
 _UNAME_R=`uname -r`
 _UNAME_R=${_UNAME_R%-p*}
@@ -104,24 +185,6 @@ case ${_UNAME_R} in
 esac
 
 BSDINSTALL_DISTSITE="$MIRROR/pub/FreeBSD/${RELDIR}/`uname -m`/`uname -p`/${_UNAME_R}"
-
-case $MIRROR_BUTTON in
-$BSDDIALOG_ERROR | $BSDDIALOG_CANCEL | $BSDDIALOG_ESC)
-	exit 1
-	;;
-$BSDDIALOG_OK)
-	;;
-$BSDDIALOG_EXTRA)
-	exec 5>&1
-	BSDINSTALL_DISTSITE=`bsddialog --backtitle "$OSNAME Installer" \
-	    --title "Mirror Selection" \
-	    --inputbox "Please enter the URL to an alternate $OSNAME mirror:" \
-	    0 74 "$BSDINSTALL_DISTSITE" 2>&1 1>&5`
-	MIRROR_BUTTON=$?
-	exec 5>&-
-	test $MIRROR_BUTTON -eq $BSDDIALOG_OK || exec $0 $@
-	;;
-esac
 
 export BSDINSTALL_DISTSITE
 echo $BSDINSTALL_DISTSITE >&2

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -337,50 +337,18 @@ dialog_menu_main()
 {
 	local title="$DIALOG_TITLE"
 	local btitle="$DIALOG_BACKTITLE"
-	local prompt="$msg_configure_options"
-	local force4k="$msg_no"
-	local usegeli="$msg_no"
-	local swapgeli="$msg_no"
-	local swapmirror="$msg_no"
-	[ "$ZFSBOOT_FORCE_4K_SECTORS" ] && force4k="$msg_yes"
-	[ "$ZFSBOOT_GELI_ENCRYPTION" ] && usegeli="$msg_yes"
-	[ "$ZFSBOOT_SWAP_ENCRYPTION" ] && swapgeli="$msg_yes"
-	[ "$ZFSBOOT_SWAP_MIRROR" ] && swapmirror="$msg_yes"
-	local disks n disks_grammar
-	f_count n $ZFSBOOT_DISKS
-	{ [ $n -eq 1 ] && disks_grammar=$msg_disk_singular; } ||
-		disks_grammar=$msg_disk_plural # grammar
+	local prompt="ZFS Configuration Main Menu"
 	local menu_list="
-		'>>> $msg_install'      '$msg_install_desc'
-		                        '$msg_install_help'
-		'T $msg_pool_type_disks'
-		               '$ZFSBOOT_VDEV_TYPE: $n $disks_grammar'
-		               '$msg_pool_type_disks_help'
-		'- $msg_rescan_devices' '*'
-		                        '$msg_rescan_devices_help'
-		'- $msg_disk_info'      '*'
-		                        '$msg_disk_info_help'
-		'N $msg_pool_name'      '$ZFSBOOT_POOL_NAME'
-		                        '$msg_pool_name_help'
-		'4 $msg_force_4k_sectors'
-		                        '$force4k'
-		                        '$msg_force_4k_sectors_help'
-		'E $msg_encrypt_disks'  '$usegeli'
-		                        '$msg_encrypt_disks_help'
-		'P $msg_partition_scheme'
-		               '$ZFSBOOT_PARTITION_SCHEME ($ZFSBOOT_BOOT_TYPE)'
-		               '$msg_partition_scheme_help'
-		'S $msg_swap_size'      '$ZFSBOOT_SWAP_SIZE'
-		                        '$msg_swap_size_help'
-		'M $msg_swap_mirror'    '$swapmirror'
-		                        '$msg_swap_mirror_help'
-		'W $msg_swap_encrypt'   '$swapgeli'
-		                        '$msg_swap_encrypt_help'
-		'O $msg_zfs_options_name'   '$ZFSBOOT_POOL_CREATE_OPTIONS'
-		                        '$msg_zfs_options_name_help'
+		'Install'           'Proceed with Installation' ''
+		'Pool Type/Disks'   'Configure ZFS Pool Type and Disks' ''
+		'Pool Options'      'Configure Pool Name, 4K Sectors, etc.' ''
+		'Swap Options'      'Configure Swap Size, Mirroring, and Encryption' ''
+		'Encryption Options' 'Configure ZFS GELI Encryption' ''
+		'- Rescan Devices'  'Scan for device changes' ''
+		'- Disk Info'       'Get detailed information on disk device(s)' ''
 	" # END-QUOTE
 	local defaultitem= # Calculated below
-	local hline="$hline_alnum_arrows_punc_tab_enter"
+	local hline="$hline_arrows_tab_enter"
 
 	local height width rows
 	eval f_dialog_menu_with_help_size height width rows \
@@ -412,6 +380,245 @@ dialog_menu_main()
 
 	return $retval
 }
+
+# dialog_menu_pool_type_disks
+#
+# Submenu for configuring ZFS Pool Type and Disks.
+#
+dialog_menu_pool_type_disks()
+{
+	# This function will call dialog_menu_layout
+	ZFSBOOT_CONFIRM_LAYOUT=1
+	dialog_menu_layout
+	# User has poked settings, disable later confirmation
+	ZFSBOOT_CONFIRM_LAYOUT=
+}
+
+# dialog_menu_pool_options
+#
+# Submenu for configuring Pool Name, 4K Sectors, etc.
+#
+dialog_menu_pool_options()
+{
+	local title="$DIALOG_TITLE"
+	local btitle="$DIALOG_BACKTITLE"
+	local prompt="Configure Pool Options"
+	local force4k="$msg_no"
+	[ "$ZFSBOOT_FORCE_4K_SECTORS" ] && force4k="$msg_yes"
+	local menu_list="
+		'N $msg_pool_name'          '$ZFSBOOT_POOL_NAME' '$msg_pool_name_help'
+		'4 $msg_force_4k_sectors'   '$force4k' '$msg_force_4k_sectors_help'
+		'O $msg_zfs_options_name'   '$ZFSBOOT_POOL_CREATE_OPTIONS' '$msg_zfs_options_name_help'
+		'P $msg_partition_scheme'   '$ZFSBOOT_PARTITION_SCHEME ($ZFSBOOT_BOOT_TYPE)' '$msg_partition_scheme_help'
+	" # END-QUOTE
+	local defaultitem=
+	local hline="$hline_alnum_arrows_punc_tab_enter"
+	local height width rows
+	eval f_dialog_menu_with_help_size height width rows \
+		\"\$title\" \"\$btitle\" \"\$prompt\" \"\$hline\" $menu_list
+	f_dialog_default_fetch defaultitem
+
+	local menu_choice
+	menu_choice=$( eval $DIALOG \
+		--title \"\$title\"              \
+		--backtitle \"\$btitle\"         \
+		--hline \"\$hline\"              \
+		--item-help                      \
+		--ok-label \"\$msg_select\"      \
+		--cancel-label \"\$msg_back\"    \
+		--default-item \"\$defaultitem\" \
+		--menu \"\$prompt\"              \
+		$height $width $rows             \
+		${USE_DIALOG:+--} $menu_list     \
+		2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
+	)
+	local retval=$?
+	f_dialog_data_sanitize menu_choice
+	[ $retval -eq $DIALOG_OK ] && f_dialog_default_store "$menu_choice"
+
+	case "$menu_choice" in
+	"N $msg_pool_name")
+		f_dialog_input input \
+			"$msg_please_enter_a_name_for_your_pool" \
+			"$ZFSBOOT_POOL_NAME" &&
+			ZFSBOOT_POOL_NAME="$input"
+		;;
+	"4 $msg_force_4k_sectors")
+		if [ "$ZFSBOOT_FORCE_4K_SECTORS" ]; then
+			ZFSBOOT_FORCE_4K_SECTORS=
+		else
+			ZFSBOOT_FORCE_4K_SECTORS=1
+		fi
+		;;
+	"O $msg_zfs_options_name")
+		f_dialog_input input \
+			"$msg_please_enter_options_for_your_pool" \
+			"$ZFSBOOT_POOL_CREATE_OPTIONS" &&
+			ZFSBOOT_POOL_CREATE_OPTIONS="$input"
+		;;
+	"P $msg_partition_scheme")
+		if [ "$ZFSBOOT_PARTITION_SCHEME" = "GPT" -a \
+		     "$ZFSBOOT_BOOT_TYPE" = "BIOS" ]; then
+			ZFSBOOT_PARTITION_SCHEME="GPT"
+			ZFSBOOT_BOOT_TYPE="UEFI"
+		elif [ "$ZFSBOOT_PARTITION_SCHEME" = "GPT" -a \
+		       "$ZFSBOOT_BOOT_TYPE" = "UEFI" ]; then
+			ZFSBOOT_PARTITION_SCHEME="GPT"
+			ZFSBOOT_BOOT_TYPE="BIOS+UEFI"
+		elif [ "$ZFSBOOT_PARTITION_SCHEME" = "GPT" ]; then
+			ZFSBOOT_PARTITION_SCHEME="MBR"
+			ZFSBOOT_BOOT_TYPE="BIOS"
+		elif [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
+			ZFSBOOT_PARTITION_SCHEME="GPT + Active"
+			ZFSBOOT_BOOT_TYPE="BIOS"
+		elif [ "$ZFSBOOT_PARTITION_SCHEME" = "GPT + Active" ]; then
+			ZFSBOOT_PARTITION_SCHEME="GPT + Lenovo Fix"
+			ZFSBOOT_BOOT_TYPE="BIOS"
+		else
+			ZFSBOOT_PARTITION_SCHEME="GPT"
+			ZFSBOOT_BOOT_TYPE="BIOS"
+		fi
+		;;
+	esac
+	return $retval
+}
+
+# dialog_menu_swap_options
+#
+# Submenu for configuring Swap Size, Mirroring, and Encryption.
+#
+dialog_menu_swap_options()
+{
+	local title="$DIALOG_TITLE"
+	local btitle="$DIALOG_BACKTITLE"
+	local prompt="Configure Swap Options"
+	local swapgeli="$msg_no"
+	local swapmirror="$msg_no"
+	[ "$ZFSBOOT_SWAP_ENCRYPTION" ] && swapgeli="$msg_yes"
+	[ "$ZFSBOOT_SWAP_MIRROR" ] && swapmirror="$msg_yes"
+	local menu_list="
+		'S $msg_swap_size'      '$ZFSBOOT_SWAP_SIZE' '$msg_swap_size_help'
+		'M $msg_swap_mirror'    '$swapmirror' '$msg_swap_mirror_help'
+		'W $msg_swap_encrypt'   '$swapgeli' '$msg_swap_encrypt_help'
+	" # END-QUOTE
+	local defaultitem=
+	local hline="$hline_alnum_arrows_punc_tab_enter"
+	local height width rows
+	eval f_dialog_menu_with_help_size height width rows \
+		\"\$title\" \"\$btitle\" \"\$prompt\" \"\$hline\" $menu_list
+	f_dialog_default_fetch defaultitem
+
+	local menu_choice
+	menu_choice=$( eval $DIALOG \
+		--title \"\$title\"              \
+		--backtitle \"\$btitle\"         \
+		--hline \"\$hline\"              \
+		--item-help                      \
+		--ok-label \"\$msg_select\"      \
+		--cancel-label \"\$msg_back\"    \
+		--default-item \"\$defaultitem\" \
+		--menu \"\$prompt\"              \
+		$height $width $rows             \
+		${USE_DIALOG:+--} $menu_list     \
+		2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
+	)
+	local retval=$?
+	f_dialog_data_sanitize menu_choice
+	[ $retval -eq $DIALOG_OK ] && f_dialog_default_store "$menu_choice"
+
+	case "$menu_choice" in
+	"S $msg_swap_size")
+		while :; do
+		    f_dialog_input input \
+			    "$msg_please_enter_amount_of_swap_space" \
+			    "$ZFSBOOT_SWAP_SIZE" &&
+			    ZFSBOOT_SWAP_SIZE="${input:-0}"
+		    if f_expand_number "$ZFSBOOT_SWAP_SIZE" swapsize
+		    then
+			if [ $swapsize -ne 0 -a $swapsize -lt 104857600 ]; then
+			    f_show_err "$msg_swap_toosmall" \
+				       "$ZFSBOOT_SWAP_SIZE"
+			    continue
+			else
+			    break
+			fi
+		    else
+			f_show_err "$msg_swap_invalid" \
+				   "$ZFSBOOT_SWAP_SIZE"
+			continue
+		    fi
+		done
+		;;
+	"M $msg_swap_mirror")
+		if [ "$ZFSBOOT_SWAP_MIRROR" ]; then
+			ZFSBOOT_SWAP_MIRROR=
+		else
+			ZFSBOOT_SWAP_MIRROR=1
+		fi
+		;;
+	"W $msg_swap_encrypt")
+		if [ "$ZFSBOOT_SWAP_ENCRYPTION" ]; then
+			ZFSBOOT_SWAP_ENCRYPTION=
+		else
+			ZFSBOOT_SWAP_ENCRYPTION=1
+		fi
+		;;
+	esac
+	return $retval
+}
+
+# dialog_menu_encryption_options
+#
+# Submenu for configuring ZFS GELI Encryption.
+#
+dialog_menu_encryption_options()
+{
+	local title="$DIALOG_TITLE"
+	local btitle="$DIALOG_BACKTITLE"
+	local prompt="Configure Encryption Options"
+	local usegeli="$msg_no"
+	[ "$ZFSBOOT_GELI_ENCRYPTION" ] && usegeli="$msg_yes"
+	local menu_list="
+		'E $msg_encrypt_disks'  '$usegeli' '$msg_encrypt_disks_help'
+	" # END-QUOTE
+	local defaultitem=
+	local hline="$hline_alnum_arrows_punc_tab_enter"
+	local height width rows
+	eval f_dialog_menu_with_help_size height width rows \
+		\"\$title\" \"\$btitle\" \"\$prompt\" \"\$hline\" $menu_list
+	f_dialog_default_fetch defaultitem
+
+	local menu_choice
+	menu_choice=$( eval $DIALOG \
+		--title \"\$title\"              \
+		--backtitle \"\$btitle\"         \
+		--hline \"\$hline\"              \
+		--item-help                      \
+		--ok-label \"\$msg_select\"      \
+		--cancel-label \"\$msg_back\"    \
+		--default-item \"\$defaultitem\" \
+		--menu \"\$prompt\"              \
+		$height $width $rows             \
+		${USE_DIALOG:+--} $menu_list     \
+		2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
+	)
+	local retval=$?
+	f_dialog_data_sanitize menu_choice
+	[ $retval -eq $DIALOG_OK ] && f_dialog_default_store "$menu_choice"
+
+	case "$menu_choice" in
+	"E $msg_encrypt_disks")
+		if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
+			ZFSBOOT_GELI_ENCRYPTION=
+		else
+			ZFSBOOT_FORCE_4K_SECTORS=1 # GELI benefits from 4k alignment
+			ZFSBOOT_GELI_ENCRYPTION=1
+		fi
+		;;
+	esac
+	return $retval
+}
+
 
 # dialog_last_chance $disks ...
 #
@@ -1673,7 +1880,7 @@ esac
 while :; do
 	if ! f_interactive; then
 		retval=$DIALOG_OK
-		mtag=">>> $msg_install"
+		mtag="Install" # Default to Install for non-interactive
 	else
 		dialog_menu_main
 		retval=$?
@@ -1684,7 +1891,7 @@ while :; do
 	[ $retval -eq $DIALOG_OK ] || f_die
 
 	case "$mtag" in
-	">>> $msg_install")
+	"Install")
 		#
 		# First, validate the user's selections
 		#
@@ -1699,7 +1906,7 @@ while :; do
 		# Validate vdev type against number of disks selected/scripted
 		# (also validates that ZFSBOOT_DISKS are real [probed] disks)
 		# NB: dialog_menu_layout supports running non-interactively
-		dialog_menu_layout || continue
+		dialog_menu_pool_type_disks || continue
 
 		# Make sure each disk will have room for ZFS
 		if f_expand_number "$ZFSBOOT_SWAP_SIZE" swapsize &&
@@ -1760,110 +1967,20 @@ while :; do
 
 		break # to success
 		;;
-	?" $msg_pool_type_disks")
-		ZFSBOOT_CONFIRM_LAYOUT=1
-		dialog_menu_layout
-		# User has poked settings, disable later confirmation
-		ZFSBOOT_CONFIRM_LAYOUT=
+	"Pool Type/Disks")
+		dialog_menu_pool_type_disks
 		;;
-	"- $msg_rescan_devices") f_device_rescan ;;
-	"- $msg_disk_info") dialog_menu_diskinfo ;;
-	?" $msg_pool_name")
-		# Prompt the user to input/change the name for the new pool
-		f_dialog_input input \
-			"$msg_please_enter_a_name_for_your_pool" \
-			"$ZFSBOOT_POOL_NAME" &&
-			ZFSBOOT_POOL_NAME="$input"
+	"Pool Options")
+		dialog_menu_pool_options
 		;;
-	?" $msg_force_4k_sectors")
-		# Toggle the variable referenced both by the menu and later
-		if [ "$ZFSBOOT_FORCE_4K_SECTORS" ]; then
-			ZFSBOOT_FORCE_4K_SECTORS=
-		else
-			ZFSBOOT_FORCE_4K_SECTORS=1
-		fi
+	"Swap Options")
+		dialog_menu_swap_options
 		;;
-	?" $msg_encrypt_disks")
-		# Toggle the variable referenced both by the menu and later
-		if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
-			ZFSBOOT_GELI_ENCRYPTION=
-		else
-			ZFSBOOT_FORCE_4K_SECTORS=1
-			ZFSBOOT_GELI_ENCRYPTION=1
-		fi
+	"Encryption Options")
+		dialog_menu_encryption_options
 		;;
-	?" $msg_partition_scheme")
-		# Toggle between GPT (BIOS), GPT (UEFI) and MBR
-		if [ "$ZFSBOOT_PARTITION_SCHEME" = "GPT" -a \
-		     "$ZFSBOOT_BOOT_TYPE" = "BIOS" ]
-		then
-			ZFSBOOT_PARTITION_SCHEME="GPT"
-			ZFSBOOT_BOOT_TYPE="UEFI"
-		elif [ "$ZFSBOOT_PARTITION_SCHEME" = "GPT" -a \
-		       "$ZFSBOOT_BOOT_TYPE" = "UEFI" ]
-		then
-			ZFSBOOT_PARTITION_SCHEME="GPT"
-			ZFSBOOT_BOOT_TYPE="BIOS+UEFI"
-		elif [ "$ZFSBOOT_PARTITION_SCHEME" = "GPT" ]; then
-			ZFSBOOT_PARTITION_SCHEME="MBR"
-			ZFSBOOT_BOOT_TYPE="BIOS"
-		elif [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
-			ZFSBOOT_PARTITION_SCHEME="GPT + Active"
-			ZFSBOOT_BOOT_TYPE="BIOS"
-		elif [ "$ZFSBOOT_PARTITION_SCHEME" = "GPT + Active" ]; then
-			ZFSBOOT_PARTITION_SCHEME="GPT + Lenovo Fix"
-			ZFSBOOT_BOOT_TYPE="BIOS"
-		else
-			ZFSBOOT_PARTITION_SCHEME="GPT"
-			ZFSBOOT_BOOT_TYPE="BIOS"
-		fi
-		;;
-	?" $msg_swap_size")
-		# Prompt the user to input/change the swap size for each disk
-		while :; do
-		    f_dialog_input input \
-			    "$msg_please_enter_amount_of_swap_space" \
-			    "$ZFSBOOT_SWAP_SIZE" &&
-			    ZFSBOOT_SWAP_SIZE="${input:-0}"
-		    if f_expand_number "$ZFSBOOT_SWAP_SIZE" swapsize
-		    then
-			if [ $swapsize -ne 0 -a $swapsize -lt 104857600 ]; then
-			    f_show_err "$msg_swap_toosmall" \
-				       "$ZFSBOOT_SWAP_SIZE"
-			    continue
-			else
-			    break
-			fi
-		    else
-			f_show_err "$msg_swap_invalid" \
-				   "$ZFSBOOT_SWAP_SIZE"
-			continue
-		    fi
-		done
-		;;
-	?" $msg_swap_mirror")
-		# Toggle the variable referenced both by the menu and later
-		if [ "$ZFSBOOT_SWAP_MIRROR" ]; then
-			ZFSBOOT_SWAP_MIRROR=
-		else
-			ZFSBOOT_SWAP_MIRROR=1
-		fi
-		;;
-	?" $msg_swap_encrypt")
-		# Toggle the variable referenced both by the menu and later
-		if [ "$ZFSBOOT_SWAP_ENCRYPTION" ]; then
-			ZFSBOOT_SWAP_ENCRYPTION=
-		else
-			ZFSBOOT_SWAP_ENCRYPTION=1
-		fi
-		;;
-	?" $msg_zfs_options_name")
-		# Prompt the user to input/change the pool options
-		f_dialog_input input \
-			"$msg_please_enter_options_for_your_pool" \
-			"$ZFSBOOT_POOL_CREATE_OPTIONS" &&
-			ZFSBOOT_POOL_CREATE_OPTIONS="$input"
-		;;
+	"- Rescan Devices") f_device_rescan ;;
+	"- Disk Info") dialog_menu_diskinfo ;;
 	esac
 done
 


### PR DESCRIPTION
bsdinstall: Improve installer UI for mirrorselect and zfsboot

Refactored `mirrorselect` to organize mirrors by region using submenus,
making it easier for users to locate appropriate mirrors based on geography.

Refactored `zfsboot` to use submenus for ZFS configuration options.
This improves clarity and streamlines the installation process for users
choosing ZFS setups.

Author: Recep Karahan <rkarahan83@gmail.com>
