### PR TITLE
sockstat: Reintroduce -w flag to automatically size the columns

### DIFF
--- a/sys/kern/vfs_cache.c
+++ b/sys/kern/vfs_cache.c
@@ -332,7 +332,8 @@ SDT_PROBE_DEFINE2(vfs, namecache, evict_negative, done, "struct vnode *",
     "char *");
 SDT_PROBE_DEFINE1(vfs, namecache, symlink, alloc__fail, "size_t");
 
-SDT_PROBE_DEFINE3(vfs, fplookup, lookup, done, "struct nameidata", "int", "bool");
+SDT_PROBE_DEFINE3(vfs, fplookup, lookup, done, "struct nameidata *", "int",
+    "enum cache_fpl_status");
 SDT_PROBE_DECLARE(vfs, namei, lookup, entry);
 SDT_PROBE_DECLARE(vfs, namei, lookup, return);
 

--- a/usr.bin/sockstat/sockstat.1
+++ b/usr.bin/sockstat/sockstat.1
@@ -25,7 +25,7 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd June 27, 2025
+.Dd June 30, 2025
 .Dt SOCKSTAT 1
 .Os
 .Sh NAME
@@ -33,7 +33,7 @@
 .Nd list open sockets
 .Sh SYNOPSIS
 .Nm
-.Op Fl 46ACcfIiLlnqSsUuv
+.Op Fl 46ACcfIiLlnqSsUuvw
 .Op Fl j Ar jail
 .Op Fl p Ar ports
 .Op Fl P Ar protocols
@@ -119,6 +119,8 @@ Show
 sockets.
 .It Fl v
 Verbose mode.
+.It Fl w
+Automatically size the columns.
 .El
 .Pp
 If neither


### PR DESCRIPTION
The -w flag was previously removed when automatic column sizing was introduced. However, that approach was not compact on small terminal windows, such as 80-column widths.

In this commit, sockstat now uses fixed-width columns by default for cleaner and more compact output. The -w flag has been reintroduced to automatically size the columns, ensuring they are wide enough to fit the longest entry in each column.

Sponsored by:  Google, LLC (GSoC 2025)
MFC after:  2 weeks