### PR TITLE
if_ethersubr: preserve entropy of MAC addresses

### DIFF
--- a/sys/net/if_ethersubr.c
+++ b/sys/net/if_ethersubr.c
@@ -1486,7 +1486,7 @@ ether_gen_addr_byname(const char *nameunit, struct ether_addr *hwaddr)
 	char uuid[HOSTUUIDLEN + 1];
 	uint64_t addr;
 	int i, sz;
-	char digest[SHA1_RESULTLEN];
+	unsigned char digest[SHA1_RESULTLEN];
 	char jailname[MAXHOSTNAMELEN];
 
 	getcredhostuuid(curthread->td_ucred, uuid, sizeof(uuid));


### PR DESCRIPTION
Ethernet MAC addresses are currently generated by concatenating the first bytes of a SHA1 digest. However the digest buffer is defined as a signed char buffer, which means that any digest digit greater than 0x80 will be promoted to a signed int before the concatenation.

As a result, any digest digit greater than 0x80 will overwrite the previous one throught the application of the bitwise-or with its 0xFF higher bytes, effectively reducing the entropy of addresses generated and significantly increasing the risk of conflict.

Defining the digest buffer as unsigned ensures there will be no unwanted consequences during integer promotion and the concatenation will work as expected.