### PR TITLE
sockstat: microoptimize cap-getnameinfo

### DIFF
--- a/usr.bin/sockstat/sockstat.c
+++ b/usr.bin/sockstat/sockstat.c
@@ -951,7 +951,7 @@ formataddr(struct sockaddr_storage *ss, char *buf, size_t bufsize)
 	}
 	if (addrstr[0] == '\0') {
 		error = cap_getnameinfo(capnet, sstosa(ss), ss->ss_len,
-			addrstr, sizeof(addrstr), buf, bufsize, NI_NUMERICHOST);
+		    addrstr, sizeof(addrstr), NULL, 0, NI_NUMERICHOST);
 		if (error)
 			errx(1, "cap_getnameinfo()");
 	}


### PR DESCRIPTION
Revert a change to the cap_getnameinfo, introduced in 0726c6574f8 and probably unintended, that caused cap_getnameinfo to populate a buffer which was about to be thrown away.

Fixes:		0726c6574f889507e5030173bf4c82c80911394d
Sponsored by:	ConnectWise