### PR TITLE
tests/ci: run ci-full kyua tests in parallel

### DIFF
--- a/tests/ci/tools/freebsdci
+++ b/tests/ci/tools/freebsdci
@@ -34,6 +34,7 @@ rcvar=freebsdci_enable
 start_cmd="firstboot_ci_run"
 stop_cmd=":"
 os_arch=$(uname -p)
+parallelism=$(nproc)
 tardev=/dev/vtbd1
 metadir=/meta
 istar=$(file -s ${tardev} | grep "POSIX tar archive" | wc -l)
@@ -74,7 +75,7 @@ full_tests()
 		tar xvf ${tardev} -C ${metadir}
 		cd /usr/tests
 		set +e
-		kyua test
+		kyua -v parallelism=${parallelism} test
 		rc=$?
 		set -e
 		if [ ${rc} -ne 0 ] && [ ${rc} -ne 1 ]; then


### PR DESCRIPTION
By default, use all available cpus given to the VM. This can be controlled with the already available PARALLEL_JOBS make variable.