### PR TITLE
Minor O_CLOFORK fixes

### DIFF
--- a/lib/libc/stdio/mktemp.3
+++ b/lib/libc/stdio/mktemp.3
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd July 29, 2019
+.Dd July 07, 2025
 .Dt MKTEMP 3
 .Os
 .Sh NAME
@@ -101,9 +101,10 @@ The permitted flags are
 .Dv O_DIRECT ,
 .Dv O_SHLOCK ,
 .Dv O_EXLOCK ,
-.Dv O_SYNC
+.Dv O_SYNC ,
+.Dv O_CLOEXEC
 and
-.Dv O_CLOEXEC .
+.Dv O_CLOFORK .
 .Pp
 The
 .Fn mkstemps

--- a/lib/libc/stdio/mktemp.c
+++ b/lib/libc/stdio/mktemp.c
@@ -121,7 +121,7 @@ _gettemp(int dfd, char *path, int *doopen, int domkdir, int slen, int oflags)
 
 	if ((doopen != NULL && domkdir) || slen < 0 ||
 	    (oflags & ~(O_APPEND | O_DIRECT | O_SHLOCK | O_EXLOCK | O_SYNC |
-	    O_CLOEXEC)) != 0) {
+	    O_CLOEXEC | O_CLOFORK)) != 0) {
 		errno = EINVAL;
 		return (0);
 	}


### PR DESCRIPTION
- [mkostemp(3)](https://man.freebsd.org/cgi/man.cgi?query=mkostemp) should support O_CLOFORK as per https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkdtemp.html
- ~Fix calls that naively set F_SETFD~

~The latter follows the same spirit as this patch suggested in OpenBSD, though the scope of this PR are not the security enhancements that are now possible with this flag~:
https://marc.info/?l=openbsd-tech&m=175055263416829&w=2

Ticket: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=286843