### PR TITLE
libc/powerpc64: Fix swapcontext(3)

### DIFF
--- a/lib/libc/powerpc64/gen/_ctx_start.S
+++ b/lib/libc/powerpc64/gen/_ctx_start.S
@@ -34,6 +34,16 @@
 	ld	%r2,8(%r14)
 	ld	%r14,0(%r14)
 #else
+	/*
+	 * The stack frame was already set up in makecontext(),
+	 * so we can safely use the guaranteed fields here.
+	 *
+	 * Note we do step on the allocated stack frame's TOC,
+	 * but since we never return from this function (i.e.
+	 * never restore the stack frame) this should be safe.
+	 */
+	std	%r2,24(%r1)	/* save TOC */
+
 	/* Load global entry point */
 	mr	%r12,%r14
 #endif
@@ -41,6 +51,10 @@
 	blrl			/* branch to start function */
 	mr	%r3,%r15	/* pass pointer to ucontext as argument */
 	nop
+#if defined(_CALL_ELF) && _CALL_ELF != 1
+	/* Restore TOC */
+	ld	%r2,24(%r1)
+#endif
 	bl	CNAME(_ctx_done) /* branch to ctxt completion func */
 	/*
 	 * we should never return from the

--- a/lib/libc/powerpc64/gen/makecontext.c
+++ b/lib/libc/powerpc64/gen/makecontext.c
@@ -78,7 +78,7 @@ __makecontext(ucontext_t *ucp, void (*start)(void), int argc, ...)
 	 */
 	stackargs = (argc > 8) ? argc - 8 : 0;
 	sp = (char *) ucp->uc_stack.ss_sp + ucp->uc_stack.ss_size
-		- sizeof(uintptr_t)*(stackargs + 2);
+		- sizeof(uintptr_t)*(stackargs + 6);
 	sp = (char *)((uintptr_t)sp & ~0x1f);
 
 	mc = &ucp->uc_mcontext;
@@ -119,6 +119,7 @@ __makecontext(ucontext_t *ucp, void (*start)(void), int argc, ...)
 	mc->mc_srr0 = *(uintptr_t *)_ctx_start;
 #else
 	mc->mc_srr0 = (uintptr_t) _ctx_start;
+	mc->mc_gpr[12] = (uintptr_t) _ctx_start;/* required for prologue */
 #endif
 	mc->mc_gpr[1] = (uintptr_t) sp;		/* new stack pointer */
 	mc->mc_gpr[14] = (uintptr_t) start;	/* r14 <- start */

--- a/lib/libc/tests/sys/Makefile
+++ b/lib/libc/tests/sys/Makefile
@@ -7,11 +7,11 @@ ATF_TESTS_C+=			brk_test
 .endif
 ATF_TESTS_C+=			cpuset_test
 ATF_TESTS_C+=			errno_test
+ATF_TESTS_C+=			swapcontext_test
 ATF_TESTS_C+=			queue_test
 ATF_TESTS_C+=			sendfile_test
 
-# TODO: clone, lwp_create, lwp_ctl, posix_fadvise, recvmmsg,
-# swapcontext
+# TODO: clone, lwp_create, lwp_ctl, posix_fadvise, recvmmsg
 NETBSD_ATF_TESTS_C+=		access_test
 NETBSD_ATF_TESTS_C+=		bind_test
 NETBSD_ATF_TESTS_C+=		chroot_test

--- a/lib/libc/tests/sys/swapcontext_test.c
+++ b/lib/libc/tests/sys/swapcontext_test.c
@@ -1,0 +1,63 @@
+/*-
+ * Copyright (c) 2025 Raptor Computing Systems, LLC
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <ucontext.h>
+#include <errno.h>
+
+#include <atf-c.h>
+
+#define STACK_SIZE	(64ull << 10)
+
+static volatile int callback_reached = 0;
+
+static ucontext_t uctx_save, uctx_switch;
+
+static void swapcontext_callback()
+{
+	// Increment callback reached variable
+	// If this is called multiple times, we will fail the test
+	// If this is not called at all, we will fail the test
+	callback_reached++;
+}
+
+ATF_TC(swapcontext_basic);
+ATF_TC_HEAD(swapcontext_basic, tc)
+{
+	atf_tc_set_md_var(tc, "descr",
+		"Verify basic functionality of swapcontext");
+}
+
+ATF_TC_BODY(swapcontext_basic, tc)
+{
+	char *stack;
+        int res;
+
+	stack = malloc(STACK_SIZE);
+	ATF_REQUIRE_MSG(stack != NULL, "malloc failed: %s", strerror(errno));
+	res = getcontext(&uctx_switch);
+	ATF_REQUIRE_MSG(res == 0, "getcontext failed: %s", strerror(errno));
+
+	uctx_switch.uc_stack.ss_sp = stack;
+	uctx_switch.uc_stack.ss_size = STACK_SIZE;
+	uctx_switch.uc_link = &uctx_save;
+	makecontext(&uctx_switch, swapcontext_callback, 0);
+
+	res = swapcontext(&uctx_save, &uctx_switch);
+
+        ATF_REQUIRE_MSG(res == 0, "swapcontext failed: %s", strerror(errno));
+        ATF_REQUIRE_MSG(callback_reached == 1,
+		"callback failed, reached %d times", callback_reached);
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+	ATF_TP_ADD_TC(tp, swapcontext_basic);
+
+	return (atf_no_error());
+}
+


### PR DESCRIPTION
On PowerPC platforms a valid link to the Table of Contents (TOC) is required for PLT lookups to function.  This TOC pointer is stored in a dedicated register, and is used along with the stack pointer by both C prologue and PLT lookup code.

When calling swapcontext() with uc_link != NULL, a PLT lookup to setcontext(3) is attempted from within the _ctx_done context.  The exiting process has usually trashed both r1 and r2 at this point[1], leading to a crash within the PLT lookup before setcontext(2) is reached to restore the linked context.

Restore r1 and r2 from the incoming context to ensure the PLT lookup to setcontext(3) succeeds.  As this subsequently calls setcontext(2), which overwrites r1 and r2 from the same context a second time, this should be safe.

[1] For clarity, since the interaction between compiler and context assembly is not obvious, the text of the comment from the patch is reproduced below:

...the current stack and TOC have almost _certainly_ been trashed by the callback function.  Since the compiler "knows" (incorrectly) that the callback in _ctx_start() is noreturn, it does not reserve a stack frame in the function prologue, and does not emit an epilogue.  Since the prologue always reloads the TOC based on the global entry point, corruption at return is all but guaranteed.

This is not a compiler bug; the compiler is free to use that optimization in this situation (we are literally changing context underneath the compiler here).  It is simply something we need to be aware of due to the immediate PLT call before setcontext(2) is reached.