### PR TITLE
tests/ci: add /usr/local/{sbin,bin} to freebsdci rc PATH

### DIFF
--- a/tests/ci/tools/freebsdci
+++ b/tests/ci/tools/freebsdci
@@ -25,9 +25,6 @@
 
 . /etc/rc.subr
 
-: ${freebsdci_enable:="NO"}
-: ${freebsdci_type:="full"}
-
 name="freebsdci"
 desc="Run FreeBSD CI"
 rcvar=freebsdci_enable
@@ -38,6 +35,11 @@ parallelism=$(nproc)
 tardev=/dev/vtbd1
 metadir=/meta
 istar=$(file -s ${tardev} | grep "POSIX tar archive" | wc -l)
+
+load_rc_config $name
+: ${freebsdci_enable:="NO"}
+: ${freebsdci_type:="full"}
+PATH="${PATH}:/usr/local/sbin:/usr/local/bin"
 
 auto_shutdown()
 {
@@ -105,5 +107,4 @@ firstboot_ci_run()
 	auto_shutdown
 }
 
-load_rc_config $name
 run_rc_command "$1"


### PR DESCRIPTION
Currently, a lot of tests report 'skipped' due to missing binaries in the PATH. The real issue is that /etc/rc forcibly restricts the PATH to the base system only.

This patch re-enables a large chunk of skipped tests by adding the missing LOCALBASE directories to the PATH so that Kyua can discover third-party packages. It also fixes some minor rc scripting style as per the official freebsd scripting guide[0].

[kyua-reports.tar.gz](https://github.com/user-attachments/files/21132840/kyua-reports.tar.gz)

This attached diff between kyua runs shows that we skip 128 fewer tests with this change (and reveal one new broken test).

[0] https://docs.freebsd.org/en/articles/rc-scripting