### PR TITLE
devd/moused.conf: Stop moused quietly on destroy of a ums device

### DIFF
--- a/sbin/devd/moused.conf
+++ b/sbin/devd/moused.conf
@@ -31,5 +31,5 @@ notify 100 {
 	match "type" "DESTROY";
 	match "cdev" "ums[0-9]+";
 
-	action "service moused stop $cdev";
+	action "service moused quietstop $cdev";
 };


### PR DESCRIPTION
If "moused" service is not enabled, devd action related to the "ums" driver will print an error message in the console.
Stopping it quietly avoids that message.

Example message:
```
Cannot 'stop' moused. Set moused_ums0_enable to YES in /etc/rc.conf or use 'onestop' instead of 'stop'.
```