### PR TITLE
Improve renice user error messages

### DIFF
--- a/usr.bin/renice/renice.c
+++ b/usr.bin/renice/renice.c
@@ -10,7 +10,7 @@
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the disclaimer in the
+ *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
  * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software

--- a/usr.bin/renice/renice.c
+++ b/usr.bin/renice/renice.c
@@ -10,7 +10,7 @@
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
+ *    notice, this list of conditions and the disclaimer in the
  *    documentation and/or other materials provided with the distribution.
  * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
@@ -97,12 +97,13 @@ main(int argc, char *argv[])
 			if ((pwd = getpwnam(*argv)) != NULL)
 				who = pwd->pw_uid;
 			else if (getnum("uid", *argv, &who)) {
-				errs++;
-				continue;
+				warnx("invalid user name or uid: %s", *argv);
+				errno = EINVAL;
+				err("invalid user name or uid: %s", *argv);
 			} else if (who < 0) {
-				warnx("%s: bad value", *argv);
-				errs++;
-				continue;
+				warnx("invalid uid: %s", *argv);
+				errno = EINVAL;
+				err("invalid uid: %s", *argv);
 			}
 		} else {
 			if (getnum("pid", *argv, &who)) {
@@ -126,24 +127,72 @@ static int
 donice(int which, int who, int prio, bool incr)
 {
 	int oldprio;
+	const char *who_type;
+	char who_str[20];
 
+	/* Determine the type of identifier we're working with */
+	switch (which) {
+	case PRIO_PROCESS:
+		who_type = "process";
+		break;
+	case PRIO_PGRP:
+		who_type = "process group";
+		break;
+	case PRIO_USER:
+		who_type = "user";
+		break;
+	default:
+		who_type = "unknown";
+		break;
+	}
+
+	/* Get current priority */
 	errno = 0;
 	oldprio = getpriority(which, who);
-	if (oldprio == -1 && errno) {
-		warn("%d: getpriority", who);
-		return (1);
+	if (oldprio == -1) {
+		if (errno == EPERM) {
+			fprintf(stderr, "Permission denied: cannot get priority for %s %d\n",
+				who_type, who);
+			return (1);
+		} else if (errno == ESRCH) {
+			fprintf(stderr, "%s %d not found\n", who_type, who);
+			return (1);
+		} else {
+			warn("%s %d: getpriority", who_type, who);
+			return (1);
+		}
 	}
+
+	/* Validate and adjust priority */
 	if (incr)
 		prio = oldprio + prio;
-	if (prio > PRIO_MAX)
+
+	/* Validate priority range */
+	if (prio > PRIO_MAX) {
+		fprintf(stderr, "Warning: Priority %d exceeds maximum (%d), using %d\n",
+			    prio, PRIO_MAX, PRIO_MAX);
 		prio = PRIO_MAX;
-	if (prio < PRIO_MIN)
+	} else if (prio < PRIO_MIN) {
+		fprintf(stderr, "Warning: Priority %d below minimum (%d), using %d\n",
+			    prio, PRIO_MIN, PRIO_MIN);
 		prio = PRIO_MIN;
-	if (setpriority(which, who, prio) < 0) {
-		warn("%d: setpriority", who);
-		return (1);
 	}
-	fprintf(stderr, "%d: old priority %d, new priority %d\n", who,
+
+	/* Set new priority */
+	if (setpriority(which, who, prio) < 0) {
+		if (errno == EPERM) {
+			fprintf(stderr, "Permission denied: cannot set priority for %s %d\n",
+				who_type, who);
+			return (1);
+		} else {
+			warn("%s %d: setpriority", who_type, who);
+			return (1);
+		}
+	}
+
+	/* Format output */
+	snprintf(who_str, sizeof(who_str), "%s %d", who_type, who);
+	fprintf(stderr, "%s: old priority %d, new priority %d\n", who_str,
 	    oldprio, prio);
 	return (0);
 }

--- a/usr.bin/renice/renice.c
+++ b/usr.bin/renice/renice.c
@@ -29,200 +29,152 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/types.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-
-#include <err.h>
-#include <errno.h>
-#include <limits.h>
-#include <pwd.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-static int	donice(int, int, int, bool);
-static int	getnum(const char *, const char *, int *);
-static void	usage(void);
-
-/*
- * Change the priority (nice) of processes
- * or groups of processes which are already
- * running.
- */
-int
-main(int argc, char *argv[])
-{
-	struct passwd *pwd;
-	bool havedelim = false, haveprio = false, incr = false;
-	int errs = 0, prio = 0, who = 0, which = PRIO_PROCESS;
-
-	for (argc--, argv++; argc > 0; argc--, argv++) {
-		if (!havedelim) {
-			/* can occur at any time prior to delimiter */
-			if (strcmp(*argv, "-g") == 0) {
-				which = PRIO_PGRP;
-				continue;
-			}
-			if (strcmp(*argv, "-u") == 0) {
-				which = PRIO_USER;
-				continue;
-			}
-			if (strcmp(*argv, "-p") == 0) {
-				which = PRIO_PROCESS;
-				continue;
-			}
-			if (strcmp(*argv, "--") == 0) {
-				havedelim = true;
-				continue;
-			}
-			if (strcmp(*argv, "-n") == 0) {
-				/* may occur only once, prior to priority */
-				if (haveprio || incr || argc < 2)
-					usage();
-				incr = true;
-				(void)argc--, argv++;
-				/* fall through to priority */
-			}
-		}
-		if (!haveprio) {
-			/* must occur exactly once, prior to target */
-			if (getnum("priority", *argv, &prio))
-				return (1);
-			haveprio = true;
-			continue;
-		}
-		if (which == PRIO_USER) {
-			if ((pwd = getpwnam(*argv)) != NULL)
-				who = pwd->pw_uid;
-			else if (getnum("uid", *argv, &who)) {
-				warnx("invalid user name or uid: %s", *argv);
-				errno = EINVAL;
-				err("invalid user name or uid: %s", *argv);
-			} else if (who < 0) {
+ #include <sys/types.h>
+ #include <sys/time.h>
+ #include <sys/resource.h>
+ 
+ #include <err.h>
+ #include <errno.h>
+ #include <limits.h>
+ #include <pwd.h>
+ #include <stdbool.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+ 
+ static int	donice(int, int, int, bool);
+ static int	getnum(const char *, const char *, int *);
+ static void	usage(void);
+ 
+ /*
+  * Change the priority (nice) of processes
+  * or groups of processes which are already
+  * running.
+  */
+ int
+ main(int argc, char *argv[])
+ {
+	 struct passwd *pwd;
+	 bool havedelim = false, haveprio = false, incr = false;
+	 int errs = 0, prio = 0, who = 0, which = PRIO_PROCESS;
+ 
+	 for (argc--, argv++; argc > 0; argc--, argv++) {
+		 if (!havedelim) {
+			 /* can occur at any time prior to delimiter */
+			 if (strcmp(*argv, "-g") == 0) {
+				 which = PRIO_PGRP;
+				 continue;
+			 }
+			 if (strcmp(*argv, "-u") == 0) {
+				 which = PRIO_USER;
+				 continue;
+			 }
+			 if (strcmp(*argv, "-p") == 0) {
+				 which = PRIO_PROCESS;
+				 continue;
+			 }
+			 if (strcmp(*argv, "--") == 0) {
+				 havedelim = true;
+				 continue;
+			 }
+			 if (strcmp(*argv, "-n") == 0) {
+				 /* may occur only once, prior to priority */
+				 if (haveprio || incr || argc < 2)
+					 usage();
+				 incr = true;
+				 (void)argc--, argv++;
+				 /* fall through to priority */
+			 }
+		 }
+		 if (!haveprio) {
+			 /* must occur exactly once, prior to target */
+			 if (getnum("priority", *argv, &prio))
+				 return (1);
+			 haveprio = true;
+			 continue;
+		 }
+		 if (which == PRIO_USER) {
+			 if ((pwd = getpwnam(*argv)) != NULL)
+				 who = pwd->pw_uid;
+			 else if (getnum("uid", *argv, &who)) {
 				warnx("invalid uid: %s", *argv);
-				errno = EINVAL;
-				err("invalid uid: %s", *argv);
-			}
-		} else {
-			if (getnum("pid", *argv, &who)) {
 				errs++;
 				continue;
-			}
-			if (who < 0) {
+			 } else if (who < 0) {
 				warnx("%s: bad value", *argv);
 				errs++;
 				continue;
-			}
-		}
-		errs += donice(which, who, prio, incr);
-	}
-	if (!haveprio)
+			 }
+		 } else {
+			 if (getnum("pid", *argv, &who)) {
+				warnx("invalid pid: %s", *argv);
+				errs++;
+				continue;
+			 }
+			 if (who < 0) {
+				warnx("%s: bad value", *argv);
+				errs++;
+				continue;
+			 }
+		 }
+		 errs += donice(which, who, prio, incr);
+	 }
+	 if (!haveprio)
 		usage();
-	exit(errs != 0);
-}
-
-static int
-donice(int which, int who, int prio, bool incr)
-{
-	int oldprio;
-	const char *who_type;
-	char who_str[20];
-
-	/* Determine the type of identifier we're working with */
-	switch (which) {
-	case PRIO_PROCESS:
-		who_type = "process";
-		break;
-	case PRIO_PGRP:
-		who_type = "process group";
-		break;
-	case PRIO_USER:
-		who_type = "user";
-		break;
-	default:
-		who_type = "unknown";
-		break;
-	}
-
-	/* Get current priority */
-	errno = 0;
-	oldprio = getpriority(which, who);
-	if (oldprio == -1) {
-		if (errno == EPERM) {
-			fprintf(stderr, "Permission denied: cannot get priority for %s %d\n",
-				who_type, who);
-			return (1);
-		} else if (errno == ESRCH) {
-			fprintf(stderr, "%s %d not found\n", who_type, who);
-			return (1);
-		} else {
-			warn("%s %d: getpriority", who_type, who);
-			return (1);
-		}
-	}
-
-	/* Validate and adjust priority */
-	if (incr)
-		prio = oldprio + prio;
-
-	/* Validate priority range */
-	if (prio > PRIO_MAX) {
-		fprintf(stderr, "Warning: Priority %d exceeds maximum (%d), using %d\n",
-			    prio, PRIO_MAX, PRIO_MAX);
-		prio = PRIO_MAX;
-	} else if (prio < PRIO_MIN) {
-		fprintf(stderr, "Warning: Priority %d below minimum (%d), using %d\n",
-			    prio, PRIO_MIN, PRIO_MIN);
-		prio = PRIO_MIN;
-	}
-
-	/* Set new priority */
-	if (setpriority(which, who, prio) < 0) {
-		if (errno == EPERM) {
-			fprintf(stderr, "Permission denied: cannot set priority for %s %d\n",
-				who_type, who);
-			return (1);
-		} else {
-			warn("%s %d: setpriority", who_type, who);
-			return (1);
-		}
-	}
-
-	/* Format output */
-	snprintf(who_str, sizeof(who_str), "%s %d", who_type, who);
-	fprintf(stderr, "%s: old priority %d, new priority %d\n", who_str,
-	    oldprio, prio);
-	return (0);
-}
-
-static int
-getnum(const char *com, const char *str, int *val)
-{
-	long v;
-	char *ep;
-
-	errno = 0;
-	v = strtol(str, &ep, 10);
-	if (v < INT_MIN || v > INT_MAX || errno == ERANGE) {
-		warnx("%s argument %s is out of range.", com, str);
-		return (1);
-	}
-	if (ep == str || *ep != '\0' || errno != 0) {
-		warnx("%s argument %s is invalid.", com, str);
-		return (1);
-	}
-
-	*val = (int)v;
-	return (0);
-}
-
-static void
-usage(void)
-{
-	fprintf(stderr, "%s\n%s\n",
-"usage: renice priority [[-p] pid ...] [[-g] pgrp ...] [[-u] user ...]",
-"       renice -n increment [[-p] pid ...] [[-g] pgrp ...] [[-u] user ...]");
-	exit(1);
-}
+	 exit(errs != 0);
+ }
+ 
+ static int
+ donice(int which, int who, int prio, bool incr)
+ {
+	 int oldprio;
+ 
+	 errno = 0;
+	 oldprio = getpriority(which, who);
+	 if (oldprio == -1 && errno) {
+		 warn("%d: getpriority", who);
+		 return (1);
+	 }
+	 if (incr)
+		 prio = oldprio + prio;
+	 if (prio > PRIO_MAX)
+		 prio = PRIO_MAX;
+	 if (prio < PRIO_MIN)
+		 prio = PRIO_MIN;
+	 if (setpriority(which, who, prio) < 0) {
+		 warn("%d: setpriority", who);
+		 return (1);
+	 }
+	 fprintf(stderr, "%s %d: old priority %d, new priority %d\n", who_type, who, oldprio, prio);
+	 return (0);
+ }
+ 
+ static int
+ getnum(const char *com, const char *str, int *val)
+ {
+	 long v;
+	 char *ep;
+ 
+	 errno = 0;
+	 v = strtol(str, &ep, 10);
+	 if (v < INT_MIN || v > INT_MAX || errno == ERANGE) {
+		 warnx("%s argument %s is out of range.", com, str);
+		 return (1);
+	 }
+	 if (ep == str || *ep != '\0' || errno != 0) {
+		 warnx("%s argument %s is invalid.", com, str);
+		 return (1);
+	 }
+ 
+	 *val = (int)v;
+	 return (0);
+ }
+ 
+ static void
+ usage(void)
+ {
+	 fprintf(stderr, "%s\n%s\n",
+ "usage: renice priority [[-p] pid ...] [[-g] pgrp ...] [[-u] user ...]",
+ "       renice -n increment [[-p] pid ...] [[-g] pgrp ...] [[-u] user ...]");
+	 exit(1);
+ }


### PR DESCRIPTION
Improve error handling for invalid user names and UIDs in renice:

Use warnx() and err() for consistent error reporting
Set errno = EINVAL for invalid input
Provide clearer error messages for invalid user names and UIDs
Add test cases for invalid user input