### PR TITLE
getfmac.8: add missing cross-references

### DIFF
--- a/usr.sbin/getfmac/getfmac.8
+++ b/usr.sbin/getfmac/getfmac.8
@@ -51,5 +51,8 @@ specified files.
 .Xr mac 3 ,
 .Xr mac_get_file 3 ,
 .Xr mac 4 ,
+.Xr maclabel 7 ,
+.Xr getpmac 8 ,
 .Xr setfmac 8 ,
+.Xr setpmac 8 ,
 .Xr mac 9


### PR DESCRIPTION
Bring getfmac.8 up to par with getpmac.8 by adding cross-references.

This can help orient users that are getting started with the MAC framework and browsing the docs.