### PR TITLE
devd: accept new clients before notifying them

### DIFF
--- a/sbin/devd/devd.cc
+++ b/sbin/devd/devd.cc
@@ -1107,6 +1107,14 @@ event_loop(void)
 			err(1, "select");
 		} else if (rv == 0)
 			check_clients();
+		/*
+		 * Aside from the socket type, both sockets use the same
+		 * protocol, so we can process clients the same way.
+		 */
+		if (FD_ISSET(stream_fd, &fds))
+			new_client(stream_fd, SOCK_STREAM);
+		if (FD_ISSET(seqpacket_fd, &fds))
+			new_client(seqpacket_fd, SOCK_SEQPACKET);
 		if (FD_ISSET(fd, &fds)) {
 			rv = read(fd, buffer, sizeof(buffer) - 1);
 			if (rv > 0) {
@@ -1135,14 +1143,6 @@ event_loop(void)
 				break;
 			}
 		}
-		if (FD_ISSET(stream_fd, &fds))
-			new_client(stream_fd, SOCK_STREAM);
-		/*
-		 * Aside from the socket type, both sockets use the same
-		 * protocol, so we can process clients the same way.
-		 */
-		if (FD_ISSET(seqpacket_fd, &fds))
-			new_client(seqpacket_fd, SOCK_SEQPACKET);
 	}
 	cfg.remove_pidfile();
 	close(seqpacket_fd);


### PR DESCRIPTION
This patch fixes a race condition in devd that could lead to lost notifications:

If a client program `connect()`s to devd and then does something that causes a new device to show up (for example, creating a `uinput` device), devd can occasionally receive both events in the same `select()` loop iteration. The code would then:

1. Broadcast the notification to all connected clients
2. `accept()` the incoming connection, adding a new client to the list

This causes the notification for the device to never arrive at the program creating the device. The patch fixes this behavior by simply swapping the two steps, always accepting incoming connections before sending out the notification.

I ran into this while writing a test suite for my `evdev`/`uinput` library here: https://github.com/SludgePhD/evdevil/issues/13. "Organic" code is unlikely to run into this problem, but the test suite of that library does, since it deliberately tries to receive hotplug events for its own uinput devices.