### PR TITLE
kldstat: Memory zeroing using memset()

### DIFF
--- a/sbin/kldstat/kldstat.c
+++ b/sbin/kldstat/kldstat.c
@@ -51,7 +51,7 @@ printmod(int modid)
 {
 	struct module_stat stat;
 
-	bzero(&stat, sizeof(stat));
+	memset(&stat, 0, sizeof(stat));
 	stat.version = sizeof(struct module_stat);
 	if (modstat(modid, &stat) < 0) {
 		warn("can't stat module id %d", modid);


### PR DESCRIPTION
- Using memset() instead of the outdated bzero() function when zeroing memory
- bzero() has been removed since the POSIX.1-2001 standard