### PR TITLE
g_concat_add_disk: should set an error number here

### DIFF
--- a/sys/geom/concat/g_concat.c
+++ b/sys/geom/concat/g_concat.c
@@ -590,6 +590,7 @@ g_concat_add_disk(struct g_concat_softc *sc, struct g_provider *pp, u_int no)
 		    strcmp(md.md_name, sc->sc_name) != 0 ||
 		    md.md_id != sc->sc_id) {
 			G_CONCAT_DEBUG(0, "Metadata on %s changed.", pp->name);
+			error = EINVAL;
 			goto fail;
 		}
 


### PR DESCRIPTION
Otherwise the error will be 0.