### PR TITLE
fusefs: report that all tests require the fusefs kernel module

### DIFF
--- a/tests/sys/fs/fusefs/Makefile
+++ b/tests/sys/fs/fusefs/Makefile
@@ -70,7 +70,8 @@ TEST_METADATA.nfs+=	required_user="root"
 TEST_METADATA.ctl+=	is_exclusive="true"
 TEST_METADATA.ctl+=	required_user="root"
 
-TEST_METADATA+= timeout=10
+TEST_METADATA+=	timeout=10
+TEST_METADATA+=	required_kmods="fusefs"
 
 FUSEFS=		${SRCTOP}/sys/fs/fuse
 # Suppress warnings that GCC generates for the libc++ and gtest headers.


### PR DESCRIPTION
Previously the googletest tests would skip themselves if /dev/fuse could not be found.  But that information would not be passed to Kyua. Instead it would think that they had passed.  Also, the atf-sh test would previously fail if the fusefs module weren't loaded.  Now both tests will correctly report their requirements to Kyua.

Note that fusefs's googletest tests still require that the mac_bsdextended(4) module _not_ be loaded, but Kyua has no way to report such a requirement.

MFC after:	2 weeks
Sponsored by:	ConnectWise