### PR TITLE
mac_bsdextended: report that all tests require the kernel module

### DIFF
--- a/tests/sys/mac/bsdextended/Makefile
+++ b/tests/sys/mac/bsdextended/Makefile
@@ -9,5 +9,6 @@ TEST_METADATA.ugidfw_test+=	required_user="root"
 # Each test case of matches_test reuses the same ruleset number, so they cannot
 # be run simultaneously
 TEST_METADATA.matches_test+=	is_exclusive=true
+TEST_METADATA+=			required_kmods="mac_bsdextended"
 
 .include <bsd.test.mk>

--- a/tests/sys/mac/bsdextended/matches_test.sh
+++ b/tests/sys/mac/bsdextended/matches_test.sh
@@ -12,9 +12,6 @@ gidoutrange="daemon" # We expect $uidinrange in this group
 
 check_ko()
 {
-	if ! sysctl -N security.mac.bsdextended >/dev/null 2>&1; then
-		atf_skip "mac_bsdextended(4) support isn't available"
-	fi
 	if [ $(sysctl -n security.mac.bsdextended.enabled) = "0" ]; then
 		# The kernel module is loaded but disabled.  Enable it for the
 		# duration of the test.


### PR DESCRIPTION
Use the standard required_kmods reporting mechanism to notify Kyua of which kernel modules are required.

MFC after:	2 weeks
Sponsored by:	ConnectWise