### PR TITLE
ctladm: Use require.kmods for cfiscsi

### DIFF
--- a/sys/fs/smbfs/smbfs_node.h
+++ b/sys/fs/smbfs/smbfs_node.h
@@ -93,7 +93,7 @@ u_int32_t smbfs_hash(const u_char *name, int nmlen);
 
 int  smbfs_getpages(struct vop_getpages_args *);
 int  smbfs_putpages(struct vop_putpages_args *);
-int  smbfs_readvnode(struct vnode *vp, struct uio *uiop, struct ucred *cred);
+int  smbfs_readvnode(struct vnode *vp, struct uio *uiop, struct ucred *cred, int *eofp);
 int  smbfs_writevnode(struct vnode *vp, struct uio *uiop, struct ucred *cred, int ioflag);
 void smbfs_attr_cacheenter(struct vnode *vp, struct smbfattr *fap);
 int  smbfs_attr_cachelookup(struct vnode *vp ,struct vattr *va);

--- a/sys/fs/smbfs/smbfs_vnops.c
+++ b/sys/fs/smbfs/smbfs_vnops.c
@@ -466,7 +466,7 @@ smbfs_read(struct vop_read_args *ap)
 	SMBVDEBUG("\n");
 	if (vp->v_type != VREG && vp->v_type != VDIR)
 		return EPERM;
-	return smbfs_readvnode(vp, uio, ap->a_cred);
+	return smbfs_readvnode(vp, uio, ap->a_cred, NULL);
 }
 
 static int
@@ -748,7 +748,6 @@ smbfs_readdir(struct vop_readdir_args *ap)
 {
 	struct vnode *vp = ap->a_vp;
 	struct uio *uio = ap->a_uio;
-	int error;
 
 	if (vp->v_type != VDIR)
 		return (EPERM);
@@ -758,8 +757,7 @@ smbfs_readdir(struct vop_readdir_args *ap)
 		return (EOPNOTSUPP);
 	}
 #endif
-	error = smbfs_readvnode(vp, uio, ap->a_cred);
-	return error;
+	return (smbfs_readvnode(vp, uio, ap->a_cred, ap->a_eofflag));
 }
 
 /* ARGSUSED */

--- a/sys/kern/vfs_subr.c
+++ b/sys/kern/vfs_subr.c
@@ -6533,17 +6533,6 @@ vop_read_pgcache_post(void *ap, int rc)
 		VFS_KNOTE_UNLOCKED(a->a_vp, NOTE_READ);
 }
 
-void
-vop_readdir_post(void *ap, int rc)
-{
-	struct vop_readdir_args *a = ap;
-
-	if (!rc) {
-		VFS_KNOTE_LOCKED(a->a_vp, NOTE_READ);
-		INOTIFY(a->a_vp, IN_ACCESS);
-	}
-}
-
 static struct knlist fs_knlist;
 
 static void

--- a/sys/kern/vnode_if.src
+++ b/sys/kern/vnode_if.src
@@ -242,8 +242,8 @@ vop_read_pgcache {
 
 
 %% write	vp	L L L
-%! write	pre	VOP_WRITE_PRE
-%! write	post	VOP_WRITE_POST
+%! write	pre	vop_write_pre
+%! write	post	vop_write_post
 
 vop_write {
 	IN struct vnode *vp;

--- a/sys/kern/vnode_if.src
+++ b/sys/kern/vnode_if.src
@@ -380,6 +380,7 @@ vop_symlink {
 
 
 %% readdir	vp	L L L
+%! readdir	pre	vop_readdir_pre
 %! readdir	post	vop_readdir_post
 
 vop_readdir {

--- a/sys/sys/vnode.h
+++ b/sys/sys/vnode.h
@@ -1042,7 +1042,7 @@ void	vop_rename_fail(struct vop_rename_args *ap);
 	}								\
 } while (0)
 
-#define	VOP_WRITE_PRE(ap)						\
+#define	vop_write_pre(ap)						\
 	struct vattr va;						\
 	int error;							\
 	off_t osize, ooffset, noffset;					\
@@ -1056,7 +1056,7 @@ void	vop_rename_fail(struct vop_rename_args *ap);
 		osize = (off_t)va.va_size;				\
 	}
 
-#define VOP_WRITE_POST(ap, ret)						\
+#define vop_write_post(ap, ret)						\
 	noffset = (ap)->a_uio->uio_offset;				\
 	if (noffset > ooffset) {					\
 		if (!VN_KNLIST_EMPTY((ap)->a_vp)) {			\

--- a/usr.sbin/ctladm/tests/port.sh
+++ b/usr.sbin/ctladm/tests/port.sh
@@ -38,12 +38,6 @@
 # PGTAG,TARGET pair must be globally unique.
 PGTAG=30257
 
-load_cfiscsi() {
-	if ! kldstat -q -m cfiscsi; then
-		kldload cfiscsi || atf_skip "could not load cfscsi kernel mod"
-	fi
-}
-
 skip_if_ctld() {
 	if service ctld onestatus > /dev/null; then
 		# If ctld is running on this server, let's not interfere.
@@ -118,11 +112,11 @@ create_iscsi_head()
 	atf_set "descr" "ctladm can create a new iscsi port"
 	atf_set "require.user" "root"
 	atf_set "require.progs" ctladm
+	atf_set "require.kmods" "cfiscsi"
 }
 create_iscsi_body()
 {
 	skip_if_ctld
-	load_cfiscsi
 
 	TARGET=iqn.2018-10.myhost.create_iscsi
 	atf_check -o save:port-create.txt ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
@@ -146,11 +140,11 @@ create_iscsi_alias_head()
 	atf_set "descr" "ctladm can create a new iscsi port with a target alias"
 	atf_set "require.user" "root"
 	atf_set "require.progs" ctladm
+	atf_set "require.kmods" "cfiscsi"
 }
 create_iscsi_alias_body()
 {
 	skip_if_ctld
-	load_cfiscsi
 
 	TARGET=iqn.2018-10.myhost.create_iscsi_alias
 	ALIAS="foobar"
@@ -173,11 +167,11 @@ create_iscsi_without_required_args_head()
 	atf_set "descr" "ctladm will gracefully fail to create an iSCSI target if required arguments are missing"
 	atf_set "require.user" "root"
 	atf_set "require.progs" ctladm
+	atf_set "require.kmods" "cfiscsi"
 }
 create_iscsi_without_required_args_body()
 {
 	skip_if_ctld
-	load_cfiscsi
 
 	TARGET=iqn.2018-10.myhost.create_iscsi
 	atf_check -s exit:1 -e match:"Missing required argument: cfiscsi_target" ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG
@@ -288,11 +282,11 @@ remove_iscsi_head()
 	atf_set "descr" "ctladm can remove an iscsi port"
 	atf_set "require.user" "root"
 	atf_set "require.progs" ctladm
+	atf_set "require.kmods" "cfiscsi"
 }
 remove_iscsi_body()
 {
 	skip_if_ctld
-	load_cfiscsi
 
 	TARGET=iqn.2018-10.myhost.remove_iscsi
 	atf_check -o save:port-create.txt ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"
@@ -314,11 +308,11 @@ remove_iscsi_without_required_args_head()
 	atf_set "descr" "ctladm will gracefully fail to remove an iSCSI target if required arguments are missing"
 	atf_set "require.user" "root"
 	atf_set "require.progs" ctladm
+	atf_set "require.kmods" "cfiscsi"
 }
 remove_iscsi_without_required_args_body()
 {
 	skip_if_ctld
-	load_cfiscsi
 
 	TARGET=iqn.2018-10.myhost.remove_iscsi_without_required_args
 	atf_check -o save:port-create.txt ctladm port -c -d "iscsi" -O cfiscsi_portal_group_tag=$PGTAG -O cfiscsi_target="$TARGET"


### PR DESCRIPTION
Use the standard require.kmods ATF variable instead of ad-hoc code to load the cfiscsi kernel module.

MFC after:	2 weeks
Sponsored by:	ConnectWise