### PR TITLE
GEOM: add a new function g_new_geom

### DIFF
--- a/share/man/man9/g_geom.9
+++ b/share/man/man9/g_geom.9
@@ -27,12 +27,15 @@
 .Os
 .Sh NAME
 .Nm g_new_geomf ,
+.Nm g_new_geom ,
 .Nm g_destroy_geom
 .Nd "geom management"
 .Sh SYNOPSIS
 .In geom/geom.h
 .Ft "struct g_geom *"
 .Fn g_new_geomf "struct g_class *mp" "const char *fmt" ...
+.Ft "struct g_geom *"
+.Fn g_new_geom "struct g_class *mp" "const char *name"
 .Ft void
 .Fn g_destroy_geom "struct g_geom *gp"
 .Sh DESCRIPTION
@@ -56,6 +59,14 @@ function creates a new geom, which will be an instance of the class
 The geom's name is created in a
 .Xr printf 3 Ns
 -like way from the rest of the arguments.
+.Pp
+The
+.Fn g_new_geom
+function is very similar to
+.Fn g_new_geomf
+except that it accepts a regular string instead of a
+.Xr printf 3 Ns
+-like format strng as the geom's name.
 .Pp
 The
 .Fn g_destroy_geom
@@ -94,7 +105,9 @@ and
 .Va access
 for it.
 .Pp
-.Fn g_new_geomf :
+.Fn g_new_geomf
+and
+.Fn g_new_geom :
 .Bl -item -offset indent
 .It
 Class

--- a/sys/geom/cache/g_cache.c
+++ b/sys/geom/cache/g_cache.c
@@ -504,7 +504,7 @@ g_cache_create(struct g_class *mp, struct g_provider *pp,
 		return (NULL);
 	}
 
-	gp = g_new_geomf(mp, "%s", md->md_name);
+	gp = g_new_geom(mp, md->md_name);
 	sc = g_malloc(sizeof(*sc), M_WAITOK | M_ZERO);
 	sc->sc_type = type;
 	sc->sc_bshift = bshift;
@@ -665,7 +665,7 @@ g_cache_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 
 	G_CACHE_DEBUG(3, "Tasting %s.", pp->name);
 
-	gp = g_new_geomf(mp, "cache:taste");
+	gp = g_new_geom(mp, "cache:taste");
 	gp->start = g_cache_start;
 	gp->orphan = g_cache_orphan;
 	gp->access = g_cache_access;

--- a/sys/geom/concat/g_concat.c
+++ b/sys/geom/concat/g_concat.c
@@ -646,7 +646,7 @@ g_concat_create(struct g_class *mp, const struct g_concat_metadata *md,
 			return (NULL);
 		}
 	}
-	gp = g_new_geomf(mp, "%s", md->md_name);
+	gp = g_new_geom(mp, md->md_name);
 	sc = malloc(sizeof(*sc), M_CONCAT, M_WAITOK | M_ZERO);
 	gp->start = g_concat_start;
 	gp->spoiled = g_concat_orphan;
@@ -753,7 +753,7 @@ g_concat_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 
 	G_CONCAT_DEBUG(3, "Tasting %s.", pp->name);
 
-	gp = g_new_geomf(mp, "concat:taste");
+	gp = g_new_geom(mp, "concat:taste");
 	gp->start = g_concat_start;
 	gp->access = g_concat_access;
 	gp->orphan = g_concat_orphan;

--- a/sys/geom/eli/g_eli.c
+++ b/sys/geom/eli/g_eli.c
@@ -769,7 +769,7 @@ g_eli_read_metadata_offset(struct g_class *mp, struct g_provider *pp,
 
 	g_topology_assert();
 
-	gp = g_new_geomf(mp, "eli:taste");
+	gp = g_new_geom(mp, "eli:taste");
 	gp->start = g_eli_start;
 	gp->access = g_std_access;
 	/*

--- a/sys/geom/gate/g_gate.c
+++ b/sys/geom/gate/g_gate.c
@@ -571,7 +571,7 @@ g_gate_create(struct g_gate_ctl_create *ggio)
 		}
 	}
 
-	gp = g_new_geomf(&g_gate_class, "%s", name);
+	gp = g_new_geom(&g_gate_class, name);
 	gp->start = g_gate_start;
 	gp->access = g_gate_access;
 	gp->orphan = g_gate_orphan;

--- a/sys/geom/geom.h
+++ b/sys/geom/geom.h
@@ -289,8 +289,9 @@ int g_handleattr_int(struct bio *bp, const char *attribute, int val);
 int g_handleattr_off_t(struct bio *bp, const char *attribute, off_t val);
 int g_handleattr_uint16_t(struct bio *bp, const char *attribute, uint16_t val);
 int g_handleattr_str(struct bio *bp, const char *attribute, const char *str);
-struct g_consumer * g_new_consumer(struct g_geom *gp);
-struct g_geom * g_new_geomf(struct g_class *mp, const char *fmt, ...)
+struct g_consumer *g_new_consumer(struct g_geom *gp);
+struct g_geom *g_new_geom(struct g_class *mp, const char *name);
+struct g_geom *g_new_geomf(struct g_class *mp, const char *fmt, ...)
     __printflike(2, 3);
 struct g_provider * g_new_providerf(struct g_geom *gp, const char *fmt, ...)
     __printflike(2, 3);

--- a/sys/geom/geom_dev.c
+++ b/sys/geom/geom_dev.c
@@ -355,7 +355,7 @@ g_dev_taste(struct g_class *mp, struct g_provider *pp, int insist __unused)
 
 	g_trace(G_T_TOPOLOGY, "dev_taste(%s,%s)", mp->name, pp->name);
 	g_topology_assert();
-	gp = g_new_geomf(mp, "%s", pp->name);
+	gp = g_new_geom(mp, pp->name);
 	sc = g_malloc(sizeof(*sc), M_WAITOK | M_ZERO);
 	mtx_init(&sc->sc_mtx, "g_dev", NULL, MTX_DEF);
 	cp = g_new_consumer(gp);

--- a/sys/geom/geom_slice.c
+++ b/sys/geom/geom_slice.c
@@ -529,7 +529,7 @@ g_slice_new(struct g_class *mp, u_int slices, struct g_provider *pp, struct g_co
 
 	g_topology_assert();
 	vp = (void **)extrap;
-	gp = g_new_geomf(mp, "%s", pp->name);
+	gp = g_new_geom(mp, pp->name);
 	gsp = g_slice_alloc(slices, extra);
 	gsp->start = start;
 	gp->softc = gsp;

--- a/sys/geom/geom_subr.c
+++ b/sys/geom/geom_subr.c
@@ -376,7 +376,7 @@ g_new_geom(struct g_class *mp, const char *name)
 	g_topology_assert();
 	G_VALID_CLASS(mp);
 	len = strlen(name);
-	gp = g_malloc(sizeof *gp + len + 1, M_WAITOK | M_ZERO);
+	gp = g_malloc(sizeof(*gp) + len + 1, M_WAITOK | M_ZERO);
 	gp->name = (char *)(gp + 1);
 	gp->class = mp;
 	gp->rank = 1;

--- a/sys/geom/journal/g_journal.c
+++ b/sys/geom/journal/g_journal.c
@@ -2477,7 +2477,7 @@ g_journal_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 	if (pp->geom->class == mp)
 		return (NULL);
 
-	gp = g_new_geomf(mp, "journal:taste");
+	gp = g_new_geom(mp, "journal:taste");
 	/* This orphan function should be never called. */
 	gp->orphan = g_journal_taste_orphan;
 	cp = g_new_consumer(gp);

--- a/sys/geom/label/g_label.c
+++ b/sys/geom/label/g_label.c
@@ -399,7 +399,7 @@ g_label_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 	if (strcmp(pp->geom->class->name, mp->name) == 0)
 		return (NULL);
 
-	gp = g_new_geomf(mp, "label:taste");
+	gp = g_new_geom(mp, "label:taste");
 	gp->start = g_label_start_taste;
 	gp->access = g_label_access_taste;
 	gp->orphan = g_label_orphan_taste;

--- a/sys/geom/linux_lvm/g_linux_lvm.c
+++ b/sys/geom/linux_lvm/g_linux_lvm.c
@@ -537,7 +537,7 @@ g_llvm_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 
 	g_topology_assert();
 	g_trace(G_T_TOPOLOGY, "%s(%s, %s)", __func__, mp->name, pp->name);
-	gp = g_new_geomf(mp, "linux_lvm:taste");
+	gp = g_new_geom(mp, "linux_lvm:taste");
 	/* This orphan function should be never called. */
 	gp->orphan = g_llvm_taste_orphan;
 	cp = g_new_consumer(gp);
@@ -557,7 +557,7 @@ g_llvm_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 	vg = md.md_vg;
 	if (vg->vg_geom == NULL) {
 		/* new volume group */
-		gp = g_new_geomf(mp, "%s", vg->vg_name);
+		gp = g_new_geom(mp, vg->vg_name);
 		gp->start = g_llvm_start;
 		gp->spoiled = g_llvm_orphan;
 		gp->orphan = g_llvm_orphan;

--- a/sys/geom/mirror/g_mirror.c
+++ b/sys/geom/mirror/g_mirror.c
@@ -3149,7 +3149,7 @@ g_mirror_create(struct g_class *mp, const struct g_mirror_metadata *md,
 	/*
 	 * Action geom.
 	 */
-	gp = g_new_geomf(mp, "%s", md->md_name);
+	gp = g_new_geom(mp, md->md_name);
 	sc = malloc(sizeof(*sc), M_MIRROR, M_WAITOK | M_ZERO);
 	gp->start = g_mirror_start;
 	gp->orphan = g_mirror_orphan;
@@ -3290,7 +3290,7 @@ g_mirror_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 	g_trace(G_T_TOPOLOGY, "%s(%s, %s)", __func__, mp->name, pp->name);
 	G_MIRROR_DEBUG(2, "Tasting %s.", pp->name);
 
-	gp = g_new_geomf(mp, "mirror:taste");
+	gp = g_new_geom(mp, "mirror:taste");
 	/*
 	 * This orphan function should be never called.
 	 */

--- a/sys/geom/mirror/g_mirror_ctl.c
+++ b/sys/geom/mirror/g_mirror_ctl.c
@@ -433,7 +433,7 @@ g_mirror_ctl_create(struct gctl_req *req, struct g_class *mp)
 	g_topology_lock();
 	mediasize = OFF_MAX;
 	sectorsize = 0;
-	gp = g_new_geomf(mp, "%s", md.md_name);
+	gp = g_new_geom(mp, md.md_name);
 	gp->orphan = g_mirror_create_orphan;
 	cp = g_new_consumer(gp);
 	for (no = 1; no < *nargs; no++) {

--- a/sys/geom/mountver/g_mountver.c
+++ b/sys/geom/mountver/g_mountver.c
@@ -291,7 +291,7 @@ g_mountver_create(struct gctl_req *req, struct g_class *mp, struct g_provider *p
 			return (EEXIST);
 		}
 	}
-	gp = g_new_geomf(mp, "%s", name);
+	gp = g_new_geom(mp, name);
 	sc = g_malloc(sizeof(*sc), M_WAITOK | M_ZERO);
 	mtx_init(&sc->sc_mtx, "gmountver", NULL, MTX_DEF | MTX_RECURSE);
 	TAILQ_INIT(&sc->sc_queue);

--- a/sys/geom/multipath/g_multipath.c
+++ b/sys/geom/multipath/g_multipath.c
@@ -549,7 +549,7 @@ g_multipath_create(struct g_class *mp, struct g_multipath_metadata *md)
 		}
 	}
 
-	gp = g_new_geomf(mp, "%s", md->md_name);
+	gp = g_new_geom(mp, md->md_name);
 	sc = g_malloc(sizeof(*sc), M_WAITOK | M_ZERO);
 	mtx_init(&sc->sc_mtx, "multipath", NULL, MTX_DEF);
 	memcpy(sc->sc_uuid, md->md_uuid, sizeof (sc->sc_uuid));
@@ -821,7 +821,7 @@ g_multipath_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 
 	g_topology_assert();
 
-	gp = g_new_geomf(mp, "multipath:taste");
+	gp = g_new_geom(mp, "multipath:taste");
 	gp->start = g_multipath_start;
 	gp->access = g_multipath_access;
 	gp->orphan = g_multipath_orphan;

--- a/sys/geom/nop/g_nop.c
+++ b/sys/geom/nop/g_nop.c
@@ -416,7 +416,7 @@ g_nop_create(struct gctl_req *req, struct g_class *mp, struct g_provider *pp,
 			return (EEXIST);
 		}
 	}
-	gp = g_new_geomf(mp, "%s", name);
+	gp = g_new_geom(mp, name);
 	sc = g_malloc(sizeof(*sc), M_WAITOK | M_ZERO);
 	sc->sc_offset = offset;
 	sc->sc_explicitsize = explicitsize;

--- a/sys/geom/part/g_part.c
+++ b/sys/geom/part/g_part.c
@@ -998,7 +998,7 @@ g_part_ctl_create(struct gctl_req *req, struct g_part_parms *gpp)
 	}
 
 	if (null == NULL)
-		gp = g_new_geomf(&g_part_class, "%s", pp->name);
+		gp = g_new_geom(&g_part_class, pp->name);
 	gp->softc = kobj_create((kobj_class_t)gpp->gpp_scheme, M_GEOM,
 	    M_WAITOK);
 	table = gp->softc;
@@ -1979,7 +1979,7 @@ g_part_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 	 * With that we become part of the topology. Obtain read access
 	 * to the provider.
 	 */
-	gp = g_new_geomf(mp, "%s", pp->name);
+	gp = g_new_geom(mp, pp->name);
 	cp = g_new_consumer(gp);
 	cp->flags |= G_CF_DIRECT_SEND | G_CF_DIRECT_RECEIVE;
 	error = g_attach(cp, pp);

--- a/sys/geom/raid/g_raid.c
+++ b/sys/geom/raid/g_raid.c
@@ -1876,7 +1876,7 @@ g_raid_create_node(struct g_class *mp,
 	g_topology_assert();
 	G_RAID_DEBUG(1, "Creating array %s.", name);
 
-	gp = g_new_geomf(mp, "%s", name);
+	gp = g_new_geom(mp, name);
 	sc = malloc(sizeof(*sc), M_RAID, M_WAITOK | M_ZERO);
 	gp->start = g_raid_start;
 	gp->orphan = g_raid_orphan;
@@ -2217,7 +2217,7 @@ g_raid_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 
 	geom = NULL;
 	status = G_RAID_MD_TASTE_FAIL;
-	gp = g_new_geomf(mp, "raid:taste");
+	gp = g_new_geom(mp, "raid:taste");
 	/*
 	 * This orphan function should be never called.
 	 */

--- a/sys/geom/raid3/g_raid3.c
+++ b/sys/geom/raid3/g_raid3.c
@@ -3164,7 +3164,7 @@ g_raid3_create(struct g_class *mp, const struct g_raid3_metadata *md)
 	/*
 	 * Action geom.
 	 */
-	gp = g_new_geomf(mp, "%s", md->md_name);
+	gp = g_new_geom(mp, md->md_name);
 	sc = malloc(sizeof(*sc), M_RAID3, M_WAITOK | M_ZERO);
 	sc->sc_disks = malloc(sizeof(struct g_raid3_disk) * md->md_all, M_RAID3,
 	    M_WAITOK | M_ZERO);
@@ -3338,7 +3338,7 @@ g_raid3_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 	g_trace(G_T_TOPOLOGY, "%s(%s, %s)", __func__, mp->name, pp->name);
 	G_RAID3_DEBUG(2, "Tasting %s.", pp->name);
 
-	gp = g_new_geomf(mp, "raid3:taste");
+	gp = g_new_geom(mp, "raid3:taste");
 	/* This orphan function should be never called. */
 	gp->orphan = g_raid3_taste_orphan;
 	cp = g_new_consumer(gp);

--- a/sys/geom/raid3/g_raid3_ctl.c
+++ b/sys/geom/raid3/g_raid3_ctl.c
@@ -425,7 +425,7 @@ g_raid3_ctl_insert(struct gctl_req *req, struct g_class *mp)
 		no = gctl_get_paraml(req, "number", sizeof(*no));
 	else
 		no = NULL;
-	gp = g_new_geomf(mp, "raid3:insert");
+	gp = g_new_geom(mp, "raid3:insert");
 	gp->orphan = g_raid3_ctl_insert_orphan;
 	cp = g_new_consumer(gp);
 	error = g_attach(cp, pp);

--- a/sys/geom/shsec/g_shsec.c
+++ b/sys/geom/shsec/g_shsec.c
@@ -545,7 +545,7 @@ g_shsec_create(struct g_class *mp, const struct g_shsec_metadata *md)
 			return (NULL);
 		}
 	}
-	gp = g_new_geomf(mp, "%s", md->md_name);
+	gp = g_new_geom(mp, md->md_name);
 	sc = malloc(sizeof(*sc), M_SHSEC, M_WAITOK | M_ZERO);
 	gp->start = g_shsec_start;
 	gp->spoiled = g_shsec_orphan;
@@ -643,7 +643,7 @@ g_shsec_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 
 	G_SHSEC_DEBUG(3, "Tasting %s.", pp->name);
 
-	gp = g_new_geomf(mp, "shsec:taste");
+	gp = g_new_geom(mp, "shsec:taste");
 	gp->start = g_shsec_start;
 	gp->access = g_shsec_access;
 	gp->orphan = g_shsec_orphan;

--- a/sys/geom/stripe/g_stripe.c
+++ b/sys/geom/stripe/g_stripe.c
@@ -864,7 +864,7 @@ g_stripe_create(struct g_class *mp, const struct g_stripe_metadata *md,
 			return (NULL);
 		}
 	}
-	gp = g_new_geomf(mp, "%s", md->md_name);
+	gp = g_new_geom(mp, md->md_name);
 	sc = malloc(sizeof(*sc), M_STRIPE, M_WAITOK | M_ZERO);
 	gp->start = g_stripe_start;
 	gp->spoiled = g_stripe_orphan;
@@ -965,7 +965,7 @@ g_stripe_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 
 	G_STRIPE_DEBUG(3, "Tasting %s.", pp->name);
 
-	gp = g_new_geomf(mp, "stripe:taste");
+	gp = g_new_geom(mp, "stripe:taste");
 	gp->start = g_stripe_start;
 	gp->access = g_stripe_access;
 	gp->orphan = g_stripe_orphan;

--- a/sys/geom/union/g_union.c
+++ b/sys/geom/union/g_union.c
@@ -246,7 +246,7 @@ g_union_ctl_create(struct gctl_req *req, struct g_class *mp, bool verbose)
 			return;
 		}
 	}
-	gp = g_new_geomf(mp, "%s", name);
+	gp = g_new_geom(mp, name);
 	sc = g_malloc(sizeof(*sc), M_WAITOK | M_ZERO);
 	rw_init(&sc->sc_rwlock, "gunion");
 	TAILQ_INIT(&sc->sc_wiplist);

--- a/sys/geom/virstor/g_virstor.c
+++ b/sys/geom/virstor/g_virstor.c
@@ -771,7 +771,7 @@ g_virstor_taste(struct g_class *mp, struct g_provider *pp, int flags)
 	LOG_MSG(LVL_DEBUG, "Tasting %s", pp->name);
 
 	/* We need a dummy geom to attach a consumer to the given provider */
-	gp = g_new_geomf(mp, "virstor:taste.helper");
+	gp = g_new_geom(mp, "virstor:taste.helper");
 	gp->start = (void *)invalid_call;	/* XXX: hacked up so the        */
 	gp->access = (void *)invalid_call;	/* compiler doesn't complain.   */
 	gp->orphan = (void *)invalid_call;	/* I really want these to fail. */
@@ -1085,7 +1085,7 @@ create_virstor_geom(struct g_class *mp, struct g_virstor_metadata *md)
 			return (NULL);
 		}
 	}
-	gp = g_new_geomf(mp, "%s", md->md_name);
+	gp = g_new_geom(mp, md->md_name);
 	gp->softc = NULL; /* to circumevent races that test softc */
 
 	gp->start = g_virstor_start;

--- a/sys/geom/zero/g_zero.c
+++ b/sys/geom/zero/g_zero.c
@@ -102,7 +102,7 @@ g_zero_init(struct g_class *mp)
 	struct g_provider *pp;
 
 	g_topology_assert();
-	gp = g_new_geomf(mp, "gzero");
+	gp = g_new_geom(mp, "gzero");
 	gp->start = g_zero_start;
 	gp->access = g_std_access;
 	gpp = pp = g_new_providerf(gp, "%s", gp->name);


### PR DESCRIPTION
This function accepts a regular string as its input string so the callers calling this function can save the time wasted on format string processing.