### PR TITLE
tests/sys/netpfil: unskip tests that no longer need to be skipped

### DIFF
--- a/tests/sys/netpfil/common/dummynet.sh
+++ b/tests/sys/netpfil/common/dummynet.sh
@@ -265,10 +265,6 @@ queue_body()
 {
 	fw=$1
 
-	if [ $fw = "ipfw" ] && [ "$(atf_config_get ci false)" = "true" ]; then
-		atf_skip "https://bugs.freebsd.org/264805"
-	fi
-
 	firewall_init $fw
 	dummynet_init $fw
 

--- a/tests/sys/netpfil/pf/forward.sh
+++ b/tests/sys/netpfil/pf/forward.sh
@@ -101,10 +101,6 @@ v6_body()
 {
 	pft_init
 
-	if [ "$(atf_config_get ci false)" = "true" ]; then
-		atf_skip "https://bugs.freebsd.org/260460"
-	fi
-
 	epair_send=$(vnet_mkepair)
 	epair_recv=$(vnet_mkepair)
 

--- a/tests/sys/netpfil/pf/killstate.sh
+++ b/tests/sys/netpfil/pf/killstate.sh
@@ -117,10 +117,6 @@ v6_body()
 {
 	pft_init
 
-	if [ "$(atf_config_get ci false)" = "true" ]; then
-		atf_skip "https://bugs.freebsd.org/260458"
-	fi
-
 	epair=$(vnet_mkepair)
 	ifconfig ${epair}a inet6 2001:db8::1/64 up no_dad
 

--- a/tests/sys/netpfil/pf/set_tos.sh
+++ b/tests/sys/netpfil/pf/set_tos.sh
@@ -129,10 +129,6 @@ v6_body()
 {
 	pft_init
 
-	if [ "$(atf_config_get ci false)" = "true" ]; then
-            atf_skip "https://bugs.freebsd.org/260459"
-	fi
-
 	epair=$(vnet_mkepair)
 	ifconfig ${epair}a inet6 add 2001:db8:192::1
 	vnet_mkjail alcatraz ${epair}b


### PR DESCRIPTION
All of these are passing consistently in the latest CI environment in 15+ back-to-back test runs.