### PR TITLE
tests/mac_portacl: enable is_exclusive for now

### DIFF
--- a/tests/sys/mac/portacl/Makefile
+++ b/tests/sys/mac/portacl/Makefile
@@ -10,6 +10,7 @@ TAP_TESTS_SH+=	root_test
 .for t in ${TAP_TESTS_SH}
 TEST_METADATA.$t+=	required_user="root"
 TEST_METADATA.$t+=	timeout="450"
+TEST_METADATA.$t+=	is_exclusive="true"
 .endfor
 
 .include <bsd.test.mk>


### PR DESCRIPTION
Both tests rely on ports 77 and 7777 to be available and thus cannot be run concurrently. This is a temporary measure to ensure that they don't conflict with each other.

In the future, these should be rewritten to wait until the necessary ports are available, or deterministically select a free port instead.