### PR TITLE
makefd_xprt: fix wrong text in message

### DIFF
--- a/lib/libc/rpc/svc_vc.c
+++ b/lib/libc/rpc/svc_vc.c
@@ -247,7 +247,7 @@ makefd_xprt(int fd, u_int sendsize, u_int recvsize)
 	}
 	cd = mem_alloc(sizeof(struct cf_conn));
 	if (cd == NULL) {
-		warnx("svc_tcp: makefd_xprt: out of memory");
+		warnx("svc_vc: makefd_xprt: out of memory");
 		svc_xprt_free(xprt);
 		xprt = NULL;
 		goto done;


### PR DESCRIPTION
Fix copy-paste bug in error message in makefd_xprt.

Obtained from:	linux libtirpc
PR:		285502