### PR TITLE
Fix function return test in syslogd

### DIFF
--- a/usr.sbin/syslogd/syslogd.c
+++ b/usr.sbin/syslogd/syslogd.c
@@ -2571,7 +2571,7 @@ syslogd_cap_enter(void)
 	if (cap_syslogd == NULL)
 		err(1, "Failed to open the syslogd.casper libcasper service");
 	cap_net = cap_service_open(cap_casper, "system.net");
-	if (cap_syslogd == NULL)
+	if (cap_net == NULL)
 		err(1, "Failed to open the system.net libcasper service");
 	cap_close(cap_casper);
 	limit = cap_net_limit_init(cap_net,


### PR DESCRIPTION
Looks like during the capsicum setup the return value for cap_syslogd is checked twice rather than checking the return value of cap_net after initializing the casper service.