### PR TITLE
release/vmimage.subr: don't run newaliases in default setup

### DIFF
--- a/release/tools/vmimage.subr
+++ b/release/tools/vmimage.subr
@@ -118,7 +118,6 @@ vm_emulation_setup() {
 
 	mkdir -p ${DESTDIR}/dev
 	mount -t devfs devfs ${DESTDIR}/dev
-	chroot ${DESTDIR} ${EMULATOR} /usr/bin/newaliases
 	chroot ${DESTDIR} ${EMULATOR} /bin/sh /etc/rc.d/ldconfig forcestart
 	cp /etc/resolv.conf ${DESTDIR}/etc/resolv.conf
 


### PR DESCRIPTION
release/scripts/mk-vmimage.sh calls vm_emulation_setup to perform any emulator-specific setup needed for the desired output VM image. Currently, this script calls newaliases (coming from commit 1e7c1f1) which was originally needed to build the aliases.db file when sendmail(8) was the default MTA.

When running dma(8) with emulators like qemu-user-static (which doesn't yet honour setgid executables on FreeBSD), this step fails with a 'permission denied' error while trying to read dma.conf, which is now chown root:mail and chmod 0640 after commit a3d4ae7.

Since moving to dma(8) as the base MTA in FreeBSD 14+, newaliases is a no-op in the default image configuration. This patch removes this unnecessary command from the default vm_emulation_setup() function. If mk-vmimage.sh users require newaliases for a sendmail(8)-based VM image setup, they can override vm_emulation_setup() in their own configs, since an override will be required anyway to use sendmail(8) instead of dma(8).