### PR TITLE
sockstat: revert incorrect use of path-state for SCTP connections

### DIFF
--- a/usr.bin/sockstat/sockstat.c
+++ b/usr.bin/sockstat/sockstat.c
@@ -1510,10 +1510,9 @@ display_sock(struct sock *s, struct col_widths *cw, char *buf, size_t bufsize)
 				    s->proto == IPPROTO_TCP) {
 					switch (s->proto) {
 					case IPPROTO_SCTP:
-						xo_emit(" {:path-state/%-*s}",
-							cw->path_state,
-							sctp_path_state(
-								faddr->state));
+						xo_emit(" {:conn-state/%-*s}",
+							cw->conn_state,
+							sctp_conn_state(s->state));
 						break;
 					case IPPROTO_TCP:
 						if (s->state >= 0 &&


### PR DESCRIPTION
Revert a change that mistakenly used SCTP path state and the field name `path-state` instead of the correct `conn-state` and `sctp_conn_state()` call. This was introduced in 7b35b4d during the addition of libxo support.

Fixes:		7b35b4d (sockstat: add libxo support)
Reported by:	Phil Shafer <phil@juniper.net>
Sponsored by:	Google, LLC (GSoC 2025)