### PR TITLE
gstripe: rm redundant bio->bio_ma_n assignment

### DIFF
--- a/sys/geom/stripe/g_stripe.c
+++ b/sys/geom/stripe/g_stripe.c
@@ -454,11 +454,9 @@ g_stripe_start_economic(struct bio *bp, u_int no, off_t offset, off_t length)
 		cbp->bio_done = g_stripe_done;
 	cbp->bio_offset = offset;
 	cbp->bio_length = length;
-	if ((bp->bio_flags & BIO_UNMAPPED) != 0) {
-		bp->bio_ma_n = round_page(bp->bio_ma_offset +
-		    bp->bio_length) / PAGE_SIZE;
+	if ((bp->bio_flags & BIO_UNMAPPED) != 0)
 		addr = NULL;
-	} else
+	else
 		addr = bp->bio_data;
 	cbp->bio_caller2 = sc->sc_disks[no];
 


### PR DESCRIPTION
Do not touch the parent bio's number of pages. This is already set by the upper layer, e.g., in `physio()`, etc. No other GEOM class does this.


Also I want to ask if using bitwise operations for DIV and MOD operations in the striping calculations for unmapped I/O would be welcome as another PR or commit addition to this PR? Commit here: [e45c671b0e9d972172c0dbd1b21f1af01ca9996d](https://github.com/mcimerman/freebsd-src/commit/e45c671b0e9d972172c0dbd1b21f1af01ca9996d)