### PR TITLE
vkbd: use the real dev in the man page

### DIFF
--- a/share/man/man4/vkbd.4
+++ b/share/man/man4/vkbd.4
@@ -101,7 +101,7 @@ main(void)
 {
         int     fd, len;
 
-        fd = open("/dev/vkbdctl0", O_RDWR);
+        fd = open("/dev/vkbdctl", O_RDWR);
         if (fd < 0)
                 err(1, "open");
 


### PR DESCRIPTION
I noticed this in vkbd when porting it to Dragonfly then forgot it, thankfully I believe mneumann figured out the issue and patched it in 0885527.