### PR TITLE
libspl: Don't build tunables.c when bootstrapping

### DIFF
--- a/cddl/lib/libspl/Makefile
+++ b/cddl/lib/libspl/Makefile
@@ -16,16 +16,16 @@ SRCS = \
         os/freebsd/zone.c \
         page.c \
         timestamp.c \
-	tunables.c \
         include/sys/list.h \
         include/sys/list_impl.h
 
-# These functions are not required when bootstrapping and the atomic code
-# will not compile when building on macOS.
+# These functions are not required when bootstrapping and the atomic code,
+# among others, will not compile when building on macOS.
 .if !defined(BOOTSTRAPPING)
 SRCS += \
         atomic.c \
         getexecname.c \
+        tunables.c \
         os/freebsd/getexecname.c \
         os/freebsd/gethostid.c \
         os/freebsd/getmntany.c \

--- a/sys/contrib/openzfs/lib/libspl/tunables.c
+++ b/sys/contrib/openzfs/lib/libspl/tunables.c
@@ -74,9 +74,7 @@ extern const zfs_tunable_t *__stop_zfs_tunables;
  * any NULL pointers.
  */
 static void *__zfs_tunable__placeholder
-#if !defined(__APPLE__)
 	__attribute__((__section__("zfs_tunables")))
-#endif
 	__attribute__((__used__)) = NULL;
 
 /*


### PR DESCRIPTION
Test PR for CI.
