### PR TITLE
openssh: Use SSH_TUN_COMPAT_AF to fix tun device forwarding interoperability with other OSes

### DIFF
--- a/crypto/openssh/config.h
+++ b/crypto/openssh/config.h
@@ -1898,7 +1898,7 @@
 #define SSH_PRIVSEP_USER "sshd"
 
 /* Use tunnel device compatibility to OpenBSD */
-/* #undef SSH_TUN_COMPAT_AF */
+#define SSH_TUN_COMPAT_AF 1
 
 /* Open tunnel devices the FreeBSD way */
 #define SSH_TUN_FREEBSD 1

--- a/crypto/openssh/configure.ac
+++ b/crypto/openssh/configure.ac
@@ -1059,6 +1059,8 @@ mips-sony-bsd|mips-sony-newsos4)
 	SKIP_DISABLE_LASTLOG_DEFINE=yes
 	AC_DEFINE([LOCKED_PASSWD_PREFIX], ["*LOCKED*"], [Account locked with pw(1)])
 	AC_DEFINE([SSH_TUN_FREEBSD], [1], [Open tunnel devices the FreeBSD way])
+	AC_DEFINE([SSH_TUN_COMPAT_AF], [1],
+	    [Use tunnel device compatibility to OpenBSD])
 	AC_CHECK_HEADER([net/if_tap.h], ,
 	    AC_DEFINE([SSH_TUN_NO_L2], [1], [No layer 2 tunnel support]))
 	AC_DEFINE([BROKEN_GLOB], [1], [FreeBSD glob does not do what we need])


### PR DESCRIPTION
See also: https://github.com/openssh/openssh-portable/pull/588