### PR TITLE
libcrypto: diable KTLS in the bootstrap libcrypto

### DIFF
--- a/secure/lib/libcrypto/Makefile
+++ b/secure/lib/libcrypto/Makefile
@@ -3,7 +3,12 @@ SHLIBDIR?=	/lib
 SUBDIR=		engines modules
 .endif
 .ifdef BOOTSTRAPPING
+.if ${.MAKE.OS} == "macOS"
+# This is undeniably a gross hack.
+MACHINE_ABI+=	long64
+.endif
 CFLAGS+=	-DOPENSSL_NO_SCTP
+CFLAGS+=	-DOPENSSL_NO_KTLS
 .endif
 
 .include <bsd.own.mk>
@@ -235,7 +240,7 @@ SRCS+=	ecdsa_vrf.c eck_prn.c ecp_mont.c ecp_nist.c
 SRCS+=	ecp_oct.c ecp_smpl.c ecx_backend.c ecx_key.c ecx_meth.c eddsa.c
 SRCS+=	f_generic.c f_impl32.c f_impl64.c scalar.c
 # see OPENSSL_NO_EC_NISTP_64_GCC_128 in configuration.h
-.if ${MACHINE_ABI:Mlittle-endian} && ${MACHINE_ABI:Mlong64}
+.if ${TARGET_ENDIANNESS} == 1234 && ${MACHINE_ABI:Mlong64}
 SRCS+=	ecp_nistp224.c ecp_nistp256.c ecp_nistp384.c ecp_nistp521.c ecp_nistputil.c
 .else
 CFLAGS+=-DOPENSSL_NO_EC_NISTP_64_GCC_128


### PR DESCRIPTION
It won't be supported on, e.g., macOS, and we don't actually need it for what we do with libcrypto in bootstrap tools.

(Just to trigger builds)