### PR TITLE
fusefs: Upgrade FUSE protocol to version 7.36.

### DIFF
--- a/sys/fs/fuse/fuse_internal.c
+++ b/sys/fs/fuse/fuse_internal.c
@@ -1117,6 +1117,9 @@ fuse_internal_send_init(struct fuse_data *data, struct thread *td)
 		| FUSE_BIG_WRITES | FUSE_WRITEBACK_CACHE
 		| FUSE_NO_OPEN_SUPPORT | FUSE_NO_OPENDIR_SUPPORT;
 
+	if (fuse_libabi_geq(data, 7, 36))
+		fiii->flags2 = 0;
+
 	fuse_insert_callback(fdi.tick, fuse_internal_init_callback);
 	fuse_insert_message(fdi.tick, false);
 	fdisp_destroy(&fdi);


### PR DESCRIPTION
This commit upgrades the FUSE API to protocol 7.36, it doesn't implement any of protocol 7.36's new features,