### PR TITLE
jail(8): Implement and document NUL-terminated output

### DIFF
--- a/usr.sbin/jail/jail.8
+++ b/usr.sbin/jail/jail.8
@@ -105,7 +105,9 @@ Exhibit a list of all configured non-wildcard jails and their parameters.
 No jail creation, modification or removal performed if this option is used.
 The
 .Ar separator
-string is used to separate parameters.
+string is used to separate parameters.  If the separator string is empty (''
+or "") then each parameter will be followed by a NUL byte, with one additional
+NUL byte at end of each jail's parameters.
 Use
 .Xr jls 8
 utility to list running jails.

--- a/usr.sbin/jail/jail.c
+++ b/usr.sbin/jail/jail.c
@@ -978,6 +978,7 @@ print_jail(FILE *fp, struct cfjail *j, int oldcl, int running)
 #endif
 		fputs(separator, fp);
 		print_param(fp, j->intparams[IP_COMMAND], ' ', 0);
+		putc('\n', fp);
 	} else {
 		printsep = 0;
 		if (running) {
@@ -987,13 +988,19 @@ print_jail(FILE *fp, struct cfjail *j, int oldcl, int running)
 		TAILQ_FOREACH(p, &j->params, tq)
 			if (strcmp(p->name, "jid")) {
 				if (printsep)
-					fputs(separator, fp);
+					*separator ?
+					    fputs(separator, fp) : putc(0, fp);
 				else
 					printsep = 1;
-				print_param(fp, p, ',', 1);
+				print_param(fp, p, *separator ? ',' : '\n', 1);
 			}
+		if (*separator)
+			putc('\n', fp);
+		else {
+			putc(0, fp);
+			putc(0, fp);
+		}
 	}
-	putc('\n', fp);
 }
 
 /*
@@ -1038,7 +1045,8 @@ quoted_print(FILE *fp, char *str)
 	int c, qc;
 	char *p = str;
 
-	qc = !*p ? '"'
+	qc = !*separator ? 0
+	    : !*p ? '"'
 	    : strchr(p, '\'') ? '"'
 	    : strchr(p, '"') ? '\''
 	    : strchr(p, ' ') || strchr(p, '\t') ? '"'


### PR DESCRIPTION
`jail(8)` has only simple string-quoting logic with regard to the output from `jail -e`. This pull request adds NUL-delimited output (ala `find(1)`, `xargs(1)`, `grep(1)`, et al.) so that arbitrary strings defined in the `/etc/jail.conf(5)` configuration hierarchy can be unambiguously represented in the `jail -e` output.  Specifically, this patch changes the behavior of **only** the `jail -e` command.  Previously the command `jail -e ''` resulted in **NO** delimiter between adjacent jail parameters.  This patch changes the behavior to use one NUL byte between adjacent jail parameters, and one addtional NUL (i.e. two consecutive NULs) to indicate the end of each jail's parameters.  Also, the standard behavior of `jail(8)` for multi-valued parameters (`ip4.addr`, `mount`, et al.) is to quote the strings and separate them with commas.  When NUL-delimiting is requested, multi-value parameters are left unquoted, and separated by newlines.

All new behavior is triggered only when the parameter to `-e` evaluates to an empty string.  These syntaxes are equivalent:

`jail -e ''`
`jail -e ""`
`Jail -e $'\0'`
`Jail -e $''`

For more clarity, examine the patched code's output for:

`jail -e '' | hexdump -Cv | less +/" 00"`
`jail -e '' | xargs -0 -I xx echo xx`

For an example of a `bash(1)` script that can leverage `jail(8)`'s enhanced behavior, please see:

[https://github.com/kraken-jim/jail-info/blob/master/FreeBSD/stage/usr/local/bin/jail-info](https://github.com/kraken-jim/jail-info/blob/master/FreeBSD/stage/usr/local/bin/jail-info)

Upon adoption of this pull request, it is anticipated that the `jail-info` project will be submitted as a proposed port, `sysutils/jail-info`.