### PR TITLE
Update vmimage.subr

### DIFF
--- a/release/tools/vmimage.subr
+++ b/release/tools/vmimage.subr
@@ -82,7 +82,7 @@ vm_install_base() {
 	echo '# Custom /etc/fstab for FreeBSD VM images' \
 		> ${DESTDIR}/etc/fstab
 	if [ "${VMFS}" != zfs ]; then
-		echo "/dev/${ROOTLABEL}/rootfs   /       ${VMFS}   rw      1       1" \
+		echo "/dev/${ROOTLABEL}/rootfs   /       ${VMFS}   rw,noatime      1       1" \
 			>> ${DESTDIR}/etc/fstab
 	fi
 	if [ -z "${NOSWAP}" ]; then


### PR DESCRIPTION
This "noatime" tweak, reduced the OPNsense constant 50kb - 80kb disk writes that wear down the SSD / NVME.

before
<img width="1040" height="331" alt="image" src="https://github.com/user-attachments/assets/de0918d4-8e7f-459b-a61a-4272df350fa9" />

after
<img width="1054" height="349" alt="image" src="https://github.com/user-attachments/assets/2f6715a6-4aff-4a1d-888a-1b70a1bd704c" />

Signed-off-by: Unicorn9x