### PR TITLE
Update vmimage.subr to create fstab with noatime reduced the OPNsense constant 50kb - 80kb disk writes that wear down the SSD / NVME

### DIFF
--- a/release/tools/vmimage.subr
+++ b/release/tools/vmimage.subr
@@ -82,7 +82,7 @@ vm_install_base() {
 	echo '# Custom /etc/fstab for FreeBSD VM images' \
 		> ${DESTDIR}/etc/fstab
 	if [ "${VMFS}" != zfs ]; then
-		echo "/dev/${ROOTLABEL}/rootfs   /       ${VMFS}   rw      1       1" \
+		echo "/dev/${ROOTLABEL}/rootfs   /       ${VMFS}   rw,noatime      1       1" \
 			>> ${DESTDIR}/etc/fstab
 	fi
 	if [ -z "${NOSWAP}" ]; then


### PR DESCRIPTION
This "noatime" tweak, reduced the OPNsense constant 50kb - 80kb disk writes that wear down the SSD / NVME.

before
<img width="1040" height="331" alt="image" src="https://github.com/user-attachments/assets/2692270d-e00e-43fa-b0db-cf3877797698" />

after
<img width="1054" height="349" alt="image" src="https://github.com/user-attachments/assets/7c237be6-e485-442f-9665-ffab83f0650c" />

Signed-off-by: Unicorn9x