### PR TITLE
libc: prevent incorrect %a/%La rounding at full precision

### DIFF
--- a/lib/libc/gdtoa/_hdtoa.c
+++ b/lib/libc/gdtoa/_hdtoa.c
@@ -40,6 +40,7 @@
 
 #define	DBL_ADJ	(DBL_MAX_EXP - 2)
 #define	SIGFIGS	((DBL_MANT_DIG + 3) / 4 + 1)
+#define	MAX_HEX_DIGITS	((DBL_MANT_DIG + 3 - 1) / 4 + 1)
 
 static const float one[] = { 1.0f, -1.0f };
 
@@ -111,7 +112,7 @@ __hdtoa(double d, const char *xdigs, int ndigits, int *decpt, int *sign,
 	s0 = rv_alloc(bufsize);
 
 	/* Round to the desired number of digits. */
-	if (SIGFIGS > ndigits && ndigits > 0) {
+	if (MAX_HEX_DIGITS > ndigits && ndigits > 0) {
 		float redux = one[u.bits.sign];
 		int offset = 4 * ndigits + DBL_MAX_EXP - 4 - DBL_MANT_DIG;
 		u.bits.exp = offset;

--- a/lib/libc/gdtoa/_hldtoa.c
+++ b/lib/libc/gdtoa/_hldtoa.c
@@ -65,6 +65,7 @@ typedef uint32_t manl_t;
 
 #define	LDBL_ADJ	(LDBL_MAX_EXP - 2)
 #define	SIGFIGS		((LDBL_MANT_DIG + 3) / 4 + 1)
+#define	MAX_HEX_DIGITS	((LDBL_MANT_DIG + 3 - 1) / 4 + 1)
 
 static const float one[] = { 1.0f, -1.0f };
 
@@ -125,7 +126,7 @@ __hldtoa(long double e, const char *xdigs, int ndigits, int *decpt, int *sign,
 	s0 = rv_alloc(bufsize);
 
 	/* Round to the desired number of digits. */
-	if (SIGFIGS > ndigits && ndigits > 0) {
+	if (MAX_HEX_DIGITS > ndigits && ndigits > 0) {
 		float redux = one[u.bits.sign];
 		int offset = 4 * ndigits + LDBL_MAX_EXP - 4 - LDBL_MANT_DIG;
 #ifdef __i386__

--- a/lib/libc/tests/stdio/printfloat_test.c
+++ b/lib/libc/tests/stdio/printfloat_test.c
@@ -398,6 +398,18 @@ ATF_TC_BODY(subnormal_float, tc)
 	testfmt("-0X1P-149", "%A", negative);
 }
 
+ATF_TC_WITHOUT_HEAD(hexadecimal_rounding_fullprec);
+ATF_TC_BODY(hexadecimal_rounding_fullprec, tc)
+{
+	/* Double: %.13a with binary64 mantissa=53 */
+	testfmt("0x1.1234567890bbbp+0", "%.13a", 0x1.1234567890bbbp+0);
+
+#if defined(__aarch64__)
+	/* On arm64, long double is IEEE binary128 (mantissa=113) */
+	testfmt("0x1.3c0ca428c59fbbbbbbbbbbbbbbbbp+0", "%.28La", 0x1.3c0ca428c59fbbbbbbbbbbbbbbbbp+0L);
+#endif
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 
@@ -414,6 +426,7 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, hexadecimal_rounding);
 	ATF_TP_ADD_TC(tp, subnormal_double);
 	ATF_TP_ADD_TC(tp, subnormal_float);
+	ATF_TP_ADD_TC(tp, hexadecimal_rounding_fullprec);
 
 	return (atf_no_error());
 }


### PR DESCRIPTION
In __hdtoa() and __hldtoa(), rounding is incorrectly applied when the requested precision exactly matches the number of significant hexadecimal digits. In this case, the redux adjustment can trigger an unintended exponent increment and shift the rounding position left by one bit. This causes the least significant digit to be rounded incorrectly.

The fix adds a new condition based on MAX_HEX_DIGITS (derived from MANT_DIG) so that rounding is performed only when precision is strictly less than the number of significant digits. This avoids the unintended shift while preserving correct rounding for other cases.

A new regression test
(printfloat_test:hexadecimal_rounding_offset_eq_exp) covers both the binary64 (%.13a) and binary128 (%.28La on arm64) cases that previously fail, ensuring the bug does not regress.

### Problem
When printing with %a and a precision that exactly matches the number of available hexadecimal digits, rounding logic may incorrectly increment the last digit.

Example with binary64 (DBL_MANT_DIG=53):

```
printf("%.13a", 0x1.1234567890123p+0);
```
Expected:
```
0x1.1234567890123p+0
```
Actual (before fix):
```
0x1.1234567890124p+0
```

### Cause
- At precision 13, the mantissa is fully consumed (1 integer digit + 13 fractional digits = 53 bits).
- The rounding step (+redux) forces the implicit leading 1 to overflow, incrementing the exponent and shifting the significand left by one bit.
- The least significant mantissa bit is then misinterpreted as a guard bit, causing an unwanted carry.

### Fix
Introduce a new check based on the maximum number of representable hex digits (MAX_HEX_DIGITS, derived from MANT_DIG).
Rounding is applied only when precision is strictly less than this limit.
This prevents the spurious shift but preserves correct rounding otherwise.

### Validation
- Verified on double (binary64, precision 13).
- Verified on long double (binary128, precision 28 on arm64).
- No regression observed on x87 80-bit long double where maximum hex digits differ.
- Added regression tests in libc/tests/stdio/printfloat_test.c.

