### PR TITLE
Update vmimage.subr to create fstab with noatime reduced the OPNsense constant 50kb - 80kb disk writes that wear down the SSD / NVME

### DIFF
--- a/release/tools/vmimage.subr
+++ b/release/tools/vmimage.subr
@@ -69,7 +69,7 @@ vm_install_base() {
 	echo '# Custom /etc/fstab for FreeBSD VM images' \
 		> ${DESTDIR}/etc/fstab
 	if [ "${VMFS}" != zfs ]; then
-		echo "/dev/${ROOTLABEL}/rootfs   /       ${VMFS}   rw      1       1" \
+		echo "/dev/${ROOTLABEL}/rootfs   /       ${VMFS}   rw,noatime      1       1" \
 			>> ${DESTDIR}/etc/fstab
 	fi
 	if [ -z "${NOSWAP}" ]; then


### PR DESCRIPTION
This "noatime" tweak reduced the OPNsense (FreeBSD 14.3-RELEASE-p2) constant 50kb - 80kb disk writes that wear down the SSD / NVME.

<img width="340" height="87" alt="image" src="https://github.com/user-attachments/assets/53c4f188-d994-45cc-98e0-90426b092998" />

before
<img width="1040" height="331" alt="image" src="https://github.com/user-attachments/assets/5fbba52a-420f-4f78-ab00-56bf7f24372b" />

after
<img width="1054" height="349" alt="image" src="https://github.com/user-attachments/assets/78e0ccaa-ec91-44d8-b507-36e1608da696" />

Signed-off-by: Unicorn9x