### PR TITLE
freebsd-update.sh: improve the pkgbase statement

### DIFF
--- a/usr.sbin/freebsd-update/freebsd-update.sh
+++ b/usr.sbin/freebsd-update/freebsd-update.sh
@@ -3616,8 +3616,9 @@ get_params "$@"
 # Disallow use with packaged base.
 if check_pkgbase; then
 	cat <<EOF
-freebsd-update is incompatible with the use of packaged base.  Please see
-https://wiki.freebsd.org/PkgBase for more information.
+Systems that use pkgbase can not use this version of freebsd-update.
+Please see
+https://docs.freebsd.org/en/books/handbook/cutting-edge/#pkgbase 
 EOF
 	exit 1
 fi


### PR DESCRIPTION
The wiki page for pkgbase is outdated, and quite overwhelming. Instead, direct readers to the FreeBSD Handbook.

Use the commonplace phrase 'pkgbase', not 'packaged base'.

Describe the incompatibility in a slightly different way.