### PR TITLE
sockstat: fix the -j option with piped output after libxo integration

### DIFF
--- a/usr.bin/sockstat/main.c
+++ b/usr.bin/sockstat/main.c
@@ -1612,7 +1612,7 @@ display(void)
 		}
 	}
 	if (opt_j >= 0)
-		return;
+		goto out;
 	SLIST_FOREACH(s, &nosocks, socket_list) {
 		if (!check_ports(s))
 			continue;
@@ -1637,6 +1637,7 @@ display(void)
 		display_sock(s, &cw, buf, bufsize);
 		xo_close_instance("socket");
 	}
+out:
 	xo_close_list("socket");
 	xo_close_container("sockstat");
 	if (xo_finish() < 0)


### PR DESCRIPTION
The legacy code handling -j in display() was causing xo_finish() to be skipped.  It has also been causing a memory leak since 0726c6574f8 (sockstat: Add automatic column sizing and remove -w option)

Fixes:		7b35b4d1963 (sockstat: add libxo support)
MFC after:	1 week
Reported by:	gleb
Sponsored by:	ConnectWise