### PR TITLE
taskqueue.9: replace ithread(9) with intr_event(9)

### DIFF
--- a/share/man/man9/taskqueue.9
+++ b/share/man/man9/taskqueue.9
@@ -530,7 +530,7 @@ If queueing delays cannot be tolerated then a private taskqueue should
 be created with a dedicated processing thread.
 .Sh SEE ALSO
 .Xr callout 9 ,
-.Xr ithread 9 ,
+.Xr intr_event 9 ,
 .Xr kthread 9 ,
 .Xr swi 9
 .Sh HISTORY


### PR DESCRIPTION
Replace old SEE ALSO reference to ithread(9). [This commit](https://github.com/freebsd/freebsd-src/commit/3cdbaee3548a6caa3ab7aca5788775057b1bd1fd) probably forgot to update taskqueue.9