### PR TITLE
atf_pytest: fix xfail detection from pytest report

### DIFF
--- a/tests/atf_python/atf_pytest.py
+++ b/tests/atf_python/atf_pytest.py
@@ -256,7 +256,7 @@ class ATFHandler(object):
                 # Record failure  & override "skipped" state
                 self.set_report_state(test_name, state, reason)
             elif state == "skipped":
-                if hasattr(reason, "wasxfail"):
+                if hasattr(report, "wasxfail"):
                     # xfail() called in the test body
                     state = "expected_failure"
                 else:
@@ -264,7 +264,7 @@ class ATFHandler(object):
                     pass
                 self.set_report_state(test_name, state, reason)
             elif state == "passed":
-                if hasattr(reason, "wasxfail"):
+                if hasattr(report, "wasxfail"):
                     # the test was expected to fail but didn't
                     # mark as hard failure
                     state = "failed"


### PR DESCRIPTION
The location of the 'wasxfail' attribute was moved from the 'reason' attribute back to the parent 'report'. This fixes an issue where xfails are wrongly reported to ATF as skipped tests.