### PR TITLE
libc aarch64: fix ELF size of timingsafe_memcmp

### DIFF
--- a/lib/libc/aarch64/string/timingsafe_memcmp.S
+++ b/lib/libc/aarch64/string/timingsafe_memcmp.S
@@ -114,4 +114,4 @@ ENTRY(timingsafe_memcmp)
 	csetm	w0, lo
 	csinc	w0, w0, wzr, ls
 	ret
-END(timingsafe_bcmp)
+END(timingsafe_memcmp)


### PR DESCRIPTION
Looks like a copy and paste error. The ELF size of 0 prevents Valgrind from redirecting this function.

See also
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289845 and
https://bugs.kde.org/show_bug.cgi?id=509406