### PR TITLE
tests/mac_portacl: restore sysctls after modification

### DIFF
--- a/tests/sys/mac/portacl/Makefile
+++ b/tests/sys/mac/portacl/Makefile
@@ -8,6 +8,7 @@ TAP_TESTS_SH+=	nobody_test
 TAP_TESTS_SH+=	root_test
 
 .for t in ${TAP_TESTS_SH}
+TEST_METADATA.$t+=	required_kmods="mac_portacl"
 TEST_METADATA.$t+=	required_user="root"
 TEST_METADATA.$t+=	timeout="450"
 TEST_METADATA.$t+=	is_exclusive="true"

--- a/tests/sys/mac/portacl/misc.sh
+++ b/tests/sys/mac/portacl/misc.sh
@@ -1,15 +1,5 @@
 #!/bin/sh
 
-sysctl security.mac.portacl >/dev/null 2>&1
-if [ $? -ne 0 ]; then
-	echo "1..0 # SKIP MAC_PORTACL is unavailable."
-	exit 0
-fi
-if [ $(id -u) -ne 0 ]; then
-	echo "1..0 # SKIP testcases must be run as root"
-	exit 0
-fi
-
 ntest=1
 
 check_bind() {
@@ -95,6 +85,7 @@ bind_test() {
 	sysctl security.mac.portacl.rules= >/dev/null
 }
 
+portacl_enabled=$(sysctl -n security.mac.portacl.enabled)
 reserved_high=$(sysctl -n net.inet.ip.portrange.reservedhigh)
 suser_exempt=$(sysctl -n security.mac.portacl.suser_exempt)
 port_high=$(sysctl -n security.mac.portacl.port_high)
@@ -103,4 +94,5 @@ restore_settings() {
 	sysctl -n net.inet.ip.portrange.reservedhigh=${reserved_high} >/dev/null
 	sysctl -n security.mac.portacl.suser_exempt=${suser_exempt} >/dev/null
 	sysctl -n security.mac.portacl.port_high=${port_high} >/dev/null
+	sysctl -n security.mac.portacl.enabled=${portacl_enabled} >/dev/null
 }

--- a/tests/sys/mac/portacl/nobody_test.sh
+++ b/tests/sys/mac/portacl/nobody_test.sh
@@ -13,6 +13,7 @@ trap restore_settings EXIT INT TERM
 
 sysctl security.mac.portacl.suser_exempt=1 >/dev/null
 sysctl net.inet.ip.portrange.reservedhigh=78 >/dev/null
+sysctl security.mac.portacl.enabled=1 >/dev/null
 
 bind_test fl fl uid nobody tcp 77
 bind_test ok ok uid nobody tcp 7777

--- a/tests/sys/mac/portacl/root_test.sh
+++ b/tests/sys/mac/portacl/root_test.sh
@@ -10,6 +10,7 @@ echo "1..48"
 trap restore_settings EXIT INT TERM
 
 sysctl security.mac.portacl.suser_exempt=1 >/dev/null
+sysctl security.mac.portacl.enabled=1 >/dev/null
 
 bind_test ok ok uid root tcp 77
 bind_test ok ok uid root tcp 7777


### PR DESCRIPTION
While here, use 'required_kmods' instead of ad-hoc checks.