### PR TITLE
libcasper: explicit cast in cap_fileargs header

### DIFF
--- a/lib/libcasper/services/cap_fileargs/cap_fileargs.h
+++ b/lib/libcasper/services/cap_fileargs/cap_fileargs.h
@@ -75,7 +75,7 @@ fileargs_init(int argc __unused, char *argv[] __unused, int flags, mode_t mode,
     cap_rights_t *rightsp __unused, int operations __unused) {
 	fileargs_t *fa;
 
-	fa = malloc(sizeof(*fa));
+	fa = (fileargs_t *)malloc(sizeof(*fa));
 	if (fa != NULL) {
 		fa->fa_flags = flags;
 		fa->fa_mode = mode;


### PR DESCRIPTION
The implicit cast is incompatible with standard compiler options in a C++ project, making the library difficult to use.

The explicit cast is already the workaround in `libcasper.h`:
https://github.com/freebsd/freebsd-src/blob/7e8fb7756c3ed89a2141b923e6da1b6fd96f509c/lib/libcasper/libcasper/libcasper.h#L106-L108

Discussed with @kevans91 