### PR TITLE
libfetch, fetch: Improve handling of HTTP request body, method, fields, and status code

### DIFF
--- a/lib/libfetch/Makefile
+++ b/lib/libfetch/Makefile
@@ -48,6 +48,7 @@ httperr.h: http.errors ${.CURDIR}/Makefile
 	@echo "    { -1, FETCH_UNKNOWN, \"Unknown HTTP error\" }" >> ${.TARGET}
 	@echo "};" >> ${.TARGET}
 
+MLINKS+= fetch.3 fetchFreeResFields.3
 MLINKS+= fetch.3 fetchFreeURL.3
 MLINKS+= fetch.3 fetchGet.3
 MLINKS+= fetch.3 fetchGetFTP.3
@@ -77,5 +78,6 @@ MLINKS+= fetch.3 fetchXGetFTP.3
 MLINKS+= fetch.3 fetchXGetFile.3
 MLINKS+= fetch.3 fetchXGetHTTP.3
 MLINKS+= fetch.3 fetchXGetURL.3
+MLINKS+= fetch.3 fetchXReqHTTP.3
 
 .include <bsd.lib.mk>

--- a/lib/libfetch/common.h
+++ b/lib/libfetch/common.h
@@ -175,9 +175,6 @@ int		 fetch_no_proxy_match(const char *);
  */
 FILE		*http_request(struct url *, const char *,
 		     struct url_stat *, struct url *, const char *);
-FILE		*http_request_body(struct url *, const char *,
-		     struct url_stat *, struct url *, const char *,
-		     const char *, const char *);
 FILE		*ftp_request(struct url *, const char *,
 		     struct url_stat *, struct url *, const char *);
 

--- a/lib/libfetch/fetch.3
+++ b/lib/libfetch/fetch.3
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 27, 2026
+.Dd July 24, 2026
 .Dt FETCH 3
 .Os
 .Sh NAME
@@ -51,7 +51,9 @@
 .Nm fetchPutHTTP ,
 .Nm fetchStatHTTP ,
 .Nm fetchListHTTP ,
+.Nm fetchXReqHTTP ,
 .Nm fetchReqHTTP ,
+.Nm fetchFreeResFields ,
 .Nm fetchXGetFTP ,
 .Nm fetchGetFTP ,
 .Nm fetchPutFTP ,
@@ -63,6 +65,7 @@
 .Lb libfetch
 .Sh SYNOPSIS
 .In sys/param.h
+.In sys/queue.h
 .In stdio.h
 .In fetch.h
 .Vt extern int fetchTimeout;
@@ -113,7 +116,11 @@
 .Ft struct url_ent *
 .Fn fetchListHTTP "struct url *u" "const char *flags"
 .Ft FILE *
+.Fn fetchXReqHTTP "struct url *u" "struct url_stat *us" "const char *method" "const char *flags" "const struct http_fields *req_headers" "const struct http_fields *req_trailers" "struct http_fields *res_headers" "struct http_fields *res_trailers" "FILE *body"
+.Ft FILE *
 .Fn fetchReqHTTP "struct url *u" "const char *method" "const char *flags" "const char *content_type" "const char *body"
+.Ft void
+.Fn fetchFreeResFields "struct http_fields *fields"
 .Ft FILE *
 .Fn fetchXGetFTP "struct url *u" "struct url_stat *us" "const char *flags"
 .Ft FILE *
@@ -371,7 +378,8 @@ and password "anonymous@<hostname>".
 The
 .Fn fetchXGetHTTP ,
 .Fn fetchGetHTTP ,
-.Fn fetchPutHTTP
+.Fn fetchPutHTTP ,
+.Fn fetchXReqHTTP ,
 and
 .Fn fetchReqHTTP
 functions implement the HTTP/1.1 protocol.
@@ -403,7 +411,18 @@ will send a conditional
 HTTP header to only fetch the content if it is newer than
 .Va ims_time .
 .Pp
-The function
+If the
+.Ql C
+(chunked) flag is specified,
+.Fn fetchXReqHTTP
+and
+.Fn fetchReqHTTP
+will send the provided body content as a chunk-encoded stream even if a size can
+be predetermined.
+.Pp
+The functions
+.Fn fetchXReqHTTP
+and
 .Fn fetchReqHTTP
 can be used to make requests with an arbitrary HTTP verb,
 including POST, DELETE, CONNECT, OPTIONS, TRACE or PATCH.
@@ -415,10 +434,32 @@ and
 .Fa body
 to the content.
 .Pp
-Since there seems to be no good way of implementing the HTTP PUT
-method in a manner consistent with the rest of the
-.Nm fetch
-library,
+In addition to returning
+.Vt "struct url_stat"
+information,
+.Fn fetchXReqHTTP
+also accepts optional lists of arbitrary additional fields to send,
+optional lists to be filled with all response fields received,
+and an optional
+.Vt "FILE"
+stream to send as the body.
+The response fields lists should be freed with
+.Fn fetchFreeResFields .
+The
+.Vt http_field
+and
+.Vt http_fields
+structures are defined as follows in
+.In fetch.h :
+.Bd -literal
+struct http_field {
+    const char *name;
+    const char *value;
+    TAILQ_ENTRY(http_field) fields;
+};
+TAILQ_HEAD(http_fields, http_field);
+.Ed
+.Pp
 .Fn fetchPutHTTP
 is currently unimplemented.
 .Sh HTTPS SCHEME

--- a/lib/libfetch/fetch.h
+++ b/lib/libfetch/fetch.h
@@ -31,7 +31,7 @@
 #ifndef _FETCH_H_INCLUDED
 #define _FETCH_H_INCLUDED
 
-#define _LIBFETCH_VER "libfetch/2.0"
+#define _LIBFETCH_VER "libfetch/2.1"
 
 #define URL_SCHEMELEN 16
 #define URL_USERLEN 256
@@ -60,6 +60,15 @@ struct url_ent {
 	char		 name[PATH_MAX];
 	struct url_stat	 stat;
 };
+
+#ifdef _SYS_QUEUE_H_
+struct http_field {
+	const char	*name;
+	const char	*value;
+	TAILQ_ENTRY(http_field)	fields;
+};
+TAILQ_HEAD(http_fields, http_field);
+#endif
 
 /* Recognized schemes */
 #define SCHEME_FTP	"ftp"
@@ -105,6 +114,13 @@ int		 fetchStatHTTP(struct url *, struct url_stat *, const char *);
 struct url_ent	*fetchListHTTP(struct url *, const char *);
 FILE		*fetchReqHTTP(struct url *, const char *, const char *,
 		    const char *, const char *);
+#ifdef _SYS_QUEUE_H_
+FILE		*fetchXReqHTTP(struct url *, struct url_stat *, const char *,
+		    const char *, const struct http_fields *,
+		    const struct http_fields *, struct http_fields *,
+		    struct http_fields *, FILE *);
+void		 fetchFreeResFields(struct http_fields *);
+#endif
 
 /* FTP-specific functions */
 FILE		*fetchXGetFTP(struct url *, struct url_stat *, const char *);

--- a/lib/libfetch/http.c
+++ b/lib/libfetch/http.c
@@ -114,6 +114,8 @@
 #define HTTP_BAD_RANGE		416
 #define HTTP_PROTOCOL_ERROR	999
 
+#define HTTP_SUCCESS(xyz) ((xyz) >= 200 && (xyz) <= 299)
+
 #define HTTP_REDIRECT(xyz) ((xyz) == HTTP_MOVED_PERM \
 			    || (xyz) == HTTP_MOVED_TEMP \
 			    || (xyz) == HTTP_TEMP_REDIRECT \
@@ -1937,8 +1939,6 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 
 		/* get reply */
 		switch (http_get_reply(conn)) {
-		case HTTP_OK:
-		case HTTP_PARTIAL:
 		case HTTP_NOT_MODIFIED:
 			/* fine */
 			break;
@@ -1993,6 +1993,8 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 			goto ouch;
 		default:
 			http_seterr(conn->err);
+			if (HTTP_SUCCESS(conn->err))
+				break;
 			if (!verbose)
 				goto ouch;
 			/* fall through so we can get the full error message */
@@ -2141,9 +2143,8 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 		}
 
 		/* we have a hit or an error */
-		if (conn->err == HTTP_OK
+		if (HTTP_SUCCESS(conn->err)
 		    || conn->err == HTTP_NOT_MODIFIED
-		    || conn->err == HTTP_PARTIAL
 		    || HTTP_ERROR(conn->err))
 			break;
 

--- a/lib/libfetch/http.c
+++ b/lib/libfetch/http.c
@@ -1000,10 +1000,20 @@ http_parse_range(const char *p, off_t *offset, off_t *length, off_t *size)
 	}
 	if (first > last || *p != '/')
 		return (-1);
-	for (len = 0, ++p; *p && isdigit((unsigned char)*p); ++p)
-		len = len * 10 + *p - '0';
-	if (*p || len < last - first + 1)
-		return (-1);
+	++p;
+	if (*p == '*') {
+		if (first == -1)
+			return (-1);
+		++p;
+		if (*p)
+			return (-1);
+		len = -1;
+	} else {
+		for (len = 0; *p && isdigit((unsigned char)*p); ++p)
+			len = len * 10 + *p - '0';
+		if (*p || len < last - first + 1)
+			return (-1);
+	}
 	if (first == -1) {
 		DEBUGF("content range: [*/%lld]\n", (long long)len);
 		*length = 0;
@@ -1833,8 +1843,17 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 			http_cmd(conn, "User-Agent: %s " _LIBFETCH_VER,
 			    getprogname());
 		}
-		if (url->offset > 0)
-			http_cmd(conn, "Range: bytes=%lld-", (long long)url->offset);
+		if (url->offset < 0) {
+			http_cmd(conn, "Range: bytes=%lld",
+			    (long long)url->offset);
+		} else if (url->length > 0) {
+			http_cmd(conn, "Range: bytes=%lld-%lld",
+			    (long long)url->offset,
+			    (long long)(url->offset + url->length - 1));
+		} else if (url->offset > 0) {
+			http_cmd(conn, "Range: bytes=%lld-",
+			    (long long)url->offset);
+		}
 		http_cmd(conn, "Connection: close");
 		if (req_headers != NULL) {
 			struct http_field *hdr;
@@ -2182,16 +2201,12 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 		http_seterr(HTTP_PROTOCOL_ERROR);
 		goto ouch;
 	}
+	/* fall back to Content-Range if no Content-Length */
 	if (clength == -1)
 		clength = length;
-	if (clength != -1)
-		length = offset + clength;
-	if (length != -1 && size != -1 && length != size) {
-		http_seterr(HTTP_PROTOCOL_ERROR);
-		goto ouch;
-	}
-	if (size == -1)
-		size = length;
+	/* set the size of the resource if known */
+	if (size == -1 && length == -1)
+		size = clength;
 
 	/* fill in stats */
 	if (us) {
@@ -2200,7 +2215,8 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 	}
 
 	/* too far? */
-	if (URL->offset > 0 && offset > URL->offset) {
+	if ((URL->offset > 0 && offset > URL->offset) ||
+	    (length != -1 && URL->offset < 0 && length > -URL->offset)) {
 		http_seterr(HTTP_PROTOCOL_ERROR);
 		goto ouch;
 	}

--- a/lib/libfetch/http.c
+++ b/lib/libfetch/http.c
@@ -62,7 +62,9 @@
  */
 
 #include <sys/param.h>
+#include <sys/queue.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 
 #include <ctype.h>
@@ -136,10 +138,13 @@ struct httpio {
 	int		 eof;		/* end-of-file flag */
 	int		 error;		/* error flag */
 	size_t		 chunksize;	/* remaining size of current chunk */
+	struct http_fields *trailers;	/* optional trailer fields to fill */
 #ifndef NDEBUG
 	size_t		 total;
 #endif
 };
+
+static int http_filltrailers(struct httpio *);
 
 /*
  * Get next chunk header
@@ -233,8 +238,9 @@ http_fillbuf(struct httpio *io, size_t len)
 			io->error = EPROTO;
 			return (-1);
 		case 0:
-			io->eof = 1;
-			return (0);
+			/* got last-chunk */
+			io->chunked = 0;
+			return (http_filltrailers(io));
 		}
 	}
 
@@ -324,7 +330,7 @@ http_closefn(void *v)
  * Wrap a file descriptor up
  */
 static FILE *
-http_funopen(conn_t *conn, int chunked)
+http_funopen(conn_t *conn, int chunked, struct http_fields *trailers)
 {
 	struct httpio *io;
 	FILE *f;
@@ -335,6 +341,7 @@ http_funopen(conn_t *conn, int chunked)
 	}
 	io->conn = conn;
 	io->chunked = chunked;
+	io->trailers = trailers;
 	f = funopen(io, http_readfn, http_writefn, NULL, http_closefn);
 	if (f == NULL) {
 		fetch_syserr();
@@ -567,6 +574,79 @@ http_next_header(conn_t *conn, http_headerbuf_t *hbuf, const char **p)
 
 	return (hdr_unknown);
 }
+
+/*
+ * Fill the trailers list with any trailing fields, if present.
+ */
+static int
+http_filltrailers(struct httpio *io)
+{
+	conn_t *conn = io->conn;
+	const char *p;
+	http_headerbuf_t headerbuf;
+	hdr_t h;
+
+	if (io->trailers == NULL) {
+		/* Cut off any trailers, we don't want them. */
+		io->eof = 1;
+		return (0);
+	}
+
+	/* get trailers. http_next_header expects one line readahead */
+	if (fetch_getln(conn) == -1) {
+		fetch_syserr();
+		return (-1);
+	}
+
+	/* http_next_header is overkill, but convenient */
+	init_http_headerbuf(&headerbuf);
+	do {
+		switch ((h = http_next_header(conn, &headerbuf, &p))) {
+		case hdr_syserror:
+			fetch_syserr();
+			goto ouch;
+		case hdr_error:
+			http_seterr(HTTP_PROTOCOL_ERROR);
+			goto ouch;
+		default:
+			/* ignore */
+			break;
+		}
+		if (h > hdr_end) {
+			struct http_field *trl;
+			char *sep;
+
+			if ((trl = malloc(sizeof(*trl))) == NULL ||
+			    (trl->name = strdup(headerbuf.buf))
+			    == NULL) {
+				fetch_syserr();
+				free(trl);
+				goto ouch;
+			}
+			sep = strchr(trl->name, ':');
+			if (sep == NULL) {
+				DEBUGF("missing delimiter in trailer\n");
+				http_seterr(HTTP_PROTOCOL_ERROR);
+				free(__DECONST(char *, trl->name));
+				free(trl);
+				goto ouch;
+			}
+			*sep = '\0';
+			trl->value = sep + 1;
+			trl->value += strspn(trl->value, " \t");
+			TAILQ_INSERT_TAIL(io->trailers, trl, fields);
+		}
+	} while (h > hdr_end);
+	clean_http_headerbuf(&headerbuf);
+	io->eof = 1;
+	return (0);
+ouch:
+	fetchFreeResFields(io->trailers);
+	clean_http_headerbuf(&headerbuf);
+	io->eof = 1;
+	return (-1);
+}
+
 
 /**************************
  * [Proxy-]Authenticate header parsing
@@ -1538,18 +1618,23 @@ http_print_html(FILE *out, FILE *in)
 	free(line);
 }
 
+static bool
+has_field(const struct http_fields *fields, const char *name)
+{
+	struct http_field *field;
+
+	if (fields == NULL)
+		return (false);
+	TAILQ_FOREACH(field, fields, fields)
+		if (strcasecmp(field->name, name) == 0)
+			return (true);
+	return (false);
+}
+
 
 /*****************************************************************************
  * Core
  */
-
-FILE *
-http_request(struct url *URL, const char *op, struct url_stat *us,
-	struct url *purl, const char *flags)
-{
-
-	return (http_request_body(URL, op, us, purl, flags, NULL, NULL));
-}
 
 /*
  * Send a request and process the reply
@@ -1557,10 +1642,13 @@ http_request(struct url *URL, const char *op, struct url_stat *us,
  * XXX This function is way too long, the do..while loop should be split
  * XXX off into a separate function.
  */
-FILE *
+static FILE *
 http_request_body(struct url *URL, const char *op, struct url_stat *us,
-	struct url *purl, const char *flags, const char *content_type,
-	const char *body)
+	struct url *purl, const char *flags,
+	const struct http_fields *req_headers,
+	const struct http_fields *req_trailers,
+	struct http_fields *res_headers, struct http_fields *res_trailers,
+	FILE *body)
 {
 	char timebuf[80];
 	char hbuf[MAXHOSTNAMELEN + 7], *host;
@@ -1577,7 +1665,7 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 	http_headerbuf_t headerbuf;
 	http_auth_challenges_t server_challenges;
 	http_auth_challenges_t proxy_challenges;
-	size_t body_len;
+	bool chunked_body;
 
 	/* The following calls don't allocate anything */
 	init_http_headerbuf(&headerbuf);
@@ -1588,6 +1676,7 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 	noredirect = CHECK_FLAG('A');
 	verbose = CHECK_FLAG('v');
 	ims = CHECK_FLAG('i');
+	chunked_body = CHECK_FLAG('C');
 
 	if (direct && purl) {
 		fetchFreeURL(purl);
@@ -1723,7 +1812,7 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 		if ((p = getenv("HTTP_ACCEPT")) != NULL) {
 			if (*p != '\0')
 				http_cmd(conn, "Accept: %s", p);
-		} else {
+		} else if (!has_field(req_headers, "Accept")) {
 			http_cmd(conn, "Accept: */*");
 		}
 		if ((p = getenv("HTTP_REFERER")) != NULL && *p != '\0') {
@@ -1737,7 +1826,7 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 			/* no User-Agent if defined but empty */
 			if  (*p != '\0')
 				http_cmd(conn, "User-Agent: %s", p);
-		} else {
+		} else if (!has_field(req_headers, "User-Agent")) {
 			/* default User-Agent */
 			http_cmd(conn, "User-Agent: %s " _LIBFETCH_VER,
 			    getprogname());
@@ -1745,18 +1834,92 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 		if (url->offset > 0)
 			http_cmd(conn, "Range: bytes=%lld-", (long long)url->offset);
 		http_cmd(conn, "Connection: close");
+		if (req_headers != NULL) {
+			struct http_field *hdr;
 
-		if (body) {
-			body_len = strlen(body);
-			http_cmd(conn, "Content-Length: %zu", body_len);
-			if (content_type != NULL)
-				http_cmd(conn, "Content-Type: %s", content_type);
+			TAILQ_FOREACH(hdr, req_headers, fields)
+				http_cmd(conn, "%s: %s", hdr->name, hdr->value);
+		}
+
+		if (body != NULL) {
+			off_t body_len;
+
+			/* Add a Content-Length header if possible. */
+			if (!chunked_body) {
+				struct stat st;
+				int fd;
+
+				if ((fd = fileno(body)) != -1) {
+					if (fstat(fd, &st) == 0 &&
+					    S_ISREG(st.st_mode))
+						body_len = st.st_size;
+					else
+						chunked_body = true;
+				} else if (fseek(body, 0, SEEK_END) == 0) {
+					/*
+					 * Try fseek+ftell for fmemopen streams.
+					 * We assume we are not in the middle.
+					 */
+					if ((body_len = ftello(body)) < 0)
+						chunked_body = true;
+					fseek(body, 0, SEEK_SET);
+				} else
+					chunked_body = true;
+			}
+			if (chunked_body)
+				http_cmd(conn, "Transfer-Encoding: chunked");
+			else
+				http_cmd(conn, "Content-Length: %lld",
+				    (long long)body_len);
 		}
 
 		http_cmd(conn, "");
 
-		if (body)
-			fetch_write(conn, body, body_len);
+		if (body != NULL) {
+#define CHUNK_SIZE 4096
+			char buf[CHUNK_SIZE];
+			char chunk_size[sizeof("1000\r\n")]; /* 4096 in hex */
+			struct iovec chunk[3];
+			size_t len;
+			int hdrlen, iovcnt;
+
+			while ((len = fread(buf, 1, CHUNK_SIZE, body)) > 0) {
+				if (chunked_body) {
+					hdrlen = snprintf(chunk_size,
+					    sizeof(chunk_size), "%zx\r\n", len);
+					chunk[0].iov_base = chunk_size;
+					chunk[0].iov_len = hdrlen;
+					chunk[1].iov_base = buf;
+					chunk[1].iov_len = len;
+					chunk[2].iov_base =
+					    __DECONST(char *, "\r\n");
+					chunk[2].iov_len = 2;
+					iovcnt = 3;
+					len += hdrlen + 2;
+				} else {
+					chunk[0].iov_base = buf;
+					chunk[0].iov_len = len;
+					iovcnt = 1;
+				}
+				if (fetch_writev(conn, chunk, iovcnt)
+				    != (ssize_t)len)
+					goto ouch;
+			}
+			if (chunked_body) {
+				/* last-chunk */
+				http_cmd(conn, "0");
+				/* trailer-section */
+				if (req_trailers != NULL) {
+					struct http_field *trl;
+
+					TAILQ_FOREACH(trl, req_trailers, fields)
+						http_cmd(conn, "%s: %s",
+						    trl->name, trl->value);
+				}
+				/* CRLF */
+				http_cmd(conn, "");
+			}
+		}
 
 		/*
 		 * Force the queued request to be dispatched.  Normally, one
@@ -1920,6 +2083,30 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 				/* ignore */
 				break;
 			}
+			if (res_headers != NULL && h > hdr_end) {
+				struct http_field *hdr;
+				char *sep;
+
+				if ((hdr = malloc(sizeof(*hdr))) == NULL ||
+				    (hdr->name = strdup(headerbuf.buf))
+				    == NULL) {
+					fetch_syserr();
+					free(hdr);
+					goto ouch;
+				}
+				sep = strchr(hdr->name, ':');
+				if (sep == NULL) {
+					DEBUGF("missing delimiter in header\n");
+					http_seterr(HTTP_PROTOCOL_ERROR);
+					free(__DECONST(char *, hdr->name));
+					free(hdr);
+					goto ouch;
+				}
+				*sep = '\0';
+				hdr->value = sep + 1;
+				hdr->value += strspn(hdr->value, " \t");
+				TAILQ_INSERT_TAIL(res_headers, hdr, fields);
+			}
 		} while (h > hdr_end);
 
 		/* we need to provide authentication */
@@ -2022,7 +2209,7 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 	URL->length = clength;
 
 	/* wrap it up in a FILE */
-	if ((f = http_funopen(conn, chunked)) == NULL) {
+	if ((f = http_funopen(conn, chunked, res_trailers)) == NULL) {
 		fetch_syserr();
 		goto ouch;
 	}
@@ -2053,6 +2240,14 @@ ouch:
 	clean_http_auth_challenges(&server_challenges);
 	clean_http_auth_challenges(&proxy_challenges);
 	return (NULL);
+}
+
+FILE *
+http_request(struct url *URL, const char *op, struct url_stat *us,
+	struct url *purl, const char *flags)
+{
+	return (http_request_body(URL, op, us, purl, flags, NULL, NULL, NULL,
+	    NULL, NULL));
 }
 
 
@@ -2114,13 +2309,63 @@ fetchListHTTP(struct url *url __unused, const char *flags __unused)
 }
 
 /*
+ * Arbitrary HTTP verb stat and content requests with additional fields
+ */
+FILE *
+fetchXReqHTTP(struct url *URL, struct url_stat *us, const char *method,
+	const char *flags, const struct http_fields *req_headers,
+	const struct http_fields *req_trailers, struct http_fields *res_headers,
+	struct http_fields *res_trailers, FILE *body)
+{
+	return (http_request_body(URL, method, us, http_get_proxy(URL, flags),
+	    flags, req_headers, req_trailers, res_headers, res_trailers, body));
+}
+
+/*
  * Arbitrary HTTP verb and content requests
  */
 FILE *
 fetchReqHTTP(struct url *URL, const char *method, const char *flags,
 	const char *content_type, const char *body)
 {
+	struct http_fields headers;
+	struct http_field hdr;
+	FILE *b, *f;
 
-	return (http_request_body(URL, method, NULL, http_get_proxy(URL, flags),
-	    flags, content_type, body));
+	TAILQ_INIT(&headers);
+	if (content_type != NULL) {
+		hdr.name = "Content-Type";
+		hdr.value = content_type;
+		TAILQ_INSERT_TAIL(&headers, &hdr, fields);
+	}
+	if (body == NULL)
+		b = NULL;
+	else if ((b = fmemopen(__DECONST(char *, body), strlen(body), "r"))
+	    == NULL) {
+		fetch_syserr();
+		return (NULL);
+	}
+	f = fetchXReqHTTP(URL, NULL, method, flags, &headers, NULL, NULL, NULL,
+	    b);
+	if (b != NULL)
+		fclose(b);
+	return (f);
+}
+
+/*
+ * Free response fields
+ */
+void
+fetchFreeResFields(struct http_fields *fields)
+{
+	struct http_field *f1, *f2;
+
+	f1 = TAILQ_FIRST(fields);
+	while (f1 != NULL) {
+		f2 = TAILQ_NEXT(f1, fields);
+		free(__DECONST(char *, f1->name));
+		free(f1);
+		f1 = f2;
+	}
+	TAILQ_INIT(fields);
 }

--- a/usr.bin/fetch/fetch.1
+++ b/usr.bin/fetch/fetch.1
@@ -28,7 +28,7 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd June 27, 2026
+.Dd July 24, 2026
 .Dt FETCH 1
 .Os
 .Sh NAME
@@ -43,6 +43,7 @@
 .Op Fl -ca-path= Ns Ar dir
 .Op Fl -cert= Ns Ar file
 .Op Fl -crl= Ns Ar file
+.Op Fl H Ar header
 .Op Fl i Ar file
 .Op Fl -key= Ns Ar file
 .Op Fl N Ar file
@@ -58,6 +59,7 @@
 .Op Fl T Ar seconds
 .Op Fl -user-agent= Ns Ar agent-string
 .Op Fl w Ar seconds
+.Op Fl X Ar method
 .Ar URL ...
 .Nm
 .Op Fl 146AadFlMmnPpqRrsUv
@@ -67,6 +69,7 @@
 .Op Fl -ca-path= Ns Ar dir
 .Op Fl -cert= Ns Ar file
 .Op Fl -crl= Ns Ar file
+.Op Fl H Ar header
 .Op Fl i Ar file
 .Op Fl -key= Ns Ar file
 .Op Fl N Ar file
@@ -82,6 +85,7 @@
 .Op Fl T Ar seconds
 .Op Fl -user-agent= Ns Ar agent-string
 .Op Fl w Ar seconds
+.Op Fl X Ar method
 .Fl h Ar host Fl f Ar file Oo Fl c Ar dir Oc
 .Sh DESCRIPTION
 The
@@ -164,6 +168,11 @@ The file to retrieve is named
 on the remote host.
 This option is deprecated and is provided for backward compatibility
 only.
+.It Fl H Ar header , Fl -header= Ns Ar header
+Send
+.Ar header
+as an additional header line with the HTTP request.
+This option may be specified multiple times.
 .It Fl h Ar host
 The file to retrieve is located on the host
 .Ar host .
@@ -306,6 +315,10 @@ Increase verbosity level.
 When the
 .Fl a
 flag is specified, wait this many seconds between successive retries.
+.It Fl X Ar method , Fl -request= Ns Ar method
+Use the given
+.Ar method
+for HTTP requests.
 .El
 .Pp
 If

--- a/usr.bin/fetch/fetch.1
+++ b/usr.bin/fetch/fetch.1
@@ -36,13 +36,14 @@
 .Nd retrieve a file by Uniform Resource Locator
 .Sh SYNOPSIS
 .Nm
-.Op Fl 146AadFlMmnPpqRrsUv
+.Op Fl 146AaCdFlMmnPpqRrsUv
 .Op Fl B Ar bytes
 .Op Fl -bind-address= Ns Ar host
 .Op Fl -ca-cert= Ns Ar file
 .Op Fl -ca-path= Ns Ar dir
 .Op Fl -cert= Ns Ar file
 .Op Fl -crl= Ns Ar file
+.Op Fl D Ar file
 .Op Fl H Ar header
 .Op Fl i Ar file
 .Op Fl -key= Ns Ar file
@@ -62,13 +63,14 @@
 .Op Fl X Ar method
 .Ar URL ...
 .Nm
-.Op Fl 146AadFlMmnPpqRrsUv
+.Op Fl 146AaCdFlMmnPpqRrsUv
 .Op Fl B Ar bytes
 .Op Fl -bind-address= Ns Ar host
 .Op Fl -ca-cert= Ns Ar file
 .Op Fl -ca-path= Ns Ar dir
 .Op Fl -cert= Ns Ar file
 .Op Fl -crl= Ns Ar file
+.Op Fl D Ar file
 .Op Fl H Ar header
 .Op Fl i Ar file
 .Op Fl -key= Ns Ar file
@@ -126,6 +128,10 @@ flag).
 .It Fl -bind-address= Ns Ar host
 Specifies a hostname or IP address to which sockets used for outgoing
 connections will be bound.
+.It Fl C , -chunked
+Force chunked transfer of HTTP request body contents.
+By default, the transfer is automatically chunk-encoded when the body size
+cannot be predetermined.
 .It Fl c Ar dir
 The file to retrieve is in directory
 .Ar dir
@@ -153,6 +159,16 @@ Points to certificate revocation list
 .Ar file ,
 which has to be in PEM format and may contain peer certificates that have
 been revoked.
+.It Fl D Ar file , Fl -data= Ns Ar file
+Send the contents of
+.Ar file
+as the body of HTTP requests.
+If
+.Ar file
+is a single dash
+.Pq Sq Fl ,
+.Nm
+reads the body from the standard input.
 .It Fl d , -direct
 Use a direct connection even if a proxy is configured.
 .It Fl F , -force-restart

--- a/usr.bin/fetch/fetch.c
+++ b/usr.bin/fetch/fetch.c
@@ -30,6 +30,7 @@
  */
 
 #include <sys/param.h>
+#include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -39,6 +40,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <signal.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -85,7 +87,10 @@ static int	 v_tty;		/*        stdout is a tty */
 static int	 v_progress;	/*        whether to display progress */
 static pid_t	 pgrp;		/*        our process group */
 static long	 w_secs;	/*    -w: retry delay */
+static char	*method;	/*    -X: HTTP method */
 static int	 family = PF_UNSPEC;	/* -[46]: address family to use */
+static struct http_fields headers = TAILQ_HEAD_INITIALIZER(headers);
+				/*    -H: HTTP headers */
 
 static int	 siginfo;	/* SIGINFO received */
 static int	 sigint;	/* SIGINT received */
@@ -126,6 +131,7 @@ static struct option longopts[] =
 	{ "direct", no_argument, NULL, 'd' },
 	{ "force-restart", no_argument, NULL, 'F' },
 	/* -f not mapped, since it's deprecated */
+	{ "header", required_argument, NULL, 'H' },
 	/* -h not mapped, since it's deprecated */
 	{ "if-modified-since", required_argument, NULL, 'i' },
 	{ "symlink", no_argument, NULL, 'l' },
@@ -145,6 +151,7 @@ static struct option longopts[] =
 	{ "passive-portrange-default", no_argument, NULL, 'T' },
 	{ "verbose", no_argument, NULL, 'v' },
 	{ "retry-delay", required_argument, NULL, 'w' },
+	{ "request", required_argument, NULL, 'X' },
 
 	/* options without a single character equivalent */
 	{ "bind-address", required_argument, NULL, OPTION_BIND_ADDRESS },
@@ -415,10 +422,22 @@ query_auth(struct url *URL)
 }
 
 /*
+ * Decide how to invoke libfetch
+ */
+static FILE *
+invoke(struct url *url, struct url_stat *us, const char *flags, bool is_http)
+{
+	if (is_http)
+		return (fetchXReqHTTP(url, us, method ? method : "GET", flags,
+		    &headers, NULL, NULL, NULL, NULL));
+	return (fetchXGet(url, us, flags));
+}
+
+/*
  * Fetch a file
  */
 static int
-fetch(char *URL, const char *path, int *is_http)
+fetch(char *URL, const char *path, bool *is_http)
 {
 	struct url *url;
 	struct url_stat us;
@@ -565,7 +584,7 @@ again:
 	size_prev = sb.st_size;
 
 	/* start the transfer */
-	f = fetchXGet(url, &us, flags);
+	f = invoke(url, &us, flags, *is_http);
 	if (f == NULL) {
 		if (i_flag && *is_http && fetchLastErrCode == FETCH_OK &&
 		    strcmp(fetchLastErrString, "Not Modified") == 0) {
@@ -693,7 +712,7 @@ again:
 			 * from scratch if we want the whole file
 			 */
 			url->offset = 0;
-			if ((f = fetchXGet(url, &us, flags)) == NULL) {
+			if ((f = invoke(url, &us, flags, *is_http)) == NULL) {
 				warnx("%s: %s", URL, fetchLastErrString);
 				goto failure;
 			}
@@ -870,21 +889,39 @@ again:
 }
 
 static void
+add_header(char *arg)
+{
+	struct http_field *hdr;
+	char *split;
+
+	if ((split = strchr(arg, ':')) == NULL)
+		errx(1, "invalid header (%s)", arg);
+	*split = '\0';
+	if ((hdr = malloc(sizeof(*hdr))) == NULL)
+		errx(1, "%s", strerror(ENOMEM));
+	hdr->name = arg;
+	hdr->value = split + 1;
+	hdr->value += strspn(hdr->value, " \t"); /* skip leading whitespace */
+	TAILQ_INSERT_TAIL(&headers, hdr, fields);
+}
+
+static void
 usage(void)
 {
-	fprintf(stderr, "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
+	fprintf(stderr, "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
 "usage: fetch [-146AadFlMmnPpqRrsUv] [-B bytes] [--bind-address=host]",
 "       [--ca-cert=file] [--ca-path=dir] [--cert=file] [--crl=file]",
-"       [-i file] [--key=file] [-N file] [--no-passive] [--no-proxy=list]",
-"       [--no-sslv3] [--no-tlsv1] [--no-verify-hostname] [--no-verify-peer]",
-"       [-o file] [--referer=URL] [-S bytes] [-T seconds]",
-"       [--user-agent=agent-string] [-w seconds] URL ...",
+"       [-H header] [-i file] [--key=file] [-N file] [--no-passive]",
+"       [--no-proxy=list] [--no-sslv3] [--no-tlsv1] [--no-verify-hostname]",
+"       [--no-verify-peer] [-o file] [--referer=URL] [-S bytes] [-T seconds]",
+"       [--user-agent=agent-string] [-w seconds] [-X method] URL ...",
 "       fetch [-146AadFlMmnPpqRrsUv] [-B bytes] [--bind-address=host]",
 "       [--ca-cert=file] [--ca-path=dir] [--cert=file] [--crl=file]",
-"       [-i file] [--key=file] [-N file] [--no-passive] [--no-proxy=list]",
-"       [--no-sslv3] [--no-tlsv1] [--no-verify-hostname] [--no-verify-peer]",
-"       [-o file] [--referer=URL] [-S bytes] [-T seconds]",
-"       [--user-agent=agent-string] [-w seconds] -h host -f file [-c dir]");
+"       [-H header] [-i file] [--key=file] [-N file] [--no-passive]",
+"       [--no-proxy=list] [--no-sslv3] [--no-tlsv1] [--no-verify-hostname]",
+"       [--no-verify-peer] [-o file] [--referer=URL] [-S bytes] [-T seconds]",
+"       [--user-agent=agent-string] [-w seconds] [-X method] -h host -f file",
+"       [-c dir]");
 }
 
 
@@ -898,11 +935,12 @@ main(int argc, char *argv[])
 	struct sigaction sa;
 	const char *p, *s;
 	char *end, *q;
-	int c, e, is_http, r;
+	int c, e, r;
+	bool is_http;
 
 
 	while ((c = getopt_long(argc, argv,
-	    "146AaB:bc:dFf:Hh:i:lMmN:nPpo:qRrS:sT:tUvw:",
+	    "146AaB:bc:dFf:H:h:i:lMmN:nPpo:qRrS:sT:tUvw:X:",
 	    longopts, NULL)) != -1)
 		switch (c) {
 		case '1':
@@ -942,8 +980,7 @@ main(int argc, char *argv[])
 			f_filename = optarg;
 			break;
 		case 'H':
-			warnx("the -H option is now implicit, "
-			    "use -U to disable");
+			add_header(optarg);
 			break;
 		case 'h':
 			h_hostname = optarg;
@@ -1016,6 +1053,9 @@ main(int argc, char *argv[])
 			w_secs = strtol(optarg, &end, 10);
 			if (*optarg == '\0' || *end != '\0')
 				errx(1, "invalid delay (%s)", optarg);
+			break;
+		case 'X':
+			method = optarg;
 			break;
 		case OPTION_BIND_ADDRESS:
 			setenv("FETCH_BIND_ADDRESS", optarg, 1);

--- a/usr.bin/fetch/fetch.c
+++ b/usr.bin/fetch/fetch.c
@@ -57,8 +57,9 @@
 static int	 A_flag;	/*    -A: do not follow 302 redirects */
 static int	 a_flag;	/*    -a: auto retry */
 static off_t	 B_size;	/*    -B: buffer size */
-static int	 b_flag;	/*!   -b: workaround TCP bug */
-static char    *c_dirname;	/*    -c: remote directory */
+static int	 C_flag;	/*    -C: force HTTP request chunk-encoding */
+static char	*c_dirname;	/*    -c: remote directory */
+static char	*D_filename;	/*    -D: HTTP request body content file */
 static int	 d_flag;	/*    -d: direct connection */
 static int	 F_flag;	/*    -F: restart without checking mtime  */
 static char	*f_filename;	/*    -f: file to fetch */
@@ -127,7 +128,9 @@ static struct option longopts[] =
 	{ "no-redirect", no_argument, NULL, 'A' },
 	{ "retry", no_argument, NULL, 'a' },
 	{ "buffer-size", required_argument, NULL, 'B' },
+	{ "chunked", no_argument, NULL, 'C' },
 	/* -c not mapped, since it's deprecated */
+	{ "data", required_argument, NULL, 'D' },
 	{ "direct", no_argument, NULL, 'd' },
 	{ "force-restart", no_argument, NULL, 'F' },
 	/* -f not mapped, since it's deprecated */
@@ -427,9 +430,36 @@ query_auth(struct url *URL)
 static FILE *
 invoke(struct url *url, struct url_stat *us, const char *flags, bool is_http)
 {
-	if (is_http)
-		return (fetchXReqHTTP(url, us, method ? method : "GET", flags,
-		    &headers, NULL, NULL, NULL, NULL));
+	static bool rewind_stdin = false;
+	FILE *body, *f;
+
+	if (is_http) {
+		if (D_filename == NULL)
+			body = NULL;
+		else if (strcmp(D_filename, "-") == 0) {
+			if (rewind_stdin) {
+				if (fseek(stdin, 0, SEEK_SET) == 0)
+					clearerr(stdin);
+				else {
+					snprintf(fetchLastErrString,
+					    MAXERRSTRING, "cannot rewind: "
+					    "stdin is not seekable");
+					return (NULL);
+				}
+			}
+			rewind_stdin = true;
+			body = stdin;
+		} else if ((body = fopen(D_filename, "r")) == NULL) {
+			snprintf(fetchLastErrString, MAXERRSTRING, "%s: %s",
+			    D_filename, strerror(errno));
+			return (NULL);
+		}
+		f = fetchXReqHTTP(url, us, method ? method : "GET", flags,
+		    &headers, NULL, NULL, NULL, body);
+		if (body != NULL && body != stdin)
+			fclose(body);
+		return (f);
+	}
 	return (fetchXGet(url, us, flags));
 }
 
@@ -519,6 +549,8 @@ fetch(char *URL, const char *path, bool *is_http)
 			strcat(flags, "d");
 		if (A_flag)
 			strcat(flags, "A");
+		if (C_flag)
+			strcat(flags, "C");
 		timeout = T_secs ? T_secs : http_timeout;
 		if (i_flag) {
 			if (stat(i_filename, &sb)) {
@@ -909,15 +941,15 @@ static void
 usage(void)
 {
 	fprintf(stderr, "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
-"usage: fetch [-146AadFlMmnPpqRrsUv] [-B bytes] [--bind-address=host]",
+"usage: fetch [-146AaCdFlMmnPpqRrsUv] [-B bytes] [--bind-address=host]",
 "       [--ca-cert=file] [--ca-path=dir] [--cert=file] [--crl=file]",
-"       [-H header] [-i file] [--key=file] [-N file] [--no-passive]",
+"       [-D file] [-H header] [-i file] [--key=file] [-N file] [--no-passive]",
 "       [--no-proxy=list] [--no-sslv3] [--no-tlsv1] [--no-verify-hostname]",
 "       [--no-verify-peer] [-o file] [--referer=URL] [-S bytes] [-T seconds]",
 "       [--user-agent=agent-string] [-w seconds] [-X method] URL ...",
-"       fetch [-146AadFlMmnPpqRrsUv] [-B bytes] [--bind-address=host]",
+"       fetch [-146AaCdFlMmnPpqRrsUv] [-B bytes] [--bind-address=host]",
 "       [--ca-cert=file] [--ca-path=dir] [--cert=file] [--crl=file]",
-"       [-H header] [-i file] [--key=file] [-N file] [--no-passive]",
+"       [-D file] [-H header] [-i file] [--key=file] [-N file] [--no-passive]",
 "       [--no-proxy=list] [--no-sslv3] [--no-tlsv1] [--no-verify-hostname]",
 "       [--no-verify-peer] [-o file] [--referer=URL] [-S bytes] [-T seconds]",
 "       [--user-agent=agent-string] [-w seconds] [-X method] -h host -f file",
@@ -940,7 +972,7 @@ main(int argc, char *argv[])
 
 
 	while ((c = getopt_long(argc, argv,
-	    "146AaB:bc:dFf:H:h:i:lMmN:nPpo:qRrS:sT:tUvw:X:",
+	    "146AaB:bCc:D:dFf:H:h:i:lMmN:nPpo:qRrS:sT:tUvw:X:",
 	    longopts, NULL)) != -1)
 		switch (c) {
 		case '1':
@@ -965,10 +997,15 @@ main(int argc, char *argv[])
 			break;
 		case 'b':
 			warnx("warning: the -b option is deprecated");
-			b_flag = 1;
+			break;
+		case 'C':
+			C_flag = 1;
 			break;
 		case 'c':
 			c_dirname = optarg;
+			break;
+		case 'D':
+			D_filename = optarg;
 			break;
 		case 'd':
 			d_flag = 1;


### PR DESCRIPTION
Modern APIs often rely on HTTP fields as part of their interface, both
in requests and responses.

[lib/libfetch: Add fetchXReqHTTP(3)](https://github.com/freebsd/freebsd-src/commit/b54ab720456455decacc91ee52e349051797c25d) 

Add a function to libfetch allowing additional request fields to be
specified for an HTTP request and response fields to be returned to the
caller.

This function accepts an optional stream for the body content, as a
nul-terminated C string may be inadequate for some content.  If the
length of the stream can be determined, a Content-Length header is
added.  Otherwise, the body is sent chunk-encoded.

[usr.bin/fetch: Handle custom headers and method for HTTP](https://github.com/freebsd/freebsd-src/commit/af6163d844fce56230d09e91658cf7b72d8aa425) 

Add functionality to fetch allowing HTTP method and headers to be
specified.  The option names align with those used by curl.

[usr.bin/fetch: Add options for HTTP upload data](https://github.com/freebsd/freebsd-src/commit/9ac571a1e4eb4ce03c03d8131e4888c78c86635a) 

Add a -D/--data option to specify a file from which to read HTTP request
body contents, with the special case that "-" will read from stdin.

This option deviates from curl, taking a much more barebones approach
for simplicity.

Add a -C/--chunked option to specify that the HTTP request body contents
are to use chunked transfer-encoding.  Otherwise, it is automatically
used by libfetch when the size of the file cannot be predetermined.

[lib/libfetch: Accept all HTTP 2xx (Successful) status codes](https://github.com/freebsd/freebsd-src/commit/747ae417c56408fe33923ac42073b938e0373977) 

Some HTTP 2xx (Successful) class status codes were being treated as
errors.  Add a definition for the full range of successful status codes
and use it to test for a success response.

This allows libfetch and fetch to receive the response body from more
practical requests, such as POST responding 201 Created with content.

### Demonstration

Here is an example of the new functionality being used to access the GitHub REST API.  The API requires a valid bearer token in the Authorization header, along with a couple other recommended headers described in the documentation.

```sh
$ fetch -q \
    -X GET \
    -H "Accept: application/vnd.github+json" \
    -H "Authorization: Bearer $GITHUB_TOKEN" \
    -H "X-GitHub-Api-Version: 2022-11-28" \
    -o - \
    https://api.github.com/repos/ryan-moeller/kernel-nbd-client/branches
[{"name":"main","commit":{"sha":"d69b0a1c8d2b63ab48726027e6e756ccf9a0f2fb","url":"https://api.github.com/repos/ryan-moeller/kernel-nbd-client/commits/d69b0a1c8d2b63ab48726027e6e756ccf9a0f2fb"},"protected":false},{"name":"structured","commit":{"sha":"4831ee5ece393e596262d76609a0be69d3d408bf","url":"https://api.github.com/repos/ryan-moeller/kernel-nbd-client/commits/4831ee5ece393e596262d76609a0be69d3d408bf"},"protected":false},{"name":"unix/stream","commit":{"sha":"7f020b22ec0e9414a212fe34b01701b23443d825","url":"https://api.github.com/repos/ryan-moeller/kernel-nbd-client/commits/7f020b22ec0e9414a212fe34b01701b23443d825"},"protected":false}]
```

The (redundant, as it is the default) GET method is specified along with a valid token in an Authorization header, and the server responds with the requested data.

Specifying a different HTTP method is allowed by fetch(1) and rejected by the server as expected:

```sh
$ fetch -q \
    -X TEST \
    -H "Accept: application/vnd.github+json" \
    -H "Authorization: Bearer $GITHUB_TOKEN" \
    -H "X-GitHub-Api-Version: 2022-11-28" \
    -o - \
    https://api.github.com/repos/ryan-moeller/kernel-nbd-client/branches
fetch: https://api.github.com/repos/ryan-moeller/kernel-nbd-client/branches: Forbidden
```

The server does not respond to requests with an invalid token:

```sh
$ fetch -q \
    -H "Accept: application/vnd.github+json" \
    -H "Authorization: Bearer not$GITHUB_TOKEN" \
    -H "X-GitHub-Api-Version: 2022-11-28" \
    -o - \
    https://api.github.com/repos/ryan-moeller/kernel-nbd-client/branches
fetch: https://api.github.com/repos/ryan-moeller/kernel-nbd-client/branches:
$ echo $?
1
```

This is not the most compelling example, as this is a read-only use of the GitHub API to access public data that would have been allowed with no token.  There are of course other API endpoints with stricter access controls where the headers are actually necessary.  And this functionality becomes even more useful with support for fetch(1) uploading a request body. This enables use of common HTTP methods like PUT, POST, and PATCH.

For example, uploading a gist to GitHub uses most of the new features:

```sh
$ fetch -q \
    -X POST \
    -H "Authorization: Bearer $GITHUB_TOKEN" \
    -H "Accept: application/vnd.github+json" \
    -H "Content-Type: application/json" \
    -D - \
    -o - \
    https://api.github.com/gists <<EOF
{
  "description": "fetch(1) test gist",
  "public": false,
  "files": {
    "demo.txt": {
      "content": "This gist was created using fetch(1)"
    }
  }
}
EOF
<verbose JSON response omitted>
```

`-X POST` tells fetch to use the POST method for the HTTP request
`-H ...` adds custom headers to the request
`-D -` sends a request body from a file (stdin, in this case)

### Testing

FreeBSD has no tests for libfetch or fetch.  I didn't go so far as to implement a Kyua test suite for inclusion in FreeBSD, but I do have some ancillary testing apparatus used to exercise my changes.

My test harness for this uses a Lua library wrapping libfetch with a Lua script exercising all request and response field sections as well as different request and response body transfer encodings and different success status codes. This can all be found [here](https://github.com/ryan-moeller/flualibs/tree/73b2f602b9dc2b9f889f5f653b60bc458be2bc1d/libfetch).

CI runs: https://cirrus-ci.com/build/5568610090876928
15.0-ALPHA4 test output: https://api.cirrus-ci.com/v1/task/5673940506378240/logs/libfetch_test.log