### PR TITLE
Update the Github action to use LLVM 15

### DIFF
--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -22,9 +22,9 @@ jobs:
         include:
           # TODO: both Ubuntu and macOS have bmake packages, we should try them instead of bootstrapping our own copy.
           - os: ubuntu-22.04
-            compiler: clang-14
-            cross-bindir: /usr/lib/llvm-14/bin
-            pkgs: bmake libarchive-dev clang-14 lld-14
+            compiler: clang-15
+            cross-bindir: /usr/lib/llvm-15/bin
+            pkgs: bmake libarchive-dev clang-15 lld-15
           - os: ubuntu-24.04
             compiler: clang-18
             cross-bindir: /usr/lib/llvm-18/bin


### PR DESCRIPTION
This is the latest supported version in Ubuntu 22.04 Sponsored by:	Arm Ltd