### PR TITLE
vmimage.subr: fix typo in checking NO_ROOT var

### DIFF
--- a/release/tools/vmimage.subr
+++ b/release/tools/vmimage.subr
@@ -95,7 +95,7 @@ vm_install_base() {
 		pkg_cmd="pkg --rootdir ${DESTDIR} --repo-conf-dir ${PKGBASE_REPO_DIR}
 			-o ASSUME_ALWAYS_YES=yes -o IGNORE_OSVERSION=yes
 			-o ABI=${PKG_ABI} -o INSTALL_AS_USER=yes "
-		if -n "${NO_ROOT}" ]; then
+		if [ -n "${NO_ROOT}" ]; then
 			pkg_cmd="$pkg_cmd -o METALOG=METALOG"
 		fi
 		$pkg_cmd update


### PR DESCRIPTION
Fixes: 08b497d

@cperciva 