### PR TITLE
speaker(4): drop NEEDGIANT and modernize the driver

### DIFF
--- a/sys/dev/speaker/spkr.c
+++ b/sys/dev/speaker/spkr.c
@@ -24,7 +24,7 @@ static	d_ioctl_t	spkrioctl;
 
 static struct cdevsw spkr_cdevsw = {
 	.d_version =	D_VERSION,
-	.d_flags =	D_NEEDGIANT,
+	.d_flags =	0,
 	.d_open =	spkropen,
 	.d_close =	spkrclose,
 	.d_write =	spkrwrite,
@@ -78,10 +78,8 @@ tone(unsigned int thz, unsigned int centisecs)
 	if (timer_spkr_acquire()) {
 		return;
 	}
-	disable_intr();
 	/* Configure the speaker with the tone frequency. */
 	timer_spkr_setfreq(thz);
-	enable_intr();
 
 	/*
 	 * Make the current thread sleep while the tone is being

--- a/sys/dev/speaker/spkr.c
+++ b/sys/dev/speaker/spkr.c
@@ -71,23 +71,29 @@ tone(unsigned int thz, unsigned int centisecs)
 	(void) printf("tone: thz=%d centisecs=%d\n", thz, centisecs);
 #endif /* DEBUG */
 
-	/* set timer to generate clicks at given frequency in Hertz */
+	/*
+	 * Acquire the i8254 clock, configure it to drive the speaker
+	 * signal, and turn on the speaker.
+	 */
 	if (timer_spkr_acquire()) {
-		/* enter list of waiting procs ??? */
 		return;
 	}
 	disable_intr();
+	/* Configure the speaker with the tone frequency. */
 	timer_spkr_setfreq(thz);
 	enable_intr();
 
 	/*
-	 * Set timeout to endtone function, then give up the timeslice.
-	 * This is so other processes can execute while the tone is being
+	 * Make the current thread sleep while the tone is being
 	 * emitted.
 	 */
 	timo = centisecs * hz / 100;
 	if (timo > 0)
 		tsleep(&endtone, SPKRPRI | PCATCH, "spkrtn", timo);
+
+	/*
+	 * Turn off the speaker and release the i8254 clock.
+	 */
 	timer_spkr_release();
 }
 

--- a/sys/dev/speaker/spkr.c
+++ b/sys/dev/speaker/spkr.c
@@ -419,8 +419,8 @@ spkr_dtor(void *data)
 static int
 spkropen(struct cdev *dev, int flags, int fmt, struct thread *td)
 {
-	int error;
 	struct spkr_state *state;
+	int error;
 #ifdef DEBUG
 	(void) printf("spkropen: entering with dev = %s\n", devtoname(dev));
 #endif /* DEBUG */
@@ -437,17 +437,17 @@ spkropen(struct cdev *dev, int flags, int fmt, struct thread *td)
 	if (error) {
 		free(state->inbuf, M_SPKR);
 		free(state, M_SPKR);
-		return error;
+		return (error);
 	}
 
-	return 0;
+	return (0);
 }
 
 static int
 spkrwrite(struct cdev *dev, struct uio *uio, int ioflag)
 {
-	int error;
 	struct spkr_state *state;
+	int error;
 	unsigned n;
 
 #ifdef DEBUG
@@ -457,18 +457,18 @@ spkrwrite(struct cdev *dev, struct uio *uio, int ioflag)
 
 	/* is the melody too long? */
 	if (uio->uio_resid > (DEV_BSIZE - 1))
-		return E2BIG;
+		return (E2BIG);
 
 	/* get this fd's state */
 	error = devfs_get_cdevpriv((void **)&state);
 	if (error)
-		return error;
+		return (error);
 
 	/* copy melody from userspace */
 	n = uio->uio_resid;
 	error = uiomove(state->inbuf, n, uio);
 	if (error)
-	    return error;
+		return (error);
 	state->inbuf[n] = '\0';
 
 	/* play the melody. */
@@ -476,7 +476,7 @@ spkrwrite(struct cdev *dev, struct uio *uio, int ioflag)
 	playstring(state, state->inbuf, n);
 	sx_xunlock(&spkr_op_locked);
 
-	return 0;
+	return (0);
 }
 
 static int
@@ -489,7 +489,7 @@ spkrclose(struct cdev *dev, int flags, int fmt, struct thread *td)
 	wakeup(&endtone);
 	wakeup(&endrest);
 	/* devfs_clear_cdevpriv() calls spkr_dtor automatically */
-	return(0);
+	return (0);
 }
 
 static int
@@ -510,7 +510,7 @@ spkrioctl(struct cdev *dev, unsigned long cmd, caddr_t cmdarg, int flags,
 		else
 			tone(tp->frequency, tp->duration);
 		sx_xunlock(&spkr_op_locked);
-		return 0;
+		return (0);
 	} else if (cmd == SPKRTUNE) {
 		tone_t  *tp = (tone_t *)(*(caddr_t *)cmdarg);
 		tone_t ttp;
@@ -521,7 +521,7 @@ spkrioctl(struct cdev *dev, unsigned long cmd, caddr_t cmdarg, int flags,
 			error = copyin(tp, &ttp, sizeof(tone_t));
 			if (error) {
 				sx_xunlock(&spkr_op_locked);
-				return(error);
+				return (error);
 			}
 
 			if (ttp.duration == 0)
@@ -533,9 +533,9 @@ spkrioctl(struct cdev *dev, unsigned long cmd, caddr_t cmdarg, int flags,
 				tone(ttp.frequency, ttp.duration);
 		}
 		sx_xunlock(&spkr_op_locked);
-		return(0);
+		return (0);
 	}
-	return(EINVAL);
+	return (EINVAL);
 }
 
 static struct cdev *speaker_dev;

--- a/sys/dev/speaker/spkr.c
+++ b/sys/dev/speaker/spkr.c
@@ -154,7 +154,7 @@ static bool octprefix;	/* override current octave-tracking state? */
 #define DENOM_MULT	2	/* denominator of dot multiplier */
 
 /* letter to half-tone:  A   B  C  D  E  F  G */
-static int notetab[8] = {9, 11, 0, 2, 4, 5, 7};
+static const int notetab[8] = {9, 11, 0, 2, 4, 5, 7};
 
 /*
  * This is the American Standard A440 Equal-Tempered scale with frequencies
@@ -162,7 +162,7 @@ static int notetab[8] = {9, 11, 0, 2, 4, 5, 7};
  * our octave 0 is standard octave 2.
  */
 #define OCTAVE_NOTES	12	/* semitones per octave */
-static int pitchtab[] =
+static const int pitchtab[] =
 {
 /*        C     C#    D     D#    E     F     F#    G     G#    A     A#    B*/
 /* 0 */   65,   69,   73,   78,   82,   87,   93,   98,  103,  110,  117,  123,


### PR DESCRIPTION
**Summary:** the calls to `disable_intr()` / `enable_intr()` in `spkr.c` were leftover from previous refactorings and unnecessary for correctness, so this PR removes them. There are also a few other improvements to bring this driver to the 21th century.

My detailed analysis of why this change is correct can be found here:  [spkr.md](https://github.com/user-attachments/files/24087193/spkr.md)

The main related commit referenced in the analysis is this 2008 change by phk: e46598588587b4897f6604489364f83fffd4d033 - where a mutex was added to clock.c and the disable_intr/enable_intr pair could have been removed, but wasn't.

**Motivation:** I am a fervent spkr(4) user and would like it to persist beyond FreeBSD 16, so we needed to do something about its use of the GIANT mutex.

cc @bsdphk @bsdimp 