### PR TITLE
pcpu_aux: refine error message and add more checks

### DIFF
--- a/sys/amd64/include/pcpu.h
+++ b/sys/amd64/include/pcpu.h
@@ -101,7 +101,7 @@ _Static_assert(sizeof(struct monitorbuf) == 128, "2x cache line");
 	u_int	pc_small_core;						\
 	u_int	pc_pcid_invlpg_workaround;				\
 	struct pmap_pcid pc_kpmap_store;				\
-	char	__pad[2900]		/* pad to UMA_PCPU_ALLOC_SIZE */
+	char	__pad[2928]		/* pad to UMA_PCPU_ALLOC_SIZE */
 
 #define	PC_DBREG_CMD_NONE	0
 #define	PC_DBREG_CMD_LOAD	1

--- a/sys/amd64/include/pcpu_aux.h
+++ b/sys/amd64/include/pcpu_aux.h
@@ -44,7 +44,11 @@
 #endif
 
 /* Required for counters(9) to work on x86. */
-_Static_assert(sizeof(struct pcpu) == UMA_PCPU_ALLOC_SIZE, "fix pcpu size");
+_Static_assert(sizeof(struct pcpu) == UMA_PCPU_ALLOC_SIZE,
+	"pcpu size should be equal to UMA_PCPU_ALLOC_SIZE");
+_Static_assert(offsetof(struct pcpu, __pad) +
+	sizeof(((struct pcpu *)0)->__pad) == sizeof(struct pcpu),
+	"pcpu padding should be the last field in pcpu");
 
 extern struct pcpu *__pcpu;
 extern struct pcpu temp_bsp_pcpu;

--- a/sys/arm/include/pcpu_aux.h
+++ b/sys/arm/include/pcpu_aux.h
@@ -43,7 +43,14 @@
  * To minimize memory waste in per-cpu UMA zones, the page size should
  * be a multiple of the size of struct pcpu.
  */
-_Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0, "fix pcpu size");
+_Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0,
+	"pcpu size should be a factor of PAGE_SIZE");
+_Static_assert(offsetof(struct pcpu, __pad) +
+	sizeof(((struct pcpu *)0)->__pad) == sizeof(struct pcpu),
+	"pcpu padding should be the last field in pcpu");
+_Static_assert(offsetof(struct pcpu, __pad) >
+	sizeof(((struct pcpu *)0)->__pad),
+	"pcpu padding should be smaller than the rest of pcpu");
 
 extern struct pcpu __pcpu[];
 

--- a/sys/arm64/include/pcpu.h
+++ b/sys/arm64/include/pcpu.h
@@ -51,7 +51,7 @@ struct debug_monitor_state;
 	uint64_t pc_mpidr;						\
 	u_int	pc_bcast_tlbi_workaround;				\
 	uint64_t pc_release_addr;					\
-	char __pad[189]
+	char __pad[0]
 
 #ifdef _KERNEL
 

--- a/sys/arm64/include/pcpu_aux.h
+++ b/sys/arm64/include/pcpu_aux.h
@@ -47,7 +47,14 @@
  * To minimize memory waste in per-cpu UMA zones, the page size should
  * be a multiple of the size of struct pcpu.
  */
-_Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0, "fix pcpu size");
+_Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0,
+	"pcpu size should be a factor of PAGE_SIZE");
+_Static_assert(offsetof(struct pcpu, __pad) +
+	sizeof(((struct pcpu *)0)->__pad) == sizeof(struct pcpu),
+	"pcpu padding should be the last field in pcpu");
+_Static_assert(offsetof(struct pcpu, __pad) >
+	sizeof(((struct pcpu *)0)->__pad),
+	"pcpu padding should be smaller than the rest of pcpu");
 
 extern struct pcpu pcpu0;
 

--- a/sys/powerpc/include/pcpu_aux.h
+++ b/sys/powerpc/include/pcpu_aux.h
@@ -43,7 +43,14 @@
  * To minimize memory waste in per-cpu UMA zones, the page size should
  * be a multiple of the size of struct pcpu.
  */
-_Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0, "fix pcpu size");
+_Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0,
+	"pcpu size should be a factor of PAGE_SIZE");
+_Static_assert(offsetof(struct pcpu, __pad) +
+	sizeof(((struct pcpu *)0)->__pad) == sizeof(struct pcpu),
+	"pcpu padding should be the last field in pcpu");
+_Static_assert(offsetof(struct pcpu, __pad) >
+	sizeof(((struct pcpu *)0)->__pad),
+	"pcpu padding should be smaller than the rest of pcpu");
 
 extern struct pcpu __pcpu[];
 

--- a/sys/riscv/include/pcpu_aux.h
+++ b/sys/riscv/include/pcpu_aux.h
@@ -43,10 +43,14 @@
  * To minimize memory waste in per-cpu UMA zones, the page size should
  * be a multiple of the size of struct pcpu.
  */
-_Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0, "fix pcpu size");
+_Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0,
+	"pcpu size should be a factor of PAGE_SIZE");
 _Static_assert(offsetof(struct pcpu, __pad) +
-    sizeof(((struct pcpu *)0)->__pad) == sizeof(struct pcpu),
-    "fix pcpu padding");
+	sizeof(((struct pcpu *)0)->__pad) == sizeof(struct pcpu),
+	"pcpu padding should be the last field in pcpu");
+_Static_assert(offsetof(struct pcpu, __pad) >
+	sizeof(((struct pcpu *)0)->__pad),
+	"pcpu padding should be smaller than the rest of pcpu");
 
 extern struct pcpu __pcpu[];
 


### PR DESCRIPTION
This refines error message and adds more checks.

When padding needs to be increased so the total size of `pcpu` is next factor of `PAGE_SIZE` (4096 bytes), current static assertion doesn't show `sizeof(pcpu)` in number and thus developers doesn't know the next factor of page size unless they print `sizeof(pcpu)`. This check always guarantees that `pcpu` is as small as possible while being a factor page size.

I didn't touch `i386/include/pcpu_aux.h` since i386 is now deprecated and the build is broken.