### PR TITLE
make check: Add KYUADEBUG to target specific kyua tests

### DIFF
--- a/share/man/man7/build.7
+++ b/share/man/man7/build.7
@@ -114,6 +114,12 @@ The default directory used is
 .Pa ${.OBJDIR} ,
 but the check directory can be changed with
 .Pa ${CHECKDIR} .
+List available test cases with
+.Pa -DKYUALIST ,
+or include their metadata with
+.Pa -DKYUALIST_V .
+Run a specific test case in debug mode with
+.Pa KYUADEBUG=test_file:case_name .
 .It Cm checkworld
 Run the
 .Fx

--- a/share/mk/suite.test.mk
+++ b/share/mk/suite.test.mk
@@ -46,6 +46,9 @@ KYUAFILE?= auto
 # unqualified TEST_METADATA variable.
 #TEST_METADATA.<test-program>+= key="value"
 
+# Test name to run with kyua debug instead of running all tests.
+#KYUADEBUG
+
 .if ${KYUAFILE:tl} != "no"
 ${PACKAGE}FILES+=	Kyuafile
 ${PACKAGE}FILESDIR_Kyuafile=	${TESTSDIR}
@@ -78,6 +81,18 @@ Kyuafile: Makefile
 
 KYUA?=	kyua
 
+.if defined(KYUALIST)
+KYUA_CMD_VERB=list
+.elif defined(KYUALIST_V)
+KYUA_CMD_VERB=list
+KYUA_CMD_ARGS=-v
+.elif !empty(KYUADEBUG)
+KYUA_CMD_VERB=debug
+KYUA_CMD_ARGS=${KYUADEBUG}
+.endif
+
+KYUA_CMD= ${KYUA} ${KYUA_CMD_VERB:Utest} -k ${DESTDIR}${TESTSDIR}/Kyuafile ${KYUA_CMD_ARGS}
+
 # Definition of the "make check" target and supporting variables.
 #
 # This target, by necessity, can only work for native builds (i.e. a FreeBSD
@@ -98,7 +113,7 @@ realcheck: .PHONY
 		echo "KYUA=\"${LOCALBASE}/bin/kyua\""; \
 		false; \
 	fi
-	@env ${TESTS_ENV:Q} ${KYUA} test -k ${DESTDIR}${TESTSDIR}/Kyuafile
+	@env ${TESTS_ENV:Q} ${KYUA_CMD}
 
 MAKE_CHECK_SANDBOX_DIR=	checkdir
 CLEANDIRS+=	${MAKE_CHECK_SANDBOX_DIR}


### PR DESCRIPTION
# make check: Add make vars to list and debug kyua test cases

kyua supports listing tests, optionally including metadata. It also supports targeting a specific test in debug mode. It shows the commands that were run, stdout / stderr, and details of the checks that failed.

Examples:

    make -C bin/ls check -DKYUALIST
    make -C bin/ls check -DKYUALIST_V
    make -C bin/ls check KYUADEBUG=ls_tests:T_flag

---

(looks like I'm unable to edit the PR subject)