### PR TITLE
build.7: Add an example for developing and testing userspace

### DIFF
--- a/share/man/man7/build.7
+++ b/share/man/man7/build.7
@@ -1109,7 +1109,22 @@ cd /usr/src/bin/ls
 make clean all
 make install
 .Ed
-.Ss Example 4: Build and upgrade a loadable kernel module
+.Ss Example 4: Develop and test a single piece of userspace with a dependency
+Develop and check a single piece of userspace with a dependency, in this case
+.Xr bectl 1 ,
+which depends on
+.Xr libbe 3 :
+.Bd -literal -offset indent
+cd /usr/src
+make buildworld
+make -C lib/libbe
+LD_LIBRARY_PATH=$(make -C lib/libbe -V .OBJDIR) make -C lib/libbe check
+CFLAGS="-I$(realpath lib/libbe)" make -C sbin/bectl
+PATH=$(make -C sbin/bectl -V .OBJDIR):$PATH \\
+	LD_LIBRARY_PATH=$(make -C lib/libbe -V .OBJDIR) \\
+	make -C sbin/bectl check
+.Ed
+.Ss Example 5: Build and upgrade a loadable kernel module
 Rebuild and reinstall a single loadable kernel module, in this case
 .Xr sound 4 :
 .Bd -literal -offset indent
@@ -1156,7 +1171,7 @@ config -d /home/user/my-kernel-builddir -s /home/user/src/sys/amd64/conf MY-KERN
 cd my-module
 make all KERNBUILDDIR=/home/user/my-kernel-builddir SYSDIR
 .Ed
-.Ss Example 5: Quickly rebuild a kernel in place
+.Ss Example 6: Quickly rebuild a kernel in place
 Quickly rebuild and reinstall the kernel, only recompiling the files
 changed since last build; note that this will only work if the full
 kernel build has been completed in the past, not on a fresh source tree:
@@ -1164,13 +1179,13 @@ kernel build has been completed in the past, not on a fresh source tree:
 cd /usr/src
 make kernel KERNFAST=1
 .Ed
-.Ss Example 6: Cross-compiling for different architectures
+.Ss Example 7: Cross-compiling for different architectures
 To rebuild parts of
 .Fx
 for another CPU architecture,
 first prepare your source tree by building the cross-toolchain:
 .Bd -literal -offset indent
-cd src
+cd /usr/src
 make toolchain TARGET_ARCH=aarch64
 .Ed
 .Pp
@@ -1185,14 +1200,14 @@ make TARGET_ARCH=aarch64 DESTDIR=/client installworld installkernel
 .Pp
 Afterwards, to build and install a single piece of userspace, use:
 .Bd -literal -offset indent
-cd src/bin/ls
+cd /usr/src/bin/ls
 make buildenv TARGET_ARCH=aarch64
 make clean all install DESTDIR=/client
 .Ed
 .Pp
 Likewise, to quickly rebuild and reinstall the kernel, use:
 .Bd -literal -offset indent
-cd src
+cd /usr/src
 make buildenv TARGET_ARCH=aarch64
 make kernel KERNFAST=1 DESTDIR=/client
 .Ed


### PR DESCRIPTION
Adding new functionality to userspace sometimes requires updating a lib and bin together. This example demonstrates how to build the lib, and use the build result for building the bin and running tests.

This example differs from "Example 3: Build and upgrade a single piece of userspace" because it demonstrates how a developer may quickly iterate on a piece of userspace before installing it to its final destination.

While here, update examples to consistently use /usr/src.
