### PR TITLE
release: Support VMCONFIG for vm-image

### DIFF
--- a/release/Makefile.vm
+++ b/release/Makefile.vm
@@ -211,6 +211,7 @@ vm-image:	${QEMUTGT} ${PKGBASE_REPO_DIR}
 		PKGBASE_REPO_DIR=${.OBJDIR}/pkgbase-repo-dir \
 		${.CURDIR}/scripts/mk-vmimage.sh \
 		-C ${.CURDIR}/tools/vmimage.subr \
+		${VM_IMAGE_CONFIG:D-c ${VM_IMAGE_CONFIG}} \
 		-d ${.OBJDIR}/${.TARGET}-${FORMAT}-${FS} -F ${FS} \
 		-i ${.OBJDIR}/${FORMAT}.${FS}.img -s ${VMSIZE} -f ${FORMAT} \
 		-S ${WORLDDIR} -o ${.OBJDIR}/${VMBASE}.${FS}.${FORMAT} || true


### PR DESCRIPTION
# release: Pass optional VM_IMAGE_CONFIG to vm-image

`make vm-image` calls mk-vmimage.sh, which supports `-c CONFFILE`. This file gets sourced before building the image.

One example of how to use it is to define vm_extra_filter_base_packages() to filter the list of packages installed into the VM image:

    # vm-nodbg32.conf
    vm_extra_filter_base_packages() {
        grep -v -E '(-dbg|lib32)'
    }

    $ make VM_IMAGE_CONFIG=path/to/vm-nodbg32.conf \
        VMFORMATS=raw \
        -DWITH_VMIMAGES \
        vm-image