### PR TITLE
stdio: Support 32-bit file descriptors in FILE objects

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -191,7 +191,8 @@ __END_DECLS
 #define	__SALC	0x4000		/* allocate string space dynamically */
 #define	__SIGN	0x8000		/* ignore this file in _fwalk */
 
-#define	__S2OAP	0x0001		/* O_APPEND mode is set */
+#define	__S2OAP	0x00000001	/* O_APPEND mode is set */
+#define	__S2FDX	0x0001fffe	/* Encoded upper sixteen bits of fileno */
 
 /*
  * The following three definitions are for ANSI C, which took them

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -277,7 +277,8 @@ int	 fprintf(FILE * __restrict, const char * __restrict, ...);
 int	 fputc(int, FILE *);
 int	 fputs(const char * __restrict, FILE * __restrict);
 size_t	 fread(void * __restrict, size_t, size_t, FILE * __restrict);
-FILE	*freopen(const char * __restrict, const char * __restrict, FILE * __restrict);
+FILE	*freopen(const char * __restrict, const char * __restrict,
+	    FILE * __restrict);
 int	 fscanf(FILE * __restrict, const char * __restrict, ...);
 int	 fseek(FILE *, long, int);
 int	 fsetpos(FILE *, const fpos_t *);
@@ -304,11 +305,9 @@ int	 sscanf(const char * __restrict, const char * __restrict, ...);
 FILE	*tmpfile(void);
 char	*tmpnam(char *);
 int	 ungetc(int, FILE *);
-int	 vfprintf(FILE * __restrict, const char * __restrict,
-	    __va_list);
+int	 vfprintf(FILE * __restrict, const char * __restrict, __va_list);
 int	 vprintf(const char * __restrict, __va_list);
-int	 (vsprintf)(char * __restrict, const char * __restrict,
-	    __va_list);
+int	 (vsprintf)(char * __restrict, const char * __restrict, __va_list);
 
 #if __ISO_C_VISIBLE >= 1999 || __POSIX_VISIBLE >= 199506
 int	 (snprintf)(char * __restrict, size_t, const char * __restrict,
@@ -471,7 +470,9 @@ int	__swbuf(int, FILE *);
  */
 #define	__sgetc(p) (--(p)->_r < 0 ? __srget(p) : (int)(*(p)->_p++))
 #if defined(__GNUC__) && defined(__STDC__)
-static __inline int __sputc(int _c, FILE *_p) {
+static __inline int
+__sputc(int _c, FILE *_p)
+{
 	if (--_p->_w >= 0 || (_p->_w >= _p->_lbfsize && (char)_c != '\n'))
 		return (*_p->_p++ = _c);
 	else
@@ -500,7 +501,7 @@ extern int __isthreaded;
 
 #define	__sfeof(p)	(((p)->_flags & __SEOF) != 0)
 #define	__sferror(p)	(((p)->_flags & __SERR) != 0)
-#define	__sclearerr(p)	((void)((p)->_flags &= ~(__SERR|__SEOF)))
+#define	__sclearerr(p)	((void)((p)->_flags &= ~(__SERR | __SEOF)))
 
 
 #define	feof(p)		(!__isthreaded ? __sfeof(p) : (feof)(p))

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -500,7 +500,6 @@ extern int __isthreaded;
 #define	__sfeof(p)	(((p)->_flags & __SEOF) != 0)
 #define	__sferror(p)	(((p)->_flags & __SERR) != 0)
 #define	__sclearerr(p)	((void)((p)->_flags &= ~(__SERR|__SEOF)))
-#define	__sfileno(p)	((p)->_file)
 
 
 #define	feof(p)		(!__isthreaded ? __sfeof(p) : (feof)(p))
@@ -521,7 +520,6 @@ extern int __isthreaded;
 #define	clearerr_unlocked(p)	__sclearerr(p)
 #define	feof_unlocked(p)	__sfeof(p)
 #define	ferror_unlocked(p)	__sferror(p)
-#define	fileno_unlocked(p)	__sfileno(p)
 #define	fputc_unlocked(s, p)	__sputc(s, p)
 #endif
 #if __POSIX_VISIBLE >= 199506

--- a/lib/libc/include/libc_private.h
+++ b/lib/libc/include/libc_private.h
@@ -78,6 +78,11 @@ void *libc_dlopen(const char *, int);
 void _rtld_error(const char *fmt, ...);
 
 /*
+ * Stdio cleanup function which is called by exit() and abort().
+ */
+extern __weak_symbol void _cleanup(void);
+
+/*
  * File lock contention is difficult to diagnose without knowing
  * where locks were set. Allow a debug library to be built which
  * records the source file and line number of each lock call.

--- a/lib/libc/stdio/Symbol.map
+++ b/lib/libc/stdio/Symbol.map
@@ -6,7 +6,6 @@ FBSD_1.0 {
 	clearerr;
 	fclose;
 	fcloseall;
-	fdopen;
 	feof;
 	ferror;
 	fflush;
@@ -22,7 +21,6 @@ FBSD_1.0 {
 	__stdoutp;
 	__stderrp;
 	f_prealloc;	/* deprecated??? */
-	fopen;
 	fprintf;
 	fpurge;
 	fputc;
@@ -30,7 +28,6 @@ FBSD_1.0 {
 	fputwc;
 	fputws;
 	fread;
-	freopen;
 	fscanf;
 	fseek;
 	fseeko;
@@ -174,6 +171,12 @@ FBSD_1.6 {
 	mkostempsat;
 };
 
+FBSD_1.9 {
+	fdopen;
+	fopen;
+	freopen;
+};
+
 FBSDprivate_1.0 {
 	_flockfile;
 	_flockfile_debug_stub;
@@ -212,4 +215,6 @@ FBSDprivate_1.0 {
 	__printf_render_time;
 	__printf_arginfo_vis;
 	__printf_render_vis;
+
+	__stdio_force_short_fildes;
 };

--- a/lib/libc/stdio/fclose.c
+++ b/lib/libc/stdio/fclose.c
@@ -54,8 +54,10 @@ cleanfile(FILE *fp, bool c)
 			r = EOF;
 	}
 
-	if (fp->_flags & __SMBF)
+	if (fp->_flags & __SMBF) {
 		free((char *)fp->_bf._base);
+		fp->_bf._base = NULL;
+	}
 	if (HASUB(fp))
 		FREEUB(fp);
 	if (HASLB(fp))

--- a/lib/libc/stdio/fclose.c
+++ b/lib/libc/stdio/fclose.c
@@ -62,7 +62,7 @@ cleanfile(FILE *fp, bool c)
 		FREEUB(fp);
 	if (HASLB(fp))
 		FREELB(fp);
-	fp->_file = -1;
+	__sfileno_set(fp, -1);
 	fp->_r = fp->_w = 0;	/* Mess up if reaccessed. */
 
 	/*
@@ -85,7 +85,7 @@ cleanfile(FILE *fp, bool c)
 int
 fdclose(FILE *fp, int *fdp)
 {
-	int r, err;
+	int err, fd, r;
 
 	if (fdp != NULL)
 		*fdp = -1;
@@ -100,7 +100,7 @@ fdclose(FILE *fp, int *fdp)
 	if (fp->_close != __sclose) {
 		r = EOF;
 		errno = EOPNOTSUPP;
-	} else if (fp->_file < 0) {
+	} else if ((fd = __sfileno(fp)) < 0) {
 		r = EOF;
 		errno = EBADF;
 	}
@@ -110,7 +110,7 @@ fdclose(FILE *fp, int *fdp)
 		errno = err;
 	} else {
 		if (fdp != NULL)
-			*fdp = fp->_file;
+			*fdp = fd;
 		r = cleanfile(fp, false);
 	}
 	FUNLOCKFILE_CANCELSAFE();

--- a/lib/libc/stdio/fdopen.c
+++ b/lib/libc/stdio/fdopen.c
@@ -106,7 +106,7 @@ fdopen(int fd, const char *mode)
 		fp->_flags2 |= __S2OAP;
 	else if (oflags & O_APPEND)
 		fp->_flags |= __SAPP;
-	fp->_file = fd;
+	__sfileno_set(fp, fd);
 	fp->_cookie = fp;
 	fp->_read = __sread;
 	fp->_write = __swrite;

--- a/lib/libc/stdio/fdopen.c
+++ b/lib/libc/stdio/fdopen.c
@@ -48,6 +48,11 @@ fdopen(int fd, const char *mode)
 	FILE *fp;
 	int flags, oflags, fdflags, rc, tmp;
 
+	if (fd < 0) {
+		errno = EBADF;
+		return (NULL);
+	}
+
 	/*
 	 * File descriptors are a full int, but _file is only a short.
 	 * If we get a valid file descriptor that is greater than

--- a/lib/libc/stdio/fdopen.c
+++ b/lib/libc/stdio/fdopen.c
@@ -39,11 +39,12 @@
 #include <stdio.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdbool.h>
 #include "un-namespace.h"
 #include "local.h"
 
-FILE *
-fdopen(int fd, const char *mode)
+static FILE *
+__sfdopen(int fd, const char * __restrict mode, bool short_only)
 {
 	FILE *fp;
 	int flags, oflags, fdflags, rc, tmp;
@@ -60,7 +61,7 @@ fdopen(int fd, const char *mode)
 	 * invalid file descriptor.  Handle this case by failing the
 	 * open.
 	 */
-	if (fd > SHRT_MAX) {
+	if (__sforce_short_fildes(short_only) && fd > SHRT_MAX) {
 		errno = EMFILE;
 		return (NULL);
 	}
@@ -113,4 +114,17 @@ fdopen(int fd, const char *mode)
 	fp->_seek = __sseek;
 	fp->_close = __sclose;
 	return (fp);
+}
+
+FILE *
+freebsd15_fdopen(int fd, const char *mode)
+{
+	return (__sfdopen(fd, mode, true));
+}
+__sym_compat(fdopen, freebsd15_fdopen, FBSD_1.0);
+
+FILE *
+fdopen(int fd, const char *mode)
+{
+	return (__sfdopen(fd, mode, false));
 }

--- a/lib/libc/stdio/fileno.c
+++ b/lib/libc/stdio/fileno.c
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include "un-namespace.h"
 #include "libc_private.h"
+#include "local.h"
 
 #undef fileno
 #undef fileno_unlocked
@@ -46,7 +47,7 @@ __fileno_impl(FILE *fp)
 {
 	int fd;
 
-	fd = fp->_file;
+	fd = __sfileno(fp);
 	if (fd == -1)
 		errno = EBADF;
 	return (fd);

--- a/lib/libc/stdio/fileno.c
+++ b/lib/libc/stdio/fileno.c
@@ -42,7 +42,7 @@
 #undef fileno
 #undef fileno_unlocked
 
-static int
+static inline int
 __fileno_impl(FILE *fp)
 {
 	int fd;

--- a/lib/libc/stdio/findfp.c
+++ b/lib/libc/stdio/findfp.c
@@ -91,7 +91,6 @@ static struct glue *
 moreglue(int n)
 {
 	struct glue *g;
-	static FILE empty = { ._fl_mutex = PTHREAD_MUTEX_INITIALIZER };
 	FILE *p;
 	size_t align;
 
@@ -104,7 +103,7 @@ moreglue(int n)
 	g->niobs = n;
 	g->iobs = p;
 	while (--n >= 0)
-		*p++ = empty;
+		*p++ = (FILE)FAKE_FILE;
 	return (g);
 }
 

--- a/lib/libc/stdio/findfp.c
+++ b/lib/libc/stdio/findfp.c
@@ -182,17 +182,3 @@ f_prealloc(void)
 		STDIO_THREAD_UNLOCK();
 	}
 }
-
-/*
- * exit() calls _cleanup() through *__cleanup, set via a weak reference
- * at program initialisation.  This chicanery is done so that programs
- * that do not use stdio need not link it all in.
- *
- * The name `_cleanup' is, alas, fairly well known outside stdio.
- */
-void
-_cleanup(void)
-{
-	/* (void) _fwalk(fclose); */
-	(void) _fwalk(__sflush);		/* `cheating' */
-}

--- a/lib/libc/stdio/findfp.c
+++ b/lib/libc/stdio/findfp.c
@@ -46,8 +46,6 @@
 #include "local.h"
 #include "glue.h"
 
-int	__sdidinit;
-
 #define	NDYNAMIC 10		/* add ten more whenever necessary */
 
 #define	std(flags, file) {		\
@@ -117,8 +115,6 @@ __sfp(void)
 	int	n;
 	struct glue *g;
 
-	if (!__sdidinit)
-		__sinit();
 	/*
 	 * The list must be locked because a FILE may be updated.
 	 */
@@ -188,8 +184,8 @@ f_prealloc(void)
 }
 
 /*
- * exit() calls _cleanup() through *__cleanup, set whenever we
- * open or buffer a file.  This chicanery is done so that programs
+ * exit() calls _cleanup() through *__cleanup, set via a weak reference
+ * at program initialisation.  This chicanery is done so that programs
  * that do not use stdio need not link it all in.
  *
  * The name `_cleanup' is, alas, fairly well known outside stdio.
@@ -199,16 +195,4 @@ _cleanup(void)
 {
 	/* (void) _fwalk(fclose); */
 	(void) _fwalk(__sflush);		/* `cheating' */
-}
-
-/*
- * __sinit() is called whenever stdio's internal variables must be set up.
- */
-void
-__sinit(void)
-{
-
-	/* Make sure we clean up on exit. */
-	__cleanup = _cleanup;		/* conservative */
-	__sdidinit = 1;
 }

--- a/lib/libc/stdio/findfp.c
+++ b/lib/libc/stdio/findfp.c
@@ -65,7 +65,7 @@ static struct glue uglue = { NULL, FOPEN_MAX - 3, usual };
 static FILE __sF[3] = {
 	std(__SRD, STDIN_FILENO),
 	std(__SWR, STDOUT_FILENO),
-	std(__SWR|__SNBF, STDERR_FILENO)
+	std(__SWR | __SNBF, STDERR_FILENO)
 };
 
 FILE *__stdinp = &__sF[0];
@@ -75,7 +75,7 @@ FILE *__stderrp = &__sF[2];
 struct glue __sglue = { &uglue, 3, __sF };
 static struct glue *lastglue = &uglue;
 
-static struct glue *	moreglue(int);
+static struct glue *moreglue(int);
 
 spinlock_t __stdio_thread_lock = _SPINLOCK_INITIALIZER;
 
@@ -157,9 +157,8 @@ found:
  * XXX.  Force immediate allocation of internal memory.  Not used by stdio,
  * but documented historically for certain applications.  Bad applications.
  */
-__warn_references(f_prealloc, 
+__warn_references(f_prealloc,
 	"warning: this program uses f_prealloc(), which is not recommended.");
-void f_prealloc(void);
 
 void
 f_prealloc(void)
@@ -174,7 +173,7 @@ f_prealloc(void)
 	 * removed.
 	 */
 	for (g = &__sglue; (n -= g->niobs) > 0 && g->next; g = g->next)
-		/* void */;
+		;	/* nothing */
 	if ((n > 0) && ((g = moreglue(n)) != NULL)) {
 		STDIO_THREAD_LOCK();
 		SET_GLUE_PTR(lastglue->next, g);

--- a/lib/libc/stdio/fopen.3
+++ b/lib/libc/stdio/fopen.3
@@ -260,6 +260,12 @@ is returned and the global variable
 is set to indicate the error.
 .Sh ERRORS
 .Bl -tag -width Er
+.It Bq Er EBADF
+The
+.Fa fildes
+argument to
+.Fn fdopen
+was not a valid file descriptor.
 .It Bq Er EINVAL
 The
 .Fa mode
@@ -271,6 +277,10 @@ to
 or
 .Fn fmemopen
 was invalid.
+.It Bq Er EMFILE
+The file descriptor for the opened
+.Tn FILE
+is greater than 32,767 and legacy compatibility mode is enabled.
 .El
 .Pp
 The
@@ -320,6 +330,18 @@ may also fail and set
 if the
 .Fa size
 argument is 0.
+.Pp
+The
+.Fn fopen ,
+.Fn fdopen
+and
+.Fn freopen
+functions will enforce the legacy limit of at most 32,767 open files with
+binaries linked against previous versions of the standard C library.
+As a debugging aid, this legacy compatibility mode can also be enabled for
+the time being by setting the environment variable
+.Va __STDIO_FORCE_SHORT_FILDES
+prior to executing the program.
 .Sh SEE ALSO
 .Xr open 2 ,
 .Xr fclose 3 ,

--- a/lib/libc/stdio/fopen.c
+++ b/lib/libc/stdio/fopen.c
@@ -72,7 +72,7 @@ fopen(const char * __restrict file, const char * __restrict mode)
 		errno = EMFILE;
 		return (NULL);
 	}
-	fp->_file = f;
+	__sfileno_set(fp, f);
 	fp->_flags = flags;
 	fp->_cookie = fp;
 	fp->_read = __sread;

--- a/lib/libc/stdio/fopen.c
+++ b/lib/libc/stdio/fopen.c
@@ -67,8 +67,8 @@ fopen(const char * __restrict file, const char * __restrict mode)
 	 * open.
 	 */
 	if (f > SHRT_MAX) {
-		fp->_flags = 0;			/* release */
 		_close(f);
+		fp->_flags = 0;			/* release */
 		errno = EMFILE;
 		return (NULL);
 	}

--- a/lib/libc/stdio/fopen.c
+++ b/lib/libc/stdio/fopen.c
@@ -40,12 +40,14 @@
 #include <stdio.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdbool.h>
 #include "un-namespace.h"
 
 #include "local.h"
 
-FILE *
-fopen(const char * __restrict file, const char * __restrict mode)
+static FILE *
+__sfopen(const char * __restrict file, const char * __restrict mode,
+    bool short_only)
 {
 	FILE *fp;
 	int f;
@@ -66,7 +68,7 @@ fopen(const char * __restrict file, const char * __restrict mode)
 	 * invalid file descriptor.  Handle this case by failing the
 	 * open.
 	 */
-	if (f > SHRT_MAX) {
+	if (__sforce_short_fildes(short_only) && f > SHRT_MAX) {
 		_close(f);
 		fp->_flags = 0;			/* release */
 		errno = EMFILE;
@@ -92,4 +94,17 @@ fopen(const char * __restrict file, const char * __restrict mode)
 		(void)_sseek(fp, (fpos_t)0, SEEK_END);
 	}
 	return (fp);
+}
+
+FILE *
+freebsd15_fopen(const char * __restrict file, const char * __restrict mode)
+{
+	return (__sfopen(file, mode, true));
+}
+__sym_compat(fopen, freebsd15_fopen, FBSD_1.0);
+
+FILE *
+fopen(const char * __restrict file, const char * __restrict mode)
+{
+	return (__sfopen(file, mode, false));
 }

--- a/lib/libc/stdio/freopen.c
+++ b/lib/libc/stdio/freopen.c
@@ -66,9 +66,6 @@ freopen(const char * __restrict file, const char * __restrict mode,
 
 	FLOCKFILE_CANCELSAFE(fp);
 
-	if (!__sdidinit)
-		__sinit();
-
 	/*
 	 * If the filename is a NULL pointer, the caller is asking us to
 	 * re-open the same file with a different mode. We allow this only

--- a/lib/libc/stdio/freopen.c
+++ b/lib/libc/stdio/freopen.c
@@ -78,7 +78,8 @@ freopen(const char * __restrict file, const char * __restrict mode,
 			fp = NULL;
 			goto end;
 		}
-		if ((dflags = _fcntl(fp->_file, F_GETFL)) < 0) {
+		f = __sfileno(fp);
+		if ((dflags = _fcntl(f, F_GETFL)) < 0) {
 			sverrno = errno;
 			fclose(fp);
 			errno = sverrno;
@@ -98,7 +99,7 @@ freopen(const char * __restrict file, const char * __restrict mode,
 		if ((oflags ^ dflags) & O_APPEND) {
 			dflags &= ~O_APPEND;
 			dflags |= oflags & O_APPEND;
-			if (_fcntl(fp->_file, F_SETFL, dflags) < 0) {
+			if (_fcntl(f, F_SETFL, dflags) < 0) {
 				sverrno = errno;
 				fclose(fp);
 				errno = sverrno;
@@ -107,16 +108,15 @@ freopen(const char * __restrict file, const char * __restrict mode,
 			}
 		}
 		if (oflags & O_TRUNC)
-			(void) ftruncate(fp->_file, (off_t)0);
+			(void) ftruncate(f, (off_t)0);
 		if (!(oflags & O_APPEND))
 			(void) _sseek(fp, (fpos_t)0, SEEK_SET);
 		if ((oflags & O_CLOEXEC) != 0) {
-			fdflags = _fcntl(fp->_file, F_GETFD, 0);
+			fdflags = _fcntl(f, F_GETFD, 0);
 			if (fdflags != -1 && (fdflags & FD_CLOEXEC) == 0)
-				(void) _fcntl(fp->_file, F_SETFD,
+				(void) _fcntl(f, F_SETFD,
 				    fdflags | FD_CLOEXEC);
 		}
-		f = fp->_file;
 		isopen = 0;
 		wantfd = -1;
 		goto finish;
@@ -140,7 +140,7 @@ freopen(const char * __restrict file, const char * __restrict mode,
 			(void) __sflush(fp);
 		/* if close is NULL, closing is a no-op, hence pointless */
 		isopen = fp->_close != NULL;
-		if ((wantfd = fp->_file) < 0 && isopen) {
+		if ((wantfd = __sfileno(fp)) < 0 && isopen) {
 			(void) (*fp->_close)(fp->_cookie);
 			isopen = 0;
 		}
@@ -225,7 +225,7 @@ finish:
 	}
 
 	fp->_flags = flags;
-	fp->_file = f;
+	__sfileno_set(fp, f);
 	fp->_cookie = fp;
 	fp->_read = __sread;
 	fp->_write = __swrite;

--- a/lib/libc/stdio/freopen.c
+++ b/lib/libc/stdio/freopen.c
@@ -220,6 +220,7 @@ finish:
 	 * open.
 	 */
 	if (f > SHRT_MAX) {
+		_close(f);
 		fp->_flags = 0;		/* set it free */
 		errno = EMFILE;
 		fp = NULL;

--- a/lib/libc/stdio/freopen.c
+++ b/lib/libc/stdio/freopen.c
@@ -39,6 +39,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <unistd.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "un-namespace.h"
@@ -50,9 +51,9 @@
  * ANSI is written such that the original file gets closed if at
  * all possible, no matter what.
  */
-FILE *
-freopen(const char * __restrict file, const char * __restrict mode,
-    FILE * __restrict fp)
+static FILE *
+__sfreopen(const char * __restrict file, const char * __restrict mode,
+    FILE * __restrict fp, bool short_only)
 {
 	int f;
 	int dflags, fdflags, flags, isopen, oflags, sverrno, wantfd;
@@ -216,7 +217,7 @@ finish:
 	 * invalid file descriptor.  Handle this case by failing the
 	 * open.
 	 */
-	if (f > SHRT_MAX) {
+	if (__sforce_short_fildes(short_only) && f > SHRT_MAX) {
 		_close(f);
 		fp->_flags = 0;		/* set it free */
 		errno = EMFILE;
@@ -246,4 +247,19 @@ finish:
 end:
 	FUNLOCKFILE_CANCELSAFE();
 	return (fp);
+}
+
+FILE *
+freebsd15_freopen(const char * __restrict file,
+    const char * __restrict mode, FILE * __restrict fp)
+{
+	return (__sfreopen(file, mode, fp, true));
+}
+__sym_compat(freopen, freebsd15_freopen, FBSD_1.0);
+
+FILE *
+freopen(const char * __restrict file, const char * __restrict mode,
+    FILE * __restrict fp)
+{
+	return (__sfreopen(file, mode, fp, false));
 }

--- a/lib/libc/stdio/fseek.c
+++ b/lib/libc/stdio/fseek.c
@@ -85,7 +85,7 @@ _fseeko(FILE *fp, off_t offset, int whence, int ltest)
 	fpos_t target, curoff, ret;
 	size_t n;
 	struct stat st;
-	int havepos;
+	int fd, havepos;
 
 	/*
 	 * Have to be able to seek.
@@ -158,9 +158,10 @@ _fseeko(FILE *fp, off_t offset, int whence, int ltest)
 		__smakebuf(fp);
 	if (fp->_flags & (__SWR | __SRW | __SNBF | __SNPT))
 		goto dumb;
+	fd = __sfileno(fp);
 	if ((fp->_flags & __SOPT) == 0) {
 		if (seekfn != __sseek ||
-		    fp->_file < 0 || _fstat(fp->_file, &st) ||
+		    fd < 0 || _fstat(fd, &st) ||
 		    (st.st_mode & S_IFMT) != S_IFREG) {
 			fp->_flags |= __SNPT;
 			goto dumb;
@@ -176,7 +177,7 @@ _fseeko(FILE *fp, off_t offset, int whence, int ltest)
 	if (whence == SEEK_SET)
 		target = offset;
 	else {
-		if (_fstat(fp->_file, &st))
+		if (_fstat(fd, &st))
 			goto dumb;
 		if (offset > 0 && st.st_size > OFF_MAX - offset) {
 			errno = EOVERFLOW;

--- a/lib/libc/stdio/fseek.c
+++ b/lib/libc/stdio/fseek.c
@@ -52,10 +52,6 @@ fseek(FILE *fp, long offset, int whence)
 	int ret;
 	int serrno = errno;
 
-	/* make sure stdio is set up */
-	if (!__sdidinit)
-		__sinit();
-
 	FLOCKFILE_CANCELSAFE(fp);
 	ret = _fseeko(fp, (off_t)offset, whence, 1);
 	FUNLOCKFILE_CANCELSAFE();
@@ -69,10 +65,6 @@ fseeko(FILE *fp, off_t offset, int whence)
 {
 	int ret;
 	int serrno = errno;
-
-	/* make sure stdio is set up */
-	if (!__sdidinit)
-		__sinit();
 
 	FLOCKFILE_CANCELSAFE(fp);
 	ret = _fseeko(fp, offset, whence, 0);

--- a/lib/libc/stdio/funopen.c
+++ b/lib/libc/stdio/funopen.c
@@ -62,7 +62,6 @@ funopen(const void *cookie,
 	if ((fp = __sfp()) == NULL)
 		return (NULL);
 	fp->_flags = flags;
-	fp->_file = -1;
 	fp->_cookie = (void *)cookie;
 	fp->_read = readfn;
 	fp->_write = writefn;

--- a/lib/libc/stdio/local.h
+++ b/lib/libc/stdio/local.h
@@ -41,10 +41,11 @@
 #define	_STDIO_LOCAL_H
 
 #include <sys/types.h>	/* for off_t */
+#include <limits.h>
+#include <locale.h>
 #include <pthread.h>
 #include <string.h>
 #include <wchar.h>
-#include <locale.h>
 
 /*
  * Information local to this implementation of stdio,
@@ -91,6 +92,18 @@ __fgetwc(FILE *fp, locale_t locale)
 	int nread;
 
 	return (__fgetwc_mbs(fp, &fp->_mbstate, &nread, locale));
+}
+
+static inline int
+__sfileno(const FILE *fp)
+{
+	return ((fp)->_file);
+}
+
+static inline void
+__sfileno_set(FILE *fp, int fd)
+{
+	fp->_file = (unsigned)fd > SHRT_MAX ? -1 : fd;
 }
 
 /*

--- a/lib/libc/stdio/local.h
+++ b/lib/libc/stdio/local.h
@@ -68,7 +68,6 @@ extern int	__sread(void *, char *, int);
 extern int	__swrite(void *, char const *, int);
 extern fpos_t	__sseek(void *, fpos_t, int);
 extern int	__sclose(void *);
-extern void	__sinit(void);
 extern void	_cleanup(void);
 extern void	__smakebuf(FILE *);
 extern int	__swhatbuf(FILE *, size_t *, int *);
@@ -85,7 +84,6 @@ extern int	__vfwscanf(FILE * __restrict, locale_t, const wchar_t * __restrict,
 		    __va_list);
 extern size_t	__fread(void * __restrict buf, size_t size, size_t count,
 		FILE * __restrict fp);
-extern int	__sdidinit;
 
 static inline wint_t
 __fgetwc(FILE *fp, locale_t locale)

--- a/lib/libc/stdio/local.h
+++ b/lib/libc/stdio/local.h
@@ -53,41 +53,41 @@
  * in particular, macros and private variables.
  */
 
-extern int	_sread(FILE *, char *, int);
-extern int	_swrite(FILE *, char const *, int);
-extern fpos_t	_sseek(FILE *, fpos_t, int);
-extern int	_ftello(FILE *, fpos_t *);
-extern int	_fseeko(FILE *, off_t, int, int);
-extern int	__fflush(FILE *fp);
-extern void	__fcloseall(void);
-extern wint_t	__fgetwc_mbs(FILE *, mbstate_t *, int *, locale_t);
-extern wint_t	__fputwc(wchar_t, FILE *, locale_t);
-extern int	__sflush(FILE *);
+extern void	 __fcloseall(void);
+extern int	 __fflush(FILE *fp);
+extern wint_t	 __fgetwc_mbs(FILE *, mbstate_t *, int *, locale_t);
+extern wint_t	 __fputwc(wchar_t, FILE *, locale_t);
+extern size_t	 __fread(void * __restrict buf, size_t size, size_t count,
+		    FILE * __restrict fp);
+extern int	 __sclose(void *);
+extern int	 __sflags(const char *, int *);
+extern int	 __sflush(FILE *);
 extern FILE	*__sfp(void);
-extern int	__slbexpand(FILE *, size_t);
-extern int	__srefill(FILE *);
-extern int	__sread(void *, char *, int);
-extern int	__swrite(void *, char const *, int);
-extern fpos_t	__sseek(void *, fpos_t, int);
-extern int	__sclose(void *);
-extern void	_cleanup(void);
-extern void	__smakebuf(FILE *);
-extern int	__swhatbuf(FILE *, size_t *, int *);
-extern int	_fwalk(int (*)(FILE *));
-extern int	__svfscanf(FILE *, locale_t, const char *, __va_list);
-extern int	__swsetup(FILE *);
-extern int	__sflags(const char *, int *);
-extern int	__ungetc(int, FILE *);
-extern wint_t	__ungetwc(wint_t, FILE *, locale_t);
-extern int	__vfprintf(FILE *, locale_t, int, const char *, __va_list);
-extern int	__vfscanf(FILE *, const char *, __va_list);
-extern int	__vfwprintf(FILE *, locale_t, const wchar_t *, __va_list);
-extern int	__vfwscanf(FILE * __restrict, locale_t, const wchar_t * __restrict,
-		    __va_list);
-extern size_t	__fread(void * __restrict buf, size_t size, size_t count,
-		FILE * __restrict fp);
+extern int	 __slbexpand(FILE *, size_t);
+extern void	 __smakebuf(FILE *);
+extern int	 __sread(void *, char *, int);
+extern int	 __srefill(FILE *);
+extern fpos_t	 __sseek(void *, fpos_t, int);
+extern int	 __svfscanf(FILE *, locale_t, const char *, __va_list);
+extern int	 __swhatbuf(FILE *, size_t *, int *);
+extern int	 __swrite(void *, char const *, int);
+extern int	 __swsetup(FILE *);
+extern int	 __ungetc(int, FILE *);
+extern wint_t	 __ungetwc(wint_t, FILE *, locale_t);
+extern int	 __vfprintf(FILE *, locale_t, int, const char *, __va_list);
+extern int	 __vfscanf(FILE *, const char *, __va_list);
+extern int	 __vfwprintf(FILE *, locale_t, const wchar_t *, __va_list);
+extern int	 __vfwscanf(FILE * __restrict, locale_t,
+		    const wchar_t * __restrict, __va_list);
+extern void	 _cleanup(void);
+extern int	 _fseeko(FILE *, off_t, int, int);
+extern int	 _ftello(FILE *, fpos_t *);
+extern int	 _fwalk(int (*)(FILE *));
+extern int	 _sread(FILE *, char *, int);
+extern fpos_t	 _sseek(FILE *, fpos_t, int);
+extern int	 _swrite(FILE *, char const *, int);
 
-extern bool	__stdio_force_short_fildes;
+extern bool	 __stdio_force_short_fildes;
 
 static inline wint_t
 __fgetwc(FILE *fp, locale_t locale)

--- a/lib/libc/stdio/local.h
+++ b/lib/libc/stdio/local.h
@@ -45,6 +45,7 @@
 #include <locale.h>
 #include <pthread.h>
 #include <string.h>
+#include <stdbool.h>
 #include <wchar.h>
 
 /*
@@ -86,6 +87,8 @@ extern int	__vfwscanf(FILE * __restrict, locale_t, const wchar_t * __restrict,
 extern size_t	__fread(void * __restrict buf, size_t size, size_t count,
 		FILE * __restrict fp);
 
+extern bool	__stdio_force_short_fildes;
+
 static inline wint_t
 __fgetwc(FILE *fp, locale_t locale)
 {
@@ -94,16 +97,97 @@ __fgetwc(FILE *fp, locale_t locale)
 	return (__fgetwc_mbs(fp, &fp->_mbstate, &nread, locale));
 }
 
+static inline bool
+__sforce_short_fildes(bool short_only)
+{
+	return (short_only || __stdio_force_short_fildes);
+}
+
+/*
+ * The following macros and functions support encoding 32-bit
+ * file descriptors in a backward compatible way in FILE objects
+ * using the existing 16-bit _file field as well as a 16-bit
+ * slice of the _flags2 field.
+ *
+ * A signed 32-bit file descriptor 'F' is encoded into two 16-bit
+ * parts 'L' and 'H' as follows:
+ *
+ * 'L' is simply the lower sixteen bits of 'F':
+ *
+ *     short L = (short)F
+ *
+ * 'H' is the upper sixteen bits of 'F' exclusive or'd with the fifteenth
+ * bit of 'F' (i.e. the sign bit of 'L'), or equivalently, the upper
+ * sixteen bits of the result of exclusive or'ing 'F' with the lower
+ * sixteen bits of 'F' sign extended to thirty two bits.
+ *
+ *     short H = (short)((F ^ (int)(short)F) >> 16)
+ *
+ * 'L' is stored in FILE->_file and 'H' is stored in a new 16-bit slice
+ * in FILE->_flags2. Note that for values of 'F' between SHRT_MIN and
+ * SHRT_MAX, 'H' will be zero and thus this encoding has the advantage
+ * of preserving binary encodings of FILE->_file and FILE->_flags2 for
+ * file descriptors in this range.
+ */
+#define __S2FDX_SHFT			(1)
+#define __S2FDX_EXTRACT(_flags2)	\
+	    ((int)((unsigned)((_flags2) & __S2FDX) >> __S2FDX_SHFT))
+
+#define __S2FDX_INSERT(_flags2, val)	\
+	    ((_flags2) & (~__S2FDX) | (__S2FDX & ((val) << __S2FDX_SHFT)))
+
+#define __SFD_TO_LOW(fd)		((short)(fd))
+#define __SFD_TO_HSX(fd)		\
+	    ((unsigned)((fd) ^ (int)(short)(fd)) >> 16)
+
+#define __SLOW_HSX_TO_FD(low, hsx)	((int)(short)(low) ^ ((int)(hsx) << 16))
+
+_Static_assert(USHRT_MAX << __S2FDX_SHFT	== __S2FDX,	 "__S2FDX");
+_Static_assert(__S2FDX_EXTRACT(__S2FDX)		== USHRT_MAX,	 "__S2FDX");
+_Static_assert(__S2FDX_INSERT(~0, 0)		== ~__S2FDX,	 "__S2FDX");
+_Static_assert(__SFD_TO_LOW(SHRT_MIN - 1)	== SHRT_MAX,	 "__S2FDX");
+_Static_assert(__SFD_TO_LOW(SHRT_MIN)		== SHRT_MIN,	 "__S2FDX");
+_Static_assert(__SFD_TO_LOW(-1)			== -1,		 "__S2FDX");
+_Static_assert(__SFD_TO_LOW(0)			== 0,		 "__S2FDX");
+_Static_assert(__SFD_TO_LOW(SHRT_MAX)		== SHRT_MAX,	 "__S2FDX");
+_Static_assert(__SFD_TO_LOW(SHRT_MAX + 1)	== SHRT_MIN,	 "__S2FDX");
+_Static_assert(__SFD_TO_HSX(SHRT_MIN - 1)	== USHRT_MAX,	 "__S2FDX");
+_Static_assert(__SFD_TO_HSX(SHRT_MIN)		== 0,		 "__S2FDX");
+_Static_assert(__SFD_TO_HSX(-1)			== 0,		 "__S2FDX");
+_Static_assert(__SFD_TO_HSX(0)			== 0,		 "__S2FDX");
+_Static_assert(__SFD_TO_HSX(SHRT_MAX)		== 0,		 "__S2FDX");
+_Static_assert(__SFD_TO_HSX(SHRT_MAX + 1)	== USHRT_MAX,	 "__S2FDX");
+_Static_assert(__SLOW_HSX_TO_FD(0, SHRT_MIN)	== INT_MIN,	 "__S2FDX");
+_Static_assert(__SLOW_HSX_TO_FD(SHRT_MIN, 0)	== SHRT_MIN,	 "__S2FDX");
+_Static_assert(__SLOW_HSX_TO_FD(-1, 0)		== -1,		 "__S2FDX");
+_Static_assert(__SLOW_HSX_TO_FD(0, 0)		== 0,		 "__S2FDX");
+_Static_assert(__SLOW_HSX_TO_FD(SHRT_MAX, 0)	== SHRT_MAX,	 "__S2FDX");
+_Static_assert(__SLOW_HSX_TO_FD(SHRT_MIN, -1)	== SHRT_MAX + 1, "__S2FDX");
+_Static_assert(__SLOW_HSX_TO_FD(-1, SHRT_MIN)	== INT_MAX,	 "__S2FDX");
+
 static inline int
 __sfileno(const FILE *fp)
 {
-	return ((fp)->_file);
+	int fd;
+
+	if (__stdio_force_short_fildes)
+		fd = fp->_file;
+	else {
+		fd = __S2FDX_EXTRACT(fp->_flags2);
+		fd = __SLOW_HSX_TO_FD(fp->_file, fd);
+	}
+	return (fd);
 }
 
 static inline void
 __sfileno_set(FILE *fp, int fd)
 {
-	fp->_file = (unsigned)fd > SHRT_MAX ? -1 : fd;
+	if (__stdio_force_short_fildes)
+		fp->_file = (unsigned)fd > SHRT_MAX ? -1 : (short)fd;
+	else {
+		fp->_file = __SFD_TO_LOW(fd);
+		fp->_flags2 = __S2FDX_INSERT(fp->_flags2, __SFD_TO_HSX(fd));
+	}
 }
 
 /*

--- a/lib/libc/stdio/makebuf.c
+++ b/lib/libc/stdio/makebuf.c
@@ -70,7 +70,6 @@ __smakebuf(FILE *fp)
 		fp->_bf._size = 1;
 		return;
 	}
-	__cleanup = _cleanup;
 	flags |= __SMBF;
 	fp->_bf._base = fp->_p = p;
 	fp->_bf._size = size;

--- a/lib/libc/stdio/makebuf.c
+++ b/lib/libc/stdio/makebuf.c
@@ -73,7 +73,7 @@ __smakebuf(FILE *fp)
 	flags |= __SMBF;
 	fp->_bf._base = fp->_p = p;
 	fp->_bf._size = size;
-	if (couldbetty && isatty(fp->_file))
+	if (couldbetty && isatty(__sfileno(fp)))
 		flags |= __SLBF;
 	fp->_flags |= flags;
 }
@@ -85,8 +85,9 @@ int
 __swhatbuf(FILE *fp, size_t *bufsize, int *couldbetty)
 {
 	struct stat st;
+	int fd;
 
-	if (fp->_file < 0 || _fstat(fp->_file, &st) < 0) {
+	if ((fd = __sfileno(fp)) < 0 || _fstat(fd, &st) < 0) {
 		*couldbetty = 0;
 		*bufsize = BUFSIZ;
 		return (__SNPT);

--- a/lib/libc/stdio/perror.c
+++ b/lib/libc/stdio/perror.c
@@ -65,7 +65,7 @@ perror(const char *s)
 	v->iov_len = 1;
 	FLOCKFILE_CANCELSAFE(stderr);
 	__sflush(stderr);
-	(void)_writev(stderr->_file, iov, (v - iov) + 1);
+	(void)_writev(__sfileno(stderr), iov, (v - iov) + 1);
 	stderr->_flags &= ~__SOFF;
 	FUNLOCKFILE_CANCELSAFE();
 }

--- a/lib/libc/stdio/printf.3
+++ b/lib/libc/stdio/printf.3
@@ -780,10 +780,18 @@ system call, the
 .Fn printf
 family of functions may fail if:
 .Bl -tag -width Er
+.It Bq Er EBADF
+The
+.Fa fd
+argument to
+.Fn dprintf
+or
+.Fn vdprintf
+was not a valid file descriptor.
 .It Bq Er EILSEQ
 An invalid wide character code was encountered.
 .It Bq Er ENOMEM
-Insufficient storage space is available.
+Insufficient storage space was available.
 .It Bq Er EOVERFLOW
 The
 .Fa size

--- a/lib/libc/stdio/refill.c
+++ b/lib/libc/stdio/refill.c
@@ -48,7 +48,7 @@ lflush(FILE *fp)
 {
 	int	ret = 0;
 
-	if ((fp->_flags & (__SLBF|__SWR)) == (__SLBF|__SWR)) {
+	if ((fp->_flags & (__SLBF | __SWR)) == (__SLBF | __SWR)) {
 		FLOCKFILE_CANCELSAFE(fp);
 		ret = __sflush(fp);
 		FUNLOCKFILE_CANCELSAFE();
@@ -111,14 +111,14 @@ __srefill(FILE *fp)
 	 * flush all line buffered output files, per the ANSI C
 	 * standard.
 	 */
-	if (fp->_flags & (__SLBF|__SNBF)) {
+	if (fp->_flags & (__SLBF | __SNBF)) {
 		/* Ignore this file in _fwalk to avoid potential deadlock. */
 		fp->_flags |= __SIGN;
 		(void) _fwalk(lflush);
 		fp->_flags &= ~__SIGN;
 
 		/* Now flush this file without locking it. */
-		if ((fp->_flags & (__SLBF|__SWR)) == (__SLBF|__SWR))
+		if ((fp->_flags & (__SLBF | __SWR)) == (__SLBF | __SWR))
 			__sflush(fp);
 	}
 	fp->_p = fp->_bf._base;

--- a/lib/libc/stdio/refill.c
+++ b/lib/libc/stdio/refill.c
@@ -63,11 +63,6 @@ lflush(FILE *fp)
 int
 __srefill(FILE *fp)
 {
-
-	/* make sure stdio is set up */
-	if (!__sdidinit)
-		__sinit();
-
 	ORIENT(fp, -1);
 
 	fp->_r = 0;		/* largely a convenience for callers */

--- a/lib/libc/stdio/rewind.c
+++ b/lib/libc/stdio/rewind.c
@@ -44,10 +44,6 @@ rewind(FILE *fp)
 {
 	int serrno = errno;
 
-	/* make sure stdio is set up */
-	if (!__sdidinit)
-		__sinit();
-
 	FLOCKFILE(fp);
 	if (_fseeko(fp, (off_t)0, SEEK_SET, 1) == 0)
 		errno = serrno;

--- a/lib/libc/stdio/setvbuf.c
+++ b/lib/libc/stdio/setvbuf.c
@@ -127,8 +127,7 @@ nbf:
 		flags |= __SNPT;
 
 	/*
-	 * Fix up the FILE fields, and set __cleanup for output flush on
-	 * exit (since we are buffered in some way).
+	 * Fix up the FILE fields.
 	 */
 	if (mode == _IOLBF)
 		flags |= __SLBF;
@@ -150,7 +149,6 @@ nbf:
 		/* begin/continue reading, or stay in intermediate state */
 		fp->_w = 0;
 	}
-	__cleanup = _cleanup;
 
 end:
 	FUNLOCKFILE_CANCELSAFE();

--- a/lib/libc/stdio/setvbuf.c
+++ b/lib/libc/stdio/setvbuf.c
@@ -75,7 +75,8 @@ setvbuf(FILE * __restrict fp, char * __restrict buf, int mode, size_t size)
 	flags = fp->_flags;
 	if (flags & __SMBF)
 		free((void *)fp->_bf._base);
-	flags &= ~(__SLBF | __SNBF | __SMBF | __SOPT | __SOFF | __SNPT | __SEOF);
+	flags &= ~(__SLBF | __SNBF | __SMBF | __SOPT | __SOFF | __SNPT |
+	    __SEOF);
 
 	/* If setting unbuffered mode, skip all the hard work. */
 	if (mode == _IONBF)

--- a/lib/libc/stdio/stdio.c
+++ b/lib/libc/stdio/stdio.c
@@ -50,7 +50,7 @@ __sread(void *cookie, char *buf, int n)
 {
 	FILE *fp = cookie;
 
-	return(_read(fp->_file, buf, (size_t)n));
+	return (_read(__sfileno(fp), buf, (size_t)n));
 }
 
 int
@@ -58,7 +58,7 @@ __swrite(void *cookie, char const *buf, int n)
 {
 	FILE *fp = cookie;
 
-	return (_write(fp->_file, buf, (size_t)n));
+	return (_write(__sfileno(fp), buf, (size_t)n));
 }
 
 fpos_t
@@ -66,14 +66,15 @@ __sseek(void *cookie, fpos_t offset, int whence)
 {
 	FILE *fp = cookie;
 
-	return (lseek(fp->_file, (off_t)offset, whence));
+	return (lseek(__sfileno(fp), (off_t)offset, whence));
 }
 
 int
 __sclose(void *cookie)
 {
+	FILE *fp = cookie;
 
-	return (_close(((FILE *)cookie)->_file));
+	return (_close(__sfileno(fp)));
 }
 
 /*

--- a/lib/libc/stdio/stdio.c
+++ b/lib/libc/stdio/stdio.c
@@ -167,9 +167,8 @@ _sseek(FILE *fp, fpos_t offset, int whence)
 }
 
 void
-__stdio_cancel_cleanup(void * arg)
+__stdio_cancel_cleanup(void *arg)
 {
-
 	if (arg != NULL)
 		_funlockfile((FILE *)arg);
 }

--- a/lib/libc/stdio/stdio.c
+++ b/lib/libc/stdio/stdio.c
@@ -170,3 +170,17 @@ __stdio_cancel_cleanup(void * arg)
 	if (arg != NULL)
 		_funlockfile((FILE *)arg);
 }
+
+/*
+ * exit() calls _cleanup() through *__cleanup, set via a weak reference
+ * at program initialisation.  This chicanery is done so that programs
+ * that do not use stdio need not link it all in.
+ *
+ * The name `_cleanup' is, alas, fairly well known outside stdio.
+ */
+void
+_cleanup(void)
+{
+	/* (void) _fwalk(fclose); */
+	(void) _fwalk(__sflush);		/* `cheating' */
+}

--- a/lib/libc/stdio/stdio.c
+++ b/lib/libc/stdio/stdio.c
@@ -42,6 +42,8 @@
 #include "un-namespace.h"
 #include "local.h"
 
+__weak_symbol bool __stdio_force_short_fildes;
+
 /*
  * Small standard I/O/seek/close functions.
  */
@@ -184,4 +186,15 @@ _cleanup(void)
 {
 	/* (void) _fwalk(fclose); */
 	(void) _fwalk(__sflush);		/* `cheating' */
+}
+
+/*
+ * This function runs at program load time before main() runs
+ * and initialises stdio based on the environment.
+ */
+static void __attribute__((constructor))
+__stdio_init(void)
+{
+	if (secure_getenv("__STDIO_FORCE_SHORT_FILDES") != NULL)
+		__stdio_force_short_fildes = true;
 }

--- a/lib/libc/stdio/ungetc.c
+++ b/lib/libc/stdio/ungetc.c
@@ -101,7 +101,6 @@ ungetc(int c, FILE *fp)
 int
 __ungetc(int c, FILE *fp)
 {
-
 	if (c == EOF)
 		return (EOF);
 	if ((fp->_flags & __SRD) == 0) {

--- a/lib/libc/stdio/ungetc.c
+++ b/lib/libc/stdio/ungetc.c
@@ -88,8 +88,6 @@ ungetc(int c, FILE *fp)
 {
 	int ret;
 
-	if (!__sdidinit)
-		__sinit();
 	FLOCKFILE_CANCELSAFE(fp);
 	ORIENT(fp, -1);
 	ret = __ungetc(c, fp);

--- a/lib/libc/stdio/vdprintf.c
+++ b/lib/libc/stdio/vdprintf.c
@@ -49,6 +49,11 @@ vdprintf(int fd, const char * __restrict fmt, va_list ap)
 	int serrno = errno;
 	int ret;
 
+	if (fd < 0) {
+		errno = EBADF;
+		return (-1);
+	}
+
 	if (fd > SHRT_MAX) {
 		errno = EMFILE;
 		return (EOF);

--- a/lib/libc/stdio/vdprintf.c
+++ b/lib/libc/stdio/vdprintf.c
@@ -72,7 +72,7 @@ vdprintf(int fd, const char * __restrict fmt, va_list ap)
 	f._p = buf;
 	f._w = sizeof(buf);
 	f._flags = __SWR;
-	f._file = fd;
+	__sfileno_set(&f, fd);
 	f._cookie = &f;
 	f._write = __swrite;
 	f._bf._base = buf;

--- a/lib/libc/stdio/vdprintf.c
+++ b/lib/libc/stdio/vdprintf.c
@@ -55,11 +55,6 @@ vdprintf(int fd, const char * __restrict fmt, va_list ap)
 		return (-1);
 	}
 
-	if (fd > SHRT_MAX) {
-		errno = EMFILE;
-		return (EOF);
-	}
-
 	/* Ensure descriptor has been opened for writing */
 	if ((fdflags = _fcntl(fd, F_GETFL, 0)) == -1)
 		return (-1);

--- a/lib/libc/stdio/vdprintf.c
+++ b/lib/libc/stdio/vdprintf.c
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -47,7 +48,7 @@ vdprintf(int fd, const char * __restrict fmt, va_list ap)
 	FILE f = FAKE_FILE;
 	unsigned char buf[BUFSIZ];
 	int serrno = errno;
-	int ret;
+	int fdflags, ret;
 
 	if (fd < 0) {
 		errno = EBADF;
@@ -57,6 +58,15 @@ vdprintf(int fd, const char * __restrict fmt, va_list ap)
 	if (fd > SHRT_MAX) {
 		errno = EMFILE;
 		return (EOF);
+	}
+
+	/* Ensure descriptor has been opened for writing */
+	if ((fdflags = _fcntl(fd, F_GETFL, 0)) == -1)
+		return (-1);
+	fdflags &= (O_ACCMODE | O_EXEC);
+	if (fdflags != O_RDWR && fdflags != O_WRONLY) {
+		errno = EINVAL;
+		return (-1);
 	}
 
 	f._p = buf;

--- a/lib/libc/stdio/vfprintf.c
+++ b/lib/libc/stdio/vfprintf.c
@@ -106,7 +106,7 @@ grouping_init(struct grouping_state *gs, int ndigits, locale_t loc)
 		if (gs->lead <= *gs->grouping)
 			break;
 		gs->lead -= *gs->grouping;
-		if (*(gs->grouping+1)) {
+		if (*(gs->grouping + 1)) {
 			gs->nseps++;
 			gs->grouping++;
 		} else
@@ -274,7 +274,7 @@ vfprintf_l(FILE * __restrict fp, locale_t locale, const char * __restrict fmt0,
 
 	FLOCKFILE_CANCELSAFE(fp);
 	/* optimise fprintf(stderr) (and other unbuffered Unix files) */
-	if ((fp->_flags & (__SNBF|__SWR|__SRW)) == (__SNBF|__SWR) &&
+	if ((fp->_flags & (__SNBF | __SWR | __SRW)) == (__SNBF | __SWR) &&
 	    __sfileno(fp) >= 0)
 		ret = __sbprintf(fp, locale, serrno, fmt0, ap);
 	else
@@ -285,7 +285,7 @@ vfprintf_l(FILE * __restrict fp, locale_t locale, const char * __restrict fmt0,
 int
 vfprintf(FILE * __restrict fp, const char * __restrict fmt0, va_list ap)
 {
-	return vfprintf_l(fp, __get_locale(), fmt0, ap);
+	return (vfprintf_l(fp, __get_locale(), fmt0, ap));
 }
 
 /*
@@ -340,7 +340,7 @@ __vfprintf(FILE *fp, locale_t locale, int serrno, const char *fmt0, va_list ap)
 	char *dtoaend;		/* pointer to end of converted digits */
 	int expsize;		/* character count for expstr */
 	int ndig;		/* actual number of digits returned by dtoa */
-	char expstr[MAXEXPDIG+2];	/* buffer for exponent string: e+ZZZ */
+	char expstr[MAXEXPDIG + 2];	/* buffer for exponent string: e+ZZZ */
 	char *dtoaresult;	/* buffer allocated by dtoa */
 	u_long	ulval;		/* integer arguments %[diouxX] */
 	uintmax_t ujval;	/* %j, %ll, %q, %t, %z integers */
@@ -354,7 +354,7 @@ __vfprintf(FILE *fp, locale_t locale, int serrno, const char *fmt0, va_list ap)
 	char buf[BUF];		/* buffer with space for digits of uintmax_t */
 	char ox[2];		/* space for 0x; ox[1] is either x, X, or \0 */
 	union arg *argtable;    /* args, built due to positional arg */
-	union arg statargtable [STATIC_ARG_TBL_SIZE];
+	union arg statargtable[STATIC_ARG_TBL_SIZE];
 	int nextarg;            /* 1-based argument index */
 	va_list orgap;          /* original argument pointer */
 	char *convbuf;		/* wide to multibyte conversion result */
@@ -387,7 +387,7 @@ __vfprintf(FILE *fp, locale_t locale, int serrno, const char *fmt0, va_list ap)
 	 * argument (and arguments must be gotten sequentially).
 	 */
 #define GETARG(type) \
-	((argtable != NULL) ? *((type*)(&argtable[nextarg++])) : \
+	((argtable != NULL) ? *((type *)(&argtable[nextarg++])) : \
 	    (nextarg++, va_arg(ap, type)))
 
 	/*
@@ -395,25 +395,25 @@ __vfprintf(FILE *fp, locale_t locale, int serrno, const char *fmt0, va_list ap)
 	 * argument extraction methods.
 	 */
 #define	SARG() \
-	(flags&LONGINT ? GETARG(long) : \
-	    flags&SHORTINT ? (long)(short)GETARG(int) : \
-	    flags&CHARINT ? (long)(signed char)GETARG(int) : \
+	(flags & LONGINT ? GETARG(long) : \
+	    flags & SHORTINT ? (long)(short)GETARG(int) : \
+	    flags & CHARINT ? (long)(signed char)GETARG(int) : \
 	    (long)GETARG(int))
 #define	UARG() \
-	(flags&LONGINT ? GETARG(u_long) : \
-	    flags&SHORTINT ? (u_long)(u_short)GETARG(int) : \
-	    flags&CHARINT ? (u_long)(u_char)GETARG(int) : \
+	(flags & LONGINT ? GETARG(u_long) : \
+	    flags & SHORTINT ? (u_long)(u_short)GETARG(int) : \
+	    flags & CHARINT ? (u_long)(u_char)GETARG(int) : \
 	    (u_long)GETARG(u_int))
-#define	INTMAX_SIZE	(INTMAXT|SIZET|PTRDIFFT|LLONGINT)
+#define	INTMAX_SIZE	(INTMAXT | SIZET | PTRDIFFT | LLONGINT)
 #define SJARG() \
-	(flags&INTMAXT ? GETARG(intmax_t) : \
-	    flags&SIZET ? (intmax_t)GETARG(ssize_t) : \
-	    flags&PTRDIFFT ? (intmax_t)GETARG(ptrdiff_t) : \
+	(flags & INTMAXT ? GETARG(intmax_t) : \
+	    flags & SIZET ? (intmax_t)GETARG(ssize_t) : \
+	    flags & PTRDIFFT ? (intmax_t)GETARG(ptrdiff_t) : \
 	    (intmax_t)GETARG(long long))
 #define	UJARG() \
-	(flags&INTMAXT ? GETARG(uintmax_t) : \
-	    flags&SIZET ? (uintmax_t)GETARG(size_t) : \
-	    flags&PTRDIFFT ? (uintmax_t)GETARG(ptrdiff_t) : \
+	(flags & INTMAXT ? GETARG(uintmax_t) : \
+	    flags & SIZET ? (uintmax_t)GETARG(size_t) : \
+	    flags & PTRDIFFT ? (uintmax_t)GETARG(ptrdiff_t) : \
 	    (uintmax_t)GETARG(unsigned long long))
 
 	/*
@@ -431,17 +431,17 @@ __vfprintf(FILE *fp, locale_t locale, int serrno, const char *fmt0, va_list ap)
 		int hold = nextarg; \
 		if (argtable == NULL) { \
 			argtable = statargtable; \
-			if (__find_arguments (fmt0, orgap, &argtable)) { \
+			if (__find_arguments(fmt0, orgap, &argtable)) { \
 				ret = EOF; \
 				goto error; \
 			} \
 		} \
 		nextarg = n2; \
-		val = GETARG (int); \
+		val = GETARG(int); \
 		nextarg = hold; \
 		fmt = ++cp; \
 	} else { \
-		val = GETARG (int); \
+		val = GETARG(int); \
 	}
 
 	if (__use_xprintf > 0)
@@ -473,7 +473,7 @@ __vfprintf(FILE *fp, locale_t locale, int serrno, const char *fmt0, va_list ap)
 	 */
 	for (;;) {
 		for (cp = fmt; (ch = *fmt) != '\0' && ch != '%'; fmt++)
-			/* void */;
+			;	/* nothing */
 		if ((n = fmt - cp) != 0) {
 			if ((unsigned)ret + n > INT_MAX) {
 				ret = EOF;
@@ -516,7 +516,7 @@ reswitch:	switch (ch) {
 			 *	-- ANSI X3J11
 			 * They don't exclude field widths read from args.
 			 */
-			GETASTER (width);
+			GETASTER(width);
 			if (width >= 0)
 				goto rflag;
 			width = -width;
@@ -532,7 +532,7 @@ reswitch:	switch (ch) {
 			goto rflag;
 		case '.':
 			if ((ch = *fmt++) == '*') {
-				GETASTER (prec);
+				GETASTER(prec);
 				goto rflag;
 			}
 			prec = 0;
@@ -560,8 +560,8 @@ reswitch:	switch (ch) {
 				nextarg = n;
 				if (argtable == NULL) {
 					argtable = statargtable;
-					if (__find_arguments (fmt0, orgap,
-							      &argtable)) {
+					if (__find_arguments(fmt0, orgap,
+					    &argtable)) {
 						ret = EOF;
 						goto error;
 					}
@@ -606,7 +606,8 @@ reswitch:	switch (ch) {
 			 * int_fast32_t are equivalent to int, and
 			 * int_fast64_t is equivalent to long long int.
 			 */
-			flags &= ~(CHARINT|SHORTINT|LONGINT|LLONGINT|INTMAXT);
+			flags &= ~(CHARINT | SHORTINT | LONGINT | LLONGINT |
+			    INTMAXT);
 			if (fmt[0] == 'f') {
 				flags |= FASTINT;
 				fmt++;
@@ -617,16 +618,16 @@ reswitch:	switch (ch) {
 				if (!(flags & FASTINT))
 					flags |= CHARINT;
 				else
-					/* no flag set = 32 */ ;
+					; /* no flag set = 32 */
 				fmt += 1;
 			} else if (fmt[0] == '1' && fmt[1] == '6') {
 				if (!(flags & FASTINT))
 					flags |= SHORTINT;
 				else
-					/* no flag set = 32 */ ;
+					; /* no flag set = 32 */
 				fmt += 2;
 			} else if (fmt[0] == '3' && fmt[1] == '2') {
-				/* no flag set = 32 */ ;
+				; /* no flag set = 32 */
 				fmt += 2;
 			} else if (fmt[0] == '6' && fmt[1] == '4') {
 				flags |= LLONGINT;
@@ -813,7 +814,8 @@ fp_common:
 				if (prec || flags & ALT)
 					size += prec + decpt_len;
 				if ((flags & GROUPING) && expt > 0)
-					size += grouping_init(&gs, expt, locale);
+					size += grouping_init(&gs, expt,
+					    locale);
 			}
 			break;
 		case 'm':
@@ -972,8 +974,8 @@ invalid:
 
 		/*
 		 * All reasonable formats wind up here.  At this point, `cp'
-		 * points to a string which (if not flags&LADJUST) should be
-		 * padded out to `width' places.  If flags&ZEROPAD, it should
+		 * points to a string which (if not flags & LADJUST) should be
+		 * padded out to `width' places.  If flags & ZEROPAD, it should
 		 * first be prefixed by any sign or other prefix; otherwise,
 		 * it should be blank padded before the prefix is emitted.
 		 * After any left-hand padding and prefixing, emit zeroes
@@ -998,7 +1000,7 @@ invalid:
 		}
 
 		/* right-adjusting blank padding */
-		if ((flags & (LADJUST|ZEROPAD)) == 0)
+		if ((flags & (LADJUST | ZEROPAD)) == 0)
 			PAD(width - realsz, blanks);
 
 		/* prefix */
@@ -1011,7 +1013,7 @@ invalid:
 		}
 
 		/* right-adjusting zero padding */
-		if ((flags & (LADJUST|ZEROPAD)) == ZEROPAD)
+		if ((flags & (LADJUST | ZEROPAD)) == ZEROPAD)
 			PAD(width - realsz, zeroes);
 
 		/* the string or number proper */
@@ -1019,7 +1021,8 @@ invalid:
 			/* leading zeroes from decimal precision */
 			PAD(dprec - size, zeroes);
 			if (gs.grouping) {
-				if (grouping_print(&gs, &io, cp, buf+BUF, locale) < 0)
+				if (grouping_print(&gs, &io, cp, buf + BUF,
+				    locale) < 0)
 					goto error;
 			} else {
 				PRINT(cp, size);
@@ -1029,7 +1032,7 @@ invalid:
 				if (expt <= 0) {
 					PRINT(zeroes, 1);
 					if (prec || flags & ALT)
-						PRINT(decimal_point,decpt_len);
+						PRINT(decimal_point, decpt_len);
 					PAD(-expt, zeroes);
 					/* already handled initial 0's */
 					prec += expt;
@@ -1046,14 +1049,14 @@ invalid:
 						cp += expt;
 					}
 					if (prec || flags & ALT)
-						PRINT(decimal_point,decpt_len);
+						PRINT(decimal_point, decpt_len);
 				}
 				PRINTANDPAD(cp, dtoaend, prec, zeroes);
 			} else {	/* %[eE] or sufficiently long %[gG] */
 				if (prec > 1 || flags & ALT) {
 					PRINT(cp++, 1);
 					PRINT(decimal_point, decpt_len);
-					PRINT(cp, ndig-1);
+					PRINT(cp, ndig - 1);
 					PAD(prec - ndig, zeroes);
 				} else	/* XeYYY */
 					PRINT(cp, 1);
@@ -1082,7 +1085,7 @@ error:
 	else
 		fp->_flags |= savserr;
 	if ((argtable != NULL) && (argtable != statargtable))
-		free (argtable);
+		free(argtable);
 	return (ret);
 	/* NOTREACHED */
 }

--- a/lib/libc/stdio/vfprintf.c
+++ b/lib/libc/stdio/vfprintf.c
@@ -275,7 +275,7 @@ vfprintf_l(FILE * __restrict fp, locale_t locale, const char * __restrict fmt0,
 	FLOCKFILE_CANCELSAFE(fp);
 	/* optimise fprintf(stderr) (and other unbuffered Unix files) */
 	if ((fp->_flags & (__SNBF|__SWR|__SRW)) == (__SNBF|__SWR) &&
-	    fp->_file >= 0)
+	    __sfileno(fp) >= 0)
 		ret = __sbprintf(fp, locale, serrno, fmt0, ap);
 	else
 		ret = __vfprintf(fp, locale, serrno, fmt0, ap);

--- a/lib/libc/stdio/vfprintf.c
+++ b/lib/libc/stdio/vfprintf.c
@@ -187,11 +187,11 @@ __sbprintf(FILE *fp, locale_t locale, int serrno, const char *fmt, va_list ap)
 	fake._write = fp->_write;
 	fake._orientation = fp->_orientation;
 	fake._mbstate = fp->_mbstate;
+	fake._flags2 = fp->_flags2;
 
 	/* set up the buffer */
 	fake._bf._base = fake._p = buf;
 	fake._bf._size = fake._w = sizeof(buf);
-	fake._lbfsize = 0;	/* not actually used, but Just In Case */
 
 	/* do the work, then copy any error status */
 	ret = __vfprintf(&fake, locale, serrno, fmt, ap);

--- a/lib/libc/stdio/vfwprintf.c
+++ b/lib/libc/stdio/vfwprintf.c
@@ -209,7 +209,7 @@ static int
 __sbprintf(FILE *fp, locale_t locale, const wchar_t *fmt, va_list ap)
 {
 	int ret;
-	FILE fake;
+	FILE fake = FAKE_FILE;
 	unsigned char buf[BUFSIZ];
 
 	/* XXX This is probably not needed. */
@@ -223,11 +223,11 @@ __sbprintf(FILE *fp, locale_t locale, const wchar_t *fmt, va_list ap)
 	fake._write = fp->_write;
 	fake._orientation = fp->_orientation;
 	fake._mbstate = fp->_mbstate;
+	fake._flags2 = fp->_flags2;
 
 	/* set up the buffer */
 	fake._bf._base = fake._p = buf;
 	fake._bf._size = fake._w = sizeof(buf);
-	fake._lbfsize = 0;	/* not actually used, but Just In Case */
 
 	/* do the work, then copy any error status */
 	ret = __vfwprintf(&fake, locale, fmt, ap);

--- a/lib/libc/stdio/vfwprintf.c
+++ b/lib/libc/stdio/vfwprintf.c
@@ -67,9 +67,10 @@
 #include "printflocal.h"
 #include "xlocale_private.h"
 
-static int	__sprint(FILE *, struct __suio *, locale_t);
-static int	__sbprintf(FILE *, locale_t, const wchar_t *, va_list) __noinline;
-static wint_t	__xfputwc(wchar_t, FILE *, locale_t);
+static int	 __sprint(FILE *, struct __suio *, locale_t);
+static int	 __sbprintf(FILE *, locale_t, const wchar_t *, va_list)
+		    __noinline;
+static wint_t	 __xfputwc(wchar_t, FILE *, locale_t);
 static wchar_t	*__mbsconv(char *, int);
 
 #define	CHAR	wchar_t
@@ -93,7 +94,8 @@ get_decpt(locale_t locale)
 	int nconv;
 
 	mbs = initial_mbs;
-	nconv = mbrtowc(&decpt, localeconv_l(locale)->decimal_point, MB_CUR_MAX, &mbs);
+	nconv = mbrtowc(&decpt, localeconv_l(locale)->decimal_point,
+	    MB_CUR_MAX, &mbs);
 	if (nconv == (size_t)-1 || nconv == (size_t)-2)
 		decpt = '.';    /* failsafe */
 	return (decpt);
@@ -122,7 +124,6 @@ get_thousep(locale_t locale)
 static int
 grouping_init(struct grouping_state *gs, int ndigits, locale_t locale)
 {
-
 	gs->grouping = localeconv_l(locale)->grouping;
 	gs->thousands_sep = get_thousep(locale);
 
@@ -132,7 +133,7 @@ grouping_init(struct grouping_state *gs, int ndigits, locale_t locale)
 		if (gs->lead <= *gs->grouping)
 			break;
 		gs->lead -= *gs->grouping;
-		if (*(gs->grouping+1)) {
+		if (*(gs->grouping + 1)) {
 			gs->nseps++;
 			gs->grouping++;
 		} else
@@ -352,7 +353,7 @@ vfwprintf_l(FILE * __restrict fp, locale_t locale,
 	FIX_LOCALE(locale);
 	FLOCKFILE_CANCELSAFE(fp);
 	/* optimise fprintf(stderr) (and other unbuffered Unix files) */
-	if ((fp->_flags & (__SNBF|__SWR|__SRW)) == (__SNBF|__SWR) &&
+	if ((fp->_flags & (__SNBF | __SWR | __SRW)) == (__SNBF | __SWR) &&
 	    __sfileno(fp) >= 0)
 		ret = __sbprintf(fp, locale, fmt0, ap);
 	else
@@ -363,7 +364,7 @@ vfwprintf_l(FILE * __restrict fp, locale_t locale,
 int
 vfwprintf(FILE * __restrict fp, const wchar_t * __restrict fmt0, va_list ap)
 {
-	return vfwprintf_l(fp, __get_locale(), fmt0, ap);
+	return (vfwprintf_l(fp, __get_locale(), fmt0, ap));
 }
 
 /*
@@ -414,7 +415,7 @@ __vfwprintf(FILE *fp, locale_t locale, const wchar_t *fmt0, va_list ap)
 	char *dtoaend;		/* pointer to end of converted digits */
 	int expsize;		/* character count for expstr */
 	int ndig;		/* actual number of digits returned by dtoa */
-	wchar_t expstr[MAXEXPDIG+2];	/* buffer for exponent string: e+ZZZ */
+	wchar_t expstr[MAXEXPDIG + 2];	/* buffer for exponent string: e+ZZZ */
 	char *dtoaresult;	/* buffer allocated by dtoa */
 	u_long	ulval;		/* integer arguments %[diouxX] */
 	uintmax_t ujval;	/* %j, %ll, %q, %t, %z integers */
@@ -428,7 +429,7 @@ __vfwprintf(FILE *fp, locale_t locale, const wchar_t *fmt0, va_list ap)
 	wchar_t buf[BUF];	/* buffer with space for digits of uintmax_t */
 	wchar_t ox[2];		/* space for 0x hex-prefix */
 	union arg *argtable;	/* args, built due to positional arg */
-	union arg statargtable [STATIC_ARG_TBL_SIZE];
+	union arg statargtable[STATIC_ARG_TBL_SIZE];
 	int nextarg;		/* 1-based argument index */
 	va_list orgap;		/* original argument pointer */
 	wchar_t *convbuf;	/* multibyte to wide conversion result */
@@ -461,7 +462,7 @@ __vfwprintf(FILE *fp, locale_t locale, const wchar_t *fmt0, va_list ap)
 	 * argument (and arguments must be gotten sequentially).
 	 */
 #define GETARG(type) \
-	((argtable != NULL) ? *((type*)(&argtable[nextarg++])) : \
+	((argtable != NULL) ? *((type *)(&argtable[nextarg++])) : \
 	    (nextarg++, va_arg(ap, type)))
 
 	/*
@@ -469,25 +470,25 @@ __vfwprintf(FILE *fp, locale_t locale, const wchar_t *fmt0, va_list ap)
 	 * argument extraction methods.
 	 */
 #define	SARG() \
-	(flags&LONGINT ? GETARG(long) : \
-	    flags&SHORTINT ? (long)(short)GETARG(int) : \
-	    flags&CHARINT ? (long)(signed char)GETARG(int) : \
+	(flags & LONGINT ? GETARG(long) : \
+	    flags & SHORTINT ? (long)(short)GETARG(int) : \
+	    flags & CHARINT ? (long)(signed char)GETARG(int) : \
 	    (long)GETARG(int))
 #define	UARG() \
-	(flags&LONGINT ? GETARG(u_long) : \
-	    flags&SHORTINT ? (u_long)(u_short)GETARG(int) : \
-	    flags&CHARINT ? (u_long)(u_char)GETARG(int) : \
+	(flags & LONGINT ? GETARG(u_long) : \
+	    flags & SHORTINT ? (u_long)(u_short)GETARG(int) : \
+	    flags & CHARINT ? (u_long)(u_char)GETARG(int) : \
 	    (u_long)GETARG(u_int))
-#define	INTMAX_SIZE	(INTMAXT|SIZET|PTRDIFFT|LLONGINT)
+#define	INTMAX_SIZE	(INTMAXT | SIZET | PTRDIFFT | LLONGINT)
 #define SJARG() \
-	(flags&INTMAXT ? GETARG(intmax_t) : \
-	    flags&SIZET ? (intmax_t)GETARG(ssize_t) : \
-	    flags&PTRDIFFT ? (intmax_t)GETARG(ptrdiff_t) : \
+	(flags & INTMAXT ? GETARG(intmax_t) : \
+	    flags & SIZET ? (intmax_t)GETARG(ssize_t) : \
+	    flags & PTRDIFFT ? (intmax_t)GETARG(ptrdiff_t) : \
 	    (intmax_t)GETARG(long long))
 #define	UJARG() \
-	(flags&INTMAXT ? GETARG(uintmax_t) : \
-	    flags&SIZET ? (uintmax_t)GETARG(size_t) : \
-	    flags&PTRDIFFT ? (uintmax_t)GETARG(ptrdiff_t) : \
+	(flags & INTMAXT ? GETARG(uintmax_t) : \
+	    flags & SIZET ? (uintmax_t)GETARG(size_t) : \
+	    flags & PTRDIFFT ? (uintmax_t)GETARG(ptrdiff_t) : \
 	    (uintmax_t)GETARG(unsigned long long))
 
 	/*
@@ -505,17 +506,17 @@ __vfwprintf(FILE *fp, locale_t locale, const wchar_t *fmt0, va_list ap)
 		int hold = nextarg; \
 		if (argtable == NULL) { \
 			argtable = statargtable; \
-			if (__find_warguments (fmt0, orgap, &argtable)) { \
+			if (__find_warguments(fmt0, orgap, &argtable)) { \
 				ret = EOF; \
 				goto error; \
 			} \
 		} \
 		nextarg = n2; \
-		val = GETARG (int); \
+		val = GETARG(int); \
 		nextarg = hold; \
 		fmt = ++cp; \
 	} else { \
-		val = GETARG (int); \
+		val = GETARG(int); \
 	}
 
 
@@ -542,7 +543,7 @@ __vfwprintf(FILE *fp, locale_t locale, const wchar_t *fmt0, va_list ap)
 	 */
 	for (;;) {
 		for (cp = fmt; (ch = *fmt) != '\0' && ch != '%'; fmt++)
-			/* void */;
+			;	/* nothing */
 		if ((n = fmt - cp) != 0) {
 			if ((unsigned)ret + n > INT_MAX) {
 				ret = EOF;
@@ -585,7 +586,7 @@ reswitch:	switch (ch) {
 			 *	-- ANSI X3J11
 			 * They don't exclude field widths read from args.
 			 */
-			GETASTER (width);
+			GETASTER(width);
 			if (width >= 0)
 				goto rflag;
 			width = -width;
@@ -601,7 +602,7 @@ reswitch:	switch (ch) {
 			goto rflag;
 		case '.':
 			if ((ch = *fmt++) == '*') {
-				GETASTER (prec);
+				GETASTER(prec);
 				goto rflag;
 			}
 			prec = 0;
@@ -629,7 +630,7 @@ reswitch:	switch (ch) {
 				nextarg = n;
 				if (argtable == NULL) {
 					argtable = statargtable;
-					if (__find_warguments (fmt0, orgap,
+					if (__find_warguments(fmt0, orgap,
 							       &argtable)) {
 						ret = EOF;
 						goto error;
@@ -675,7 +676,8 @@ reswitch:	switch (ch) {
 			 * int_fast32_t are equivalent to int, and
 			 * int_fast64_t is equivalent to long long int.
 			 */
-			flags &= ~(CHARINT|SHORTINT|LONGINT|LLONGINT|INTMAXT);
+			flags &= ~(CHARINT | SHORTINT | LONGINT | LLONGINT |
+			    INTMAXT);
 			if (fmt[0] == 'f') {
 				flags |= FASTINT;
 				fmt++;
@@ -686,16 +688,16 @@ reswitch:	switch (ch) {
 				if (!(flags & FASTINT))
 					flags |= CHARINT;
 				else
-					/* no flag set = 32 */ ;
+					; /* no flag set = 32 */
 				fmt += 1;
 			} else if (fmt[0] == '1' && fmt[1] == '6') {
 				if (!(flags & FASTINT))
 					flags |= SHORTINT;
 				else
-					/* no flag set = 32 */ ;
+					; /* no flag set = 32 */
 				fmt += 2;
 			} else if (fmt[0] == '3' && fmt[1] == '2') {
-				/* no flag set = 32 */ ;
+				; /* no flag set = 32 */
 				fmt += 2;
 			} else if (fmt[0] == '6' && fmt[1] == '4') {
 				flags |= LLONGINT;
@@ -875,7 +877,8 @@ fp_common:
 				if (prec || flags & ALT)
 					size += prec + 1;
 				if ((flags & GROUPING) && expt > 0)
-					size += grouping_init(&gs, expt, locale);
+					size += grouping_init(&gs, expt,
+					    locale);
 			}
 			break;
 		case 'n':
@@ -1029,8 +1032,8 @@ invalid:
 
 		/*
 		 * All reasonable formats wind up here.  At this point, `cp'
-		 * points to a string which (if not flags&LADJUST) should be
-		 * padded out to `width' places.  If flags&ZEROPAD, it should
+		 * points to a string which (if not flags & LADJUST) should be
+		 * padded out to `width' places.  If flags & ZEROPAD, it should
 		 * first be prefixed by any sign or other prefix; otherwise,
 		 * it should be blank padded before the prefix is emitted.
 		 * After any left-hand padding and prefixing, emit zeroes
@@ -1055,7 +1058,7 @@ invalid:
 		}
 
 		/* right-adjusting blank padding */
-		if ((flags & (LADJUST|ZEROPAD)) == 0)
+		if ((flags & (LADJUST | ZEROPAD)) == 0)
 			PAD(width - realsz, blanks);
 
 		/* prefix */
@@ -1068,7 +1071,7 @@ invalid:
 		}
 
 		/* right-adjusting zero padding */
-		if ((flags & (LADJUST|ZEROPAD)) == ZEROPAD)
+		if ((flags & (LADJUST | ZEROPAD)) == ZEROPAD)
 			PAD(width - realsz, zeroes);
 
 		/* the string or number proper */
@@ -1076,7 +1079,8 @@ invalid:
 			/* leading zeroes from decimal precision */
 			PAD(dprec - size, zeroes);
 			if (gs.grouping) {
-				if (grouping_print(&gs, &io, cp, buf+BUF, locale) < 0)
+				if (grouping_print(&gs, &io, cp, buf + BUF,
+				    locale) < 0)
 					goto error;
 			} else {
 				PRINT(cp, size);
@@ -1111,7 +1115,7 @@ invalid:
 					buf[0] = *cp++;
 					buf[1] = decimal_point;
 					PRINT(buf, 2);
-					PRINT(cp, ndig-1);
+					PRINT(cp, ndig - 1);
 					PAD(prec - ndig, zeroes);
 				} else	/* XeYYY */
 					PRINT(cp, 1);
@@ -1138,7 +1142,7 @@ error:
 	else
 		fp->_flags |= savserr;
 	if ((argtable != NULL) && (argtable != statargtable))
-		free (argtable);
+		free(argtable);
 	return (ret);
 	/* NOTREACHED */
 }

--- a/lib/libc/stdio/vfwprintf.c
+++ b/lib/libc/stdio/vfwprintf.c
@@ -353,7 +353,7 @@ vfwprintf_l(FILE * __restrict fp, locale_t locale,
 	FLOCKFILE_CANCELSAFE(fp);
 	/* optimise fprintf(stderr) (and other unbuffered Unix files) */
 	if ((fp->_flags & (__SNBF|__SWR|__SRW)) == (__SNBF|__SWR) &&
-	    fp->_file >= 0)
+	    __sfileno(fp) >= 0)
 		ret = __sbprintf(fp, locale, fmt0, ap);
 	else
 		ret = __vfwprintf(fp, locale, fmt0, ap);

--- a/lib/libc/stdio/wsetup.c
+++ b/lib/libc/stdio/wsetup.c
@@ -45,10 +45,6 @@
 int
 __swsetup(FILE *fp)
 {
-	/* make sure stdio is set up */
-	if (!__sdidinit)
-		__sinit();
-
 	/*
 	 * If we are not writing, we had better be reading and writing.
 	 */

--- a/lib/libc/stdio/wsetup.c
+++ b/lib/libc/stdio/wsetup.c
@@ -58,7 +58,7 @@ __swsetup(FILE *fp)
 			/* clobber any ungetc data */
 			if (HASUB(fp))
 				FREEUB(fp);
-			fp->_flags &= ~(__SRD|__SEOF);
+			fp->_flags &= ~(__SRD | __SEOF);
 			fp->_r = 0;
 			fp->_p = fp->_bf._base;
 		}

--- a/lib/libc/stdio/xprintf.c
+++ b/lib/libc/stdio/xprintf.c
@@ -580,11 +580,11 @@ __v3printf(FILE *fp, const char *fmt, int pct, va_list ap)
 	fake._write = fp->_write;
 	fake._orientation = fp->_orientation;
 	fake._mbstate = fp->_mbstate;
+	fake._flags2 = fp->_flags2;
 
 	/* set up the buffer */
 	fake._bf._base = fake._p = buf;
 	fake._bf._size = fake._w = sizeof(buf);
-	fake._lbfsize = 0;	/* not actually used, but Just In Case */
 
 	/* do the work, then copy any error status */
 	ret = __v2printf(&fake, fmt, pct, ap);

--- a/lib/libc/stdio/xprintf.c
+++ b/lib/libc/stdio/xprintf.c
@@ -612,7 +612,7 @@ __xvprintf(FILE *fp, const char *fmt0, va_list ap)
 
 	/* optimise fprintf(stderr) (and other unbuffered Unix files) */
 	if ((fp->_flags & (__SNBF|__SWR|__SRW)) == (__SNBF|__SWR) &&
-	    fp->_file >= 0)
+	    __sfileno(fp) >= 0)
 		return (__v3printf(fp, fmt0, u, ap));
 	else
 		return (__v2printf(fp, fmt0, u, ap));

--- a/lib/libc/stdio/xprintf.c
+++ b/lib/libc/stdio/xprintf.c
@@ -80,10 +80,14 @@ const char __lowercase_hex[17] = "0123456789abcdef?";	/*lint !e784 */
 const char __uppercase_hex[17] = "0123456789ABCDEF?";	/*lint !e784 */
 
 #define PADSIZE 16
-static char blanks[PADSIZE] =
-	 {' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' '};
-static char zeroes[PADSIZE] =
-	 {'0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0'};
+static char blanks[PADSIZE] = {
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '
+};
+static char zeroes[PADSIZE] = {
+	'0', '0', '0', '0', '0', '0', '0', '0',
+	'0', '0', '0', '0', '0', '0', '0', '0'
+};
 
 /* printing and padding functions ------------------------------------*/
 
@@ -99,7 +103,6 @@ struct __printf_io {
 static void
 __printf_init(struct __printf_io *io)
 {
-
 	io->uio.uio_iov = io->iovp = &io->iov[0];
 	io->uio.uio_resid = 0;
 	io->uio.uio_iovcnt = 0;
@@ -108,7 +111,6 @@ __printf_init(struct __printf_io *io)
 void
 __printf_flush(struct __printf_io *io)
 {
-
 	__sfvwrite(io->fp, &io->uio);
 	__printf_init(io);
 }
@@ -116,8 +118,6 @@ __printf_flush(struct __printf_io *io)
 int
 __printf_puts(struct __printf_io *io, const void *ptr, int len)
 {
-
-
 	if (io->fp->_flags & __SERR)
 		return (0);
 	if (len == 0)
@@ -145,7 +145,7 @@ __printf_pad(struct __printf_io *io, int howmany, int zero)
 		with = blanks;
 
 	if ((n = (howmany)) > 0) {
-		while (n > PADSIZE) { 
+		while (n > PADSIZE) {
 			ret += __printf_puts(io, with, PADSIZE);
 			n -= PADSIZE;
 		}
@@ -155,7 +155,8 @@ __printf_pad(struct __printf_io *io, int howmany, int zero)
 }
 
 int
-__printf_out(struct __printf_io *io, const struct printf_info *pi, const void *ptr, int len)
+__printf_out(struct __printf_io *io, const struct printf_info *pi,
+    const void *ptr, int len)
 {
 	int ret = 0;
 
@@ -171,16 +172,16 @@ __printf_out(struct __printf_io *io, const struct printf_info *pi, const void *p
 /* percent handling  -------------------------------------------------*/
 
 static int
-__printf_arginfo_pct(const struct printf_info *pi __unused, size_t n __unused, int *argt __unused)
+__printf_arginfo_pct(const struct printf_info *pi __unused, size_t n __unused,
+    int *argt __unused)
 {
-
 	return (0);
 }
 
 static int
-__printf_render_pct(struct __printf_io *io, const struct printf_info *pi __unused, const void *const *arg __unused)
+__printf_render_pct(struct __printf_io *io,
+    const struct printf_info *pi __unused, const void *const *arg __unused)
 {
-
 	return (__printf_puts(io, "%", 1));
 }
 
@@ -189,7 +190,6 @@ __printf_render_pct(struct __printf_io *io, const struct printf_info *pi __unuse
 static int
 __printf_arginfo_n(const struct printf_info *pi, size_t n, int *argt)
 {
-
 	assert(n >= 1);
 	argt[0] = PA_POINTER;
 	return (1);
@@ -201,9 +201,9 @@ __printf_arginfo_n(const struct printf_info *pi, size_t n, int *argt)
  */
 
 static int
-__printf_render_n(FILE *io __unused, const struct printf_info *pi, const void *const *arg)
+__printf_render_n(FILE *io __unused, const struct printf_info *pi,
+    const void *const *arg)
 {
-
 	if (pi->is_char)
 		**((signed char **)arg[0]) = (signed char)pi->sofar;
 	else if (pi->is_short)
@@ -292,7 +292,7 @@ __v2printf(FILE *fp, const char *fmt0, unsigned pct, va_list ap)
 		pi->begin = pi->end = fmt;
 		while (*fmt != '\0' && *fmt != '%')
 			pi->end = ++fmt;
-		if (*fmt == '\0') 
+		if (*fmt == '\0')
 			break;
 		fmt++;
 		for (;;) {
@@ -300,8 +300,8 @@ __v2printf(FILE *fp, const char *fmt0, unsigned pct, va_list ap)
 			switch (pi->spec) {
 			case ' ':
 				/*-
-				 * ``If the space and + flags both appear, the space
-				 * flag will be ignored.''
+				 * ``If the space and + flags both appear,
+				 * the space flag will be ignored.''
 				 *      -- ANSI X3J11
 				 */
 				if (pi->showsign == 0)
@@ -370,8 +370,9 @@ __v2printf(FILE *fp, const char *fmt0, unsigned pct, va_list ap)
 						maxarg = nextarg;
 					nextarg = n;
 					fmt++;
-				} else 
+				} else {
 					pi->width = n;
+				}
 				continue;
 			case 'D':
 			case 'O':
@@ -454,51 +455,51 @@ __v2printf(FILE *fp, const char *fmt0, unsigned pct, va_list ap)
 #if 0
 		fprintf(stderr, "arg %d %x\n", ch, argt[ch]);
 #endif
-		switch(argt[ch]) {
+		switch (argt[ch]) {
 		case PA_CHAR:
-			args[ch].intarg = (char)va_arg (ap, int);
+			args[ch].intarg = (char)va_arg(ap, int);
 			break;
 		case PA_INT:
-			args[ch].intarg = va_arg (ap, int);
+			args[ch].intarg = va_arg(ap, int);
 			break;
 		case PA_INT | PA_FLAG_SHORT:
-			args[ch].intarg = (short)va_arg (ap, int);
+			args[ch].intarg = (short)va_arg(ap, int);
 			break;
 		case PA_INT | PA_FLAG_LONG:
-			args[ch].longarg = va_arg (ap, long);
+			args[ch].longarg = va_arg(ap, long);
 			break;
 		case PA_INT | PA_FLAG_INTMAX:
-			args[ch].intmaxarg = va_arg (ap, intmax_t);
+			args[ch].intmaxarg = va_arg(ap, intmax_t);
 			break;
 		case PA_INT | PA_FLAG_QUAD:
-			args[ch].intmaxarg = va_arg (ap, quad_t);
+			args[ch].intmaxarg = va_arg(ap, quad_t);
 			break;
 		case PA_INT | PA_FLAG_LONG_LONG:
-			args[ch].intmaxarg = va_arg (ap, long long);
+			args[ch].intmaxarg = va_arg(ap, long long);
 			break;
 		case PA_INT | PA_FLAG_SIZE:
-			args[ch].intmaxarg = va_arg (ap, size_t);
+			args[ch].intmaxarg = va_arg(ap, size_t);
 			break;
 		case PA_INT | PA_FLAG_PTRDIFF:
-			args[ch].intmaxarg = va_arg (ap, ptrdiff_t);
+			args[ch].intmaxarg = va_arg(ap, ptrdiff_t);
 			break;
 		case PA_WCHAR:
-			args[ch].wintarg = va_arg (ap, wint_t);
+			args[ch].wintarg = va_arg(ap, wint_t);
 			break;
 		case PA_POINTER:
-			args[ch].pvoidarg = va_arg (ap, void *);
+			args[ch].pvoidarg = va_arg(ap, void *);
 			break;
 		case PA_STRING:
-			args[ch].pchararg = va_arg (ap, char *);
+			args[ch].pchararg = va_arg(ap, char *);
 			break;
 		case PA_WSTRING:
-			args[ch].pwchararg = va_arg (ap, wchar_t *);
+			args[ch].pwchararg = va_arg(ap, wchar_t *);
 			break;
 		case PA_DOUBLE:
-			args[ch].doublearg = va_arg (ap, double);
+			args[ch].doublearg = va_arg(ap, double);
 			break;
 		case PA_DOUBLE | PA_FLAG_LONG_DOUBLE:
-			args[ch].longdoublearg = va_arg (ap, long double);
+			args[ch].longdoublearg = va_arg(ap, long double);
 			break;
 		default:
 			errx(1, "argtype = %x (fmt = \"%s\")\n",
@@ -511,15 +512,24 @@ __v2printf(FILE *fp, const char *fmt0, unsigned pct, va_list ap)
 		fprintf(stderr, " spec '%c'", pi->spec);
 		fprintf(stderr, " args %d",
 		    ((uintptr_t)pi->arg[0] - (uintptr_t)args) / sizeof args[0]);
-		if (pi->width) fprintf(stderr, " width %d", pi->width);
-		if (pi->pad) fprintf(stderr, " pad 0x%x", pi->pad);
-		if (pi->left) fprintf(stderr, " left");
-		if (pi->showsign) fprintf(stderr, " showsign");
-		if (pi->prec != -1) fprintf(stderr, " prec %d", pi->prec);
-		if (pi->is_char) fprintf(stderr, " char");
-		if (pi->is_short) fprintf(stderr, " short");
-		if (pi->is_long) fprintf(stderr, " long");
-		if (pi->is_long_double) fprintf(stderr, " long_double");
+		if (pi->width)
+			fprintf(stderr, " width %d", pi->width);
+		if (pi->pad)
+			fprintf(stderr, " pad 0x%x", pi->pad);
+		if (pi->left)
+			fprintf(stderr, " left");
+		if (pi->showsign)
+			fprintf(stderr, " showsign");
+		if (pi->prec != -1)
+			fprintf(stderr, " prec %d", pi->prec);
+		if (pi->is_char)
+			fprintf(stderr, " char");
+		if (pi->is_short)
+			fprintf(stderr, " short");
+		if (pi->is_long)
+			fprintf(stderr, " long");
+		if (pi->is_long_double)
+			fprintf(stderr, " long_double");
 		fprintf(stderr, "\n");
 		fprintf(stderr, "\t\"%.*s\"\n", pi->end - pi->begin, pi->begin);
 #endif
@@ -536,7 +546,7 @@ __v2printf(FILE *fp, const char *fmt0, unsigned pct, va_list ap)
 				pi->width = -pi->width;
 			}
 		}
-		if (pi->get_prec) 
+		if (pi->get_prec)
 			pi->prec = args[pi->get_prec].intarg;
 		ret += __printf_puts(&io, pi->begin, pi->end - pi->begin);
 		if (printf_tbl[pi->spec].gnurender != NULL) {
@@ -558,8 +568,6 @@ __v2printf(FILE *fp, const char *fmt0, unsigned pct, va_list ap)
 	__printf_flush(&io);
 	return (ret);
 }
-
-extern int      __fflush(FILE *fp);
 
 /*
  * Helper function for `fprintf to unbuffered unix file': creates a
@@ -611,7 +619,7 @@ __xvprintf(FILE *fp, const char *fmt0, va_list ap)
 	}
 
 	/* optimise fprintf(stderr) (and other unbuffered Unix files) */
-	if ((fp->_flags & (__SNBF|__SWR|__SRW)) == (__SNBF|__SWR) &&
+	if ((fp->_flags & (__SNBF | __SWR | __SRW)) == (__SNBF | __SWR) &&
 	    __sfileno(fp) >= 0)
 		return (__v3printf(fp, fmt0, u, ap));
 	else
@@ -621,9 +629,9 @@ __xvprintf(FILE *fp, const char *fmt0, va_list ap)
 /* extending ---------------------------------------------------------*/
 
 int
-register_printf_function(int spec, printf_function *render, printf_arginfo_function *arginfo)
+register_printf_function(int spec, printf_function *render,
+    printf_arginfo_function *arginfo)
 {
-
 	if (spec > 255 || spec < 0)
 		return (-1);
 	printf_tbl[spec].gnurender = render;
@@ -633,9 +641,9 @@ register_printf_function(int spec, printf_function *render, printf_arginfo_funct
 }
 
 int
-register_printf_render(int spec, printf_render *render, printf_arginfo_function *arginfo)
+register_printf_render(int spec, printf_render *render,
+    printf_arginfo_function *arginfo)
 {
-
 	if (spec > 255 || spec < 0)
 		return (-1);
 	printf_tbl[spec].render = render;
@@ -647,7 +655,6 @@ register_printf_render(int spec, printf_render *render, printf_arginfo_function 
 int
 register_printf_render_std(const char *specs)
 {
-
 	for (; *specs != '\0'; specs++) {
 		switch (*specs) {
 		case 'H':

--- a/lib/libc/stdlib/exit.c
+++ b/lib/libc/stdlib/exit.c
@@ -38,7 +38,15 @@
 #include "atexit.h"
 #include "libc_private.h"
 
-void (*__cleanup)(void);
+/*
+ * This variable points to the stdio cleanup function which is called
+ * by exit() and abort(). Originally this function pointer was set
+ * during runtime the first time stdio was used however as stdio is
+ * always present now we set it here at startup. The __cleanup pointer
+ * itself is retained in the unlikely event that an application should
+ * need to hook the stdio cleanup routine.
+ */
+void (*__cleanup)(void) = &_cleanup;
 
 /*
  * This variable is zero until a process has created a thread.


### PR DESCRIPTION
FreeBSD's libc stdio implementation to this day still stores file descriptors in a short integer field in FILE objects thus causing failures when more than 32,767 files are open.

This pull request allows FreeBSD libc stdio to support the full range of the larger 32-bit file descriptors that the FreeBSD kernel has supported for many years, while still maintaining ABI compatibility with the current lib stdio implementation.

This work follows discussion in both bugzilla bug report 291610 as well as prior work in phabricator D54354 and D54355; please see the URLs below for further details.

* [Bug 291610](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=291610)
* [Differential D54354](https://reviews.freebsd.org/D54354)
* [Differential D54355](https://reviews.freebsd.org/D54355)