### PR TITLE
pfctl: consistency

### DIFF
--- a/sbin/pfctl/pfctl.8
+++ b/sbin/pfctl/pfctl.8
@@ -456,7 +456,7 @@ When used together with
 .Nm
 will loop and show updated queue statistics every five seconds, including
 measured bandwidth and packets per second.
-.It Cm ether
+.It Cm ethernet
 Show the currently loaded Ethernet rules.
 When used together with
 .Fl v ,

--- a/sbin/pfctl/pfctl.c
+++ b/sbin/pfctl/pfctl.c
@@ -305,7 +305,7 @@ struct pfctl_opt_id {
 };
 
 static const struct pfctl_opt_id showopt_list[] = {
-	{ "ether",		SHOWOPT_ETHER },
+	{ "ethernet",		SHOWOPT_ETHER },
 	{ "nat",		SHOWOPT_NAT },
 	{ "queue",		SHOWOPT_QUEUE },
 	{ "rules",		SHOWOPT_RULES },


### PR DESCRIPTION
% pfctl -F ethernet
Ethernet rules cleared

% pfctl -s ethernet
pfctl: Unknown show modifier 'ethernet'

pfctl accepts 'ethernet' (or any prefix of it) in the -F flag but accepts only 'ether' (or any prefix of it) in the -s flag, which seems inconsistent.  This change brings the two to parity while remaining backwards compatible.