### PR TITLE
/bin/ps: Fix display of negative nice values on ARMv7/aarch64

### DIFF
--- a/bin/ps/keyword.c
+++ b/bin/ps/keyword.c
@@ -133,7 +133,7 @@ static VAR keywords[] = {
 	{"mwchan", {NULL}, "MWCHAN", "wait-channel", LJUST, mwchan, 0,
 	 UNSPEC, NULL},
 	{"ni", {"nice"}, NULL, NULL, 0, NULL, 0, UNSPEC, NULL},
-	{"nice", {NULL}, "NI", "nice", 0, kvar, KOFF(ki_nice), CHAR, "d"},
+	{"nice", {NULL}, "NI", "nice", 0, kvar, KOFF(ki_nice), SCHAR, "d"},
 	{"nivcsw", {NULL}, "NIVCSW", "involuntary-context-switches", USER, rvar,
 	 ROFF(ru_nivcsw), LONG, "ld"},
 	{"nlwp", {NULL}, "NLWP", "threads", 0, kvar, KOFF(ki_numthreads),

--- a/bin/ps/print.c
+++ b/bin/ps/print.c
@@ -754,6 +754,9 @@ printval(void *bp, const VAR *v)
 	case CHAR:
 		(void)asprintf(&str, ofmt, *(char *)bp);
 		break;
+	case SCHAR:
+		(void)asprintf(&str, ofmt, *(signed char *)bp);
+		break;
 	case UCHAR:
 		(void)asprintf(&str, ofmt, *(u_char *)bp);
 		break;

--- a/bin/ps/ps.h
+++ b/bin/ps/ps.h
@@ -33,7 +33,7 @@
 
 #define	UNLIMITED	0	/* unlimited terminal width */
 enum type { UNSPEC, /* For output routines that don't care and aliases. */
-	    CHAR, UCHAR, SHORT, USHORT, INT, UINT, LONG, ULONG, KPTR, PGTOK };
+	    CHAR, SCHAR, UCHAR, SHORT, USHORT, INT, UINT, LONG, ULONG, KPTR, PGTOK };
 
 typedef struct kinfo_str {
 	STAILQ_ENTRY(kinfo_str) ks_next;


### PR DESCRIPTION
On Arm-based systems (and maybe others), 'char' defaults to unsigned, causing negative nice values to be displayed incorrectly (e.g., 246 instead of -10). Explicitly using 'signed char' ensures consistent behaviour across architectures.

[ tested on RPI2 and generic aarch64 qemu install ]
```
Before:
  # /usr/bin/nice --10 ps -l | awk '(NR == 1 || $(NF-1) == "ps")'
  UID   PID  PPID C PRI  NI  VSZ  RSS MWCHAN  STAT TT     TIME COMMAND
    0 23606 22800 2 -32 246 5400 2544 -       R<+   0  0:00.06 ps -l

After:
  # /usr/bin/nice --10 ps -l | awk '(NR == 1 || $(NF-1) == "ps")'
  UID   PID  PPID C PRI  NI  VSZ  RSS MWCHAN  STAT TT     TIME COMMAND
    0 23614 22800 3 -32 -10 5400 2544 -       R<+   0  0:00.05 ps -l
```