### PR TITLE
Convert sysutils/fand into a 1st class citizen

### DIFF
--- a/libexec/rc/rc.d/fand
+++ b/libexec/rc/rc.d/fand
@@ -1,0 +1,161 @@
+#!/bin/sh
+#
+# Copyright (c) 2003 The FreeBSD Project. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE PROJECT ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE PROJECT BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+# PROVIDE: fand
+# REQUIRE: DAEMON devfs sysctl
+# KEYWORD: nojail shutdown
+
+. /etc/rc.subr
+
+name="fand"
+desc="System fan control"
+rcvar="${name}_enable"
+
+load_rc_config $name
+: ${fand_enable:=NO}
+: ${fand_list:=""}
+
+# Defaults (matching fand(8))
+fand_default_flags=
+fand_default_hi_duty=
+fand_default_hi_period=0
+fand_default_hi_temp=
+fand_default_invpol=NO
+fand_default_kelvin=YES
+fand_default_lo_duty=
+fand_default_lo_period=0
+fand_default_lo_temp=50
+fand_default_multiplier=1.0
+fand_default_off_temp=50
+fand_default_pollint=60
+fand_default_profile=
+
+command="/usr/sbin/${name}"
+start_precmd="fand_prestart"
+start_cmd="fand_start"
+status_cmd="fand_status"
+stop_cmd="fand_stop"
+
+fand_start_config()
+{
+	local name="$1"
+	local prefix="fand_${name}_"
+
+	for option_name in device sensor lo_temp hi_temp off_temp lo_period hi_period lo_duty hi_duty kelvin multiplier profile pollint invpol flags; do
+		eval "local default=\${fand_default_${option_name}}"
+		eval "local ${option_name}=\${${prefix}${option_name}:-$default}"
+	done
+	if [ -z "$device" ] || [ -z "$sensor" ]; then
+		warn "fand_${name}_sensor and fand_${name}_device are required to start a fand instance!"
+		return
+	fi
+
+	local pidfile="/var/run/fand/$name.pid"
+	local cmdline="$command"
+	cmdline="$cmdline -r $pidfile"
+	if [ -n "$profile" ]; then
+		if [ $(echo $profile | cut -c1) != '/' ]; then
+			profile="/etc/fand/$profile"
+		fi
+		cmdline="$cmdline -c $profile"
+	else
+		if [ -n "$lo_duty" ]; then
+			warn "fand_${fan}_lo_duty is required to start a fand instance!"
+			continue
+		fi
+		cmdline="${cmdline}${lo_temp:+ -t $lo_temp}${lo_period:+ -p $lo_period}${lo_duty:+ -d $lo_duty}"
+		cmdline="${cmdline}${hi_temp:+ -T $hi_temp}${hi_period:+ -P $hi_period}${hi_duty:+ -D $hi_duty}"
+		cmdline="${cmdline}${off_temp:+ -o $off_temp}"
+	fi
+	checkyesno kelvin && cmdline="$cmdline -K"
+	checkyesno invpol && cmdline="$cmdline -I"
+	cmdline="${cmdline}${multiplier:+ -m $multiplier}${pollint:+ -i $pollint}"
+	cmdline="$cmdline $sensor $device"
+
+	$cmdline
+	startmsg -n " $name"
+}
+
+fand_prestart()
+{
+	[ -d /var/run/fand ] || install -do root -g wheel -m 755 /var/run/fand
+}
+
+fand_start()
+{
+	local list=$*
+	[ -n "$list" ] || list=$fand_list
+	[ -n "$list" ] || err 1 "configuration names are required to start fand instances"
+
+	startmsg -n "Starting ${desc}:"
+	for name in $list; do
+		fand_start_config "$name"
+	done
+	startmsg '.'
+}
+
+fand_status()
+{
+	local list=$*
+	[ -n "$list" ] || list=$fand_list
+
+	local status=''
+	local pidlist=''
+	for name in $list; do
+		local pidfile="/var/run/fand/$name.pid"
+		local pid=$(check_pidfile $pidfile $command)
+		[ -n "$pid" ] && pidlist="$pidlist $pid"
+		[ -n "$pid" ] || continue
+		status="$status $name"
+	done
+	if [ -n "$status" ]; then
+		echo "Running ${desc}:$status."
+	else
+		echo "No running ${desc}."
+	fi
+}
+
+fand_stop()
+{
+	local list=$*
+	[ -n "$list" ] || list=$fand_list
+
+	local pidlist=''
+	startmsg -n "Stopping ${desc}:"
+	for name in $list; do
+		local sig_stop=${sig_stop:-TERM}
+		local pidfile="/var/run/fand/$name.pid"
+		local pid=$(check_pidfile $pidfile $command)
+		[ -n "$pid" ] && pidlist="$pidlist $pid"
+		[ -n "$pid" ] || continue
+		startmsg -n " $name"
+		kill -$sig_stop $pid
+	done
+	startmsg '.'
+	wait_for_pids $pidlist
+}
+
+run_rc_command $*

--- a/libexec/rc/rc.d/fand
+++ b/libexec/rc/rc.d/fand
@@ -1,0 +1,164 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2026 Stéphane Rochoy <stephane.rochoy@stormshield.eu>
+# Copyright (c) 2022 Corey Hinshaw <corey@electrickite.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE PROJECT ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE PROJECT BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+# PROVIDE: fand
+# REQUIRE: DAEMON devfs sysctl
+# KEYWORD: nojail shutdown
+
+. /etc/rc.subr
+
+name="fand"
+desc="System fan control"
+rcvar="${name}_enable"
+
+load_rc_config $name
+: ${fand_enable:=NO}
+: ${fand_list:=""}
+
+# Defaults (matching fand(8))
+fand_default_flags=
+fand_default_hi_duty=
+fand_default_hi_period=0
+fand_default_hi_temp=
+fand_default_invpol=NO
+fand_default_kelvin=YES
+fand_default_lo_duty=
+fand_default_lo_period=0
+fand_default_lo_temp=50
+fand_default_multiplier=1.0
+fand_default_off_temp=50
+fand_default_pollint=60
+fand_default_profile=
+
+command="/usr/sbin/${name}"
+start_precmd="fand_prestart"
+start_cmd="fand_start"
+status_cmd="fand_status"
+stop_cmd="fand_stop"
+
+fand_start_config()
+{
+	local name="$1"
+	local prefix="fand_${name}_"
+
+	for option_name in device sensor lo_temp hi_temp off_temp lo_period hi_period lo_duty hi_duty kelvin multiplier profile pollint invpol flags; do
+		eval "local default=\${fand_default_${option_name}}"
+		eval "local ${option_name}=\${${prefix}${option_name}:-$default}"
+	done
+	if [ -z "$device" ] || [ -z "$sensor" ]; then
+		warn "fand_${name}_sensor and fand_${name}_device are required to start a fand instance!"
+		return
+	fi
+
+	local pidfile="/var/run/fand/$name.pid"
+	local cmdline="$command"
+	cmdline="$cmdline -r $pidfile"
+	if [ -n "$profile" ]; then
+		if [ $(echo $profile | cut -c1) != '/' ]; then
+			profile="/etc/fand/$profile"
+		fi
+		cmdline="$cmdline -c $profile"
+	else
+		if [ -n "$lo_duty" ]; then
+			warn "fand_${fan}_lo_duty is required to start a fand instance!"
+			continue
+		fi
+		cmdline="${cmdline}${lo_temp:+ -t $lo_temp}${lo_period:+ -p $lo_period}${lo_duty:+ -d $lo_duty}"
+		cmdline="${cmdline}${hi_temp:+ -T $hi_temp}${hi_period:+ -P $hi_period}${hi_duty:+ -D $hi_duty}"
+		cmdline="${cmdline}${off_temp:+ -o $off_temp}"
+	fi
+	checkyesno kelvin && cmdline="$cmdline -K"
+	checkyesno invpol && cmdline="$cmdline -I"
+	cmdline="${cmdline}${multiplier:+ -m $multiplier}${pollint:+ -i $pollint}"
+	cmdline="$cmdline $sensor $device"
+
+	$cmdline
+	startmsg -n " $name"
+}
+
+fand_prestart()
+{
+	[ -d /var/run/fand ] || install -do root -g wheel -m 755 /var/run/fand
+}
+
+fand_start()
+{
+	local list=$*
+	[ -n "$list" ] || list=$fand_list
+	[ -n "$list" ] || err 1 "configuration names are required to start fand instances"
+
+	startmsg -n "Starting ${desc}:"
+	for name in $list; do
+		fand_start_config "$name"
+	done
+	startmsg '.'
+}
+
+fand_status()
+{
+	local list=$*
+	[ -n "$list" ] || list=$fand_list
+
+	local status=''
+	local pidlist=''
+	for name in $list; do
+		local pidfile="/var/run/fand/$name.pid"
+		local pid=$(check_pidfile $pidfile $command)
+		[ -n "$pid" ] && pidlist="$pidlist $pid"
+		[ -n "$pid" ] || continue
+		status="$status $name"
+	done
+	if [ -n "$status" ]; then
+		echo "Running ${desc}:$status."
+	else
+		echo "No running ${desc}."
+	fi
+}
+
+fand_stop()
+{
+	local list=$*
+	[ -n "$list" ] || list=$fand_list
+
+	local pidlist=''
+	startmsg -n "Stopping ${desc}:"
+	for name in $list; do
+		local sig_stop=${sig_stop:-TERM}
+		local pidfile="/var/run/fand/$name.pid"
+		local pid=$(check_pidfile $pidfile $command)
+		[ -n "$pid" ] && pidlist="$pidlist $pid"
+		[ -n "$pid" ] || continue
+		startmsg -n " $name"
+		kill -$sig_stop $pid
+	done
+	startmsg '.'
+	wait_for_pids $pidlist
+}
+
+run_rc_command $*

--- a/share/man/man5/rc.conf.5
+++ b/share/man/man5/rc.conf.5
@@ -355,6 +355,120 @@ Use
 instead.
 A whitespace-separated list of kernel modules to be ignored by
 .Xr devmatch 8 .
+.It Va fand_enable
+.Pq Vt bool
+If set to
+.Dq Li YES ,
+enable the system fan control facility with the
+.Xr fand 8
+daemon.
+.It Va fand_list
+.Pq Vt str
+A whitespace-separated list of fand configuration names.
+See the
+.Pa fand_NAME_*
+variables.
+.It Va fand_*_device
+.Pq Vt str
+The pwmc fan controller device.
+E.g.,
+.Pa pwmc1.0 .
+This devices are found in
+.Pa /dev/pwm/ .
+.It Va fand_*_flags
+.Pq Vt str
+Additional command options to pass to fand.
+Unset by default.
+.It Va fand_*_hi_duty
+.Pq Vt str
+High duty cycle as a duration in nanoseconds or as a percentage.
+Unset by default.
+Conflicts with
+.Va fand_*_profile .
+.It Va fand_*_hi_period
+.Pq Vt int
+The period in nanoseconds of the high duty cycle
+.Pq Vt hi_duty
+is enabled.
+Unset by default.
+Conflicts with
+.Va fand_*_profile .
+.It Va fand_*_hi_temp
+.Pq Vt int
+Temperature at which the fan is enabled with the high duty cycle
+.Pq Vt hi_duty .
+Unset by default.
+Conflicts with
+.Va fand_*_profile .
+.It Va fand_*_invpol
+.Pq Vt bool
+Set to
+.Dq Li YES
+to invert PWM polarity.
+Defaults to
+.Dq Li NO .
+.It Va fand_*_kelvin
+.Pq Vt bool
+Set to
+.Dq Li YES
+if the temperature sensor is in Kelvin.
+Otherwise temperature is in degrees Celsius.
+Defaults to
+.Dq Li YES .
+.It Va fand_*_lo_duty
+.Pq Vt str
+Low duty cycle as a duration in nanoseconds or as a percentage.
+Defaults to 0.
+Conflicts with
+.Va fand_*_profile .
+.It Va fand_*_lo_period
+.Pq Vt int
+The period in nanoseconds of the low duty cycle
+.Pq Vt lo_duty
+is enabled.
+Defaults to 0.
+Conflicts with
+.Va fand_*_profile .
+.It Va fand_*_lo_temp
+.Pq Vt int
+Temperature at which the fan is enabled with the low duty cycle
+.Pq Vt lo_duty .
+Defaults to 50.
+Conflicts with
+.Va fand_*_profile .
+.It Va fand_*_multiplier
+.Pq Vt float
+A multiplier to apply to the reported temperatures.
+Defaults to 1.0.
+.It Va fand_*_off_temp
+.Pq Vt int
+Temperature at which the fan is disabled.
+Defaults to 35.
+Conflicts with
+.Va fand_*_profile .
+.It Va fand_*_pollint
+.Pq Vt int
+Temperature polling interval in seconds.
+Defaults to 60.
+.It Va fand_*_profile
+.Pq Vt str
+Cooling profile.
+Unset by default.
+Conflicts with:
+.Va fand_*_hi_duty ,
+.Va fand_*_hi_period ,
+.Va fand_*_hi_temp ,
+.Va fand_*_lo_duty ,
+.Va fand_*_lo_period ,
+.Va fand_*_lo_temp
+and
+.Va fand_*_off_temp .
+.It Va fand_*_sensor
+.Pq Vt str
+.Xr sysctl 8
+variable used to read temperature.
+E.g.,
+.Pa hw.temp.CPU .
 .It Va kld_list
 .Pq Vt str
 A whitespace-separated list of kernel modules to load right after

--- a/usr.sbin/Makefile
+++ b/usr.sbin/Makefile
@@ -25,6 +25,7 @@ SUBDIR=	adduser \
 	etcupdate \
 	extattr \
 	extattrctl \
+	fand \
 	fifolog \
 	fstyp \
 	fwcontrol \

--- a/usr.sbin/fand/Makefile
+++ b/usr.sbin/fand/Makefile
@@ -1,0 +1,11 @@
+PROG=	fand
+MAN=	fand.8
+SRCS=	fand.c config.c
+INCS=	fand.h
+
+# Will limit sysctl sensors to the ones having CTLFLAG_CAPRD.
+# CFLAGS+=	-DUSE_CAPSICUM
+
+LIBADD=	util figpar
+
+.include <bsd.prog.mk>

--- a/usr.sbin/fand/config.c
+++ b/usr.sbin/fand/config.c
@@ -1,0 +1,163 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Stéphane Rochoy <stephane.rochoy@stormshield.eu>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <err.h>
+#include <figpar.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fand.h"
+
+static int store_lo_duty(struct figpar_config *option, uint32_t line,
+                         char *directive, char *value);
+static int    store_temp(struct figpar_config *option, uint32_t line,
+                         char *directive, char *value);
+static int    store_duty(struct figpar_config *option, uint32_t line,
+                         char *directive, char *value);
+
+static struct figpar_config fand_config[] = {
+	/* TYPE                DIRECTIVE          DEFAULT    HANDLER */
+	{FIGPAR_TYPE_UINT,     "lo_duty",         {0},       &store_lo_duty},
+	{FIGPAR_TYPE_DATA1,    "step.*.temp",     {0},       &store_temp},
+	{FIGPAR_TYPE_UINT,     "step.*.duty",     {0},       &store_duty},
+	{0, NULL, {0}, NULL}
+};
+
+static char *
+handle_index(char *directive, const char *prefix, size_t *index)
+{
+	unsigned long  ul;
+	char          *next;
+
+	if (strncmp(directive, prefix, strlen(prefix)))
+		return (directive);
+	ul = strtoul(directive + strlen(prefix), &next, 0);
+	*index = ul;
+	return (next);
+}
+
+static int
+store_lo_duty(struct figpar_config *option, uint32_t line __unused,
+              char *directive __unused, char *value)
+{
+	unsigned long ul;
+
+	if (option == NULL) {
+		warnx("%s:%d:%s: Missing callback parameter", __FILE__,
+		      __LINE__, __func__);
+		return (-1); /* Abort processing */
+	}
+
+	ul               = strtoul(value, NULL, 0);
+	cprofile.lo_duty = ul;
+	return (0);
+}
+
+static int
+store_temp(struct figpar_config *option, uint32_t line, char *directive,
+           char *value)
+{
+	float  f;
+	size_t s;
+
+	if (option == NULL) {
+		warnx("%s:%d:%s: Missing callback parameter", __FILE__,
+		      __LINE__, __func__);
+		return (-1); /* Abort processing */
+	}
+
+	handle_index(directive, "step.", &s);
+	if (s == (size_t)-1) {
+		warnx("Missing step index at line %u", line);
+		return (-1);
+	}
+
+	f = strtof(value, NULL);
+
+	/* Ensure temperatures are strictly increasing */
+	if (s > 0 && f <= cprofile.steps[s - 1].temp) {
+		warnx("step %zu temperature (%.2f) must be strictly greater"
+		    " than step %zu temperature (%.2f)", s, f, s - 1,
+		    cprofile.steps[s - 1].temp);
+		return (-1);
+	}
+
+	cprofile.steps[s].temp = f;
+
+	/* Update step count */
+	if (s >= cprofile.step_count) {
+		if (s != cprofile.step_count) {
+			warnx("Invalid step index at line %u;"
+			    " want %zu, got %zu", line, cprofile.step_count, s);
+			return (-1);
+		}
+		cprofile.step_count++;
+	}
+	return (0);
+}
+
+static int
+store_duty(struct figpar_config *option, uint32_t line, char *directive,
+           char *value)
+{
+	size_t         s;
+	unsigned long  ul;
+
+	if (option == NULL) {
+		warnx("%s:%d:%s: Missing callback parameter", __FILE__,
+		      __LINE__, __func__);
+		return (-1); /* Abort processing */
+	}
+
+	handle_index(directive, "step.", &s);
+	if (s == (size_t)-1) {
+		warnx("Missing step index at line %u", line);
+		return (-1);
+	}
+
+	ul = strtoul(value, NULL, 0);
+	cprofile.steps[s].duty = ul;
+
+	/* Update step count */
+	if (s >= cprofile.step_count) {
+		if (s != cprofile.step_count) {
+			warnx("Invalid step index at line %u;"
+			    " want %zu, got %zu", line, cprofile.step_count, s);
+			return (-1);
+		}
+		cprofile.step_count++;
+	}
+
+	return (0);
+}
+
+int
+parse_fand_config(const char *path)
+{
+	return (parse_config(fand_config, path, NULL,
+	                     FIGPAR_BREAK_ON_EQUALS | FIGPAR_REQUIRE_EQUALS));
+}

--- a/usr.sbin/fand/fand.8
+++ b/usr.sbin/fand/fand.8
@@ -1,0 +1,188 @@
+.\" Copyright (c) 2022 Corey Hinshaw <corey@electrickite.org>
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE DEVELOPERS ``AS IS'' AND ANY EXPRESS OR
+.\" IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+.\" OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+.\" IN NO EVENT SHALL THE DEVELOPERS BE LIABLE FOR ANY DIRECT, INDIRECT,
+.\" INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+.\" NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+.\" DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+.\" THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+.\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+.\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd February 10, 2022
+.Dt FAND 8
+.Os fand 0.2.3
+.Sh NAME
+.Nm fand
+.Nd daemon to control PWM (Pulse Width Modulation) cooling fans
+.Sh SYNOPSIS
+.Nm
+.Op options...
+.Ar temperature_sensor
+.Ar pwm_device
+.Nm
+.Op Fl fiIp
+.Op Fl m Ar multiplier
+.Op Fl r Ar path
+.Fl c Ar profile
+.Ar temperature_sensor
+.Ar pwm_device
+.Nm
+.Op options...
+.Fl s
+.Ar temperature_sensor
+.Ar pwm_device
+.Nm
+.Fl h
+.Nm
+.Fl v
+.Sh DESCRIPTION
+The
+.Nm
+daemon can be used to control a cooling fan connected to a
+.Xr pwmc 4
+.Ar pwm_device
+based on the system temperature retrived from a
+.Xr sysctl 3
+.Ar temperature_sensor
+. Low and high termperature thresholds can be configured, each with separate
+PWM parameters.
+.Pp
+.Ar temperature_sensor
+should be the name of the sysctl variable used to read the system temperature.
+.Ar pwm_device
+should be the name of the PWM device that controls the system fan. If an
+unqualified name is provided,
+.Pa /dev/pwm
+is automatically prepended.
+.Pp
+When called with the
+.Fl s
+option,
+.Nm
+will print the current status of the temperature sensor and the PWM state and
+exit. This can be useful when determining the required temperature multiplier
+and other options.
+.Pp
+The options are as follows:
+.Bl -tag -width "-t temperature"
+
+.It Fl c Ar profile
+The name of the cooling profile to use. Default to none. Conflict with the
+.Fl d ,
+.Fl D ,
+.Fl t ,
+.Fl T ,
+.Fl K ,
+.Fl o ,
+.Fl p ,
+.Fl P ,
+.Fl t
+and
+.Fl T
+options.
+
+.It Fl d Ar duty
+The duty cycle (in nanoseconds or percentage) of the PWM channel for the
+default (low) temperature threshold. Duty is the portion of the
+.Ar period
+during which the signal is asserted. Conflict with the
+.Fl c
+option.
+
+.It Fl D Ar duty
+The duty cycle (in nanoseconds or percentage) of the PWM channel for the
+high temperature threshold. Duty is the portion of the
+.Ar period
+during which the signal is asserted. Conflict with the
+.Fl c
+option.
+
+.It Fl f
+Run
+.Nm
+in the foreground. Also enables more verbose output.
+
+.It Fl i Ar seconds
+The temperature polling interval, in seconds (Default: 60)
+
+.It Fl I
+Invert PWM signal polarity
+
+.It Fl K
+Converts the temperature sensor reading from degrees Kelvin. Conflict with the
+.Fl c
+option.
+
+.It Fl m Ar multiplier
+Multiplier applied to reading from temperature sensor (Default: 1.0)
+
+.It Fl o Ar temperature
+Temperature to deactivate fan, in °C. Default to 50°C. Conflict with the
+.Fl c
+option.
+
+.It Fl p Ar period
+The period in nanoseconds of the PWM channel for the default (low) temperature
+threshold. Default to 0. Conflict with the
+.Fl c
+option.
+
+.It Fl P Ar period
+The period in nanoseconds of the PWM channel for the high temperature threshold
+Default to 0. Conflict with the
+.Fl c
+option.
+
+.It Fl r Ar path
+The PID file path
+(Default: /var/run/fand.pid)
+
+.It Fl s
+Show current temperature and PWM status, then exit.
+
+.It Fl t Ar temperature
+Default (low) temperature to enable the fan, in °C. Default to 50°C. Conflict with the
+.Fl c
+option.
+
+.It Fl T Ar temperature
+High temperature threshold, in °C. Default to none. Conflict with the
+.Fl c
+option.
+
+.It Fl v
+Print program version and exit
+
+.El
+.Sh EXAMPLES
+.Bl -bullet
+.It
+Using the "hw.temp.CPU" sensor and the pwmc1.0 controller, run the fan
+at half duty cycle when the temperature reaches 45C and run at full when the
+temperature rises above 60C. Disable the fan if the temperature falls below
+35C. When reading from the sensor, assume value is in tenth degrees Kelvin.
+.Bd -literal
+fand -t 45 -p 50000 -d "50%" -T 60 -o 35 -K -m 0.1 hw.temp.CPU pwmc1.0
+.Ed
+.El
+.Sh SEE ALSO
+.Xr sysctl 8 ,
+.Xr pwm 8
+.Sh AUTHORS
+.An -nosplit
+The
+.Nm
+utility and this manual page were written by
+.An Corey Hinshaw Aq Mt corey@electrickite.org .

--- a/usr.sbin/fand/fand.8
+++ b/usr.sbin/fand/fand.8
@@ -56,7 +56,7 @@ daemon can be used to control a cooling fan connected to a
 based on the system temperature retrived from a
 .Xr sysctl 3
 .Ar temperature_sensor
-. Low and high termperature thresholds can be configured, each with separate
+. Low and high temperature thresholds can be configured, each with separate
 PWM parameters.
 .Pp
 .Ar temperature_sensor
@@ -79,7 +79,7 @@ The options are as follows:
 .Bl -tag -width "-t temperature"
 
 .It Fl c Ar profile
-The name of the cooling profile to use. Default to none. Conflict with the
+The name of the cooling profile to use. Defaults to none. Conflicts with the
 .Fl d ,
 .Fl D ,
 .Fl t ,
@@ -97,7 +97,7 @@ options.
 The duty cycle (in nanoseconds or percentage) of the PWM channel for the
 default (low) temperature threshold. Duty is the portion of the
 .Ar period
-during which the signal is asserted. Conflict with the
+during which the signal is asserted. Conflicts with the
 .Fl c
 option.
 
@@ -105,7 +105,7 @@ option.
 The duty cycle (in nanoseconds or percentage) of the PWM channel for the
 high temperature threshold. Duty is the portion of the
 .Ar period
-during which the signal is asserted. Conflict with the
+during which the signal is asserted. Conflicts with the
 .Fl c
 option.
 
@@ -121,7 +121,7 @@ The temperature polling interval, in seconds (Default: 60)
 Invert PWM signal polarity
 
 .It Fl K
-Converts the temperature sensor reading from degrees Kelvin. Conflict with the
+Converts the temperature sensor reading from Kelvin. Conflicts with the
 .Fl c
 option.
 
@@ -129,19 +129,19 @@ option.
 Multiplier applied to reading from temperature sensor (Default: 1.0)
 
 .It Fl o Ar temperature
-Temperature to deactivate fan, in °C. Default to 50°C. Conflict with the
+Temperature to deactivate fan, in degrees Celsius. Defaults to 50 °C. Conflicts with the
 .Fl c
 option.
 
 .It Fl p Ar period
 The period in nanoseconds of the PWM channel for the default (low) temperature
-threshold. Default to 0. Conflict with the
+threshold. Defaults to 0. Conflicts with the
 .Fl c
 option.
 
 .It Fl P Ar period
 The period in nanoseconds of the PWM channel for the high temperature threshold
-Default to 0. Conflict with the
+Defaults to 0. Conflicts with the
 .Fl c
 option.
 
@@ -153,12 +153,12 @@ The PID file path
 Show current temperature and PWM status, then exit.
 
 .It Fl t Ar temperature
-Default (low) temperature to enable the fan, in °C. Default to 50°C. Conflict with the
+Default (low) temperature to enable the fan, in degrees Celsius. Defaults to 50 °C. Conflicts with the
 .Fl c
 option.
 
 .It Fl T Ar temperature
-High temperature threshold, in °C. Default to none. Conflict with the
+High temperature threshold, in degrees Celsius. Defaults to none. Conflicts with the
 .Fl c
 option.
 
@@ -170,9 +170,9 @@ Print program version and exit
 .Bl -bullet
 .It
 Using the "hw.temp.CPU" sensor and the pwmc1.0 controller, run the fan
-at half duty cycle when the temperature reaches 45C and run at full when the
-temperature rises above 60C. Disable the fan if the temperature falls below
-35C. When reading from the sensor, assume value is in tenth degrees Kelvin.
+at half duty cycle when the temperature reaches 45 °C and run at full when the
+temperature rises above 60 °C. Disable the fan if the temperature falls below
+35 °C. When reading from the sensor, assume value is in tenth Kelvin.
 .Bd -literal
 fand -t 45 -p 50000 -d "50%" -T 60 -o 35 -K -m 0.1 hw.temp.CPU pwmc1.0
 .Ed
@@ -180,6 +180,7 @@ fand -t 45 -p 50000 -d "50%" -T 60 -o 35 -K -m 0.1 hw.temp.CPU pwmc1.0
 .Sh SEE ALSO
 .Xr sysctl 8 ,
 .Xr pwm 8
+.Xr rc.conf 5
 .Sh AUTHORS
 .An -nosplit
 The

--- a/usr.sbin/fand/fand.8
+++ b/usr.sbin/fand/fand.8
@@ -1,3 +1,6 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
+.\" Copyright (c) 2026 Stéphane Rochoy <stephane.rochoy@stormshield.eu>
 .\" Copyright (c) 2022 Corey Hinshaw <corey@electrickite.org>
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -20,7 +23,7 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd February 10, 2022
+.Dd Aug 13, 2026
 .Dt FAND 8
 .Os fand 0.2.3
 .Sh NAME
@@ -56,7 +59,7 @@ daemon can be used to control a cooling fan connected to a
 based on the system temperature retrived from a
 .Xr sysctl 3
 .Ar temperature_sensor
-. Low and high termperature thresholds can be configured, each with separate
+. Low and high temperature thresholds can be configured, each with separate
 PWM parameters.
 .Pp
 .Ar temperature_sensor
@@ -79,7 +82,7 @@ The options are as follows:
 .Bl -tag -width "-t temperature"
 
 .It Fl c Ar profile
-The name of the cooling profile to use. Default to none. Conflict with the
+The name of the cooling profile to use. Defaults to none. Conflicts with the
 .Fl d ,
 .Fl D ,
 .Fl t ,
@@ -97,7 +100,7 @@ options.
 The duty cycle (in nanoseconds or percentage) of the PWM channel for the
 default (low) temperature threshold. Duty is the portion of the
 .Ar period
-during which the signal is asserted. Conflict with the
+during which the signal is asserted. Conflicts with the
 .Fl c
 option.
 
@@ -105,7 +108,7 @@ option.
 The duty cycle (in nanoseconds or percentage) of the PWM channel for the
 high temperature threshold. Duty is the portion of the
 .Ar period
-during which the signal is asserted. Conflict with the
+during which the signal is asserted. Conflicts with the
 .Fl c
 option.
 
@@ -121,7 +124,7 @@ The temperature polling interval, in seconds (Default: 60)
 Invert PWM signal polarity
 
 .It Fl K
-Converts the temperature sensor reading from degrees Kelvin. Conflict with the
+Converts the temperature sensor reading from Kelvin. Conflicts with the
 .Fl c
 option.
 
@@ -129,19 +132,19 @@ option.
 Multiplier applied to reading from temperature sensor (Default: 1.0)
 
 .It Fl o Ar temperature
-Temperature to deactivate fan, in °C. Default to 50°C. Conflict with the
+Temperature to deactivate fan, in degrees Celsius. Defaults to 50 °C. Conflicts with the
 .Fl c
 option.
 
 .It Fl p Ar period
 The period in nanoseconds of the PWM channel for the default (low) temperature
-threshold. Default to 0. Conflict with the
+threshold. Defaults to 0. Conflicts with the
 .Fl c
 option.
 
 .It Fl P Ar period
 The period in nanoseconds of the PWM channel for the high temperature threshold
-Default to 0. Conflict with the
+Defaults to 0. Conflicts with the
 .Fl c
 option.
 
@@ -153,12 +156,12 @@ The PID file path
 Show current temperature and PWM status, then exit.
 
 .It Fl t Ar temperature
-Default (low) temperature to enable the fan, in °C. Default to 50°C. Conflict with the
+Default (low) temperature to enable the fan, in degrees Celsius. Defaults to 50 °C. Conflicts with the
 .Fl c
 option.
 
 .It Fl T Ar temperature
-High temperature threshold, in °C. Default to none. Conflict with the
+High temperature threshold, in degrees Celsius. Defaults to none. Conflicts with the
 .Fl c
 option.
 
@@ -170,9 +173,9 @@ Print program version and exit
 .Bl -bullet
 .It
 Using the "hw.temp.CPU" sensor and the pwmc1.0 controller, run the fan
-at half duty cycle when the temperature reaches 45C and run at full when the
-temperature rises above 60C. Disable the fan if the temperature falls below
-35C. When reading from the sensor, assume value is in tenth degrees Kelvin.
+at half duty cycle when the temperature reaches 45 °C and run at full when the
+temperature rises above 60 °C. Disable the fan if the temperature falls below
+35 °C. When reading from the sensor, assume value is in tenth Kelvin.
 .Bd -literal
 fand -t 45 -p 50000 -d "50%" -T 60 -o 35 -K -m 0.1 hw.temp.CPU pwmc1.0
 .Ed
@@ -180,9 +183,14 @@ fand -t 45 -p 50000 -d "50%" -T 60 -o 35 -K -m 0.1 hw.temp.CPU pwmc1.0
 .Sh SEE ALSO
 .Xr sysctl 8 ,
 .Xr pwm 8
+.Xr rc.conf 5
 .Sh AUTHORS
 .An -nosplit
 The
 .Nm
-utility and this manual page were written by
+utility and this manual page were originally written by
 .An Corey Hinshaw Aq Mt corey@electrickite.org .
+.An Stéphane Rochoy Aq Mt stephane.rochoy@stormshield.eu
+modified it to add cooling profiles and
+.Xr capsicum 4
+support.

--- a/usr.sbin/fand/fand.c
+++ b/usr.sbin/fand/fand.c
@@ -204,7 +204,7 @@ static void print_cprofile(void)
 	printf("    Low Duty: %u ns\n", cprofile.lo_duty);
 	printf("    Steps:\n");
 	for (; step < step_end; step++)
-		printf("        %.2f%s → %u ns\n", step->temp, temp_unit,
+		printf("        %.2f %s → %u ns\n", step->temp, temp_unit,
 		       step->duty);
 }
 
@@ -353,7 +353,7 @@ int main(int argc, char *argv[])
 			     " use -h to display usage", optopt);
 		}
 	}
-	temp_unit = (offset == 0 ? "°C" : " K");
+	temp_unit = (offset == 0 ? "°C" : "K");
 	if (show_cprofile) {
 		print_cprofile();
 		exit(EX_OK);
@@ -424,7 +424,7 @@ int main(int argc, char *argv[])
 			    temp_name);
 
 		if (!daemonize)
-			warnx("Current Temperature: %.2f%s", temp, temp_unit);
+			warnx("Current Temperature: %.2f %s", temp, temp_unit);
 
 		if (use_cprofile) /* Apply the cooling profile */
 			apply_cprofile(temp, &current_state, &new_state);

--- a/usr.sbin/fand/fand.c
+++ b/usr.sbin/fand/fand.c
@@ -1,0 +1,470 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2022 Corey Hinshaw <corey@electrickite.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/sysctl.h>
+
+#ifdef USE_CAPSICUM
+#include <sys/capsicum.h>
+#endif
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libutil.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sysexits.h>
+#include <unistd.h>
+
+#include <dev/pwm/pwmc.h>
+
+#include "fand.h"
+
+#define PROGNAME "fand"
+#define VERSION "0.2.3"
+#define KELVIN_OFFSET (-273.15)
+
+cprofile_t cprofile = {0};
+
+static struct pidfh *pfh = NULL;
+static const char *pid_path = "/var/run/" PROGNAME ".pid";
+static char pwm_device[PATH_MAX];
+static char *temp_name = NULL;
+static int fd = -1;
+static bool inverted = false;
+static bool daemonize = true;
+static bool high_temp_set = false;
+static bool show_status = false;
+static float multiplier = 1.0;
+static float offset = 0.0;
+static const char *temp_unit;
+static int off_temp = 50;
+static int low_temp = 50;
+static int high_temp = 0;
+static unsigned int interval = 60;
+static unsigned int low_period = 0;
+static unsigned int low_duty = 0;
+static bool low_duty_percent = false;
+static unsigned int high_period = 0;
+static unsigned int high_duty = 0;
+static bool high_duty_percent = false;
+static bool quit;
+
+static void print_usage(void)
+{
+	printf("Usage:\n");
+	printf("\t%s [options...] sensor fan_device\n", PROGNAME);
+}
+
+static void print_version(void)
+{
+	printf("%s %s\n", PROGNAME, VERSION);
+}
+
+static void set_temp_name(char *name)
+{
+	if (name[0] == '\0')
+		errx(EX_USAGE, "Temperature sensor sysctl name not specified;"
+		     " use -h to display usage");
+	temp_name = name;
+}
+
+static void set_pwm_device(const char *dev)
+{
+	if (dev[0] == '\0')
+		errx(EX_USAGE, "PWM device not specified;"
+		     " use -h to display usage");
+	if (dev[0] == '/')
+		strlcpy(pwm_device, dev, sizeof(pwm_device));
+	else
+		snprintf(pwm_device, sizeof(pwm_device), "/dev/pwm/%s", dev);
+}
+
+static void set_duty(char *arg, unsigned int *duty, bool *percent)
+{
+	char *end;
+
+	*duty = strtoul(arg, &end, 10);
+	if (*end == '%') {
+		*percent = true;
+		if (*duty > 100)
+			errx(EX_USAGE, "Invalid duty percentage;"
+			     " use -h to display usage");
+	} else if (*end != '\0')
+		errx(EX_USAGE, "Invalid duty; use -h to display usage");
+}
+
+static unsigned int calculate_duty(unsigned int duty, unsigned int period,
+                                   bool percent)
+{
+	if (percent)
+		return ((uint64_t)period * duty / 100);
+	else
+		return (duty);
+}
+
+static float normalize_temperature(float raw_temp)
+{
+	return (raw_temp * multiplier + offset);
+}
+
+static int current_temperature(float *temp)
+{
+	int    raw_temp;
+	size_t len;
+
+	if (!temp) {
+		errno = EINVAL;
+		return (-1);
+	}
+
+	len = sizeof(raw_temp);
+	if (sysctlbyname(temp_name, &raw_temp, &len, NULL, 0) != 0)
+		return (-1);
+	*temp = normalize_temperature(raw_temp);
+	return (0);
+}
+
+static void fprintf_status(FILE *stream, struct pwm_state state, float temp)
+{
+	fprintf(stream, "Sensor: %s\n", temp_name);
+	fprintf(stream, "  Temperature: %.1f %s\n", temp,
+	        (offset == 0.0 ? "°C" : "K"));
+	fprintf(stream, "Fan PWM Device: %s\n", pwm_device);
+	fprintf(stream, "  Period:   %u ns\n", state.period);
+	fprintf(stream, "  Duty:     %u ns (%u%%)\n", state.duty,
+	        state.duty * 100 / state.period);
+	fprintf(stream, "  Enabled:  %d\n", state.enable);
+	fprintf(stream, "  Inverted: %d\n",
+	        state.flags & PWM_POLARITY_INVERTED);
+}
+
+static void cleanup(void)
+{
+	if (!daemonize)
+		warnx("Terminating");
+	pidfile_remove(pfh);
+	if (fd != -1) {
+		struct pwm_state state;
+
+		if (ioctl(fd, PWMGETSTATE, &state) == -1) {
+			warn("Cannot read state of the PWM controller");
+			close(fd);
+			return;
+		}
+		state.enable = false;
+		if (ioctl(fd, PWMSETSTATE, &state) == -1)
+			warn("Cannot configure the PWM controller");
+		close(fd);
+	}
+}
+
+static void print_cprofile(void)
+{
+	cstep_t *step, *step_end;
+
+	if (cprofile.step_count == 0) {
+		printf("No cooling profile.\n");
+		return;
+	}
+
+	step     = &cprofile.steps[0];
+	step_end = step + cprofile.step_count;
+
+	printf("Cooling Profile:\n");
+	printf("    Low Duty: %u ns\n", cprofile.lo_duty);
+	printf("    Steps:\n");
+	for (; step < step_end; step++)
+		printf("        %.2f%s → %u ns\n", step->temp, temp_unit,
+		       step->duty);
+}
+
+/*
+ * Change the PWM state from old to new by applying the given cooling profile to
+ * the given temperature.
+ * Assume:
+ * - step_count > 0
+ * - curtemp is already normalized
+ */
+static void apply_cprofile(float curtemp,
+                           struct pwm_state *old, struct pwm_state *new)
+{
+	cstep_t *step, *step_start;
+	float    step_temp;
+
+	step       = &cprofile.steps[cprofile.step_count - 1];
+	step_start = &cprofile.steps[0];
+
+	/* Walk backward through steps */
+	for (; step_start <= step; step--) {
+		new->duty = step->duty;
+		step_temp = normalize_temperature(step->temp);
+		if (curtemp >= step_temp) {
+			warnx("cprofile: step found: %.2f%s ≥ %.2f%s",
+			      curtemp, temp_unit, step_temp, temp_unit);
+			break;
+		}
+	}
+	if (++step == step_start) { /* no matching step found */
+		warnx("cprofile: no matching step found, using low duty");
+		new->duty = cprofile.lo_duty;
+	}
+	new->enable = true;
+
+	warnx("cprofile: %u ns (%u%%) → %u ns (%u%%)",
+	      old->duty, old->duty * 100 / old->period,
+	      new->duty, new->duty * 100 / new->period);
+}
+
+
+static void sigterm(int sig __unused)
+{
+	quit = true;
+}
+
+#ifdef USE_CAPSICUM
+/* Setup capabilities on fd. */
+static void capset(void)
+{
+	cap_rights_t        rights;
+	const unsigned long cmds[] = { PWMGETSTATE, PWMSETSTATE };
+
+	if (cap_enter() < 0)
+		err(EX_OSERR, "cap_enter");
+
+	cap_rights_init(&rights, CAP_IOCTL);
+	if (cap_rights_limit(fd, &rights) < 0)
+		err(EX_OSERR, "cap_rights_limit");
+	if (cap_ioctls_limit(fd, cmds, nitems(cmds)))
+		err(EX_OSERR, "cap_ioctls_limit");
+}
+#endif /* USE_CAPSICUM */
+
+int main(int argc, char *argv[])
+{
+	struct pwm_state current_state, new_state;
+	struct  sigaction sigtermact = {.sa_handler = sigterm };
+	pid_t otherpid;
+	int ch;
+	float temp;
+	bool use_cprofile = false, show_cprofile = false;
+
+	pwm_device[0] = '\0';
+	memset(&current_state, 0, sizeof(current_state));
+	memset(&new_state, 0, sizeof(new_state));
+
+	atexit(cleanup);
+
+	while ((ch = getopt(argc, argv,
+	                    "c:ht:T:o:i:IKlm:p:P:d:D:r:fsv")) != -1) {
+		switch (ch) {
+		case 'c':
+			if (parse_fand_config(optarg) != 0)
+				errx(EX_CONFIG, "%s: Invalid configuration",
+				     optarg);
+			use_cprofile = true;
+			break;
+		case 'h':
+			print_usage();
+			exit(EX_OK);
+		case 't':
+			low_temp = strtol(optarg, NULL, 10);
+			break;
+		case 'T':
+			high_temp_set = true;
+			high_temp = strtol(optarg, NULL, 10);
+			break;
+		case 'o':
+			off_temp = strtol(optarg, NULL, 10);
+			break;
+		case 'i':
+			interval = strtol(optarg, NULL, 10);
+			break;
+		case 'I':
+			inverted = true;
+			break;
+		case 'K':
+			offset = KELVIN_OFFSET;
+			break;
+		case 'l':
+			show_cprofile = true;
+			break;
+		case 'm':
+			multiplier = strtof(optarg, NULL);
+			break;
+		case 'p':
+			low_period = strtoul(optarg, NULL, 10);
+			break;
+		case 'P':
+			high_period = strtoul(optarg, NULL, 10);
+			break;
+		case 'd':
+			set_duty(optarg, &low_duty, &low_duty_percent);
+			break;
+		case 'D':
+			set_duty(optarg, &high_duty, &high_duty_percent);
+			break;
+		case 'f':
+			daemonize = false;
+			break;
+		case 'r':
+			pid_path = optarg;
+			break;
+		case 's':
+			show_status = true;
+			break;
+		case 'v':
+			print_version();
+			exit(EX_OK);
+		case '?':
+			errx(EX_USAGE, "Unknown option `-%c';"
+			     " use -h to display usage", optopt);
+		case ':':
+			errx(EX_USAGE, "Option -%c requires an argument;"
+			     " use -h to display usage", optopt);
+		}
+	}
+	temp_unit = (offset == 0 ? "°C" : " K");
+	if (show_cprofile) {
+		print_cprofile();
+		exit(EX_OK);
+	}
+
+	if (argc - optind != 2)
+		errx(EX_USAGE, "Wrong number of arguments;"
+		     " use -h to display usage");
+	set_temp_name(argv[optind]);
+	set_pwm_device(argv[optind + 1]);
+
+	if (use_cprofile && offset > 0)
+		errx(EX_USAGE, "Conflicting options: -K and -c;"
+		     " use -h to display usage");
+	/* FIXME Handle other conflicts with -c */
+
+	if (off_temp > low_temp)
+		off_temp = low_temp;
+	if (high_temp <= low_temp)
+		high_temp_set = false;
+
+	if ((fd = open(pwm_device, 0)) == -1)
+		err(EX_OSFILE, "Cannot open %s", pwm_device);
+#ifdef USE_CAPSICUM
+	capset(); /* will err() on error. */
+#endif /* USE_CAPSICUM */
+	if (ioctl(fd, PWMGETSTATE, &current_state) == -1)
+		err(EX_OSERR, "%s: Cannot read state of the PWM controller",
+		    pwm_device);
+	if (current_state.enable)
+		warnx("%s: Already enabled", pwm_device);
+	if (current_temperature(&temp) != 0) {
+		close(fd);
+		/* don't disable something you didn't enable yourself */
+		fd = -1;
+		err(EX_OSERR, "Cannot read temperature from %s", temp_name);
+	}
+
+	if (show_status) {
+		fprintf_status(stdout, current_state, temp);
+		exit(EX_OK);
+	}
+
+	if (daemonize) {
+		pfh = pidfile_open(pid_path, 0600, &otherpid);
+		if (pfh == NULL) {
+			if (errno == EEXIST)
+				errx(EX_SOFTWARE, "already running, pid: %jd.",
+				     (intmax_t)otherpid);
+			warn("Cannot open or create pidfile");
+		}
+		if (daemon(1, 1) < 0)
+			err(EX_OSERR, "Failed to daemonize!");
+		pidfile_write(pfh);
+	} else
+		fprintf_status(stderr, current_state, temp);
+
+	if (sigaction(SIGTERM, &sigtermact, NULL) != 0)
+		err(EX_OSERR, "sigaction(SIGTERM)");
+	if (sigaction(SIGINT, &sigtermact, NULL) != 0)
+		err(EX_OSERR, "sigaction(SIGINT)");
+
+	for (quit = false; !quit;) {
+		new_state = current_state;
+
+		if (current_temperature(&temp) != 0)
+			err(EX_OSERR, "Cannot read temperature from %s",
+			    temp_name);
+
+		if (!daemonize)
+			warnx("Current Temperature: %.2f%s", temp, temp_unit);
+
+		if (use_cprofile) /* Apply the cooling profile */
+			apply_cprofile(temp, &current_state, &new_state);
+		else {
+			if (temp >= low_temp)
+				new_state.enable = true;
+			else if (temp < off_temp)
+				new_state.enable = false;
+
+			if (high_temp_set && temp >= high_temp) {
+				if (high_period > 0)
+					new_state.period = high_period;
+				new_state.duty = calculate_duty(high_duty,
+				    new_state.period, high_duty_percent);
+			} else {
+				if (low_period > 0)
+					new_state.period = low_period;
+				new_state.duty = calculate_duty(low_duty,
+				    new_state.period, low_duty_percent);
+			}
+		}
+
+		if (inverted)
+			new_state.flags |= PWM_POLARITY_INVERTED;
+		else
+			new_state.flags &= ~PWM_POLARITY_INVERTED;
+
+		if (memcmp(&current_state, &new_state,
+		           sizeof(current_state)) != 0) {
+			if (!daemonize) {
+				warnx(">> Fan state change <<");
+				fprintf_status(stderr, new_state, temp);
+			}
+			if (ioctl(fd, PWMSETSTATE, &new_state) == -1)
+				err(EX_OSERR,
+				    "Cannot configure the PWM controller");
+		}
+		current_state = new_state;
+
+		sleep(interval);
+	}
+	return (EX_OK);
+}

--- a/usr.sbin/fand/fand.c
+++ b/usr.sbin/fand/fand.c
@@ -1,0 +1,471 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Stéphane Rochoy <stephane.rochoy@stormshield.eu>
+ * Copyright (c) 2022 Corey Hinshaw <corey@electrickite.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/sysctl.h>
+
+#ifdef USE_CAPSICUM
+#include <sys/capsicum.h>
+#endif
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libutil.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sysexits.h>
+#include <unistd.h>
+
+#include <dev/pwm/pwmc.h>
+
+#include "fand.h"
+
+#define PROGNAME "fand"
+#define VERSION "0.2.3"
+#define KELVIN_OFFSET (-273.15)
+
+cprofile_t cprofile = {0};
+
+static struct pidfh *pfh = NULL;
+static const char *pid_path = "/var/run/" PROGNAME ".pid";
+static char pwm_device[PATH_MAX];
+static char *temp_name = NULL;
+static int fd = -1;
+static bool inverted = false;
+static bool daemonize = true;
+static bool high_temp_set = false;
+static bool show_status = false;
+static float multiplier = 1.0;
+static float offset = 0.0;
+static const char *temp_unit;
+static int off_temp = 50;
+static int low_temp = 50;
+static int high_temp = 0;
+static unsigned int interval = 60;
+static unsigned int low_period = 0;
+static unsigned int low_duty = 0;
+static bool low_duty_percent = false;
+static unsigned int high_period = 0;
+static unsigned int high_duty = 0;
+static bool high_duty_percent = false;
+static bool quit;
+
+static void print_usage(void)
+{
+	printf("Usage:\n");
+	printf("\t%s [options...] sensor fan_device\n", PROGNAME);
+}
+
+static void print_version(void)
+{
+	printf("%s %s\n", PROGNAME, VERSION);
+}
+
+static void set_temp_name(char *name)
+{
+	if (name[0] == '\0')
+		errx(EX_USAGE, "Temperature sensor sysctl name not specified;"
+		     " use -h to display usage");
+	temp_name = name;
+}
+
+static void set_pwm_device(const char *dev)
+{
+	if (dev[0] == '\0')
+		errx(EX_USAGE, "PWM device not specified;"
+		     " use -h to display usage");
+	if (dev[0] == '/')
+		strlcpy(pwm_device, dev, sizeof(pwm_device));
+	else
+		snprintf(pwm_device, sizeof(pwm_device), "/dev/pwm/%s", dev);
+}
+
+static void set_duty(char *arg, unsigned int *duty, bool *percent)
+{
+	char *end;
+
+	*duty = strtoul(arg, &end, 10);
+	if (*end == '%') {
+		*percent = true;
+		if (*duty > 100)
+			errx(EX_USAGE, "Invalid duty percentage;"
+			     " use -h to display usage");
+	} else if (*end != '\0')
+		errx(EX_USAGE, "Invalid duty; use -h to display usage");
+}
+
+static unsigned int calculate_duty(unsigned int duty, unsigned int period,
+                                   bool percent)
+{
+	if (percent)
+		return ((uint64_t)period * duty / 100);
+	else
+		return (duty);
+}
+
+static float normalize_temperature(float raw_temp)
+{
+	return (raw_temp * multiplier + offset);
+}
+
+static int current_temperature(float *temp)
+{
+	int    raw_temp;
+	size_t len;
+
+	if (!temp) {
+		errno = EINVAL;
+		return (-1);
+	}
+
+	len = sizeof(raw_temp);
+	if (sysctlbyname(temp_name, &raw_temp, &len, NULL, 0) != 0)
+		return (-1);
+	*temp = normalize_temperature(raw_temp);
+	return (0);
+}
+
+static void fprintf_status(FILE *stream, struct pwm_state state, float temp)
+{
+	fprintf(stream, "Sensor: %s\n", temp_name);
+	fprintf(stream, "  Temperature: %.1f %s\n", temp,
+	        (offset == 0.0 ? "°C" : "K"));
+	fprintf(stream, "Fan PWM Device: %s\n", pwm_device);
+	fprintf(stream, "  Period:   %u ns\n", state.period);
+	fprintf(stream, "  Duty:     %u ns (%u%%)\n", state.duty,
+	        state.duty * 100 / state.period);
+	fprintf(stream, "  Enabled:  %d\n", state.enable);
+	fprintf(stream, "  Inverted: %d\n",
+	        state.flags & PWM_POLARITY_INVERTED);
+}
+
+static void cleanup(void)
+{
+	if (!daemonize)
+		warnx("Terminating");
+	pidfile_remove(pfh);
+	if (fd != -1) {
+		struct pwm_state state;
+
+		if (ioctl(fd, PWMGETSTATE, &state) == -1) {
+			warn("Cannot read state of the PWM controller");
+			close(fd);
+			return;
+		}
+		state.enable = false;
+		if (ioctl(fd, PWMSETSTATE, &state) == -1)
+			warn("Cannot configure the PWM controller");
+		close(fd);
+	}
+}
+
+static void print_cprofile(void)
+{
+	cstep_t *step, *step_end;
+
+	if (cprofile.step_count == 0) {
+		printf("No cooling profile.\n");
+		return;
+	}
+
+	step     = &cprofile.steps[0];
+	step_end = step + cprofile.step_count;
+
+	printf("Cooling Profile:\n");
+	printf("    Low Duty: %u ns\n", cprofile.lo_duty);
+	printf("    Steps:\n");
+	for (; step < step_end; step++)
+		printf("        %.2f%s → %u ns\n", step->temp, temp_unit,
+		       step->duty);
+}
+
+/*
+ * Change the PWM state from old to new by applying the given cooling profile to
+ * the given temperature.
+ * Assume:
+ * - step_count > 0
+ * - curtemp is already normalized
+ */
+static void apply_cprofile(float curtemp,
+                           struct pwm_state *old, struct pwm_state *new)
+{
+	cstep_t *step, *step_start;
+	float    step_temp;
+
+	step       = &cprofile.steps[cprofile.step_count - 1];
+	step_start = &cprofile.steps[0];
+
+	/* Walk backward through steps */
+	for (; step_start <= step; step--) {
+		new->duty = step->duty;
+		step_temp = normalize_temperature(step->temp);
+		if (curtemp >= step_temp) {
+			warnx("cprofile: step found: %.2f%s ≥ %.2f%s",
+			      curtemp, temp_unit, step_temp, temp_unit);
+			break;
+		}
+	}
+	if (++step == step_start) { /* no matching step found */
+		warnx("cprofile: no matching step found, using low duty");
+		new->duty = cprofile.lo_duty;
+	}
+	new->enable = true;
+
+	warnx("cprofile: %u ns (%u%%) → %u ns (%u%%)",
+	      old->duty, old->duty * 100 / old->period,
+	      new->duty, new->duty * 100 / new->period);
+}
+
+
+static void sigterm(int sig __unused)
+{
+	quit = true;
+}
+
+#ifdef USE_CAPSICUM
+/* Setup capabilities on fd. */
+static void capset(void)
+{
+	cap_rights_t        rights;
+	const unsigned long cmds[] = { PWMGETSTATE, PWMSETSTATE };
+
+	if (cap_enter() < 0)
+		err(EX_OSERR, "cap_enter");
+
+	cap_rights_init(&rights, CAP_IOCTL);
+	if (cap_rights_limit(fd, &rights) < 0)
+		err(EX_OSERR, "cap_rights_limit");
+	if (cap_ioctls_limit(fd, cmds, nitems(cmds)))
+		err(EX_OSERR, "cap_ioctls_limit");
+}
+#endif /* USE_CAPSICUM */
+
+int main(int argc, char *argv[])
+{
+	struct pwm_state current_state, new_state;
+	struct  sigaction sigtermact = {.sa_handler = sigterm };
+	pid_t otherpid;
+	int ch;
+	float temp;
+	bool use_cprofile = false, show_cprofile = false;
+
+	pwm_device[0] = '\0';
+	memset(&current_state, 0, sizeof(current_state));
+	memset(&new_state, 0, sizeof(new_state));
+
+	atexit(cleanup);
+
+	while ((ch = getopt(argc, argv,
+	                    "c:ht:T:o:i:IKlm:p:P:d:D:r:fsv")) != -1) {
+		switch (ch) {
+		case 'c':
+			if (parse_fand_config(optarg) != 0)
+				errx(EX_CONFIG, "%s: Invalid configuration",
+				     optarg);
+			use_cprofile = true;
+			break;
+		case 'h':
+			print_usage();
+			exit(EX_OK);
+		case 't':
+			low_temp = strtol(optarg, NULL, 10);
+			break;
+		case 'T':
+			high_temp_set = true;
+			high_temp = strtol(optarg, NULL, 10);
+			break;
+		case 'o':
+			off_temp = strtol(optarg, NULL, 10);
+			break;
+		case 'i':
+			interval = strtol(optarg, NULL, 10);
+			break;
+		case 'I':
+			inverted = true;
+			break;
+		case 'K':
+			offset = KELVIN_OFFSET;
+			break;
+		case 'l':
+			show_cprofile = true;
+			break;
+		case 'm':
+			multiplier = strtof(optarg, NULL);
+			break;
+		case 'p':
+			low_period = strtoul(optarg, NULL, 10);
+			break;
+		case 'P':
+			high_period = strtoul(optarg, NULL, 10);
+			break;
+		case 'd':
+			set_duty(optarg, &low_duty, &low_duty_percent);
+			break;
+		case 'D':
+			set_duty(optarg, &high_duty, &high_duty_percent);
+			break;
+		case 'f':
+			daemonize = false;
+			break;
+		case 'r':
+			pid_path = optarg;
+			break;
+		case 's':
+			show_status = true;
+			break;
+		case 'v':
+			print_version();
+			exit(EX_OK);
+		case '?':
+			errx(EX_USAGE, "Unknown option `-%c';"
+			     " use -h to display usage", optopt);
+		case ':':
+			errx(EX_USAGE, "Option -%c requires an argument;"
+			     " use -h to display usage", optopt);
+		}
+	}
+	temp_unit = (offset == 0 ? "°C" : " K");
+	if (show_cprofile) {
+		print_cprofile();
+		exit(EX_OK);
+	}
+
+	if (argc - optind != 2)
+		errx(EX_USAGE, "Wrong number of arguments;"
+		     " use -h to display usage");
+	set_temp_name(argv[optind]);
+	set_pwm_device(argv[optind + 1]);
+
+	if (use_cprofile && offset > 0)
+		errx(EX_USAGE, "Conflicting options: -K and -c;"
+		     " use -h to display usage");
+	/* FIXME Handle other conflicts with -c */
+
+	if (off_temp > low_temp)
+		off_temp = low_temp;
+	if (high_temp <= low_temp)
+		high_temp_set = false;
+
+	if ((fd = open(pwm_device, 0)) == -1)
+		err(EX_OSFILE, "Cannot open %s", pwm_device);
+#ifdef USE_CAPSICUM
+	capset(); /* will err() on error. */
+#endif /* USE_CAPSICUM */
+	if (ioctl(fd, PWMGETSTATE, &current_state) == -1)
+		err(EX_OSERR, "%s: Cannot read state of the PWM controller",
+		    pwm_device);
+	if (current_state.enable)
+		warnx("%s: Already enabled", pwm_device);
+	if (current_temperature(&temp) != 0) {
+		close(fd);
+		/* don't disable something you didn't enable yourself */
+		fd = -1;
+		err(EX_OSERR, "Cannot read temperature from %s", temp_name);
+	}
+
+	if (show_status) {
+		fprintf_status(stdout, current_state, temp);
+		exit(EX_OK);
+	}
+
+	if (daemonize) {
+		pfh = pidfile_open(pid_path, 0600, &otherpid);
+		if (pfh == NULL) {
+			if (errno == EEXIST)
+				errx(EX_SOFTWARE, "already running, pid: %jd.",
+				     (intmax_t)otherpid);
+			warn("Cannot open or create pidfile");
+		}
+		if (daemon(1, 1) < 0)
+			err(EX_OSERR, "Failed to daemonize!");
+		pidfile_write(pfh);
+	} else
+		fprintf_status(stderr, current_state, temp);
+
+	if (sigaction(SIGTERM, &sigtermact, NULL) != 0)
+		err(EX_OSERR, "sigaction(SIGTERM)");
+	if (sigaction(SIGINT, &sigtermact, NULL) != 0)
+		err(EX_OSERR, "sigaction(SIGINT)");
+
+	for (quit = false; !quit;) {
+		new_state = current_state;
+
+		if (current_temperature(&temp) != 0)
+			err(EX_OSERR, "Cannot read temperature from %s",
+			    temp_name);
+
+		if (!daemonize)
+			warnx("Current Temperature: %.2f%s", temp, temp_unit);
+
+		if (use_cprofile) /* Apply the cooling profile */
+			apply_cprofile(temp, &current_state, &new_state);
+		else {
+			if (temp >= low_temp)
+				new_state.enable = true;
+			else if (temp < off_temp)
+				new_state.enable = false;
+
+			if (high_temp_set && temp >= high_temp) {
+				if (high_period > 0)
+					new_state.period = high_period;
+				new_state.duty = calculate_duty(high_duty,
+				    new_state.period, high_duty_percent);
+			} else {
+				if (low_period > 0)
+					new_state.period = low_period;
+				new_state.duty = calculate_duty(low_duty,
+				    new_state.period, low_duty_percent);
+			}
+		}
+
+		if (inverted)
+			new_state.flags |= PWM_POLARITY_INVERTED;
+		else
+			new_state.flags &= ~PWM_POLARITY_INVERTED;
+
+		if (memcmp(&current_state, &new_state,
+		           sizeof(current_state)) != 0) {
+			if (!daemonize) {
+				warnx(">> Fan state change <<");
+				fprintf_status(stderr, new_state, temp);
+			}
+			if (ioctl(fd, PWMSETSTATE, &new_state) == -1)
+				err(EX_OSERR,
+				    "Cannot configure the PWM controller");
+		}
+		current_state = new_state;
+
+		sleep(interval);
+	}
+	return (EX_OK);
+}

--- a/usr.sbin/fand/fand.c
+++ b/usr.sbin/fand/fand.c
@@ -205,7 +205,7 @@ static void print_cprofile(void)
 	printf("    Low Duty: %u ns\n", cprofile.lo_duty);
 	printf("    Steps:\n");
 	for (; step < step_end; step++)
-		printf("        %.2f%s → %u ns\n", step->temp, temp_unit,
+		printf("        %.2f %s → %u ns\n", step->temp, temp_unit,
 		       step->duty);
 }
 
@@ -354,7 +354,7 @@ int main(int argc, char *argv[])
 			     " use -h to display usage", optopt);
 		}
 	}
-	temp_unit = (offset == 0 ? "°C" : " K");
+	temp_unit = (offset == 0 ? "°C" : "K");
 	if (show_cprofile) {
 		print_cprofile();
 		exit(EX_OK);
@@ -425,7 +425,7 @@ int main(int argc, char *argv[])
 			    temp_name);
 
 		if (!daemonize)
-			warnx("Current Temperature: %.2f%s", temp, temp_unit);
+			warnx("Current Temperature: %.2f %s", temp, temp_unit);
 
 		if (use_cprofile) /* Apply the cooling profile */
 			apply_cprofile(temp, &current_state, &new_state);

--- a/usr.sbin/fand/fand.h
+++ b/usr.sbin/fand/fand.h
@@ -1,0 +1,21 @@
+#ifndef FAND_H
+#define FAND_H
+
+#define MAX_CSTEPS 10
+
+typedef struct cstep {
+	float        temp; /* °C or K depending on offset */
+	unsigned int duty; /* nanoseconds */
+} cstep_t;
+
+typedef struct cprofile {
+	unsigned int  lo_duty; /* nanoseconds */
+	size_t        step_count;
+	cstep_t       steps[MAX_CSTEPS];
+} cprofile_t;
+
+extern cprofile_t cprofile;
+
+int parse_fand_config(const char *path);
+
+#endif /* FAND_H */


### PR DESCRIPTION
Integrate [Corey Hinshaw's fand](https://github.com/electrickite/fand) (68647f7), which is actually available as [sysutils/fand](https://www.freshports.org/sysutils/fand/), into base system with the following changes:

- handle multiple instances via the rc(8) script
- add capsicum(4) support (disabled for now)
- add cooling profiles support
- and some minor changes

Here is a sample cooling profile:

    lo_duty      = 532  # nanoseconds, 1%
    step.0.temp = 25.0  # °C
    step.0.duty = 532   # nanoseconds, 1%
    step.1.temp = 30.0  # °C
    step.1.duty = 10649 # nanoseconds, 20%
    step.2.temp = 35.0  # °C
    step.2.duty = 25026 # nanoseconds, 47%
    step.3.temp = 40.0  # °C
    step.3.duty = 41533 # nanoseconds, 78%
    step.4.temp = 45.0  # °C
    step.4.duty = 52183 # nanoseconds, 98%

and here is a sample rc(8) config to start two instances:

    fand_enable="YES"
    fand_list="foo bar"

    fand_foo_device="fan3"
    fand_foo_sensor="hw.acpi.thermal.tz0.temperature"
    fand_foo_hi_temp=70
    fand_foo_hi_duty=97%

    fand_bar_device="fan4"
    fand_bar_sensor="hw.acpi.thermal.tz1.temperature"
    fand_bar_profile="PLATFORM/fan4/default.conf"
    fand_bar_multiplier=0.01
    fand_bar_invpol=NO
    fand_bar_kelvin=NO
    fand_bar_pollint=5

(Note `fand_*_profile` is a path relative to `/etc/fand`)

There's some limitations:
- cooling profiles don't support modifying the period
- and the capsicum(4) support is working but currently disabled as it will require to give `CTLFLAG_CAPRD` to the various sysctl exposing temperatures (e.g., `hw.acpi.thermal.tz0.temperature`).

Oh and any pointer to help me implement some tests would be more than welcome :)
