### PR TITLE
tail(1): Fix '-r' (reverse) to work on pseudo filesystems

### DIFF
--- a/usr.bin/tail/reverse.c
+++ b/usr.bin/tail/reverse.c
@@ -78,7 +78,7 @@ reverse(FILE *fp, const char *fn, enum STYLE style, off_t off, struct stat *sbp)
 	if (style != REVERSE && off == 0)
 		return;
 
-	if (S_ISREG(sbp->st_mode))
+	if (S_ISREG(sbp->st_mode) && sbp->st_size > 0)
 		r_reg(fp, fn, style, off, sbp);
 	else
 		switch(style) {


### PR DESCRIPTION
Pseudo filesystems (e.g., procfs) advertise a zero file size.  Fix reverse() to handle such a case similarly as forward() so that '-r' works on pseudo filesystems.

This is a follow-up fix to commit 1fb3caee72241b9b4dacbfb0109c972a86d4401f.