### PR TITLE
hcreate(3): fix incorrect claim that hdestroy frees keys

### DIFF
--- a/lib/libc/stdlib/hcreate.3
+++ b/lib/libc/stdlib/hcreate.3
@@ -86,10 +86,11 @@ After the call to
 the data can no longer be considered accessible.
 The
 .Fn hdestroy
-function calls
-.Xr free 3
-for each comparison key in the search table
-but not the data item associated with the key.
+function disposes of the search table but does not free
+the comparison keys or data items stored in it.
+The caller is responsible for freeing any memory associated
+with table entries before calling
+.Fn hdestroy .
 .Pp
 The
 .Fn hsearch


### PR DESCRIPTION
The man page incorrectly stated that `hdestroy()` calls `free(3)` for each comparison key. The implementation in `hdestroy_r.c` only frees the internal table structure (`hsearch->entries` and `hsearch`), not the user-provided keys or data.

This matches POSIX, which says `hdestroy` "shall dispose of the search table" without mentioning key deallocation.

Update the description to clarify that the caller is responsible for freeing any memory associated with table entries.

PR: 291240