### PR TITLE
newsyslog.conf(5): use "rotated" instead of "trimmed"

### DIFF
--- a/usr.sbin/newsyslog/newsyslog.conf.5
+++ b/usr.sbin/newsyslog/newsyslog.conf.5
@@ -155,10 +155,10 @@ When the size of the log file reaches
 .Ar size ,
 in kilobytes by default, or with suffixes like k, M, G, ... as supported by
 .Xr expand_number 3 ,
-the log file will be trimmed as described above.
+the log file will be rotated.
 If this field contains an asterisk
 .Pq Ql * ,
-the log file will not be trimmed based on size.
+the log file will not be rotated based on size.
 .It Ar when
 The
 .Ar when
@@ -183,10 +183,10 @@ Additionally, the format may also be constructed with a
 sign along with a rotation time specification of once
 a day, once a week, or once a month.
 .Pp
-Time based trimming happens only if
+Time based rotation happens only if
 .Xr newsyslog 8
 is run within one hour of the specified time.
-If an interval is specified, the log file will be trimmed if that many
+If an interval is specified, the log file will be rotated if that many
 hours have passed since the last rotation.
 When both a time and an interval are
 specified then both conditions must be satisfied for the rotation to


### PR DESCRIPTION
Replace misleading "trimmed" with "rotated" in the newsyslog.conf(5) man page. The word "trimmed" suggests the log file is truncated to a specific size, when in reality newsyslog rotates it (renames and creates a new file).

The rest of the man page already uses "rotation" terminology consistently.

PR: 278671