### PR TITLE
bsdconfig(8): add missing vt(4) console commands

### DIFF
--- a/usr.sbin/bsdconfig/bsdconfig.8
+++ b/usr.sbin/bsdconfig/bsdconfig.8
@@ -170,29 +170,43 @@ Shortcut to the Delete menu under the View/Edit Startup Configuration menu
 (startup_rcconf) of startup.
 .It Cm startup_rcvar
 Shortcut to the Toggle Startup Services menu under startup.
-.\" use neutral name, e.g. console_keymap instead of syscons_keymap?
-.\" font (encoding) selection not applicable to vt(4)!
 .It Cm syscons_font
-Shortcut to the Font menu under console.
-.\" .It Cm console_keymap
-.\" Shortcut to the Keymap menu under console.
+Shortcut to the Font menu under console for
+.Xr syscons 4 .
 .It Cm syscons_keymap
-Shortcut to the Keymap menu under console.
-.\" .It Cm vt_repeat
-.\" Shortcut to the Repeat menu under console.
+Shortcut to the Keymap menu under console for
+.Xr syscons 4 .
 .It Cm syscons_repeat
-Shortcut to the Repeat menu under console.
+Shortcut to the Repeat menu under console for
+.Xr syscons 4 .
 .\" .It Cm vt_saver
-.\" Shortcut to the Saver menu under console.
 .It Cm syscons_saver
-Shortcut to the Saver menu under console.
-.\" screenmap (encoding) selection not applicable to vt(4)!
+Shortcut to the Saver menu under console for
+.Xr syscons 4 .
 .It Cm syscons_screenmap
-Shortcut to the Screenmap menu under console.
-.\" .It Cm vt_syscons_ttys
-.\" Shortcut to the Ttys menu under console.
+Shortcut to the Screenmap menu under console for
+.Xr syscons 4 .
 .It Cm syscons_ttys
-Shortcut to the Ttys menu under console.
+Shortcut to the Ttys menu under console for
+.Xr syscons 4 .
+.It Cm vt_font
+Shortcut to the Font menu under console for
+.Xr vt 4 .
+.It Cm vt_keymap
+Shortcut to the Keymap menu under console for
+.Xr vt 4 .
+.It Cm vt_repeat
+Shortcut to the Repeat menu under console for
+.Xr vt 4 .
+.It Cm vt_saver
+Shortcut to the Saver menu under console for
+.Xr vt 4 .
+.It Cm vt_screenmap
+Shortcut to the Screenmap menu under console for
+.Xr vt 4 .
+.It Cm vt_ttys
+Shortcut to the Ttys menu under console for
+.Xr vt 4 .
 .It Cm timezone
 Set the regional timezone of the local machine.
 .It Cm ttys


### PR DESCRIPTION
Add documentation for the vt(4) console commands that are available at runtime but were missing from the man page:

- `vt_font`, `vt_keymap`, `vt_repeat`, `vt_saver`, `vt_screenmap`, `vt_ttys`

These are the vt(4) counterparts of the existing syscons(4) commands (`syscons_font`, `syscons_keymap`, etc.). Also clarify that the `syscons_*` commands are specific to the syscons(4) driver and remove stale commented-out entries.

Verified against the `menu_selection` entries in the INDEX files under `usr.sbin/bsdconfig/console/`.

PR: 291051