### PR TITLE
cp(1): fix -P documentation to reflect it works without -R

### DIFF
--- a/bin/cp/cp.1
+++ b/bin/cp/cp.1
@@ -247,14 +247,17 @@ flags (in conjunction with the
 .Fl R
 flag) cause symbolic links to be followed as described above.
 The
-.Fl H ,
-.Fl L
+.Fl H
 and
-.Fl P
+.Fl L
 options are ignored unless the
 .Fl R
 option is specified.
-In addition, these options override each other and the
+The
+.Fl P
+option can be used with or without
+.Fl R .
+These options override each other and the
 command's actions are determined by the last one specified.
 .Pp
 If


### PR DESCRIPTION
Since commit 97e13037915c ("cp: Make -P work without -R as per POSIX"), the `-P` flag works independently of `-R`. The man page still says all three options (`-H`, `-L`, `-P`) are ignored without `-R`.

Fix: only `-H` and `-L` are ignored without `-R`. `-P` can be used independently.

PR: 289959