### PR TITLE
mail(1): fix temporary file path in FILES section

### DIFF
--- a/usr.bin/mail/mail.1
+++ b/usr.bin/mail/mail.1
@@ -1222,7 +1222,7 @@ commands.
 This can be overridden by setting the
 .Ev MAILRC
 environment variable.
-.It Pa /tmp/R*
+.It Pa /tmp/mail.R*
 Temporary files.
 .It Pa /usr/share/misc/mail.*help
 Help files.


### PR DESCRIPTION
The FILES section listed `/tmp/R*` but the source code uses `/tmp/mail.R*` as the mkstemp template prefix (e.g. `mail.RsXXXXXXXXXX`, `mail.ReXXXXXXXXXX`, `mail.RxXXXXXXXXXX` in collect.c, edit.c, lex.c).

PR: 289980