### PR TITLE
LinuxKPI: Fix strlcpy size in linuxkpi_alloc_netdev()

### DIFF
--- a/sys/compat/linuxkpi/common/src/linux_netdev.c
+++ b/sys/compat/linuxkpi/common/src/linux_netdev.c
@@ -405,7 +405,7 @@ linuxkpi_alloc_netdev(size_t len, const char *name, uint32_t flags,
 	/* Always first as it zeros! */
 	linuxkpi_init_dummy_netdev(ndev);
 
-	strlcpy(ndev->name, name, sizeof(*ndev->name));
+	strlcpy(ndev->name, name, sizeof(ndev->name));
 
 	/* This needs extending as we support more. */
 


### PR DESCRIPTION
## Summary

`linuxkpi_alloc_netdev()` passed `sizeof(*ndev->name)` to `strlcpy(3)`, which is `sizeof(char)` (1) instead of `IFNAMSIZ` for `struct net_device::name`.  Interface names were truncated to a single character.

## Change

Use `sizeof(ndev->name)` for the `char name[IFNAMSIZ]` array.

## Testing

Not run.