### PR TITLE
virtio_balloon: implement STATS_VQ and DEFLATE_ON_OOM support

### DIFF
--- a/sys/dev/virtio/balloon/virtio_balloon.c
+++ b/sys/dev/virtio/balloon/virtio_balloon.c
@@ -127,6 +127,8 @@ static int	vtballoon_sleep(struct vtballoon_softc *);
 static void	vtballoon_thread(void *);
 static void	vtballoon_guest_lowmem(void *, int);
 static void	vtballoon_setup_sysctl(struct vtballoon_softc *);
+static uint64_t	vtballoon_mem_available(struct vtballoon_softc *);
+static uint64_t	vtballoon_mem_caches(void);
 
 #define vtballoon_modern(_sc) \
     (((_sc)->vtballoon_features & VIRTIO_F_VERSION_1) != 0)
@@ -713,6 +715,35 @@ vtballoon_thread(void *xsc)
 	kthread_exit();
 }
 
+/*
+ * Estimate FreeBSD VM headroom without dipping below the page daemon's free
+ * and inactive targets.  This intentionally uses only existing VM counters;
+ * subsystem-specific reclaimable kernel caches such as ZFS ARC are outside
+ * the scope of this virtio driver estimate.
+ */
+static uint64_t
+vtballoon_mem_available(struct vtballoon_softc *sc __unused)
+{
+	int64_t available;
+	int64_t inactive;
+
+	available = ((int64_t)vm_free_count() - vm_cnt.v_free_target) * PAGE_SIZE;
+	inactive = ((int64_t)vm_inactive_count() - vm_cnt.v_inactive_target) *
+	    PAGE_SIZE;
+	if (inactive > 0)
+		available += inactive;
+
+	if (available < 0)
+		available = 0;
+	return ((uint64_t)available);
+}
+
+static uint64_t
+vtballoon_mem_caches(void)
+{
+
+	return ((uint64_t)vm_inactive_count() * PAGE_SIZE);
+}
 
 static int
 vtballoon_update_stats(struct vtballoon_softc *sc)
@@ -736,7 +767,7 @@ vtballoon_update_stats(struct vtballoon_softc *sc)
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MEMFREE,
 	    (uint64_t)vm_free_count() * PAGE_SIZE);
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_AVAIL,
-	    ((uint64_t)vm_free_count() + vm_inactive_count()) * PAGE_SIZE);
+	    vtballoon_mem_available(sc));
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_SWAP_IN,
 	    VM_CNT_FETCH(v_swappgsin) * PAGE_SIZE);
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_SWAP_OUT,
@@ -746,14 +777,12 @@ vtballoon_update_stats(struct vtballoon_softc *sc)
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MAJFLT,
 	    VM_CNT_FETCH(v_io_faults));
 	/*
-	 * Map CACHES to the inactive page queue.  The virtio spec defines
-	 * this as "disk caches" (Linux: page cache + reclaimable slab).
-	 * FreeBSD's inactive queue is the closest approximation -- it
-	 * contains pages eligible for reclaim, both file-backed and
-	 * anonymous, similar in spirit to Linux's reclaimable memory.
+	 * FreeBSD has no single Linux-style "disk caches" counter available
+	 * here.  Use inactive pages as the closest existing VM queue
+	 * approximation and avoid subsystem-specific cache accounting.
 	 */
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_CACHES,
-	    (uint64_t)vm_inactive_count() * PAGE_SIZE);
+	    vtballoon_mem_caches());
 
 #undef VTBALLOON_SET_STAT
 

--- a/sys/dev/virtio/balloon/virtio_balloon.c
+++ b/sys/dev/virtio/balloon/virtio_balloon.c
@@ -41,8 +41,11 @@
 #include <sys/mutex.h>
 #include <sys/queue.h>
 
+#include <sys/vmmeter.h>
+
 #include <vm/vm.h>
 #include <vm/vm_page.h>
+#include <vm/vm_extern.h>
 
 #include <machine/bus.h>
 #include <machine/resource.h>
@@ -64,6 +67,9 @@ struct vtballoon_softc {
 
 	struct virtqueue	*vtballoon_inflate_vq;
 	struct virtqueue	*vtballoon_deflate_vq;
+	struct virtqueue	*vtballoon_stats_vq;
+
+	struct virtio_balloon_stat vtballoon_stats[VIRTIO_BALLOON_S_NR];
 
 	uint32_t		 vtballoon_desired_npages;
 	uint32_t		 vtballoon_current_npages;
@@ -92,6 +98,8 @@ static int	vtballoon_setup_features(struct vtballoon_softc *);
 static int	vtballoon_alloc_virtqueues(struct vtballoon_softc *);
 
 static void	vtballoon_vq_intr(void *);
+static void	vtballoon_stats_vq_intr(void *);
+static int	vtballoon_update_stats(struct vtballoon_softc *);
 
 static void	vtballoon_inflate(struct vtballoon_softc *, int);
 static void	vtballoon_deflate(struct vtballoon_softc *, int);
@@ -114,7 +122,8 @@ static void	vtballoon_setup_sysctl(struct vtballoon_softc *);
     (((_sc)->vtballoon_features & VIRTIO_F_VERSION_1) != 0)
 
 /* Features desired/implemented by this driver. */
-#define VTBALLOON_FEATURES		VIRTIO_BALLOON_F_MUST_TELL_HOST
+#define VTBALLOON_FEATURES		\
+    (VIRTIO_BALLOON_F_MUST_TELL_HOST | VIRTIO_BALLOON_F_STATS_VQ)
 
 /* Timeout between retries when the balloon needs inflating. */
 #define VTBALLOON_LOWMEM_TIMEOUT	hz
@@ -219,6 +228,30 @@ vtballoon_attach(device_t dev)
 	virtqueue_enable_intr(sc->vtballoon_inflate_vq);
 	virtqueue_enable_intr(sc->vtballoon_deflate_vq);
 
+	/*
+	 * Prime the stats virtqueue with one buffer so the hypervisor
+	 * can use it to request guest memory statistics.
+	 */
+	if (sc->vtballoon_stats_vq != NULL) {
+		struct sglist sg;
+		struct sglist_seg segs[1];
+		int nstats, error __diagused;
+
+		nstats = vtballoon_update_stats(sc);
+
+		sglist_init(&sg, 1, segs);
+		error = sglist_append(&sg, sc->vtballoon_stats,
+		    sizeof(struct virtio_balloon_stat) * nstats);
+		KASSERT(error == 0, ("error adding stats to sglist"));
+
+		error = virtqueue_enqueue(sc->vtballoon_stats_vq,
+		    sc, &sg, 1, 0);
+		KASSERT(error == 0,
+		    ("error enqueuing stats to virtqueue"));
+		virtqueue_notify(sc->vtballoon_stats_vq);
+		virtqueue_enable_intr(sc->vtballoon_stats_vq);
+	}
+
 fail:
 	if (error)
 		vtballoon_detach(dev);
@@ -301,7 +334,7 @@ static int
 vtballoon_alloc_virtqueues(struct vtballoon_softc *sc)
 {
 	device_t dev;
-	struct vq_alloc_info vq_info[2];
+	struct vq_alloc_info vq_info[3];
 	int nvqs;
 
 	dev = sc->vtballoon_dev;
@@ -312,6 +345,14 @@ vtballoon_alloc_virtqueues(struct vtballoon_softc *sc)
 
 	VQ_ALLOC_INFO_INIT(&vq_info[1], 0, vtballoon_vq_intr, sc,
 	    &sc->vtballoon_deflate_vq, "%s deflate", device_get_nameunit(dev));
+
+	if (virtio_with_feature(dev, VIRTIO_BALLOON_F_STATS_VQ)) {
+		VQ_ALLOC_INFO_INIT(&vq_info[2], 0,
+		    vtballoon_stats_vq_intr, sc,
+		    &sc->vtballoon_stats_vq, "%s stats",
+		    device_get_nameunit(dev));
+		nvqs = 3;
+	}
 
 	return (virtio_alloc_virtqueues(dev, nvqs, vq_info));
 }
@@ -427,6 +468,7 @@ vtballoon_send_page_frames(struct vtballoon_softc *sc, struct virtqueue *vq,
 	VTBALLOON_LOCK(sc);
 	while ((c = virtqueue_dequeue(vq, NULL)) == NULL)
 		msleep(sc, VTBALLOON_MTX(sc), 0, "vtbspf", 0);
+	virtqueue_enable_intr(vq);
 	VTBALLOON_UNLOCK(sc);
 
 	KASSERT(c == vq, ("unexpected balloon operation response"));
@@ -446,6 +488,8 @@ vtballoon_stop(struct vtballoon_softc *sc)
 
 	virtqueue_disable_intr(sc->vtballoon_inflate_vq);
 	virtqueue_disable_intr(sc->vtballoon_deflate_vq);
+	if (sc->vtballoon_stats_vq != NULL)
+		virtqueue_disable_intr(sc->vtballoon_stats_vq);
 
 	virtio_stop(sc->vtballoon_dev);
 }
@@ -563,6 +607,87 @@ vtballoon_thread(void *xsc)
 	}
 
 	kthread_exit();
+}
+
+static int
+vtballoon_update_stats(struct vtballoon_softc *sc)
+{
+	struct virtio_balloon_stat *stat;
+	int idx;
+	bool modern;
+
+	idx = 0;
+	modern = vtballoon_modern(sc);
+	stat = sc->vtballoon_stats;
+
+#define VTBALLOON_SET_STAT(tag_, val_) do {			\
+	stat[idx].tag = modern ? htole16(tag_) : (tag_);	\
+	stat[idx].val = modern ? htole64(val_) : (val_);	\
+	idx++;							\
+} while (0)
+
+	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MEMTOT,
+	    (uint64_t)vm_cnt.v_page_count * PAGE_SIZE);
+	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MEMFREE,
+	    (uint64_t)vm_free_count() * PAGE_SIZE);
+	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_AVAIL,
+	    ((uint64_t)vm_free_count() + vm_inactive_count()) * PAGE_SIZE);
+	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_SWAP_IN,
+	    VM_CNT_FETCH(v_swappgsin) * PAGE_SIZE);
+	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_SWAP_OUT,
+	    VM_CNT_FETCH(v_swappgsout) * PAGE_SIZE);
+	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MINFLT,
+	    VM_CNT_FETCH(v_vm_faults));
+	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MAJFLT,
+	    VM_CNT_FETCH(v_io_faults));
+	/*
+	 * Map CACHES to the inactive page queue.  The virtio spec defines
+	 * this as "disk caches" (Linux: page cache + reclaimable slab).
+	 * FreeBSD's inactive queue is the closest approximation -- it
+	 * contains pages eligible for reclaim, both file-backed and
+	 * anonymous, similar in spirit to Linux's reclaimable memory.
+	 */
+	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_CACHES,
+	    (uint64_t)vm_inactive_count() * PAGE_SIZE);
+
+#undef VTBALLOON_SET_STAT
+
+	return (idx);
+}
+
+/*
+ * The stats virtqueue works in reverse: the host initiates a request by
+ * returning a buffer we previously placed in the virtqueue. We then
+ * refill the virtqueue with fresh statistics.
+ */
+static void
+vtballoon_stats_vq_intr(void *xsc)
+{
+	struct vtballoon_softc *sc;
+	struct virtqueue *vq;
+	struct sglist sg;
+	struct sglist_seg segs[1];
+	int nstats, error __diagused;
+
+	sc = xsc;
+	vq = sc->vtballoon_stats_vq;
+
+	/* Retrieve the buffer that the host returned to us. */
+	if (virtqueue_dequeue(vq, NULL) == NULL)
+		return;
+
+	/* Collect fresh statistics and re-enqueue. */
+	nstats = vtballoon_update_stats(sc);
+
+	sglist_init(&sg, 1, segs);
+	error = sglist_append(&sg, sc->vtballoon_stats,
+	    sizeof(struct virtio_balloon_stat) * nstats);
+	KASSERT(error == 0, ("error adding stats to sglist"));
+
+	error = virtqueue_enqueue(vq, sc, &sg, 1, 0);
+	KASSERT(error == 0, ("error enqueuing stats to virtqueue"));
+	virtqueue_notify(vq);
+	virtqueue_enable_intr(vq);
 }
 
 static void

--- a/sys/dev/virtio/balloon/virtio_balloon.c
+++ b/sys/dev/virtio/balloon/virtio_balloon.c
@@ -40,12 +40,14 @@
 #include <sys/lock.h>
 #include <sys/mutex.h>
 #include <sys/queue.h>
+#include <sys/eventhandler.h>
 
 #include <sys/vmmeter.h>
 
 #include <vm/vm.h>
 #include <vm/vm_page.h>
 #include <vm/vm_extern.h>
+#include <vm/vm_pageout.h>
 
 #include <machine/bus.h>
 #include <machine/resource.h>
@@ -64,6 +66,8 @@ struct vtballoon_softc {
 	uint64_t		 vtballoon_features;
 	uint32_t		 vtballoon_flags;
 #define VTBALLOON_FLAG_DETACH	 0x01
+#define VTBALLOON_FLAG_GUEST_LOWMEM	 0x02
+#define VTBALLOON_FLAG_WANTSIZE	 0x04
 
 	struct virtqueue	*vtballoon_inflate_vq;
 	struct virtqueue	*vtballoon_deflate_vq;
@@ -78,6 +82,11 @@ struct vtballoon_softc {
 	struct thread		*vtballoon_td;
 	uint32_t		*vtballoon_page_frames;
 	int			 vtballoon_timeout;
+	int			 vtballoon_debug;
+	uint64_t		 vtballoon_guest_lowmem_count;
+	uint64_t		 vtballoon_guest_lowmem_pages;
+
+	eventhandler_tag	 vtballoon_guest_lowmem_tag;
 };
 
 static struct virtio_feature_desc vtballoon_feature_desc[] = {
@@ -116,6 +125,7 @@ static void	vtballoon_free_page(struct vtballoon_softc *, vm_page_t);
 
 static int	vtballoon_sleep(struct vtballoon_softc *);
 static void	vtballoon_thread(void *);
+static void	vtballoon_guest_lowmem(void *, int);
 static void	vtballoon_setup_sysctl(struct vtballoon_softc *);
 
 #define vtballoon_modern(_sc) \
@@ -123,7 +133,9 @@ static void	vtballoon_setup_sysctl(struct vtballoon_softc *);
 
 /* Features desired/implemented by this driver. */
 #define VTBALLOON_FEATURES		\
-    (VIRTIO_BALLOON_F_MUST_TELL_HOST | VIRTIO_BALLOON_F_STATS_VQ)
+    (VIRTIO_BALLOON_F_MUST_TELL_HOST |	\
+     VIRTIO_BALLOON_F_STATS_VQ |	\
+     VIRTIO_BALLOON_F_DEFLATE_ON_OOM)
 
 /* Timeout between retries when the balloon needs inflating. */
 #define VTBALLOON_LOWMEM_TIMEOUT	hz
@@ -225,8 +237,26 @@ vtballoon_attach(device_t dev)
 		goto fail;
 	}
 
+	/*
+	 * Prime the resize flag so the thread evaluates the host's
+	 * desired balloon size on first wakeup.  This handles the
+	 * case where the host set num_pages before the guest booted.
+	 */
+	sc->vtballoon_flags |= VTBALLOON_FLAG_WANTSIZE;
+
 	virtqueue_enable_intr(sc->vtballoon_inflate_vq);
 	virtqueue_enable_intr(sc->vtballoon_deflate_vq);
+
+	/*
+	 * Register for guest low-memory events.  vm_lowmem is raised by the
+	 * FreeBSD guest when its own VM subsystem is short of pages; it is not
+	 * a host request to reclaim memory.  Deflating the balloon returns
+	 * pages to the guest before OOM handling.
+	 */
+	if (virtio_with_feature(dev, VIRTIO_BALLOON_F_DEFLATE_ON_OOM)) {
+		sc->vtballoon_guest_lowmem_tag = EVENTHANDLER_REGISTER(vm_lowmem,
+		    vtballoon_guest_lowmem, sc, EVENTHANDLER_PRI_FIRST);
+	}
 
 	/*
 	 * Prime the stats virtqueue with one buffer so the hypervisor
@@ -266,6 +296,12 @@ vtballoon_detach(device_t dev)
 
 	sc = device_get_softc(dev);
 
+	if (sc->vtballoon_guest_lowmem_tag != NULL) {
+		EVENTHANDLER_DEREGISTER(vm_lowmem,
+		    sc->vtballoon_guest_lowmem_tag);
+		sc->vtballoon_guest_lowmem_tag = NULL;
+	}
+
 	if (sc->vtballoon_td != NULL) {
 		VTBALLOON_LOCK(sc);
 		sc->vtballoon_flags |= VTBALLOON_FLAG_DETACH;
@@ -299,6 +335,7 @@ vtballoon_config_change(device_t dev)
 	sc = device_get_softc(dev);
 
 	VTBALLOON_LOCK(sc);
+	sc->vtballoon_flags |= VTBALLOON_FLAG_WANTSIZE;
 	wakeup_one(sc);
 	VTBALLOON_UNLOCK(sc);
 
@@ -557,41 +594,119 @@ vtballoon_sleep(struct vtballoon_softc *sc)
 			break;
 		}
 
-		desired = vtballoon_desired_size(sc);
-		sc->vtballoon_desired_npages = desired;
+		/* Guest low-memory event: break out immediately to deflate. */
+		if (sc->vtballoon_flags & VTBALLOON_FLAG_GUEST_LOWMEM)
+			break;
 
 		/*
-		 * If given, use non-zero timeout on the first time through
-		 * the loop. On subsequent times, timeout will be zero so
-		 * we will reevaluate the desired size of the balloon and
-		 * break out to retry if needed.
+		 * Only evaluate the host's desired balloon size when a
+		 * config change interrupt has been received.  This
+		 * prevents the thread from re-inflating pages that were
+		 * just freed in response to a guest low-memory event.
 		 */
-		timeout = sc->vtballoon_timeout;
-		sc->vtballoon_timeout = 0;
+		if (sc->vtballoon_flags & VTBALLOON_FLAG_WANTSIZE) {
+			desired = vtballoon_desired_size(sc);
+			sc->vtballoon_desired_npages = desired;
 
-		if (current > desired)
-			break;
-		if (current < desired && timeout == 0)
-			break;
+			/*
+			 * If given, use non-zero timeout on the first
+			 * time through the loop.  On subsequent times,
+			 * timeout will be zero so we will reevaluate
+			 * the desired size of the balloon and break
+			 * out to retry if needed.
+			 */
+			timeout = sc->vtballoon_timeout;
+			sc->vtballoon_timeout = 0;
 
-		msleep(sc, VTBALLOON_MTX(sc), 0, "vtbslp", timeout);
+			if (current > desired)
+				break;
+			if (current < desired && timeout == 0)
+				break;
+			if (current < desired) {
+				/* Retry after timeout. */
+				msleep(sc, VTBALLOON_MTX(sc), 0,
+				    "vtbslp", timeout);
+				continue;
+			}
+
+			/* Target reached; clear the flag. */
+			sc->vtballoon_flags &= ~VTBALLOON_FLAG_WANTSIZE;
+		}
+
+		msleep(sc, VTBALLOON_MTX(sc), 0, "vtbslp", 0);
 	}
 	VTBALLOON_UNLOCK(sc);
 
 	return (rc);
 }
 
+/*
+ * Maximum number of pages to deflate in response to a guest low-memory event.
+ * The virtio spec does not prescribe a specific amount; we use a fixed
+ * page count so that the relief scales naturally with page size.
+ */
+#define VTBALLOON_GUEST_LOWMEM_DEFLATE_PAGES	256
+
 static void
 vtballoon_thread(void *xsc)
 {
 	struct vtballoon_softc *sc;
 	uint32_t current, desired;
+	int guest_lowmem;
 
 	sc = xsc;
 
 	for (;;) {
 		if (vtballoon_sleep(sc) != 0)
 			break;
+
+		/*
+		 * Check and clear the guest low-memory flag.  Also clear any
+		 * pending host resize request so that we do not
+		 * immediately re-inflate the pages just released to
+		 * the guest VM subsystem.  The host will send a new
+		 * config change interrupt if it still requires a
+		 * larger balloon.
+		 */
+		VTBALLOON_LOCK(sc);
+		guest_lowmem = sc->vtballoon_flags &
+		    VTBALLOON_FLAG_GUEST_LOWMEM;
+		if (guest_lowmem)
+			sc->vtballoon_flags &=
+			    ~(VTBALLOON_FLAG_GUEST_LOWMEM |
+			    VTBALLOON_FLAG_WANTSIZE);
+		VTBALLOON_UNLOCK(sc);
+
+		if (guest_lowmem && sc->vtballoon_current_npages > 0) {
+			/*
+			 * Guest low memory: deflate up to
+			 * VTBALLOON_GUEST_LOWMEM_DEFLATE_PAGES regardless of
+			 * the host's desired balloon size.  This returns pages
+			 * to the guest VM subsystem before the OOM killer is
+			 * invoked.
+			 */
+			desired = sc->vtballoon_current_npages -
+			    MIN(sc->vtballoon_current_npages,
+			    VTBALLOON_GUEST_LOWMEM_DEFLATE_PAGES);
+
+			sc->vtballoon_guest_lowmem_count++;
+			sc->vtballoon_guest_lowmem_pages +=
+			    sc->vtballoon_current_npages - desired;
+
+			if (__predict_false(sc->vtballoon_debug > 0))
+				device_printf(sc->vtballoon_dev,
+				    "guest low memory, deflating balloon by "
+				    "%d pages (current: %d)\n",
+				    sc->vtballoon_current_npages - desired,
+				    sc->vtballoon_current_npages);
+
+			while (sc->vtballoon_current_npages > desired)
+				vtballoon_deflate(sc,
+				    sc->vtballoon_current_npages - desired);
+
+			vtballoon_update_size(sc);
+			continue;
+		}
 
 		current = sc->vtballoon_current_npages;
 		desired = sc->vtballoon_desired_npages;
@@ -690,6 +805,38 @@ vtballoon_stats_vq_intr(void *xsc)
 	virtqueue_enable_intr(vq);
 }
 
+/*
+ * Handler for the guest vm_lowmem event.  The FreeBSD guest's pagedaemon
+ * fires this when the guest is short of physical pages; it is unrelated to
+ * the host asking the guest to give memory back.  We respond by waking the
+ * balloon kthread to deflate pages back to the guest, giving the VM subsystem
+ * more free pages before it resorts to the OOM killer.
+ *
+ * This callback runs in the pagedaemon context, so we must not block.
+ * We simply set a flag and wake the kthread, following the same pattern as
+ * vtballoon_vq_intr() and vtballoon_config_change().
+ */
+static void
+vtballoon_guest_lowmem(void *arg, int flags)
+{
+	struct vtballoon_softc *sc;
+
+	sc = arg;
+
+	/* Only respond to physical page shortage. */
+	if ((flags & VM_LOW_PAGES) == 0)
+		return;
+
+	/* Nothing to deflate. */
+	if (sc->vtballoon_current_npages == 0)
+		return;
+
+	VTBALLOON_LOCK(sc);
+	sc->vtballoon_flags |= VTBALLOON_FLAG_GUEST_LOWMEM;
+	wakeup_one(sc);
+	VTBALLOON_UNLOCK(sc);
+}
+
 static void
 vtballoon_setup_sysctl(struct vtballoon_softc *sc)
 {
@@ -710,4 +857,16 @@ vtballoon_setup_sysctl(struct vtballoon_softc *sc)
 	SYSCTL_ADD_UINT(ctx, child, OID_AUTO, "current",
 	    CTLFLAG_RD, &sc->vtballoon_current_npages, sizeof(uint32_t),
 	    "Current balloon size in pages");
+
+	SYSCTL_ADD_INT(ctx, child, OID_AUTO, "debug",
+	    CTLFLAG_RWTUN, &sc->vtballoon_debug, 0,
+	    "Debug level");
+
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "guest_lowmem_deflations",
+	    CTLFLAG_RD, &sc->vtballoon_guest_lowmem_count,
+	    "Number of guest low-memory deflation events");
+
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "guest_lowmem_pages_freed",
+	    CTLFLAG_RD, &sc->vtballoon_guest_lowmem_pages,
+	    "Total pages freed by guest low-memory deflation");
 }

--- a/sys/dev/virtio/balloon/virtio_balloon.c
+++ b/sys/dev/virtio/balloon/virtio_balloon.c
@@ -230,22 +230,18 @@ vtballoon_attach(device_t dev)
 		goto fail;
 	}
 
+	virtqueue_enable_intr(sc->vtballoon_inflate_vq);
+	virtqueue_enable_intr(sc->vtballoon_deflate_vq);
+
+	sc->vtballoon_flags |= VTBALLOON_FLAG_WANTSIZE;
 	error = kthread_add(vtballoon_thread, sc, NULL, &sc->vtballoon_td,
 	    0, 0, "virtio_balloon");
 	if (error) {
+		virtqueue_disable_intr(sc->vtballoon_inflate_vq);
+		virtqueue_disable_intr(sc->vtballoon_deflate_vq);
 		device_printf(dev, "cannot create balloon kthread\n");
 		goto fail;
 	}
-
-	/*
-	 * Prime the resize flag so the thread evaluates the host's
-	 * desired balloon size on first wakeup.  This handles the
-	 * case where the host set num_pages before the guest booted.
-	 */
-	sc->vtballoon_flags |= VTBALLOON_FLAG_WANTSIZE;
-
-	virtqueue_enable_intr(sc->vtballoon_inflate_vq);
-	virtqueue_enable_intr(sc->vtballoon_deflate_vq);
 
 	/*
 	 * Register for guest low-memory events.  vm_lowmem is raised by the
@@ -583,9 +579,9 @@ vtballoon_sleep(struct vtballoon_softc *sc)
 {
 	int rc, timeout;
 	uint32_t current, desired;
+	bool wantsize;
 
 	rc = 0;
-	current = sc->vtballoon_current_npages;
 
 	VTBALLOON_LOCK(sc);
 	for (;;) {
@@ -598,13 +594,9 @@ vtballoon_sleep(struct vtballoon_softc *sc)
 		if (sc->vtballoon_flags & VTBALLOON_FLAG_GUEST_LOWMEM)
 			break;
 
-		/*
-		 * Only evaluate the host's desired balloon size when a
-		 * config change interrupt has been received.  This
-		 * prevents the thread from re-inflating pages that were
-		 * just freed in response to a guest low-memory event.
-		 */
-		if (sc->vtballoon_flags & VTBALLOON_FLAG_WANTSIZE) {
+		current = sc->vtballoon_current_npages;
+		wantsize = (sc->vtballoon_flags & VTBALLOON_FLAG_WANTSIZE) != 0;
+		if (wantsize) {
 			desired = vtballoon_desired_size(sc);
 			sc->vtballoon_desired_npages = desired;
 
@@ -651,7 +643,7 @@ static void
 vtballoon_thread(void *xsc)
 {
 	struct vtballoon_softc *sc;
-	uint32_t current, desired;
+	uint32_t current, desired, freed;
 	int guest_lowmem;
 
 	sc = xsc;
@@ -660,51 +652,48 @@ vtballoon_thread(void *xsc)
 		if (vtballoon_sleep(sc) != 0)
 			break;
 
-		/*
-		 * Check and clear the guest low-memory flag.  Also clear any
-		 * pending host resize request so that we do not
-		 * immediately re-inflate the pages just released to
-		 * the guest VM subsystem.  The host will send a new
-		 * config change interrupt if it still requires a
-		 * larger balloon.
-		 */
 		VTBALLOON_LOCK(sc);
 		guest_lowmem = sc->vtballoon_flags &
 		    VTBALLOON_FLAG_GUEST_LOWMEM;
 		if (guest_lowmem)
-			sc->vtballoon_flags &=
-			    ~(VTBALLOON_FLAG_GUEST_LOWMEM |
-			    VTBALLOON_FLAG_WANTSIZE);
+			sc->vtballoon_flags &= ~VTBALLOON_FLAG_GUEST_LOWMEM;
 		VTBALLOON_UNLOCK(sc);
 
-		if (guest_lowmem && sc->vtballoon_current_npages > 0) {
-			/*
-			 * Guest low memory: deflate up to
-			 * VTBALLOON_GUEST_LOWMEM_DEFLATE_PAGES regardless of
-			 * the host's desired balloon size.  This returns pages
-			 * to the guest VM subsystem before the OOM killer is
-			 * invoked.
-			 */
-			desired = sc->vtballoon_current_npages -
-			    MIN(sc->vtballoon_current_npages,
-			    VTBALLOON_GUEST_LOWMEM_DEFLATE_PAGES);
+		if (guest_lowmem) {
+			current = sc->vtballoon_current_npages;
+			if (current > 0) {
+				/*
+				 * Guest low memory: deflate up to
+				 * VTBALLOON_GUEST_LOWMEM_DEFLATE_PAGES regardless of
+				 * the host's desired balloon size.  This returns pages
+				 * to the guest VM subsystem before the OOM killer is
+				 * invoked.  Preserve the host target, but defer
+				 * re-evaluation briefly so we do not immediately
+				 * re-inflate the same pages.
+				 */
+				freed = MIN(current,
+				    VTBALLOON_GUEST_LOWMEM_DEFLATE_PAGES);
+				desired = current - freed;
 
-			sc->vtballoon_guest_lowmem_count++;
-			sc->vtballoon_guest_lowmem_pages +=
-			    sc->vtballoon_current_npages - desired;
+				if (__predict_false(sc->vtballoon_debug > 0))
+					device_printf(sc->vtballoon_dev,
+					    "guest low memory, deflating balloon by "
+					    "%d pages (current: %d)\n",
+					    freed, current);
 
-			if (__predict_false(sc->vtballoon_debug > 0))
-				device_printf(sc->vtballoon_dev,
-				    "guest low memory, deflating balloon by "
-				    "%d pages (current: %d)\n",
-				    sc->vtballoon_current_npages - desired,
-				    sc->vtballoon_current_npages);
+				while (sc->vtballoon_current_npages > desired)
+					vtballoon_deflate(sc,
+					    sc->vtballoon_current_npages - desired);
 
-			while (sc->vtballoon_current_npages > desired)
-				vtballoon_deflate(sc,
-				    sc->vtballoon_current_npages - desired);
+				sc->vtballoon_guest_lowmem_count++;
+				sc->vtballoon_guest_lowmem_pages += freed;
+				vtballoon_update_size(sc);
 
-			vtballoon_update_size(sc);
+				VTBALLOON_LOCK(sc);
+				sc->vtballoon_flags |= VTBALLOON_FLAG_WANTSIZE;
+				sc->vtballoon_timeout = VTBALLOON_LOWMEM_TIMEOUT;
+				VTBALLOON_UNLOCK(sc);
+			}
 			continue;
 		}
 
@@ -723,6 +712,7 @@ vtballoon_thread(void *xsc)
 
 	kthread_exit();
 }
+
 
 static int
 vtballoon_update_stats(struct vtballoon_softc *sc)
@@ -787,22 +777,24 @@ vtballoon_stats_vq_intr(void *xsc)
 	sc = xsc;
 	vq = sc->vtballoon_stats_vq;
 
-	/* Retrieve the buffer that the host returned to us. */
-	if (virtqueue_dequeue(vq, NULL) == NULL)
-		return;
+again:
+	while (virtqueue_dequeue(vq, NULL) != NULL) {
+		/* Collect fresh statistics and re-enqueue. */
+		nstats = vtballoon_update_stats(sc);
 
-	/* Collect fresh statistics and re-enqueue. */
-	nstats = vtballoon_update_stats(sc);
+		sglist_init(&sg, 1, segs);
+		error = sglist_append(&sg, sc->vtballoon_stats,
+		    sizeof(struct virtio_balloon_stat) * nstats);
+		KASSERT(error == 0, ("error adding stats to sglist"));
 
-	sglist_init(&sg, 1, segs);
-	error = sglist_append(&sg, sc->vtballoon_stats,
-	    sizeof(struct virtio_balloon_stat) * nstats);
-	KASSERT(error == 0, ("error adding stats to sglist"));
-
-	error = virtqueue_enqueue(vq, sc, &sg, 1, 0);
-	KASSERT(error == 0, ("error enqueuing stats to virtqueue"));
-	virtqueue_notify(vq);
-	virtqueue_enable_intr(vq);
+		error = virtqueue_enqueue(vq, sc, &sg, 1, 0);
+		KASSERT(error == 0, ("error enqueuing stats to virtqueue"));
+		virtqueue_notify(vq);
+	}
+	if (virtqueue_enable_intr(vq) != 0) {
+		virtqueue_disable_intr(vq);
+		goto again;
+	}
 }
 
 /*
@@ -825,10 +817,6 @@ vtballoon_guest_lowmem(void *arg, int flags)
 
 	/* Only respond to physical page shortage. */
 	if ((flags & VM_LOW_PAGES) == 0)
-		return;
-
-	/* Nothing to deflate. */
-	if (sc->vtballoon_current_npages == 0)
 		return;
 
 	VTBALLOON_LOCK(sc);

--- a/sys/dev/virtio/balloon/virtio_balloon.c
+++ b/sys/dev/virtio/balloon/virtio_balloon.c
@@ -127,7 +127,7 @@ static int	vtballoon_sleep(struct vtballoon_softc *);
 static void	vtballoon_thread(void *);
 static void	vtballoon_guest_lowmem(void *, int);
 static void	vtballoon_setup_sysctl(struct vtballoon_softc *);
-static uint64_t	vtballoon_mem_available(struct vtballoon_softc *);
+static uint64_t	vtballoon_mem_available(void);
 static uint64_t	vtballoon_mem_caches(void);
 
 #define vtballoon_modern(_sc) \
@@ -722,27 +722,31 @@ vtballoon_thread(void *xsc)
  * the scope of this virtio driver estimate.
  */
 static uint64_t
-vtballoon_mem_available(struct vtballoon_softc *sc __unused)
+vtballoon_mem_available(void)
 {
-	int64_t available;
-	int64_t inactive;
+	u_long available;
+	u_int count, target;
 
-	available = ((int64_t)vm_free_count() - vm_cnt.v_free_target) * PAGE_SIZE;
-	inactive = ((int64_t)vm_inactive_count() - vm_cnt.v_inactive_target) *
-	    PAGE_SIZE;
-	if (inactive > 0)
-		available += inactive;
+	available = 0;
 
-	if (available < 0)
-		available = 0;
-	return ((uint64_t)available);
+	count = vm_free_count();
+	target = vm_cnt.v_free_target;
+	if (count > target)
+		available += count - target;
+
+	count = vm_inactive_count();
+	target = vm_cnt.v_inactive_target;
+	if (count > target)
+		available += count - target;
+
+	return (ptoa((uint64_t)available));
 }
 
 static uint64_t
 vtballoon_mem_caches(void)
 {
 
-	return ((uint64_t)vm_inactive_count() * PAGE_SIZE);
+	return (ptoa((uint64_t)vm_inactive_count()));
 }
 
 static int
@@ -763,15 +767,15 @@ vtballoon_update_stats(struct vtballoon_softc *sc)
 } while (0)
 
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MEMTOT,
-	    (uint64_t)vm_cnt.v_page_count * PAGE_SIZE);
+	    ptoa((uint64_t)vm_cnt.v_page_count));
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MEMFREE,
-	    (uint64_t)vm_free_count() * PAGE_SIZE);
+	    ptoa((uint64_t)vm_free_count()));
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_AVAIL,
-	    vtballoon_mem_available(sc));
+	    vtballoon_mem_available());
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_SWAP_IN,
-	    VM_CNT_FETCH(v_swappgsin) * PAGE_SIZE);
+	    ptoa(VM_CNT_FETCH(v_swappgsin)));
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_SWAP_OUT,
-	    VM_CNT_FETCH(v_swappgsout) * PAGE_SIZE);
+	    ptoa(VM_CNT_FETCH(v_swappgsout)));
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MINFLT,
 	    VM_CNT_FETCH(v_vm_faults));
 	VTBALLOON_SET_STAT(VIRTIO_BALLOON_S_MAJFLT,

--- a/sys/dev/virtio/balloon/virtio_balloon.h
+++ b/sys/dev/virtio/balloon/virtio_balloon.h
@@ -34,7 +34,7 @@
 /* Feature bits. */
 #define VIRTIO_BALLOON_F_MUST_TELL_HOST	0x1 /* Tell before reclaiming pages */
 #define VIRTIO_BALLOON_F_STATS_VQ	0x2 /* Memory stats virtqueue */
-#define VIRTIO_BALLOON_F_DEFLATE_ON_OOM	0x4 /* Deflate balloon on OOM */
+#define VIRTIO_BALLOON_F_DEFLATE_ON_OOM	0x4 /* Deflate balloon on guest OOM */
 
 /* Size of a PFN in the balloon interface. */
 #define VIRTIO_BALLOON_PFN_SHIFT 12
@@ -45,17 +45,20 @@ struct virtio_balloon_config {
 
 	/* Number of pages we've actually got in balloon. */
 	uint32_t actual;
+
 };
 
-#define VIRTIO_BALLOON_S_SWAP_IN  0   /* Amount of memory swapped in */
-#define VIRTIO_BALLOON_S_SWAP_OUT 1   /* Amount of memory swapped out */
-#define VIRTIO_BALLOON_S_MAJFLT   2   /* Number of major faults */
-#define VIRTIO_BALLOON_S_MINFLT   3   /* Number of minor faults */
-#define VIRTIO_BALLOON_S_MEMFREE  4   /* Total amount of free memory */
-#define VIRTIO_BALLOON_S_MEMTOT   5   /* Total amount of memory */
-#define VIRTIO_BALLOON_S_AVAIL    6   /* Available memory as in /proc */
-#define VIRTIO_BALLOON_S_CACHES   7   /* Disk caches */
-#define VIRTIO_BALLOON_S_NR       8
+#define VIRTIO_BALLOON_S_SWAP_IN	0   /* Amount of memory swapped in */
+#define VIRTIO_BALLOON_S_SWAP_OUT	1   /* Amount of memory swapped out */
+#define VIRTIO_BALLOON_S_MAJFLT		2   /* Number of major faults */
+#define VIRTIO_BALLOON_S_MINFLT		3   /* Number of minor faults */
+#define VIRTIO_BALLOON_S_MEMFREE	4   /* Total amount of free memory */
+#define VIRTIO_BALLOON_S_MEMTOT		5   /* Total amount of memory */
+#define VIRTIO_BALLOON_S_AVAIL		6   /* Available memory as in /proc */
+#define VIRTIO_BALLOON_S_CACHES		7   /* Disk caches */
+#define VIRTIO_BALLOON_S_HTLB_PGALLOC	8   /* Hugetlb page allocations */
+#define VIRTIO_BALLOON_S_HTLB_PGFAIL	9   /* Hugetlb alloc failures */
+#define VIRTIO_BALLOON_S_NR		10
 
 /*
  * Memory statistics structure.


### PR DESCRIPTION
## Summary

Implement two virtio balloon features that have been missing from the FreeBSD driver since its introduction in FreeBSD 9.0:

- **VIRTIO_BALLOON_F_STATS_VQ**: Report guest memory statistics (free, total, available, swap, faults, caches) to the hypervisor via the stats virtqueue.
- **VIRTIO_BALLOON_F_DEFLATE_ON_OOM**: Automatically deflate the balloon when the guest is under memory pressure, returning pages to the VM subsystem before processes are killed.

Also update the local virtio balloon definitions needed for the implemented feature bits and stat tags.

The memory statistics intentionally stay within existing FreeBSD VM counters. `VIRTIO_BALLOON_S_AVAIL` is a conservative estimate based on free and inactive pages above VM targets, and `VIRTIO_BALLOON_S_CACHES` uses inactive pages as the closest existing VM-queue approximation. This PR does not add ZFS ARC or other subsystem-specific reclaimable-cache accounting.

## Motivation

FreeBSD guests running under QEMU/KVM cannot report memory statistics to the hypervisor. This means `info balloon` / `virsh dommemstat` only shows `actual` and `max_mem` with no `total_mem`, `free_mem`, or other stats. Platforms like Proxmox that rely on these stats to display guest memory usage and make ballooning decisions see incorrect values for FreeBSD guests.

Without DEFLATE_ON_OOM, an over-inflated balloon cannot automatically shrink under memory pressure, risking process kills while reclaimable balloon pages exist.

## References

- [QEMU: Virtio balloon memory statistics](https://www.qemu.org/docs/master/interop/virtio-balloon-stats.html)
- [OASIS virtio-v1.2 specification §5.5](https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html)

## Link bugs
- https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=292570
