### PR TITLE
pci: fix integer overflow in capability parsing

### DIFF
--- a/sys/dev/pci/pci.c
+++ b/sys/dev/pci/pci.c
@@ -3756,7 +3756,7 @@ xhci_early_takeover(device_t self)
 	struct resource *res;
 	uint32_t cparams;
 	uint32_t eec;
-	uint8_t eecp;
+	uint32_t eecp;
 	uint8_t bios_sem;
 	uint8_t offs;
 	int rid;


### PR DESCRIPTION
Change eecp from uint8_t to uint32_t. eecp holds byte offsets for hardware capabilities, which may exceed the range of uint8_t. This overflow causes the offset to wrap, leading to reads from the wrong location and potentially an infinite loop.

Discovered due to a hung boot on AMD USB Controller (PCI 1022:151e) in a Minisforum N5 Pro.