### PR TITLE
pmc: Implement the feature bits for recent Zen 4/5

### DIFF
--- a/lib/libpmc/libpmc.c
+++ b/lib/libpmc/libpmc.c
@@ -31,6 +31,9 @@
 #include <sys/module.h>
 #include <sys/pmc.h>
 #include <sys/syscall.h>
+#if defined(__amd64__) || defined(__i386__)
+#include <machine/cpufunc.h>
+#endif
 
 #include <ctype.h>
 #include <errno.h>
@@ -697,6 +700,8 @@ ibs_allocate_pmc(enum pmc_event pe, char *ctrspec,
 {
 	char *e, *p, *q;
 	uint64_t ctl, ldlat;
+	u_int ibs_features;
+	u_int regs[4];
 
 	pmc_config->pm_caps |=
 	    (PMC_CAP_SYSTEM | PMC_CAP_EDGE | PMC_CAP_PRECISE);
@@ -719,11 +724,22 @@ ibs_allocate_pmc(enum pmc_event pe, char *ctrspec,
 		return (-1);
 	}
 
+	/* Read the ibs feature flags */
+	ibs_features = 0;
+	do_cpuid(0x80000000, regs);
+	if (regs[0] >= CPUID_IBSID) {
+		do_cpuid(CPUID_IBSID, regs);
+		ibs_features = regs[0];
+	}
+
 	/* parse parameters */
 	ctl = 0;
 	if (pe == PMC_EV_IBS_FETCH) {
 		while ((p = strsep(&ctrspec, ",")) != NULL) {
 			if (KWMATCH(p, "l3miss")) {
+				if ((ibs_features & CPUID_IBSID_ZEN4IBSEXTENSIONS) == 0)
+					return (-1);
+
 				ctl |= IBS_FETCH_CTL_L3MISSONLY;
 			} else if (KWMATCH(p, "randomize")) {
 				ctl |= IBS_FETCH_CTL_RANDOMIZE;
@@ -742,6 +758,9 @@ ibs_allocate_pmc(enum pmc_event pe, char *ctrspec,
 			if (KWMATCH(p, "l3miss")) {
 				ctl |= IBS_OP_CTL_L3MISSONLY;
 			} else if (KWPREFIXMATCH(p, "ldlat=")) {
+				if ((ibs_features & CPUID_IBSID_IBSLOADLATENCYFILT) == 0)
+					return (-1);
+
 				q = strchr(p, '=');
 				if (*++q == '\0') /* skip '=' */
 					return (-1);
@@ -765,7 +784,10 @@ ibs_allocate_pmc(enum pmc_event pe, char *ctrspec,
 					return (-1);
 				ctl |= IBS_OP_CTL_LDLAT_TO_CTL(ldlat);
 				ctl |= IBS_OP_CTL_L3MISSONLY | IBS_OP_CTL_LATFLTEN;
-			} else if (KWMATCH(p, "randomize")) {
+			} else if (KWMATCH(p, "opcount")) {
+				if ((ibs_features & CPUID_IBSID_OPCNT) == 0)
+					return (-1);
+
 				ctl |= IBS_OP_CTL_COUNTERCONTROL;
 			} else {
 				return (-1);
@@ -774,6 +796,10 @@ ibs_allocate_pmc(enum pmc_event pe, char *ctrspec,
 
 		if (pmc_config->pm_count < IBS_OP_MIN_RATE ||
 		    pmc_config->pm_count > IBS_OP_MAX_RATE)
+			return (-1);
+
+		if (((ibs_features & CPUID_IBSID_OPCNTEXT) == 0) &&
+		    (pmc_config->pm_count > IBS_OP_MAX_RATE_PREEXT))
 			return (-1);
 
 		ctl |= IBS_OP_INTERVAL_TO_CTL(pmc_config->pm_count);

--- a/lib/libpmc/pmc.ibs.3
+++ b/lib/libpmc/pmc.ibs.3
@@ -107,6 +107,8 @@ IBS only supports filtering latencies that are a multiple of 128 and between
 128 and 2048.
 Load latency filtering can only be used with ibs-op events and imply the
 l3miss qualifier.
+.It Li opcount
+Count ops rather than cycles.
 .It Li randomize
 Randomize the sampling rate.
 .El
@@ -124,7 +126,7 @@ qualifier randomly sets the bottom four bits of the sample rate.
 .It Li ibs-op Xo
 .Op ,l3miss
 .Op ,ldlat= Ns Ar ldlat
-.Op ,randomize
+.Op ,opcount
 .Xc
 Collect performance samples during instruction execution.
 The

--- a/sys/dev/hwpmc/hwpmc_ibs.c
+++ b/sys/dev/hwpmc/hwpmc_ibs.c
@@ -329,9 +329,9 @@ pmc_ibs_process_fetch(struct pmc *pm, struct trapframe *tf, uint64_t config)
 	memset(&mpd, 0, sizeof(mpd));
 
 	mpd.pl_type = PMC_CC_MULTIPART_IBS_FETCH;
-	mpd.pl_length = 4;
+	mpd.pl_length = PMC_MPIDX_FETCH_MAX;
 	mpd.pl_mpdata[PMC_MPIDX_FETCH_CTL] = config;
-	if (ibs_features) {
+	if ((ibs_features & CPUID_IBSID_IBSFETCHCTLEXTD) != 0) {
 		mpd.pl_mpdata[PMC_MPIDX_FETCH_EXTCTL] = rdmsr(IBS_FETCH_EXTCTL);
 	}
 	mpd.pl_mpdata[PMC_MPIDX_FETCH_CTL] = config;
@@ -358,7 +358,7 @@ pmc_ibs_process_op(struct pmc *pm, struct trapframe *tf, uint64_t config)
 	memset(&mpd, 0, sizeof(mpd));
 
 	mpd.pl_type = PMC_CC_MULTIPART_IBS_OP;
-	mpd.pl_length = 8;
+	mpd.pl_length = PMC_MPIDX_OP_MAX;
 	mpd.pl_mpdata[PMC_MPIDX_OP_CTL] = config;
 	mpd.pl_mpdata[PMC_MPIDX_OP_RIP] = rdmsr(IBS_OP_RIP);
 	mpd.pl_mpdata[PMC_MPIDX_OP_DATA] = rdmsr(IBS_OP_DATA);
@@ -366,6 +366,12 @@ pmc_ibs_process_op(struct pmc *pm, struct trapframe *tf, uint64_t config)
 	mpd.pl_mpdata[PMC_MPIDX_OP_DATA3] = rdmsr(IBS_OP_DATA3);
 	mpd.pl_mpdata[PMC_MPIDX_OP_DC_LINADDR] = rdmsr(IBS_OP_DC_LINADDR);
 	mpd.pl_mpdata[PMC_MPIDX_OP_DC_PHYSADDR] = rdmsr(IBS_OP_DC_PHYSADDR);
+	if ((ibs_features & CPUID_IBSID_BRNTRGT) != 0) {
+		mpd.pl_mpdata[PMC_MPIDX_OP_TGT_RIP] = rdmsr(IBS_OP_TGT_RIP);
+	}
+	if ((ibs_features & CPUID_IBSID_IBSOPDATA4) != 0) {
+		mpd.pl_mpdata[PMC_MPIDX_OP_DATA4] = rdmsr(IBS_OP_DATA4);
+	}
 
 	pmc_process_interrupt_mp(PMC_HR, pm, tf, &mpd);
 

--- a/sys/dev/hwpmc/hwpmc_ibs.h
+++ b/sys/dev/hwpmc/hwpmc_ibs.h
@@ -45,11 +45,11 @@
 #define	CPUID_IBSID_BRNTRGT		0x00000020 /* Branch Target Address */
 #define	CPUID_IBSID_OPCNTEXT		0x00000040 /* Extend Counter */
 #define	CPUID_IBSID_RIPINVALIDCHK	0x00000080 /* Invalid RIP Indication */
-#define	CPUID_IBSID_OPFUSE		0x00000010 /* Fused Branch Operation */
-#define	CPUID_IBSID_IBSFETCHCTLEXTD	0x00000020 /* IBS Fetch Control Ext */
-#define	CPUID_IBSID_IBSOPDATA4		0x00000040 /* IBS OP DATA4 */
-#define	CPUID_IBSID_ZEN4IBSEXTENSIONS	0x00000080 /* IBS Zen 4 Extensions */
-#define	CPUID_IBSID_IBSLOADLATENCYFILT	0x00000100 /* Load Latency Filtering */
+#define	CPUID_IBSID_OPFUSE		0x00000100 /* Fused Branch Operation */
+#define	CPUID_IBSID_IBSFETCHCTLEXTD	0x00000200 /* IBS Fetch Control Ext */
+#define	CPUID_IBSID_IBSOPDATA4		0x00000400 /* IBS OP DATA4 */
+#define	CPUID_IBSID_ZEN4IBSEXTENSIONS	0x00000800 /* IBS Zen 4 Extensions */
+#define	CPUID_IBSID_IBSLOADLATENCYFILT	0x00001000 /* Load Latency Filtering */
 #define	CPUID_IBSID_IBSUPDTDDTLBSTATS	0x00080000 /* Simplified DTLB Stats */
 
 /*
@@ -77,6 +77,7 @@
 #define IBS_FETCH_MAX_RATE		1048560
 #define IBS_OP_MIN_RATE			65536
 #define IBS_OP_MAX_RATE			134217712
+#define IBS_OP_MAX_RATE_PREEXT		1048560
 
 /* IBS Fetch Control */
 #define IBS_FETCH_CTL			0xC0011030 /* IBS Fetch Control */
@@ -104,6 +105,7 @@
 #define PMC_MPIDX_FETCH_EXTCTL		1
 #define PMC_MPIDX_FETCH_LINADDR		2
 #define PMC_MPIDX_FETCH_PHYSADDR	3
+#define PMC_MPIDX_FETCH_MAX		(PMC_MPIDX_FETCH_PHYSADDR + 1)
 
 /* IBS Execution Control */
 #define IBS_OP_CTL			0xC0011033 /* IBS Execution Control */
@@ -143,7 +145,7 @@
 
 #define IBS_OP_DC_LINADDR		0xC0011038 /* IBS DC Linear Address */
 #define IBS_OP_DC_PHYSADDR		0xC0011039 /* IBS DC Physical Address */
-#define IBS_TGT_RIP			0xC001103B /* IBS Branch Target */
+#define IBS_OP_TGT_RIP			0xC001103B /* IBS Branch Target */
 #define IBS_OP_DATA4			0xC001103D /* IBS Op Data 4 */
 #define IBS_OP_DATA4_LDRESYNC		(1ULL << 0)  /* Load Resync */
 
@@ -156,6 +158,7 @@
 #define PMC_MPIDX_OP_DC_PHYSADDR	6
 #define PMC_MPIDX_OP_TGT_RIP		7
 #define PMC_MPIDX_OP_DATA4		8
+#define PMC_MPIDX_OP_MAX		(PMC_MPIDX_OP_DATA4 + 1)
 
 /*
  * IBS data is encoded as using the multipart flag in the existing callchain


### PR DESCRIPTION
This change ensures that the optional MSRs and the user flags that are guarded by cpuid feature flags are properly enforced.  On older AMD processors, certain feature flags may result in a kernel crash.

Sponsored by: Netflix