### PR TITLE
hwpmc_ibs: Add external error handling

### DIFF
--- a/lib/libc/gen/exterr_cat_filenames.h
+++ b/lib/libc/gen/exterr_cat_filenames.h
@@ -2,6 +2,7 @@
  * Automatically @generated, use
  * tools/build/make_libc_exterr_cat_filenames.sh
  */
+	[EXTERR_CAT_HWPMC_IBS] = "dev/hwpmc/hwpmc_ibs.c",
 	[EXTERR_CAT_VMM] = "dev/vmm/vmm_dev.c",
 	[EXTERR_CAT_FUSE_DEVICE] = "fs/fuse/fuse_device.c",
 	[EXTERR_CAT_FUSE_VFS] = "fs/fuse/fuse_vfsops.c",

--- a/sys/dev/hwpmc/hwpmc_ibs.c
+++ b/sys/dev/hwpmc/hwpmc_ibs.c
@@ -38,6 +38,9 @@
 #include <sys/smp.h>
 #include <sys/systm.h>
 
+#define	EXTERR_CATEGORY	EXTERR_CAT_HWPMC_IBS
+#include <sys/exterrvar.h>
+
 #include <machine/cpu.h>
 #include <machine/cpufunc.h>
 #include <machine/md_var.h>
@@ -166,16 +169,18 @@ ibs_allocate_pmc(int cpu __unused, int ri, struct pmc *pm,
 
 	/* check class match */
 	if (a->pm_class != PMC_CLASS_IBS)
-		return (EINVAL);
+		return (EXTERROR(EINVAL, "PMC class is not IBS"));
 	if (a->pm_md.pm_ibs.ibs_type != ri)
-		return (EINVAL);
+		return (EXTERROR(EINVAL,
+		    "IBS type %ju does not match PMC index %ju",
+		    (uint64_t)a->pm_md.pm_ibs.ibs_type, (uint64_t)ri));
 
 	caps = pm->pm_caps;
 
 	PMCDBG2(MDP, ALL, 1, "ibs-allocate ri=%d caps=0x%x", ri, caps);
 
 	if ((caps & PMC_CAP_SYSTEM) == 0)
-		return (EINVAL);
+		return (EXTERROR(EINVAL, "IBS requires SYSTEM capability"));
 
 	config = a->pm_md.pm_ibs.ibs_ctl;
 	pm->pm_md.pm_ibs.ibs_ctl = config;

--- a/sys/sys/exterr_cat.h
+++ b/sys/sys/exterr_cat.h
@@ -40,6 +40,7 @@
 #define	EXTERR_CAT_FORK		15
 #define	EXTERR_CAT_PROCEXIT	16
 #define	EXTERR_CAT_VMM		17
+#define	EXTERR_CAT_HWPMC_IBS	18
 
 #endif
 


### PR DESCRIPTION
Add EXTERR_CAT_HWPMC_IBS to the external error categories and replace generic EINVAL returns in ibs_allocate_pmc() with EXTERROR() calls that provide detailed error messages. This extended error handling will also serve as the basis for future IBS validation and checks

Sponsored by: AMD
Signed-off-by: Andre Silva <andasilv@amd.com>

