### PR TITLE
igc(4): fix Wake-on-LAN with magic packet on I225/I226

### DIFF
--- a/sys/dev/igc/if_igc.c
+++ b/sys/dev/igc/if_igc.c
@@ -683,7 +683,7 @@ igc_if_attach_pre(if_ctx_t ctx)
 
 	/* Enable only WOL MAGIC by default */
 	scctx->isc_capenable &= ~IFCAP_WOL;
-	if (sc->wol != 0)
+	if (sc->wol & IGC_WUFC_MAG)
 		scctx->isc_capenable |= IFCAP_WOL_MAGIC;
 
 	iflib_set_mac(ctx, hw->mac.addr);
@@ -2451,6 +2451,7 @@ igc_enable_wakeup(if_ctx_t ctx)
 	if_t ifp = iflib_get_ifp(ctx);
 	int error = 0;
 	u32 ctrl, rctl;
+	u32 phpm;
 
 	if (!pci_has_pm(dev))
 		return;
@@ -2461,6 +2462,8 @@ igc_enable_wakeup(if_ctx_t ctx)
 	 */
 	if ((if_getcapenable(ifp) & IFCAP_WOL_MAGIC) == 0)
 		sc->wol &= ~IGC_WUFC_MAG;
+	else
+		sc->wol |= IGC_WUFC_MAG;
 
 	if ((if_getcapenable(ifp) & IFCAP_WOL_UCAST) == 0)
 		sc->wol &= ~IGC_WUFC_EX;
@@ -2484,6 +2487,15 @@ igc_enable_wakeup(if_ctx_t ctx)
 	/* Enable wakeup by the MAC */
 	IGC_WRITE_REG(&sc->hw, IGC_WUC, IGC_WUC_PME_EN);
 	IGC_WRITE_REG(&sc->hw, IGC_WUFC, sc->wol);
+
+	/*
+	 * Clear PHPM bits that disable link speeds in D3,
+	 * otherwise the NIC won't wake on magic packet
+	 */
+	phpm = IGC_READ_REG(&sc->hw, IGC_I225_PHPM);
+	phpm &= ~(IGC_I225_PHPM_DIS_100_D3 | IGC_I225_PHPM_DIS_1000_D3 |
+	    IGC_I225_PHPM_DIS_2500_D3);
+	IGC_WRITE_REG(&sc->hw, IGC_I225_PHPM, phpm);
 
 pme:
 	if (!error && (if_getcapenable(ifp) & IFCAP_WOL))


### PR DESCRIPTION
WoL via magic packet did not work on igc(4) after poweroff: the link would come back up on the PHY but magic packets never woke the host. Two issues were responsible.

First, the I225/I226 PHY Power Management register (PHPM) has bits that disable 100/1000/2500 Mb/s link negotiation while the device is in D3.  When set, the PHY drops the link in D3 and no magic packet ever reaches the MAC.  Clear DIS_100_D3, DIS_1000_D3 and DIS_2500_D3 in igc_enable_wakeup() so the PHY can keep a link in D3.  This matches what the Linux igc driver does on the WoL configuration path.

Second, igc_enable_wakeup() cleared IGC_WUFC_MAG from sc->wol when IFCAP_WOL_MAGIC was disabled, but never set it again when the capability was (re)enabled via ifconfig.  As a result the subsequent write to WUFC programmed zero and magic-packet detection stayed off. Set IGC_WUFC_MAG in the corresponding else branch.

While here, only advertise IFCAP_WOL_MAGIC in igc_if_attach_pre() when the magic-packet bit is actually present in sc->wol, rather than for any non-zero value.  This matches the "Enable only WOL MAGIC by default" comment immediately above.

PR: 282140
Reported by: Mario Agustin Carranza
Authored by: Hiroshi Nishida
Tested by: Hiroshi Nishida & Ricardo Branco