### PR TITLE
asmc: add support for MacBookPro13,1

### DIFF
--- a/sys/dev/asmc/asmc.c
+++ b/sys/dev/asmc/asmc.c
@@ -334,6 +334,12 @@ static const struct asmc_model asmc_models[] = {
 	  ASMC_MBP115_TEMPS, ASMC_MBP115_TEMPNAMES, ASMC_MBP115_TEMPDESCS
 	},
 
+	{
+	  "MacBookPro13,1", "Apple SMC MacBook Pro Retina Core i5 (late 2016, 13-inch)",
+	  ASMC_SMS_FUNCS_DISABLED, ASMC_FAN_FUNCS2, ASMC_LIGHT_FUNCS,
+	  ASMC_MBP131_TEMPS, ASMC_MBP131_TEMPNAMES, ASMC_MBP131_TEMPDESCS
+	},
+
 	/* The Mac Mini has no SMS */
 	{
 	  "Macmini1,1", "Apple SMC Mac Mini",

--- a/sys/dev/asmc/asmcvar.h
+++ b/sys/dev/asmc/asmcvar.h
@@ -545,6 +545,24 @@ struct asmc_softc {
 				  "Pbus", "Ambient Light", "Leftside", "Rightside", "CPU Package Core", \
 				  "CPU Package GPU", "CPU Package Total", "System Total", "DC In" }
 
+#define ASMC_MBP131_TEMPS	{ "TB0T", "TB1T", "TB2T", "TC0F", \
+				  "TC0P", "TC1C", "TC2C", "TCGC", \
+				  "TCSA", "TCXC", "Th1H", "TM0P", \
+				  "TPCD", "Ts0P", "Ts0S", "TaLC", \
+				  "Ts1P", NULL }
+
+#define ASMC_MBP131_TEMPNAMES	{ "battery", "battery_1", "battery_2", "cpu_die_peci", \
+				  "cpu_proximity", "cpu_core_1", "cpu_core_2", "intel_gpu", \
+				  "cpu_sys_agent", "cpu_core_peci", "right_fin_stack", "memory_proximity", \
+				  "platform_ctrl_hub", "trackpad", "bottom_skin", "air_flow", \
+				  "trackpad_act" }
+
+#define ASMC_MBP131_TEMPDESCS	{ "Battery", "Battery Sensor 1", "Battery Sensor 2", "CPU Die (PECI)", \
+				  "CPU Proximity", "CPU Core 1", "CPU Core 2", "Intel GPU", \
+				  "CPU System Agent Core (PECI)", "CPU Core (PECI)", "Right Fin Stack", "DDR3 Proximity", \
+				  "Platform Controller Hub Die", "Trackpad", "Bottom Skin", "Air Flow", \
+				  "Trackpad Actuator" }
+
 #define ASMC_MM_TEMPS		{ "TN0P", "TN1P", NULL }
 #define ASMC_MM_TEMPNAMES	{ "northbridge1", "northbridge2" }
 #define ASMC_MM_TEMPDESCS	{ "Northbridge Point 1", \

--- a/sys/dev/asmc/asmcvar.h
+++ b/sys/dev/asmc/asmcvar.h
@@ -90,7 +90,7 @@ struct asmc_softc {
 #define ASMC_KEY_FANMANUAL	"FS! "	/* RW; 2 bytes */
 #define ASMC_KEY_FANID		"F%dID"	/* RO; 16 bytes */
 #define ASMC_KEY_FANSPEED	"F%dAc"	/* RO; 2 bytes */
-#define ASMC_KEY_FANMINSPEED	"F%dMn"	/* RO; 2 bytes */
+#define ASMC_KEY_FANMINSPEED	"F%dMn"	/* RW; 2 bytes */
 #define ASMC_KEY_FANMAXSPEED	"F%dMx"	/* RO; 2 bytes */
 #define ASMC_KEY_FANSAFESPEED	"F%dSf"	/* RO; 2 bytes */
 #define ASMC_KEY_FANTARGETSPEED	"F%dTg"	/* RW; 2 bytes */


### PR DESCRIPTION
#### asmc: add support for MacBookPro13,1

This commit adds support for the MacBookPro13,1 (late 2016, 13-inch). The SMC
keys were collected from https://logi.wiki/index.php/SMC_Sensor_Codes. Two
temperature keys are omitted because they fail to be read: TI0P (IO Proximity)
and Ta0P (Ambient Air).

Note that the with this model the `dev.asmc.0.fan.0.minspeed` setting only
applies when the fans have been activated by the system. In my testing, the fans
did not spin up until CPU temperatures hit about 80C. At lower temperatures, the
fans will happily ignore the minimum speed and remain at 0 rpm.

#### asmc: correctly label ASMC_KEY_FANMINSPEED as read-write