### PR TITLE
hkbd/ukbd: sysctls to swap macbook kbd modifiers

### DIFF
--- a/share/man/man4/hkbd.4
+++ b/share/man/man4/hkbd.4
@@ -151,6 +151,18 @@ tunables:
 Debug output level, where 0 is debugging disabled and larger values increase
 debug message verbosity.
 Default is 0.
+.It Va hw.hid.hkbd.apple_swap_cmd_opt
+Swap the Command & Option keys on Apple keyboards if set to 1.
+Default is 0.
+.It Va hw.hid.hkbd.apple_swap_cmd_ctl
+Swap the Command & Control keys on Apple keyboards if set to 1.
+Default is 0.
+.It Va hw.hid.hkbd.apple_fn_mode
+Direct access to media keys without holding Fn if set to 1.
+Default is 0.
+.It Va hw.hid.hkbd.no_leds
+Disables setting of keyboard LEDs if set to 1.
+Default is 0.
 .El
 .Sh FILES
 .Bl -tag -width ".Pa /dev/input/event*" -compact

--- a/share/man/man4/ukbd.4
+++ b/share/man/man4/ukbd.4
@@ -156,6 +156,18 @@ tunables:
 Debug output level, where 0 is debugging disabled and larger values increase
 debug message verbosity.
 Default is 0.
+.It Va hw.usb.ukbd.apple_swap_cmd_opt
+Swap the Command & Option keys on Apple keyboards if set to 1.
+Default is 0.
+.It Va hw.usb.ukbd.apple_swap_cmd_ctl
+Swap the Command & Control keys on Apple keyboards if set to 1.
+Default is 0.
+.It Va hw.usb.ukbd.apple_fn_mode
+Direct access to media keys without holding Fn if set to 1.
+Default is 0.
+.It Va hw.usb.ukbd.no_leds
+Disables setting of keyboard LEDs if set to 1.
+Default is 0.
 .El
 .Sh FILES
 .Bl -tag -width ".Pa /dev/kbd*" -compact

--- a/sys/dev/hid/hkbd.c
+++ b/sys/dev/hid/hkbd.c
@@ -100,6 +100,8 @@ static int hkbd_debug = 0;
 #endif
 static int hkbd_no_leds = 0;
 static int hkbd_apple_fn_mode = 0;
+static int hkbd_apple_swap_cmd_ctl = 0;
+static int hkbd_apple_swap_cmd_opt = 0;
 
 static SYSCTL_NODE(_hw_hid, OID_AUTO, hkbd, CTLFLAG_RW, 0, "USB keyboard");
 #ifdef HID_DEBUG
@@ -110,6 +112,10 @@ SYSCTL_INT(_hw_hid_hkbd, OID_AUTO, no_leds, CTLFLAG_RWTUN,
     &hkbd_no_leds, 0, "Disables setting of keyboard leds");
 SYSCTL_INT(_hw_hid_hkbd, OID_AUTO, apple_fn_mode, CTLFLAG_RWTUN,
     &hkbd_apple_fn_mode, 0, "0 = Fn + F1..12 -> media, 1 = F1..F12 -> media");
+SYSCTL_INT(_hw_hid_hkbd, OID_AUTO, apple_swap_cmd_ctl, CTLFLAG_RWTUN,
+    &hkbd_apple_swap_cmd_ctl, 0, "Swap Command & Control keys");
+SYSCTL_INT(_hw_hid_hkbd, OID_AUTO, apple_swap_cmd_opt, CTLFLAG_RWTUN,
+    &hkbd_apple_swap_cmd_opt, 0, "Swap Command & Option keys");
 
 #define	INPUT_EPOCH	global_epoch_preempt
 
@@ -263,7 +269,7 @@ struct hkbd_softc {
  * 0x68: F13
  * 0x69: F14
  * 0x6a: F15
- * 
+ *
  * USB Apple Keyboard JIS generates:
  * 0x90: Kana
  * 0x91: Eisu
@@ -665,6 +671,30 @@ hkbd_apple_fn_media(uint32_t keycode)
 }
 
 static uint32_t
+hkbd_apple_doswap_cmd_ctl(uint32_t keycode)
+{
+	switch (keycode) {
+	case 0xe3: return 0xe0; /* LCMD -> RCTL */
+	case 0xe7: return 0xe4; /* RCMD -> RCTL */
+	case 0xe0: return 0xe3; /* LCTL -> LCMD */
+	case 0xe4: return 0xe7; /* RCTL -> RCMD */
+	default: return keycode;
+	}
+}
+
+static uint32_t
+hkbd_apple_doswap_cmd_opt(uint32_t keycode)
+{
+	switch (keycode) {
+	case 0xe3: return 0xe2; /* LCMD -> ROPT */
+	case 0xe7: return 0xe6; /* RCMD -> ROPT */
+	case 0xe2: return 0xe3; /* LOPT -> LCMD */
+	case 0xe6: return 0xe7; /* ROPT -> RCMD */
+	default: return keycode;
+	}
+}
+
+static uint32_t
 hkbd_apple_swap(uint32_t keycode)
 {
 	switch (keycode) {
@@ -765,6 +795,10 @@ hkbd_intr_callback(void *context, void *data, hid_size_t len)
 					key = hkbd_apple_fn(key);
 				if (apply_apple_fn_media)
 					key = hkbd_apple_fn_media(key);
+				if (hkbd_apple_swap_cmd_ctl)
+					key = hkbd_apple_doswap_cmd_ctl(key);
+				if (hkbd_apple_swap_cmd_opt)
+					key = hkbd_apple_doswap_cmd_opt(key);
 				if (sc->sc_flags & HKBD_FLAG_APPLE_SWAP)
 					key = hkbd_apple_swap(key);
 				if (key == KEY_NONE || key >= HKBD_NKEYCODE)
@@ -780,6 +814,10 @@ hkbd_intr_callback(void *context, void *data, hid_size_t len)
 				key = hkbd_apple_fn(key);
 			if (apply_apple_fn_media)
 				key = hkbd_apple_fn_media(key);
+			if (hkbd_apple_swap_cmd_ctl)
+				key = hkbd_apple_doswap_cmd_ctl(key);
+			if (hkbd_apple_swap_cmd_opt)
+				key = hkbd_apple_doswap_cmd_opt(key);
 			if (sc->sc_flags & HKBD_FLAG_APPLE_SWAP)
 				key = hkbd_apple_swap(key);
 			if (key == KEY_NONE || key == KEY_ERROR || key >= HKBD_NKEYCODE)
@@ -876,7 +914,7 @@ hkbd_parse_hid(struct hkbd_softc *sc, const uint8_t *ptr, uint32_t len,
 			}
 		}
 	}
-	
+
 	/* figure out event buffer */
 	if (hidbus_locate(ptr, len,
 	    HID_USAGE2(HUP_KEYBOARD, 0x00),

--- a/sys/dev/hid/hkbd.c
+++ b/sys/dev/hid/hkbd.c
@@ -269,7 +269,7 @@ struct hkbd_softc {
  * 0x68: F13
  * 0x69: F14
  * 0x6a: F15
- *
+ * 
  * USB Apple Keyboard JIS generates:
  * 0x90: Kana
  * 0x91: Eisu
@@ -674,7 +674,7 @@ static uint32_t
 hkbd_apple_doswap_cmd_ctl(uint32_t keycode)
 {
 	switch (keycode) {
-	case 0xe3: return 0xe0; /* LCMD -> RCTL */
+	case 0xe3: return 0xe0; /* LCMD -> LCTL */
 	case 0xe7: return 0xe4; /* RCMD -> RCTL */
 	case 0xe0: return 0xe3; /* LCTL -> LCMD */
 	case 0xe4: return 0xe7; /* RCTL -> RCMD */
@@ -914,7 +914,7 @@ hkbd_parse_hid(struct hkbd_softc *sc, const uint8_t *ptr, uint32_t len,
 			}
 		}
 	}
-
+	
 	/* figure out event buffer */
 	if (hidbus_locate(ptr, len,
 	    HID_USAGE2(HUP_KEYBOARD, 0x00),

--- a/sys/dev/usb/input/ukbd.c
+++ b/sys/dev/usb/input/ukbd.c
@@ -99,6 +99,8 @@ static int ukbd_debug = 0;
 static int ukbd_no_leds = 0;
 static int ukbd_pollrate = 0;
 static int ukbd_apple_fn_mode = 0;
+static int ukbd_apple_swap_cmd_ctl = 0;
+static int ukbd_apple_swap_cmd_opt = 0;
 
 static SYSCTL_NODE(_hw_usb, OID_AUTO, ukbd, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
     "USB keyboard");
@@ -112,6 +114,10 @@ SYSCTL_INT(_hw_usb_ukbd, OID_AUTO, pollrate, CTLFLAG_RWTUN,
     &ukbd_pollrate, 0, "Force this polling rate, 1-1000Hz");
 SYSCTL_INT(_hw_usb_ukbd, OID_AUTO, apple_fn_mode, CTLFLAG_RWTUN,
     &ukbd_apple_fn_mode, 0, "0 = Fn + F1..12 -> media, 1 = F1..F12 -> media");
+SYSCTL_INT(_hw_usb_ukbd, OID_AUTO, apple_swap_cmd_ctl, CTLFLAG_RWTUN,
+    &ukbd_apple_swap_cmd_ctl, 0, "Swap Command & Control keys");
+SYSCTL_INT(_hw_usb_ukbd, OID_AUTO, apple_swap_cmd_opt, CTLFLAG_RWTUN,
+    &ukbd_apple_swap_cmd_opt, 0, "Swap Command & Option keys");
 
 #define	UKBD_EMULATE_ATSCANCODE	       1
 #define	UKBD_DRIVER_NAME          "ukbd"
@@ -257,7 +263,7 @@ struct ukbd_softc {
  * 0x68: F13
  * 0x69: F14
  * 0x6a: F15
- * 
+ *
  * USB Apple Keyboard JIS generates:
  * 0x90: Kana
  * 0x91: Eisu
@@ -721,6 +727,30 @@ ukbd_apple_fn_media(uint32_t keycode)
 }
 
 static uint32_t
+ukbd_apple_doswap_cmd_ctl(uint32_t keycode)
+{
+	switch (keycode) {
+	case 0xe3: return 0xe0; /* LCMD -> RCTL */
+	case 0xe7: return 0xe4; /* RCMD -> RCTL */
+	case 0xe0: return 0xe3; /* LCTL -> LCMD */
+	case 0xe4: return 0xe7; /* RCTL -> RCMD */
+	default: return keycode;
+	}
+}
+
+static uint32_t
+ukbd_apple_doswap_cmd_opt(uint32_t keycode)
+{
+	switch (keycode) {
+	case 0xe3: return 0xe2; /* LCMD -> ROPT */
+	case 0xe7: return 0xe6; /* RCMD -> ROPT */
+	case 0xe2: return 0xe3; /* LOPT -> LCMD */
+	case 0xe6: return 0xe7; /* ROPT -> RCMD */
+	default: return keycode;
+	}
+}
+
+static uint32_t
 ukbd_apple_swap(uint32_t keycode)
 {
 	switch (keycode) {
@@ -839,6 +869,10 @@ ukbd_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 						key = ukbd_apple_fn(key);
 					if (apply_apple_fn_media)
 						key = ukbd_apple_fn_media(key);
+					if (ukbd_apple_swap_cmd_ctl)
+						key = ukbd_apple_doswap_cmd_ctl(key);
+					if (ukbd_apple_swap_cmd_opt)
+						key = ukbd_apple_doswap_cmd_opt(key);
 					if (sc->sc_flags & UKBD_FLAG_APPLE_SWAP)
 						key = ukbd_apple_swap(key);
 					if (key == KEY_NONE || key >= UKBD_NKEYCODE)
@@ -853,6 +887,10 @@ ukbd_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 					key = ukbd_apple_fn(key);
 				if (apply_apple_fn_media)
 					key = ukbd_apple_fn_media(key);
+				if (ukbd_apple_swap_cmd_ctl)
+					key = ukbd_apple_doswap_cmd_ctl(key);
+				if (ukbd_apple_swap_cmd_opt)
+					key = ukbd_apple_doswap_cmd_opt(key);
 				if (sc->sc_flags & UKBD_FLAG_APPLE_SWAP)
 					key = ukbd_apple_swap(key);
 				if (key == KEY_NONE || key == KEY_ERROR || key >= UKBD_NKEYCODE)
@@ -1306,7 +1344,7 @@ ukbd_attach(device_t dev)
 	    (err != 0) || ukbd_any_key_valid(sc) == false) {
 		DPRINTF("Forcing boot protocol\n");
 
-		err = usbd_req_set_protocol(sc->sc_udev, NULL, 
+		err = usbd_req_set_protocol(sc->sc_udev, NULL,
 			sc->sc_iface_index, 0);
 
 		if (err != 0) {

--- a/sys/dev/usb/input/ukbd.c
+++ b/sys/dev/usb/input/ukbd.c
@@ -263,7 +263,7 @@ struct ukbd_softc {
  * 0x68: F13
  * 0x69: F14
  * 0x6a: F15
- *
+ * 
  * USB Apple Keyboard JIS generates:
  * 0x90: Kana
  * 0x91: Eisu
@@ -730,7 +730,7 @@ static uint32_t
 ukbd_apple_doswap_cmd_ctl(uint32_t keycode)
 {
 	switch (keycode) {
-	case 0xe3: return 0xe0; /* LCMD -> RCTL */
+	case 0xe3: return 0xe0; /* LCMD -> LCTL */
 	case 0xe7: return 0xe4; /* RCMD -> RCTL */
 	case 0xe0: return 0xe3; /* LCTL -> LCMD */
 	case 0xe4: return 0xe7; /* RCTL -> RCMD */
@@ -1344,7 +1344,7 @@ ukbd_attach(device_t dev)
 	    (err != 0) || ukbd_any_key_valid(sc) == false) {
 		DPRINTF("Forcing boot protocol\n");
 
-		err = usbd_req_set_protocol(sc->sc_udev, NULL,
+		err = usbd_req_set_protocol(sc->sc_udev, NULL, 
 			sc->sc_iface_index, 0);
 
 		if (err != 0) {


### PR DESCRIPTION
Many applications, desktop environments, window managers & text editors favor the usage of Alt or Ctrl over Super (Cmd). On a Macbook it is quite annoying that the Super (Cmd) key gets pride of place by the spacebar. 

The standard MacBook Cmd key location only really makes sense for macOS or maybe in some tiling wm if Mod4/Super is your main modifier. For most mainstream desktops and window managers, having Alt or Ctrl in that location makes much much more sense.

This patch adds two sysctls for swapping either Opt(Alt) or Ctrl with Cmd(Super).

Linux has similar sysctls to this; allowing a user to make an Apple keyboard more "orthodox"/useful at a level that takes effect independent of typing context - ie) tty, Xorg and/or wayland.

Having a sysctl to do these swaps means that a user doesn't have to faff about with both creating a custom vt keymap AND figure out which magic `setxkbmap` incantation one needs to make one's keyboard behave as desired across environments.

@wulf7 