### PR TITLE
pseudofs: Fix pfs_open access checks

### DIFF
--- a/sys/fs/pseudofs/pseudofs_vnops.c
+++ b/sys/fs/pseudofs/pseudofs_vnops.c
@@ -606,8 +606,8 @@ pfs_open(struct vop_open_args *va)
 	pfs_assert_not_owned(pn);
 
 	/* check if the requested mode is permitted */
-	if (((mode & FREAD) && !(mode & PFS_RD)) ||
-	    ((mode & FWRITE) && !(mode & PFS_WR)))
+	if (((mode & FREAD) && !(pn->pn_flags & PFS_RD)) ||
+	    ((mode & FWRITE) && !(pn->pn_flags & PFS_WR)))
 		PFS_RETURN (EPERM);
 
 	/* we don't support locking */


### PR DESCRIPTION
Check PFS_RD and PFS_WR against pn->pn_flags instead of the open mode.

This should be a mistake. Using the default build options, this check is compiled out and always evaluates to false.

```
(lldb) disassemble -n pfs_open -m

** 601          struct pfs_vdata *pvd = vn->v_data;

kernel[0xffffffff80aee8fa] <+10>: movq   0x18(%rax), %rax

** 602          struct pfs_node *pn = pvd->pvd_pn;

kernel[0xffffffff80aee8fe] <+14>: movq   (%rax), %rax

** 603          int mode = va->a_mode;
   604
   605          PFS_TRACE(("%s (mode 0x%x)", pn->pn_name, mode));

kernel[0xffffffff80aee901] <+17>: movl   0x10(%rdi), %ebx

   121  {
   122
** 123          mtx_assert(&pn->pn_mutex, MA_NOTOWNED);
   124  }
   125

kernel[0xffffffff80aee904] <+20>: addq   $0x20, %rax
kernel[0xffffffff80aee908] <+24>: movq   %rax, %rdi
kernel[0xffffffff80aee90b] <+27>: xorl   %esi, %esi
kernel[0xffffffff80aee90d] <+29>: movq   $-0x7edad9f1, %rdx ; imm = 0x8125260F
kernel[0xffffffff80aee914] <+36>: movl   $0x7b, %ecx
kernel[0xffffffff80aee919] <+41>: callq  0xffffffff80bb25a0 ; __mtx_assert at kern_mutex.c:1095

   612
   613          /* we don't support locking */
** 614          if ((mode & O_SHLOCK) || (mode & O_EXLOCK))
   615                  PFS_RETURN (EOPNOTSUPP);
   616
```