### PR TITLE
pfctl: clarify usage of load option flags

### DIFF
--- a/sbin/pfctl/pfctl.8
+++ b/sbin/pfctl/pfctl.8
@@ -458,7 +458,7 @@ and
 flags to load multiple rule types without (re)loading all rules.
 .It Fl r
 Perform reverse DNS lookups on states and tables when displaying them.
-.Fl N
+.Fl S
 and
 .Fl r
 are mutually exclusive.

--- a/sbin/pfctl/pfctl.8
+++ b/sbin/pfctl/pfctl.8
@@ -110,6 +110,12 @@ The options are as follows:
 .It Fl A
 Load only the queue rules present in the rule file.
 Other rules and options are ignored.
+Can be combined with the
+.Fl N ,
+.Fl O ,
+and
+.Fl R
+flags to load multiple rule types without (re)loading all rules.
 .It Fl a Ar anchor
 Apply flags
 .Fl f ,
@@ -399,11 +405,23 @@ Allows single options to be modified without disturbing the others:
 .It Fl N
 Load only the NAT rules present in the rule file.
 Other rules and options are ignored.
+Can be combined with the
+.Fl A ,
+.Fl O ,
+and
+.Fl R
+flags to load multiple rule types without (re)loading all rules.
 .It Fl n
 Do not actually load rules, just parse them.
 .It Fl O
 Load only the options present in the rule file.
 Other rules and options are ignored.
+Can be combined with the
+.Fl A ,
+.Fl N ,
+and
+.Fl R
+flags to load multiple rule types without (re)loading all rules.
 .It Fl o Ar level
 Control the ruleset optimizer, overriding any rule file settings.
 .Pp
@@ -432,6 +450,12 @@ Only print errors and warnings.
 .It Fl R
 Load only the filter rules present in the rule file.
 Other rules and options are ignored.
+Can be combined with the
+.Fl A ,
+.Fl N ,
+and
+.Fl O
+flags to load multiple rule types without (re)loading all rules.
 .It Fl r
 Perform reverse DNS lookups on states and tables when displaying them.
 .Fl N

--- a/sbin/pfctl/pfctl.c
+++ b/sbin/pfctl/pfctl.c
@@ -3809,7 +3809,7 @@ main(int argc, char *argv[])
 	}
 
 	if ((opts & PF_OPT_NODNS) && (opts & PF_OPT_USEDNS))
-		errx(1, "-N and -r are mutually exclusive");
+		errx(1, "-S and -r are mutually exclusive");
 
 	if ((tblcmdopt == NULL) ^ (tableopt == NULL) &&
 	    (tblcmdopt == NULL || *tblcmdopt != 'l'))


### PR DESCRIPTION
`pfctl -A`, `-N`, `-O`, and `-R` restrict which rule types and options are loaded. The man page language ("Load only...") does not make it clear that these options can be combined to (re)load multiple rule types and/or options without reloading the entire packet filter. Add language to make it explicitly clear that these flags combine.

Also, fix man page and error message for `-S` option. The `pfctl -S` flag was added to disable DNS resolution in https://reviews.freebsd.org/D50724 but documentation and error messages refer to a `pfctl -N` flag for the same purpose. The `pfctl -N` flag performs an unrelated function, so the docs and error messages need to be changed. Caught this when revising documentation for the `-N` flag.

