### PR TITLE
freebsd-version: fix pathname expansion bug

### DIFF
--- a/bin/freebsd-version/freebsd-version.sh.in
+++ b/bin/freebsd-version/freebsd-version.sh.in
@@ -26,7 +26,7 @@
 #
 #
 
-set -e
+set -ef
 
 USERLAND_VERSION="@@REVISION@@-@@BRANCH@@"
 
@@ -88,7 +88,7 @@ userland_version() {
 #
 jail_version() {
 	for i in $jail; do
-		jexec -- $i freebsd-version
+		jexec -- "$i" freebsd-version
 	done
 }
 

--- a/bin/freebsd-version/freebsd-version.sh.in
+++ b/bin/freebsd-version/freebsd-version.sh.in
@@ -118,6 +118,10 @@ main() {
 			opt_u=1
 			;;
 		j)
+			if [ -z "$OPTARG" ] ; then
+				echo "No arg for -j option" >&2
+				usage
+			fi
 			if [ $opt_j ] ; then
 				jail="$jail $OPTARG"
 			else

--- a/bin/freebsd-version/freebsd-version.sh.in
+++ b/bin/freebsd-version/freebsd-version.sh.in
@@ -84,11 +84,11 @@ userland_version() {
 }
 
 #
-# Print the hardcoded userland version of a jail.
+# Print the hardcoded userland version(s) of jail(s).
 #
 jail_version() {
-	for i in $jail; do
-		jexec -- "$i" freebsd-version
+	for j in $jail; do
+		jexec -- "$j" freebsd-version
 	done
 }
 


### PR DESCRIPTION
Hi,
I discovered several bugs in freebsd-version:

### Bugs:
1. `-j` option is susceptible to pathname expansion in the shell script due to the use of unquoted variable names in several places. I was able to run jails with special characters in name such as * and ?. Not only freebsd-version might not correctly work with these jail names but one can use characters like *, /, ? to reveal information in filesystem or trigger denial-of-service type of attacks.
2. freebsd-version -j "" exits silently.

### Examples:
```
# freebsd-version -j "/root/*"
jexec: jail "/root/Book" not found

# freebsd-version -j "/root/*/*/*/*"
jexec: jail "/root/Book/Jung/C.G." not found

# freebsd-version -j "/*/*/*/*/*/*/*/*/*"
# (excessive expansion leading to high resource usage)

- When provided with an empty string, the command exits silently:
# freebsd-version -j ""

# freebsd-version -j "/home/*/*/*/*/*/*/*/*"
jexec: jail "/home/nami/book/Prep/Education/Homeschool/Grade" not found

# freebsd-version -j "/etc/*conf"
jexec: jail "/etc/blacklistd.conf" not found

# freebsd-version -j "/jail/?????"
jexec: jail "/jail/nginx" not found

# freebsd-version -j "/jail/???"
jexec: jail "/jail/dev" not found

# freebsd-version -j "/jail/av/root/???"
jexec: jail "/jail/av/root/log" not found


```
This is the result on the patched version:
```
# freebsd-version -j "/*/*"
jexec: jail "/*/*" not found

# freebsd-version -j acme
15.0-RELEASE

# freebsd-version -j "?"
jexec: jail "?" not found

```
Commands like this on a slow HDD server take a lot of resources:
```
# time freebsd-version -j "/*/*/*/*/*"
jexec: jail "/jail/acme/boot/defaults/loader.conf" not found
0.133u 121.398s 2:01.70 99.8% 152+172k 0+0io 0pf+0
```
The patched version on the same server:
```
# time freebsd-version -j "/*/*/*/*/*"
jexec: jail "/*/*/*/*/*" not found
0.000u 0.077s 0:00.05 140.0% 379+358k 0+0io 0pf+0w
```
### Changes include:
- Adding quotation marks to the variable affected by the `-j` option.
- Setting `-f` to disable pathname expansion.
- Minor styling improvements.
- A check for an empty `-j` option.