### PR TITLE
linux: Add missing prctl(2) operations

### DIFF
--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -1804,6 +1804,18 @@ linux_prctl(struct thread *td, struct linux_prctl_args *args)
 
 		return (kern_procctl(td, P_PID, 0, PROC_REAP_ACQUIRE,
 		    NULL));
+	case LINUX_PR_GET_CHILD_SUBREAPER: {
+		struct procctl_reaper_status rs;
+		l_int val;
+
+		error = kern_procctl(td, P_PID, 0, PROC_REAP_STATUS, &rs);
+		if (error != 0)
+			return (error);
+		val = rs.rs_reaper == p->p_pid ? 1 : 0;
+		error = copyout(&val, (void *)(register_t)args->arg2,
+		    sizeof(val));
+		break;
+	}
 	case LINUX_PR_SET_NO_NEW_PRIVS:
 		arg = args->arg2 == 1 ?
 		    PROC_NO_NEW_PRIVS_ENABLE : PROC_NO_NEW_PRIVS_DISABLE;

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -1822,6 +1822,14 @@ linux_prctl(struct thread *td, struct linux_prctl_args *args)
 		error = kern_procctl(td, P_PID, p->p_pid,
 		    PROC_NO_NEW_PRIVS_CTL, &arg);
 		break;
+	case LINUX_PR_GET_NO_NEW_PRIVS:
+		error = kern_procctl(td, P_PID, p->p_pid,
+		    PROC_NO_NEW_PRIVS_STATUS, &arg);
+		if (error != 0)
+			return (error);
+		/* Linux returns the value as the syscall return */
+		td->td_retval[0] = arg == PROC_NO_NEW_PRIVS_ENABLE ? 1 : 0;
+		break;
 	case LINUX_PR_SET_PTRACER:
 		linux_msg(td, "unsupported prctl PR_SET_PTRACER");
 		error = EINVAL;

--- a/sys/compat/linux/linux_misc.h
+++ b/sys/compat/linux/linux_misc.h
@@ -59,7 +59,8 @@
 #define	LINUX_PR_CAPBSET_READ	23
 #define	LINUX_PR_SET_CHILD_SUBREAPER	36 /* Get child subreaper status */
 #define	LINUX_PR_GET_CHILD_SUBREAPER	37 /* Set child subreaper status */
-#define	LINUX_PR_SET_NO_NEW_PRIVS	38
+#define	LINUX_PR_SET_NO_NEW_PRIVS	38 /* Set no_new_privs attribute */
+#define	LINUX_PR_GET_NO_NEW_PRIVS	39 /* Get no_new_privs attribute */
 #define	LINUX_PR_SET_PTRACER	1499557217
 
 #define	LINUX_MAX_COMM_LEN	16	/* Maximum length of the process name. */

--- a/sys/compat/linux/linux_misc.h
+++ b/sys/compat/linux/linux_misc.h
@@ -57,7 +57,8 @@
 #define	LINUX_PR_GET_SECCOMP	21
 #define	LINUX_PR_SET_SECCOMP	22
 #define	LINUX_PR_CAPBSET_READ	23
-#define LINUX_PR_SET_CHILD_SUBREAPER 36
+#define	LINUX_PR_SET_CHILD_SUBREAPER	36 /* Get child subreaper status */
+#define	LINUX_PR_GET_CHILD_SUBREAPER	37 /* Set child subreaper status */
 #define	LINUX_PR_SET_NO_NEW_PRIVS	38
 #define	LINUX_PR_SET_PTRACER	1499557217
 


### PR DESCRIPTION
There are some Linux prctl(2) flags for which we support the SET method but we lack the GET equivalent like:

- PR_GET_CHILD_SUBREAPER 
- PR_GET_NO_NEW_PRIVS

Fixes: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=294651