### PR TITLE
powerpc: remove dead call into x86 perfmon

### DIFF
--- a/sys/powerpc/powerpc/machdep.c
+++ b/sys/powerpc/powerpc/machdep.c
@@ -195,9 +195,6 @@ cpu_startup(void *dummy)
 	 */
 	cpu_setup(PCPU_GET(cpuid));
 
-#ifdef PERFMON
-	perfmon_init();
-#endif
 	printf("real memory  = %ju (%ju MB)\n", ptoa((uintmax_t)physmem),
 	    ptoa((uintmax_t)physmem) / 1048576);
 	realmem = physmem;


### PR DESCRIPTION
FreeBSD and NetBSD copied these lines from the x86 architecture when porting to other architectures and forgot to delete them.

Sponsored by: Netflix