### PR TITLE
hwpmc: Harden ioctl interface for AMD processors

### DIFF
--- a/sys/dev/hwpmc/hwpmc_amd.c
+++ b/sys/dev/hwpmc/hwpmc_amd.c
@@ -505,6 +505,7 @@ amd_release_pmc(int cpu, int ri, struct pmc *pmc __unused)
 static int
 amd_start_pmc(int cpu __diagused, int ri, struct pmc *pm)
 {
+	int status;
 	const struct amd_descr *pd;
 	uint64_t config;
 
@@ -531,8 +532,9 @@ amd_start_pmc(int cpu __diagused, int ri, struct pmc *pm)
 
 	PMCDBG1(MDP, STA, 2, "amd-start config=0x%x", config);
 
-	wrmsr(pd->pm_evsel, config);
-	return (0);
+	status = wrmsr_safe(pd->pm_evsel, config);
+
+	return (status);
 }
 
 /*
@@ -541,6 +543,7 @@ amd_start_pmc(int cpu __diagused, int ri, struct pmc *pm)
 static int
 amd_stop_pmc(int cpu __diagused, int ri, struct pmc *pm)
 {
+	int status;
 	const struct amd_descr *pd;
 	uint64_t config;
 	int i;
@@ -560,7 +563,7 @@ amd_stop_pmc(int cpu __diagused, int ri, struct pmc *pm)
 
 	/* turn off the PMC ENABLE bit */
 	config = pm->pm_md.pm_amd.pm_amd_evsel & ~AMD_PMC_ENABLE;
-	wrmsr(pd->pm_evsel, config);
+	status = wrmsr_safe(pd->pm_evsel, config);
 
 	/*
 	 * Due to NMI latency on newer AMD processors
@@ -576,7 +579,7 @@ amd_stop_pmc(int cpu __diagused, int ri, struct pmc *pm)
 		DELAY(1);
 	}
 
-	return (0);
+	return (status);
 }
 
 /*

--- a/sys/dev/hwpmc/hwpmc_ibs.c
+++ b/sys/dev/hwpmc/hwpmc_ibs.c
@@ -332,6 +332,7 @@ ibs_release_pmc(int cpu, int ri, struct pmc *pmc __unused)
 static int
 ibs_start_pmc(int cpu __diagused, int ri, struct pmc *pm)
 {
+	int status;
 	uint64_t config;
 
 	KASSERT(cpu >= 0 && cpu < pmc_cpu_max(),
@@ -355,16 +356,16 @@ ibs_start_pmc(int cpu __diagused, int ri, struct pmc *pm)
 	case IBS_PMC_FETCH:
 		wrmsr(IBS_FETCH_CTL, 0);
 		config = pm->pm_md.pm_ibs.ibs_ctl | IBS_FETCH_CTL_ENABLE;
-		wrmsr(IBS_FETCH_CTL, config);
+		status = wrmsr_safe(IBS_FETCH_CTL, config);
 		break;
 	case IBS_PMC_OP:
 		wrmsr(IBS_OP_CTL, 0);
 		config = pm->pm_md.pm_ibs.ibs_ctl | IBS_OP_CTL_ENABLE;
-		wrmsr(IBS_OP_CTL, config);
+		status = wrmsr_safe(IBS_OP_CTL, config);
 		break;
 	}
 
-	return (0);
+	return (status);
 }
 
 /*
@@ -678,6 +679,25 @@ pmc_ibs_initialize(struct pmc_mdep *pmc_mdep, int ncpus)
 	u_int regs[4];
 	struct pmc_classdep *pcd;
 
+	if (cpu_exthigh >= CPUID_IBSID) {
+		do_cpuid(CPUID_IBSID, regs);
+		ibs_features = regs[0];
+	} else {
+		ibs_features = 0;
+	}
+
+	if ((ibs_features & CPUID_IBSID_MINIMUM) != CPUID_IBSID_MINIMUM) {
+		/*
+		 * From Family 10h we should have these four feature bits set 
+		 * confirming the basic features of IBS that we assume.  I 
+		 * searched all the BKDG and PPRs for desktop and server chips 
+		 * and don't see any missing these features.
+		 */
+		return (ENODEV);
+	}
+
+	ibs_init_policy();
+
 	/*
 	 * Allocate space for pointers to PMC HW descriptors and for
 	 * the MDEP structure used by MI code.
@@ -707,17 +727,6 @@ pmc_ibs_initialize(struct pmc_mdep *pmc_mdep, int ncpus)
 	pcd->pcd_write_pmc	= ibs_write_pmc;
 
 	pmc_mdep->pmd_npmc	+= IBS_NPMCS;
-
-	if (cpu_exthigh >= CPUID_IBSID) {
-		do_cpuid(CPUID_IBSID, regs);
-		ibs_features = regs[0];
-		if ((ibs_features & CPUID_IBSID_IBSFFV) == 0)
-			ibs_features = 0;
-	} else {
-		ibs_features = 0;
-	}
-
-	ibs_init_policy();
 
 	PMCDBG0(MDP, INI, 0, "ibs-initialize");
 

--- a/sys/dev/hwpmc/hwpmc_ibs.h
+++ b/sys/dev/hwpmc/hwpmc_ibs.h
@@ -52,6 +52,9 @@
 #define	CPUID_IBSID_IBSLOADLATENCYFILT	0x00001000 /* Load Latency Filtering */
 #define	CPUID_IBSID_IBSUPDTDDTLBSTATS	0x00080000 /* Simplified DTLB Stats */
 
+#define CPUID_IBSID_MINIMUM		(CPUID_IBSID_IBSFFV | CPUID_IBSID_FETCHSAM | \
+					    CPUID_IBSID_OPSAM | CPUID_IBSID_RDWROPCNT)
+
 /*
  * All of these definitions here come from AMD64 Architecture Programmer's
  * Manual Volume 2: System Programming (24593) 2025-07-02 Version 3.43. with


### PR DESCRIPTION
In practice we cannot be sure about what is a valid value for a given processor as AMD has redefined these values and we do not want to disable NDA'ed usage of the counters.  Various reserved bits can and do lead to general protection faults.  To avoid this we should use the wrmsr_safe when writing values from userspace.

Sponsored by: Netflix