### PR TITLE
freebsd-version(1): Disable pathname expansion

### DIFF
--- a/bin/freebsd-version/freebsd-version.sh.in
+++ b/bin/freebsd-version/freebsd-version.sh.in
@@ -26,7 +26,7 @@
 #
 #
 
-set -e
+set -ef
 
 USERLAND_VERSION="@@REVISION@@-@@BRANCH@@"
 
@@ -88,7 +88,7 @@ userland_version() {
 #
 jail_version() {
 	for i in $jail; do
-		jexec -- $i freebsd-version
+		jexec -- "$i" freebsd-version
 	done
 }
 


### PR DESCRIPTION
The "-j" flag in freebsd-version(1) is susceptible to pathname expansion. This can lead to  issues such as:

1-  freebsd-version(1) confusing legitimate jail names that contain special characters such as '*' and '?' with
 local files that match the expansion pattern.
```
# service jail start "next*cloud"
Starting jails: next*cloud.
# freebsd-version -j "next*cloud"
14.3-RELEASE
# touch next0cloud
# freebsd-version -j "next*cloud"
jexec: jail "next0cloud" not found
```
2- If unsanitized strings from remote users gets passed to "freebsd-version -j" it could potentially be abused to reveal filenames from the error messages.
```
# freebsd-version -j "/root/*"
jexec: jail "/root/Book" not found
# freebsd-version -j "/etc/*conf"
jexec: jail "/etc/blacklistd.conf" not found
# freebsd-version -j "/jail/?????"
jexec: jail "/jail/nginx" not found
```
3- Heavy performance penalty and stress on disk and cpu when multiple level deep expansion patterns are passed into the "-j" flag.
```
# time freebsd-version -j "/*/*"
jexec: jail "/bin/[" not found
0.000u 0.761s 0:00.76 100.0% 149+177k 0+0io 0pf+0w
# time freebsd-version -j "/*/*/*"
jexec: jail "/boot/defaults/loader.conf" not found
0.007u 5.488s 0:05.49 99.8% 153+173k 0+0io 0pf+0w
# time freebsd-version -j "/*/*/*/*"
jexec: jail "/etc/periodic/daily/100.clean-disks" not found
0.007u 81.728s 1:21.73 99.9% 152+172k 0+0io 0pf+0w
```
4- As shown below one can still use expansion patterns in local shell after disabling it in freebsd-version(1).
```
# freebsd-version -j "tes*"
jexec: jail "tes*" not found
# touch test
# freebsd-version -j tes*
jexec: jail "test" not found
# freebsd-version -j "tes*"
jexec: jail "tes*" not found
```
### Changes include:
1- Adding quotation marks to one of the variables affected by filename expansion.
2- Setting -f to disable pathname expansion.