### PR TITLE
ctld: Fix uninitialized variables

### DIFF
--- a/usr.sbin/ctld/ctld.cc
+++ b/usr.sbin/ctld/ctld.cc
@@ -2642,7 +2642,7 @@ conf::add_pports(struct kports &kports)
 {
 	std::unordered_map<struct pport *, struct target *> linked_ports;
 	struct pport *pp;
-	int ret, i_pp, i_vp;
+	int ret;
 
 	for (auto &kv : conf_targets) {
 		struct target *targ = kv.second.get();
@@ -2677,6 +2677,7 @@ conf::add_pports(struct kports &kports)
 			 * If this port is an ioctl port, create a new
 			 * port.
 			 */
+			int i_pp{}, i_vp{};
 			ret = sscanf(pport.c_str(), "ioctl/%d/%d", &i_pp,
 			    &i_vp);
 			if (ret == 2) {


### PR DESCRIPTION
```
/etc/ctl.conf allows shorthand "port ioctl/n" syntax, which currently
results in an uninitialized variable being used in the /dev node name:

target ... {
    port ioctl/1
}

root@vm-fbsd:/ # ls -1 /dev/cam
ctl
ctl1.-871264432     <--- Incorrect

With this fix, the variable is now initialized properly:

root@vm-fbsd:/ # ls -1 /dev/cam
ctl
ctl1.0        <--- Correct
```