### PR TITLE
Dynamic jail.conf

### DIFF
--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -331,15 +331,15 @@ open_config(const char *cfname, pid_t *const pid)
 	int read_fd, write_fd, exec_fd, pipes[2];
 	FILE *file;
 
-	/* Invalidate the child PID. */
+	// Invalidate the child PID.
 	*pid = -1;
 
-	/* The configuration must be readable. */
+	// The configuration must be readable.
 	read_fd = open(cfname, O_RDONLY);
 	if (read_fd < 0)
 		err(1, "open(): %s", cfname);
 
-	/* Try to open the configuration for execution (to parse its standard output config instead). */
+	// Try to open the configuration for execution (to parse its standard output config instead).
 	exec_fd = open(cfname, O_RDONLY | O_EXEC);
 	if (exec_fd < 0) {
 		if (errno != EACCES)
@@ -353,7 +353,7 @@ open_config(const char *cfname, pid_t *const pid)
 			err(1, "open_config(): %s", cfname);
 		}
 		
-		/* Set the argument list: <jail_conf> <jail_conf> <jail_dir> <jail_base> <jail_name>. */
+		// Set the argument list: <jail_conf> <jail_conf> <jail_dir> <jail_base> <jail_name>.
 		const struct cfjail *const current_jail = TAILQ_LAST(&cfjails, cfjails);
 		char *const jail_conf = __DECONST(char *, cfname);
 		char *const jail_dir  = dirname(memcpy(dir_buf, cfname, cfname_size));
@@ -361,24 +361,24 @@ open_config(const char *cfname, pid_t *const pid)
 		char *const jail_name = current_jail && current_jail->name ? current_jail->name : __DECONST(char *, "");
 		char *argv[] = { jail_conf, jail_conf, jail_dir, jail_base, jail_name, NULL };
 
-		/* Read from the pipe instead of the configuration. */
+		// Read from the pipe instead of the configuration.
 		close(read_fd);
 		if (pipe(pipes))
 			err(1, "pipe(): %s", cfname);
 		read_fd = pipes[0];
 		write_fd = pipes[1];
 
-		/* Run the configuration as child process. */
+		// Run the configuration as child process.
 		switch ((*pid = fork())) {
 
-		/* Failed to fork(). */
+		// Failed to fork().
 		case -1:
 			err(1, "fork(): %s", cfname);
 			break;
 
-		/* After successful fork() inside the child process. */
+		// After successful fork() inside the child process.
 		case 0:
-			/* Export the arguments to the executable configuration. */
+			// Export the arguments to the executable configuration.
 			if (setenv("JAIL_CONF", cfname, 1))
 				err(1, "setenv(\"JAIL_CONF\", \"%s\"): %s", cfname, cfname);
 			if (setenv("JAIL_DIR", jail_dir, 1))
@@ -388,28 +388,28 @@ open_config(const char *cfname, pid_t *const pid)
 			if (setenv("JAIL_NAME", jail_name, 1))
 				err(1, "setenv(\"JAIL_NAME\", \"%s\"): %s", jail_name, cfname);
 
-			/* Redirect the child's standard output into the pipe. */
+			// Redirect the child's standard output into the pipe.
 			if (write_fd != STDOUT_FILENO) {
 				if (dup2(write_fd, STDOUT_FILENO) != STDOUT_FILENO)
 					err(1, "dup2(): %s", cfname);
 				close(write_fd);
 			}
 
-			/* Replace the forked child with the configuration command. */
+			// Replace the forked child with the configuration command.
 			execve(argv[0], argv, environ);
 			err(1, "execve(): %s", cfname);
 			break;
 
-		/* After successful fork() inside the parent process. */
+		// After successful fork() inside the parent process.
 		default:
-			/* Close the write end of the pipe and the executable file descriptor in the parent. */
+			// Close the write end of the pipe and the executable file descriptor in the parent.
 			close(write_fd); write_fd = -1;
 			close(exec_fd); exec_fd = -1;
 			break;
 		}
 	}
 
-	/* Wrap a FILE handle around the read-only file descriptor. */
+	// Wrap a FILE handle around the read-only file descriptor.
 	file = fdopen(read_fd, "r");
 	if (file == NULL)
 		err(1, "fdopen(): %s", cfname);

--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -42,6 +42,7 @@
 #include <libgen.h>
 #include <netdb.h>
 #include <pwd.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -87,6 +88,7 @@ static const struct ipspec intparams[] = {
 							PF_INTERNAL | PF_BOOL},
     [IP_EXEC_SYSTEM_USER] =	{"exec.system_user",	PF_INTERNAL},
     [IP_EXEC_TIMEOUT] =		{"exec.timeout",	PF_INTERNAL | PF_INT},
+    [IP_ALLOW_EXEC_INCLUDE] =   {"allow.exec_include",	PF_INTERNAL | PF_BOOL},
 #if defined(INET) || defined(INET6)
     [IP_INTERFACE] =		{"interface",		PF_INTERNAL},
     [IP_IP_HOSTNAME] =		{"ip_hostname",		PF_INTERNAL | PF_BOOL},
@@ -324,11 +326,68 @@ include_config(void *scanner, const char *cfname)
 
 extern char **environ;
 
+/*
+ * Check if a file descriptor references a file is executable to the process
+ * at the time of check.
+ */
+static bool
+is_executable(const int fd)
+{
+	return faccessat(fd, "", X_OK, AT_EMPTY_PATH) == 0;
+}
+
+/*
+ * Check if dynamic includes are enabled.
+ *
+ * The check searches for the boolean internal parameter "dynamic_include"
+ * in the current jail, up its ancestor chain, and in the global jail
+ * in that order.
+ *
+ * An explicit search is needed because the parameter inheritance 
+ * gets applied too late for use in open_config().
+ */
+static bool
+dynamic_include(void)
+{
+	struct cfjail *jail;
+	struct cfparam *p;
+	const char *const name = intparams[IP_ALLOW_EXEC_INCLUDE].name;
+
+	// Search the jail and its ancestors.
+	jail = current_jail;
+	while (jail != NULL) {
+		TAILQ_FOREACH(p, &jail->params, tq)
+			if (equalopts(p->name, name))
+				return !!bool_param(p);
+		jail = jail->cfparent;
+	}
+
+	// Search the global jail.
+	jail = global_jail;
+	if (jail != NULL)
+		TAILQ_FOREACH(p, &jail->params, tq)
+			if (equalopts(p->name, name))
+				return !!bool_param(p);
+
+	// Default to disabled.
+	return false;
+}
+
+/*
+ * Open a jail configuration file.
+ *
+ * The configuration file can be dynamic (aka executable).
+ * For a dynamic configuration the FILE wraps the pipe to
+ * the child process.
+ * The PID is an out parameter and allowing the caller
+ * to wait for the exit status of the child.
+ * The PID is set to -1 if no child has been created.
+ */
 static FILE *
 open_config(const char *cfname, pid_t *const pid)
 {
 
-	int read_fd, write_fd, exec_fd, pipes[2];
+	int read_fd;
 	FILE *file;
 
 	// Invalidate the child PID.
@@ -339,18 +398,17 @@ open_config(const char *cfname, pid_t *const pid)
 	if (read_fd < 0)
 		err(1, "open(): %s", cfname);
 
-	// Try to open the configuration for execution.
-	exec_fd = open(cfname, O_EXEC);
-	if (exec_fd < 0) {
-		if (errno != EACCES)
-			err(1, "openat(): %s", cfname);
-	} else {
-		// Close the exec_fd, because fexecve(2) doesn't work
-		// with scripts since the interpreter can't read the
-		// source code through the exec_fd unless /dev/fd was
-		// mounted with the non-default "nodup" option.
-		close(exec_fd);
-		const size_t cfname_size = strlen(cfname) + 1;
+	const bool is_exec = is_executable(read_fd);
+	const bool dyn_include = dynamic_include();
+
+	// If the configuration is executable run it as a child of jail(8)
+	// and parse its standard output as jail.conf(5) configuration.
+	if (is_exec && !dyn_include) {
+		warnx("Warning: \"%s\" is executable, but executable includes "
+				"are disabled.", cfname);
+	} else if (is_exec && dyn_include) {
+		int exec_fd, write_fd;
+		const size_t cfname_size = strlen(cfname) + sizeof("");
 		char dir_buf[PATH_MAX], base_buf[PATH_MAX];
 		if (cfname_size > PATH_MAX) {
 			errno = ENAMETOOLONG;
@@ -372,12 +430,17 @@ open_config(const char *cfname, pid_t *const pid)
 			NULL
 		};
 
-		// Read from the pipe instead of the configuration.
-		close(read_fd);
-		if (pipe(pipes))
-			err(1, "pipe(): %s", cfname);
-		read_fd = pipes[0];
-		write_fd = pipes[1];
+		// The read end of the pipe replaces the configuration file
+		// as input to the parser, but the file descriptor
+		// is still needed as executable.
+		{
+			int pipes[2];
+			if (pipe(pipes))
+				err(1, "pipe(): %s", cfname);
+			exec_fd = read_fd;
+			read_fd = pipes[0];
+			write_fd = pipes[1];
+		}
 
 		// Run the configuration as child process.
 		switch ((*pid = fork())) {
@@ -412,16 +475,17 @@ open_config(const char *cfname, pid_t *const pid)
 
 			// Replace the forked child with the
 			// dynamic configuration command.
-			execve(argv[0], argv, environ);
-			err(1, "execve(): %s", cfname);
+			close(read_fd);
+			fexecve(exec_fd, argv, environ);
+			err(1, "fexecve(): %s", cfname);
 			break;
 
 		// After successful fork() inside the parent process.
 		default:
 			// Close the write end of the pipe as well as
 			// the executable file descriptor in the parent.
-			close(write_fd); write_fd = -1;
-			close(exec_fd); exec_fd = -1;
+			close(write_fd);
+			close(exec_fd);
 			break;
 		}
 	}

--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -325,7 +325,7 @@ include_config(void *scanner, const char *cfname)
 extern char **environ;
 
 static FILE *
-open_config(const char *cfname, pid_t pid[static 1])
+open_config(const char *cfname, pid_t *const pid)
 {
 
 	int read_fd, write_fd, exec_fd, pipes[2];

--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -335,16 +335,17 @@ open_config(const char *cfname, pid_t pid[static 1])
 	*pid = -1;
 
 	/* The configuration must be readable. */
-	read_fd = open(cfname, O_RDONLY|O_CLOEXEC);
+	read_fd = open(cfname, O_RDONLY);
 	if (read_fd < 0)
 		err(1, "open(): %s", cfname);
 
 	/* Try to open the configuration for execution (to parse its standard output config instead). */
-	exec_fd = openat(read_fd, "", O_EMPTY_PATH|O_EXEC);
+	exec_fd = open(cfname, O_RDONLY | O_EXEC);
 	if (exec_fd < 0) {
 		if (errno != EACCES)
 			err(1, "openat(): %s", cfname);
 	} else {
+		close(exec_fd);
 		const size_t cfname_size = strlen(cfname) + 1;
 		char dir_buf[PATH_MAX], base_buf[PATH_MAX];
 		if (cfname_size > PATH_MAX) {
@@ -395,8 +396,8 @@ open_config(const char *cfname, pid_t pid[static 1])
 			}
 
 			/* Replace the forked child with the configuration command. */
-			fexecve(exec_fd, argv, environ);
-			err(1, "fexecve(): %s", cfname);
+			execve(argv[0], argv, environ);
+			err(1, "execve(): %s", cfname);
 			break;
 
 		/* After successful fork() inside the parent process. */

--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -339,12 +339,16 @@ open_config(const char *cfname, pid_t *const pid)
 	if (read_fd < 0)
 		err(1, "open(): %s", cfname);
 
-	// Try to open the configuration for execution (to parse its standard output config instead).
-	exec_fd = open(cfname, O_RDONLY | O_EXEC);
+	// Try to open the configuration for execution.
+	exec_fd = open(cfname, O_EXEC);
 	if (exec_fd < 0) {
 		if (errno != EACCES)
 			err(1, "openat(): %s", cfname);
 	} else {
+		// Close the exec_fd, because fexecve(2) doesn't work
+		// with scripts since the interpreter can't read the
+		// source code through the exec_fd unless /dev/fd was
+		// mounted with the non-default "nodup" option.
 		close(exec_fd);
 		const size_t cfname_size = strlen(cfname) + 1;
 		char dir_buf[PATH_MAX], base_buf[PATH_MAX];
@@ -353,13 +357,22 @@ open_config(const char *cfname, pid_t *const pid)
 			err(1, "open_config(): %s", cfname);
 		}
 		
-		// Set the argument list: <jail_conf> <jail_conf> <jail_dir> <jail_base> <jail_name>.
-		const struct cfjail *const current_jail = TAILQ_LAST(&cfjails, cfjails);
+		// Set the argument list:
+		//   <jail_conf> <jail_conf> <jail_dir> <jail_base> <jail_name>
+		const struct cfjail *const current_jail =
+			TAILQ_LAST(&cfjails, cfjails);
 		char *const jail_conf = __DECONST(char *, cfname);
-		char *const jail_dir  = dirname(memcpy(dir_buf, cfname, cfname_size));
-		char *const jail_base = basename(memcpy(base_buf, cfname, cfname_size));
-		char *const jail_name = current_jail && current_jail->name ? current_jail->name : __DECONST(char *, "");
-		char *argv[] = { jail_conf, jail_conf, jail_dir, jail_base, jail_name, NULL };
+		char *const jail_dir  =
+			dirname(memcpy(dir_buf, cfname, cfname_size));
+		char *const jail_base =
+			basename(memcpy(base_buf, cfname, cfname_size));
+		char *const jail_name = current_jail && current_jail->name
+			? current_jail->name : __DECONST(char *, "");
+		char *const argv[]    = {
+			jail_conf,
+			jail_conf, jail_dir, jail_base, jail_name,
+			NULL
+		};
 
 		// Read from the pipe instead of the configuration.
 		close(read_fd);
@@ -378,31 +391,37 @@ open_config(const char *cfname, pid_t *const pid)
 
 		// After successful fork() inside the child process.
 		case 0:
-			// Export the arguments to the executable configuration.
+			// Export the arguments as env vars too.
 			if (setenv("JAIL_CONF", cfname, 1))
-				err(1, "setenv(\"JAIL_CONF\", \"%s\"): %s", cfname, cfname);
+				err(1, "setenv(\"JAIL_CONF\", \"%s\"): %s",
+						cfname, cfname);
 			if (setenv("JAIL_DIR", jail_dir, 1))
-				err(1, "setenv(\"JAIL_DIR\", \"%s\"): %s", jail_dir, cfname);
+				err(1, "setenv(\"JAIL_DIR\", \"%s\"): %s",
+						jail_dir, cfname);
 			if (setenv("JAIL_BASE", jail_base, 1))
-				err(1, "setenv(\"JAIL_BASE\", \"%s\"): %s", jail_base, cfname);
+				err(1, "setenv(\"JAIL_BASE\", \"%s\"): %s",
+						jail_base, cfname);
 			if (setenv("JAIL_NAME", jail_name, 1))
-				err(1, "setenv(\"JAIL_NAME\", \"%s\"): %s", jail_name, cfname);
+				err(1, "setenv(\"JAIL_NAME\", \"%s\"): %s",
+						jail_name, cfname);
 
 			// Redirect the child's standard output into the pipe.
 			if (write_fd != STDOUT_FILENO) {
-				if (dup2(write_fd, STDOUT_FILENO) != STDOUT_FILENO)
+				if (dup2(write_fd, STDOUT_FILENO) < 0)
 					err(1, "dup2(): %s", cfname);
 				close(write_fd);
 			}
 
-			// Replace the forked child with the configuration command.
+			// Replace the forked child with the
+			// dynamic configuration command.
 			execve(argv[0], argv, environ);
 			err(1, "execve(): %s", cfname);
 			break;
 
 		// After successful fork() inside the parent process.
 		default:
-			// Close the write end of the pipe and the executable file descriptor in the parent.
+			// Close the write end of the pipe as well as
+			// the executable file descriptor in the parent.
 			close(write_fd); write_fd = -1;
 			close(exec_fd); exec_fd = -1;
 			break;

--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -359,8 +359,6 @@ open_config(const char *cfname, pid_t *const pid)
 		
 		// Set the argument list:
 		//   <jail_conf> <jail_conf> <jail_dir> <jail_base> <jail_name>
-		const struct cfjail *const current_jail =
-			TAILQ_LAST(&cfjails, cfjails);
 		char *const jail_conf = __DECONST(char *, cfname);
 		char *const jail_dir  =
 			dirname(memcpy(dir_buf, cfname, cfname_size));

--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -39,6 +39,7 @@
 #include <err.h>
 #include <fcntl.h>
 #include <glob.h>
+#include <libgen.h>
 #include <netdb.h>
 #include <pwd.h>
 #include <stdio.h>
@@ -328,14 +329,13 @@ open_config(const char *cfname, pid_t pid[static 1])
 {
 
 	int read_fd, write_fd, exec_fd, pipes[2];
-	char *argv[] = { __DECONST(char *, cfname), __DECONST(char *, cfname), NULL };
 	FILE *file;
 
 	/* Invalidate the child PID. */
 	*pid = -1;
 
 	/* The configuration must be readable. */
-	read_fd = open(cfname, O_RDONLY);
+	read_fd = open(cfname, O_RDONLY|O_CLOEXEC);
 	if (read_fd < 0)
 		err(1, "open(): %s", cfname);
 
@@ -345,6 +345,21 @@ open_config(const char *cfname, pid_t pid[static 1])
 		if (errno != EACCES)
 			err(1, "openat(): %s", cfname);
 	} else {
+		const size_t cfname_size = strlen(cfname) + 1;
+		char dir_buf[PATH_MAX], base_buf[PATH_MAX];
+		if (cfname_size > PATH_MAX) {
+			errno = ENAMETOOLONG;
+			err(1, "open_config(): %s", cfname);
+		}
+		
+		/* Set the argument list: <jail_conf> <jail_conf> <jail_dir> <jail_base> <jail_name>. */
+		const struct cfjail *const current_jail = TAILQ_LAST(&cfjails, cfjails);
+		char *const jail_conf = __DECONST(char *, cfname);
+		char *const jail_dir  = dirname(memcpy(dir_buf, cfname, cfname_size));
+		char *const jail_base = basename(memcpy(base_buf, cfname, cfname_size));
+		char *const jail_name = current_jail && current_jail->name ? current_jail->name : __DECONST(char *, "");
+		char *argv[] = { jail_conf, jail_conf, jail_dir, jail_base, jail_name, NULL };
+
 		/* Read from the pipe instead of the configuration. */
 		close(read_fd);
 		if (pipe(pipes))
@@ -354,29 +369,41 @@ open_config(const char *cfname, pid_t pid[static 1])
 
 		/* Run the configuration as child process. */
 		switch ((*pid = fork())) {
-		/* Failure to fork() is fatal. */
+
+		/* Failed to fork(). */
 		case -1:
 			err(1, "fork(): %s", cfname);
 			break;
 
-		/* Redirect the child's standard output into the pipe. */
+		/* After successful fork() inside the child process. */
 		case 0:
-			close(read_fd);
+			/* Export the arguments to the executable configuration. */
+			if (setenv("JAIL_CONF", cfname, 1))
+				err(1, "setenv(\"JAIL_CONF\", \"%s\"): %s", cfname, cfname);
+			if (setenv("JAIL_DIR", jail_dir, 1))
+				err(1, "setenv(\"JAIL_DIR\", \"%s\"): %s", jail_dir, cfname);
+			if (setenv("JAIL_BASE", jail_base, 1))
+				err(1, "setenv(\"JAIL_BASE\", \"%s\"): %s", jail_base, cfname);
+			if (setenv("JAIL_NAME", jail_name, 1))
+				err(1, "setenv(\"JAIL_NAME\", \"%s\"): %s", jail_name, cfname);
+
+			/* Redirect the child's standard output into the pipe. */
 			if (write_fd != STDOUT_FILENO) {
 				if (dup2(write_fd, STDOUT_FILENO) != STDOUT_FILENO)
 					err(1, "dup2(): %s", cfname);
 				close(write_fd);
 			}
 
-			// Replace the forked child with the configuration command.
+			/* Replace the forked child with the configuration command. */
 			fexecve(exec_fd, argv, environ);
 			err(1, "fexecve(): %s", cfname);
 			break;
 
-		// Close the write end of the pipe and the executable file descriptor in the parent.
+		/* After successful fork() inside the parent process. */
 		default:
-			close(write_fd);
-			close(exec_fd);
+			/* Close the write end of the pipe and the executable file descriptor in the parent. */
+			close(write_fd); write_fd = -1;
+			close(exec_fd); exec_fd = -1;
 			break;
 		}
 	}
@@ -417,7 +444,7 @@ parse_config(const char *cfname, int is_stdin)
 		} while (exited < 0 || errno == EINTR);
 		status = WEXITSTATUS(status);
 		if (status != 0)
-			errx(status, "Config child failed with status=%i): %s", status, cfname);
+			errx(status, "Config child failed (exit code = %i): %s", status, cfname);
 	}
 }
 

--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -29,14 +29,18 @@
 #include <sys/types.h>
 #include <sys/errno.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/sysctl.h>
+#include <sys/wait.h>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
 
 #include <err.h>
+#include <fcntl.h>
 #include <glob.h>
 #include <netdb.h>
+#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -317,10 +321,77 @@ include_config(void *scanner, const char *cfname)
 	--depth;
 }
 
+extern char **environ;
+
+static FILE *
+open_config(const char *cfname, pid_t pid[static 1])
+{
+
+	int read_fd = open(cfname, O_RDONLY), write_fd, exec_fd, pipes[2];
+	char *argv[] = { (char*)(uintptr_t)cfname, (char *)(uintptr_t)cfname, NULL }; // DECONST *sigh*
+
+	// Invalidate the child PID.
+	*pid = -1;
+
+	// The configuration must be readable.
+	if (read_fd < 0)
+		err(1, "open(): %s", cfname);
+
+	// Try to open the configuration for execution (to parse its standard output config instead).
+	exec_fd = openat(read_fd, "", O_EMPTY_PATH|O_EXEC);
+	if (exec_fd < 0) {
+		if (errno != EACCES)
+			err(1, "openat(): %s", cfname);
+	} else {
+		// Read from the pipe instead of the configuration.
+		close(read_fd);
+		if (pipe(pipes))
+			err(1, "pipe(): %s", cfname);
+		read_fd = pipes[0];
+		write_fd = pipes[1];
+
+		// Run the configuration as child process.
+		switch ((*pid = fork())) {
+		// Failure to fork is fatal.
+		case -1:
+			err(1, "fork(): %s", cfname);
+			break;
+
+		// Redirect the child's standard output into the pipe.
+		case 0:
+			close(read_fd);
+			if (write_fd != STDOUT_FILENO) {
+				if ( dup2(write_fd, STDOUT_FILENO) != STDOUT_FILENO )
+					err(1, "dup2(): %s", cfname);
+				close(write_fd);
+			}
+
+			// Replace the forked child with the configuration command.
+			fexecve(exec_fd, argv, environ);
+			err(1, "fexecve(): %s", cfname);
+			break;
+
+		// Close the write end of the pipe and the executable file descriptor in the parent.
+		default:
+			close(write_fd);
+			close(exec_fd);
+			break;
+		}
+	}
+
+	// Wrap a FILE handle around the read-only file descriptor.
+	FILE *file = fdopen(read_fd, "r");
+	if (!file)
+		err(1, "fdopen(): %s", cfname);
+
+	return file;
+}
+
 static void
 parse_config(const char *cfname, int is_stdin)
 {
 	struct cflex cflex = {.cfname = cfname, .error = 0};
+	pid_t child;
 	void *scanner;
 
 	yylex_init_extra(&cflex, &scanner);
@@ -328,7 +399,7 @@ parse_config(const char *cfname, int is_stdin)
 		cflex.cfname = "STDIN";
 		yyset_in(stdin, scanner);
 	} else {
-		FILE *yfp = fopen(cfname, "r");
+		FILE *yfp = open_config(cfname, &child);
 		if (!yfp)
 			err(1, "%s", cfname);
 		yyset_in(yfp, scanner);
@@ -336,6 +407,16 @@ parse_config(const char *cfname, int is_stdin)
 	if (yyparse(scanner) || cflex.error)
 		exit(1);
 	yylex_destroy(scanner);
+	if ( child > 0 ) {
+		pid_t exited;
+		int status;
+		do {
+			exited = waitpid(child, &status, 0);
+		} while ( exited < 0 || errno == EINTR );
+		status = WEXITSTATUS(status);
+		if ( status != 0 )
+			errx(status, "Config child failed with status=%i): %s", status, cfname);
+	}
 }
 
 /*

--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -327,41 +327,43 @@ static FILE *
 open_config(const char *cfname, pid_t pid[static 1])
 {
 
-	int read_fd = open(cfname, O_RDONLY), write_fd, exec_fd, pipes[2];
-	char *argv[] = { (char*)(uintptr_t)cfname, (char *)(uintptr_t)cfname, NULL }; // DECONST *sigh*
+	int read_fd, write_fd, exec_fd, pipes[2];
+	char *argv[] = { __DECONST(char *, cfname), __DECONST(char *, cfname), NULL };
+	FILE *file;
 
-	// Invalidate the child PID.
+	/* Invalidate the child PID. */
 	*pid = -1;
 
-	// The configuration must be readable.
+	/* The configuration must be readable. */
+	read_fd = open(cfname, O_RDONLY);
 	if (read_fd < 0)
 		err(1, "open(): %s", cfname);
 
-	// Try to open the configuration for execution (to parse its standard output config instead).
+	/* Try to open the configuration for execution (to parse its standard output config instead). */
 	exec_fd = openat(read_fd, "", O_EMPTY_PATH|O_EXEC);
 	if (exec_fd < 0) {
 		if (errno != EACCES)
 			err(1, "openat(): %s", cfname);
 	} else {
-		// Read from the pipe instead of the configuration.
+		/* Read from the pipe instead of the configuration. */
 		close(read_fd);
 		if (pipe(pipes))
 			err(1, "pipe(): %s", cfname);
 		read_fd = pipes[0];
 		write_fd = pipes[1];
 
-		// Run the configuration as child process.
+		/* Run the configuration as child process. */
 		switch ((*pid = fork())) {
-		// Failure to fork is fatal.
+		/* Failure to fork() is fatal. */
 		case -1:
 			err(1, "fork(): %s", cfname);
 			break;
 
-		// Redirect the child's standard output into the pipe.
+		/* Redirect the child's standard output into the pipe. */
 		case 0:
 			close(read_fd);
 			if (write_fd != STDOUT_FILENO) {
-				if ( dup2(write_fd, STDOUT_FILENO) != STDOUT_FILENO )
+				if (dup2(write_fd, STDOUT_FILENO) != STDOUT_FILENO)
 					err(1, "dup2(): %s", cfname);
 				close(write_fd);
 			}
@@ -379,9 +381,9 @@ open_config(const char *cfname, pid_t pid[static 1])
 		}
 	}
 
-	// Wrap a FILE handle around the read-only file descriptor.
-	FILE *file = fdopen(read_fd, "r");
-	if (!file)
+	/* Wrap a FILE handle around the read-only file descriptor. */
+	file = fdopen(read_fd, "r");
+	if (file == NULL)
 		err(1, "fdopen(): %s", cfname);
 
 	return file;
@@ -391,7 +393,7 @@ static void
 parse_config(const char *cfname, int is_stdin)
 {
 	struct cflex cflex = {.cfname = cfname, .error = 0};
-	pid_t child;
+	pid_t child = -1;
 	void *scanner;
 
 	yylex_init_extra(&cflex, &scanner);
@@ -407,14 +409,14 @@ parse_config(const char *cfname, int is_stdin)
 	if (yyparse(scanner) || cflex.error)
 		exit(1);
 	yylex_destroy(scanner);
-	if ( child > 0 ) {
+	if (child > 0) {
 		pid_t exited;
 		int status;
 		do {
 			exited = waitpid(child, &status, 0);
-		} while ( exited < 0 || errno == EINTR );
+		} while (exited < 0 || errno == EINTR);
 		status = WEXITSTATUS(status);
-		if ( status != 0 )
+		if (status != 0)
 			errx(status, "Config child failed with status=%i): %s", status, cfname);
 	}
 }

--- a/usr.sbin/jail/jailp.h
+++ b/usr.sbin/jail/jailp.h
@@ -100,6 +100,7 @@ enum intparam {
 	IP_EXEC_SYSTEM_JAIL_USER,/* Get jail_user from system passwd file */
 	IP_EXEC_SYSTEM_USER,	/* Run non-jailed commands as this user */
 	IP_EXEC_TIMEOUT,	/* Time to wait for a command to complete */
+	IP_ALLOW_EXEC_INCLUDE,  /* Allow dynamic jail.conf to be executed */
 #if defined(INET) || defined(INET6)
 	IP_INTERFACE,		/* Add IP addresses to this interface */
 	IP_IP_HOSTNAME,		/* Get jail IP address(es) from hostname */

--- a/usr.sbin/jail/jailp.h
+++ b/usr.sbin/jail/jailp.h
@@ -35,6 +35,9 @@
 #include <jail.h>
 #include <stdio.h>
 
+extern struct cfjail *current_jail;
+extern struct cfjail *global_jail;
+
 #define CONF_FILE	"/etc/jail.conf"
 
 #define DEP_FROM	0

--- a/usr.sbin/jail/jailparse.y
+++ b/usr.sbin/jail/jailparse.y
@@ -38,8 +38,8 @@
 #define YYDEBUG 1
 #endif
 
-static struct cfjail *current_jail;
-static struct cfjail *global_jail;
+struct cfjail *current_jail = NULL;
+struct cfjail *global_jail = NULL;
 %}
 
 %union {


### PR DESCRIPTION
Jails often have repetitive boilerplate that can't be factored out of `jail.conf` using `.include "<glob>";` or requires external lookups that require wrappers around [jail(8)](https://man.freebsd.org/cgi/man.cgi?jail) e.g. network interface creation or IP allocation, database lookups.

This patch checks if a [jail.conf(5)](https://man.freebsd.org/cgi/man.cgi?jail.conf) is executable by trying to reopen its file descriptor for execution in which case it runs it as child process of the jail command and parses the child's standard output.

This is a continuation of [D46284](https://reviews.freebsd.org/D46284), because Phabricator fails to update the diff to multiple files. Sorry for the duplication.