### PR TITLE
linux: Implement NT_PRFPREG & NT_X86_XSTATE prctls for amd64

### DIFF
--- a/sys/amd64/linux/linux.h
+++ b/sys/amd64/linux/linux.h
@@ -235,14 +235,32 @@ struct linux_pt_regset {
 	l_ulong gs;
 };
 
+/* This corresponds to 'user_i387_struct' in Linux. */
+struct linux_pt_fpregset {
+	l_ushort cwd;
+	l_ushort swd;
+	l_ushort twd;
+	l_ushort fop;
+	uint64_t rip;
+	uint64_t rdp;
+	uint32_t mxcsr;
+	uint32_t mxcsr_mask;
+	uint32_t st_space[32];
+	uint32_t xmm_space[64];
+	uint32_t padding[24];
+};
+
 #ifdef _KERNEL
 struct reg;
+struct fpreg;
 struct syscall_info;
 
 void	bsd_to_linux_regset(const struct reg *b_reg,
 	    struct linux_pt_regset *l_regset);
 void	linux_to_bsd_regset(struct reg *b_reg,
 	    const struct linux_pt_regset *l_regset);
+void	bsd_to_linux_fpregset(const struct fpreg *b_fpreg,
+	    struct linux_pt_fpregset *l_fpregset);
 void	linux_ptrace_get_syscall_info_machdep(const struct reg *reg,
 	    struct syscall_info *si);
 int	linux_ptrace_getregs_machdep(struct thread *td, pid_t pid,

--- a/sys/amd64/linux/linux_machdep.c
+++ b/sys/amd64/linux/linux_machdep.c
@@ -282,6 +282,26 @@ linux_to_bsd_regset(struct reg *b_reg, const struct linux_pt_regset *l_regset)
 }
 
 void
+bsd_to_linux_fpregset(const struct fpreg *b_fpreg,
+    struct linux_pt_fpregset *l_fpregset)
+{
+	l_fpregset->cwd = b_fpreg->fpr_env[0];
+	l_fpregset->swd = b_fpreg->fpr_env[0] >> 16;
+	l_fpregset->twd = b_fpreg->fpr_env[0] >> 32;
+	l_fpregset->fop = b_fpreg->fpr_env[0] >> 48;
+	l_fpregset->rip = b_fpreg->fpr_env[1];
+	l_fpregset->rdp = b_fpreg->fpr_env[2];
+	l_fpregset->mxcsr = b_fpreg->fpr_env[3];
+	l_fpregset->mxcsr_mask = b_fpreg->fpr_env[3] >> 32;
+
+	memcpy(l_fpregset->st_space, b_fpreg->fpr_acc,
+	    sizeof(l_fpregset->st_space));
+	memcpy(l_fpregset->xmm_space, b_fpreg->fpr_xacc,
+	    sizeof(l_fpregset->xmm_space));
+	memset(l_fpregset->padding, 0, sizeof(l_fpregset->padding));
+}
+
+void
 linux_ptrace_get_syscall_info_machdep(const struct reg *reg,
     struct syscall_info *si)
 {

--- a/sys/compat/linux/linux_ptrace.c
+++ b/sys/compat/linux/linux_ptrace.c
@@ -335,6 +335,87 @@ linux_ptrace_getregset_prstatus(struct thread *td, pid_t pid, l_ulong data)
 	return (error);
 }
 
+#ifdef __amd64__
+static int
+linux_ptrace_getregset_prfpreg(struct thread *td, pid_t pid, l_ulong data)
+{
+	struct fpreg b_fpreg;
+	struct linux_pt_fpregset l_fpregset;
+	struct iovec iov;
+	size_t len;
+	int error;
+
+	error = copyin((const void *)data, &iov, sizeof(iov));
+	if (error != 0) {
+		linux_msg(td, "copyin error %d", error);
+		return (error);
+	}
+
+	error = kern_ptrace(td, PT_GETFPREGS, pid, &b_fpreg, 0);
+	if (error != 0)
+		return (error);
+
+	bsd_to_linux_fpregset(&b_fpreg, &l_fpregset);
+
+	len = MIN(iov.iov_len, sizeof(l_fpregset));
+	error = copyout(&l_fpregset, iov.iov_base, len);
+	if (error != 0) {
+		linux_msg(td, "copyout error %d", error);
+		return (error);
+	}
+
+	iov.iov_len = len;
+	error = copyout(&iov, (void *)data, sizeof(iov));
+	if (error != 0)
+		linux_msg(td, "iov copyout error %d", error);
+
+	return (error);
+}
+
+static int
+linux_ptrace_getregset_xstate(struct thread *td, pid_t pid, l_ulong data)
+{
+	struct ptrace_xstate_info info;
+	struct iovec iov;
+	void *xstate;
+	size_t len;
+	int error;
+
+	error = copyin((const void *)data, &iov, sizeof(iov));
+	if (error != 0) {
+		linux_msg(td, "copyin error %d", error);
+		return (error);
+	}
+
+	error = kern_ptrace(td, PT_GETXSTATE_INFO, pid, &info, sizeof(info));
+	if (error != 0)
+		return (error);
+
+	xstate = malloc(info.xsave_len, M_LINUX, M_WAITOK | M_ZERO);
+
+	error = kern_ptrace(td, PT_GETXSTATE, pid, xstate, info.xsave_len);
+	if (error != 0) {
+		free(xstate, M_LINUX);
+		return (error);
+	}
+
+	len = MIN(iov.iov_len, info.xsave_len);
+	error = copyout(xstate, iov.iov_base, len);
+	free(xstate, M_LINUX);
+	if (error != 0) {
+		linux_msg(td, "copyout error %d", error);
+		return (error);
+	}
+
+	iov.iov_len = len;
+	error = copyout(&iov, (void *)data, sizeof(iov));
+	if (error != 0)
+		linux_msg(td, "iov copyout error %d", error);
+
+	return (error);
+}
+#endif /* __amd64__ */
+
 static int
 linux_ptrace_getregset(struct thread *td, pid_t pid, l_ulong addr, l_ulong data)
 {
@@ -342,14 +423,12 @@ linux_ptrace_getregset(struct thread *td, pid_t pid, l_ulong addr, l_ulong data)
 	switch (addr) {
 	case LINUX_NT_PRSTATUS:
 		return (linux_ptrace_getregset_prstatus(td, pid, data));
+#ifdef __amd64__
 	case LINUX_NT_PRFPREG:
-		linux_msg(td, "PTRAGE_GETREGSET NT_PRFPREG not implemented; "
-		    "returning EINVAL");
-		return (EINVAL);
+		return (linux_ptrace_getregset_prfpreg(td, pid, data));
 	case LINUX_NT_X86_XSTATE:
-		linux_msg(td, "PTRAGE_GETREGSET NT_X86_XSTATE not implemented; "
-		    "returning EINVAL");
-		return (EINVAL);
+		return (linux_ptrace_getregset_xstate(td, pid, data));
+#endif
 	default:
 		linux_msg(td, "PTRACE_GETREGSET request %#lx not implemented; "
 		    "returning EINVAL", addr);


### PR DESCRIPTION
- Implement PTRACE_GETREGSET NT_PRFPREG and NT_X86_XSTATE
- Improve prctl debug for PR_SET_VMA

PR: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289285