### PR TITLE
namei: Preserve ABI root for absolute symlinks before fallback

### DIFF
--- a/sys/kern/vfs_lookup.c
+++ b/sys/kern/vfs_lookup.c
@@ -778,13 +778,17 @@ restart:
 		cnp->cn_nameptr = cnp->cn_pnbuf;
 		if (*(cnp->cn_nameptr) == '/') {
 			/*
-			 * Reset the lookup to start from the real root without
-			 * origin path name reloading.
+			 * For ABI-root lookups, preserve the ABI root while
+			 * following absolute symlinks during the first lookup.
+			 *
+			 * Only force the real root after the ABI lookup has
+			 * already failed and namei() has restarted in the
+			 * native namespace.  Otherwise absolute symlinks inside
+			 * /compat/linux, including the ELF interpreter symlink,
+			 * incorrectly escape to the native root (PR 289739).
 			 */
-			if (__predict_false(ndp->ni_rootdir != pwd->pwd_rdir)) {
-				cnp->cn_flags |= ISRESTARTED;
+			if ((cnp->cn_flags & ISRESTARTED) != 0)
 				ndp->ni_rootdir = pwd->pwd_rdir;
-			}
 			vrele(dp);
 			error = namei_handle_root(ndp, &dp);
 			if (error != 0)


### PR DESCRIPTION
D40479 changed namei() so that an absolute symlink target encountered during an ABI-root lookup restarts from the native root. This helps the native fallback case, but it also makes successful lookups inside an ABI root escape that root while following absolute symlinks.

This breaks Linuxulator userlands where the ELF interpreter is an absolute symlink inside /compat/linux:
  `/compat/linux/lib64/ld-linux-x86-64.so.2 -> /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2`

Only switch absolute symlink lookup to the native root after namei() is already in the restarted/native fallback pass.  Do not mark the lookup as restarted merely because an absolute symlink was encountered while still resolving inside the ABI root.

This preserves the intended native fallback behavior while keeping absolute symlinks within a successfully resolved ABI-root path in the ABI namespace.

PR:	https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289739