### PR TITLE
bhyve: allow read/write to full CRB buffer

### DIFF
--- a/usr.sbin/bhyve/tpm_intf_crb.c
+++ b/usr.sbin/bhyve/tpm_intf_crb.c
@@ -414,7 +414,7 @@ tpm_crb_mem_handler(struct vcpu *vcpu __unused, const int dir,
 		    4:
 		case offsetof(struct tpm_crb_regs,
 		    data_buffer) ... offsetof(struct tpm_crb_regs, data_buffer) +
-		    TPM_CRB_DATA_BUFFER_SIZE / 4:
+		    sizeof(((struct tpm_crb_regs *)NULL)->data_buffer) - 1:
 			/*
 			 * Those fields are used to execute a TPM command. The
 			 * crb_thread will access them. For that reason, we have


### PR DESCRIPTION
For some reason, we've incorrectly calculated the size of the CRB data buffer register. There's no need to divide the CRB data buffer size by 4. We should allow access to the whole buffer instead.