### PR TITLE
Fix typos in comments across several subsystems

### DIFF
--- a/sys/dev/rtsx/rtsx.c
+++ b/sys/dev/rtsx/rtsx.c
@@ -139,7 +139,7 @@ struct rtsx_softc {
 	uint64_t	rtsx_write_count;	/* count of write operations */
 	bool		rtsx_discovery_mode;	/* are we in discovery mode? */
 	bool		rtsx_tuning_mode;	/* are we tuning */
-	bool		rtsx_double_clk;	/* double clock freqency */
+	bool		rtsx_double_clk;	/* double clock frequency */
 	bool		rtsx_vpclk;		/* voltage at Pulse-width Modulation(PWM) clock? */
 	uint8_t		rtsx_ssc_depth;		/* Spread spectrum clocking depth */
 	uint8_t		rtsx_card_drive_sel;	/* value for RTSX_CARD_DRIVE_SEL */
@@ -2837,7 +2837,7 @@ rtsx_xfer_start(struct rtsx_softc *sc)
 	} else {
 		dma_dir = RTSX_DMA_DIR_TO_CARD;
 		/*
-		 * Use transfer mode AUTO_WRITE3, wich assumes we've already
+		 * Use transfer mode AUTO_WRITE3, which assumes we've already
 		 * sent the write command and gotten the response, and will
 		 * send CMD 12 manually after writing.
 		 */

--- a/sys/netinet/tcp_ratelimit.c
+++ b/sys/netinet/tcp_ratelimit.c
@@ -490,7 +490,7 @@ populate_canned_table(struct tcp_rate_set *rs, const uint64_t *rate_table_act)
 {
 	/*
 	 * The internal table is "special", it
-	 * is two seperate ordered tables that
+	 * is two separate ordered tables that
 	 * must be merged. We get here when the
 	 * adapter specifies a number of rates that
 	 * covers both ranges in the table in some

--- a/sys/netinet/tcp_stacks/rack.c
+++ b/sys/netinet/tcp_stacks/rack.c
@@ -17178,7 +17178,7 @@ pace_to_fill_cwnd(struct tcp_rack *rack, int32_t pacing_delay, uint32_t len, uin
 		return (pacing_delay);
 	/*
 	 * first lets calculate the b/w based on the last us-rtt
-	 * and the the smallest send window.
+	 * and the smallest send window.
 	 */
 	fill_bw = min(rack->rc_tp->snd_cwnd, rack->r_ctl.cwnd_to_use);
 	if (rack->rc_fillcw_apply_discount) {

--- a/sys/netinet/tcp_stacks/sack_filter.c
+++ b/sys/netinet/tcp_stacks/sack_filter.c
@@ -863,7 +863,7 @@ main(int argc, char **argv)
 			outwrite:
 				fclose(io);
 			} else {
-				printf("failed to open sack_setup.bin for writting .. sorry\n");
+				printf("failed to open sack_setup.bin for writing .. sorry\n");
 			}
 		} else if (strncmp(buffer, "restore", 7) == 0) {
 			FILE *io;

--- a/sys/netlink/netlink_domain.c
+++ b/sys/netlink/netlink_domain.c
@@ -724,7 +724,7 @@ nl_soreceive(struct socket *so, struct sockaddr **psa, struct uio *uio,
 	 * least one message, we would return it and won't truncate the next.
 	 *
 	 * We use same code for normal and MSG_PEEK case.  At first queue pass
-	 * we scan nl_bufs and count lenght.  In case we can read entire buffer
+	 * we scan nl_bufs and count length.  In case we can read entire buffer
 	 * at one write everything is trivial.  In case we can not, we save
 	 * pointer to the last (or partial) nl_buf and in the !peek case we
 	 * split the queue into two pieces.  We can safely drop the queue lock,

--- a/sys/ufs/ffs/ffs_vfsops.c
+++ b/sys/ufs/ffs/ffs_vfsops.c
@@ -2083,7 +2083,7 @@ ffs_use_bwrite(void *devfd, off_t loc, void *buf, int size)
 	 * Writing the superblock itself. We need to do special checks for it.
 	 * A negative error code is returned to indicate that a copy of the
 	 * superblock has been made and that the copy is discarded when the
-	 * I/O is done. So the the caller should not attempt to restore the
+	 * I/O is done. So the caller should not attempt to restore the
 	 * fs_si field after the write is done. The caller will convert the
 	 * error code back to its usual positive value when returning it.
 	 */

--- a/tests/sys/netinet/fibs_multibind_test.c
+++ b/tests/sys/netinet/fibs_multibind_test.c
@@ -365,7 +365,7 @@ per_fib_dgram_socket(int domain, int type, const atf_tc_t *tc __unused)
 		sin6p->sin6_addr = in6addr_loopback;
 	}
 
-	/* If we send a byte from cs1, it should be recieved by ss1. */
+	/* If we send a byte from cs1, it should be received by ss1. */
 	b = 42;
 	n = sendto(cs1, &b, sizeof(b), 0, (struct sockaddr *)&ss, sslen);
 	ATF_REQUIRE_MSG(n == 1, "sendto failed: %s", strerror(errno));

--- a/usr.sbin/mountd/mountd.c
+++ b/usr.sbin/mountd/mountd.c
@@ -323,7 +323,7 @@ static gid_t *tmp_groups = NULL;
 #define OP_MASKLEN	0x200
 #define OP_SEC		0x400
 #define OP_CLASSMASK	0x800	/* mask not specified, is Class A/B/C default */
-#define	OP_NOTROOT	0x1000	/* Mark the the mount path is not a fs root */
+#define	OP_NOTROOT	0x1000	/* Mark the mount path is not a fs root */
 
 #ifdef DEBUG
 static int debug = 1;


### PR DESCRIPTION
Fix minor spelling mistakes in code comments across multiple subsystems.
No functional changes.

- ffs_vfsops.c: remove duplicate 'the'
- mountd.c: remove duplicate 'the' in OP_NOTROOT comment
- netlink_domain.c: lenght -> length
- tcp_ratelimit.c: seperate -> separate
- rack.c: remove extra 'the'
- sack_filter.c: writting -> writing
- rtsx.c: freqency -> frequency, wich -> which
- fibs_multibind_test.c: recieved -> received