### PR TITLE
xhci: fix UB from signed 32-bit shift; kevent11: initialize error to 0

### DIFF
--- a/sys/dev/usb/controller/xhci.c
+++ b/sys/dev/usb/controller/xhci.c
@@ -2364,7 +2364,7 @@ xhci_configure_mask(struct usb_device *udev, uint32_t mask, uint8_t drop)
 
 		/* find most significant set bit */
 		for (x = 31; x != 1; x--) {
-			if (mask & (1 << x))
+			if (mask & (1U << x))
 				break;
 		}
 

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -1387,7 +1387,7 @@ kevent11_copyout(void *arg, struct kevent *kevp, int count)
 {
 	struct freebsd11_kevent_args *uap;
 	struct freebsd11_kevent kev11;
-	int error, i;
+	int error = 0, i;
 
 	KASSERT(count <= KQ_NEVENTS, ("count (%d) > KQ_NEVENTS", count));
 	uap = (struct freebsd11_kevent_args *)arg;
@@ -1416,7 +1416,7 @@ kevent11_copyin(void *arg, struct kevent *kevp, int count)
 {
 	struct freebsd11_kevent_args *uap;
 	struct freebsd11_kevent kev11;
-	int error, i;
+	int error = 0, i;
 
 	KASSERT(count <= KQ_NEVENTS, ("count (%d) > KQ_NEVENTS", count));
 	uap = (struct freebsd11_kevent_args *)arg;


### PR DESCRIPTION
## xhci: undefined behaviour from signed 32-bit shift

`xhci_configure_mask()` searches for the most significant set bit in
`mask` (typed `uint32_t`) by iterating `x` from 31 down to 2 and
testing `mask & (1 << x)`.  When `x` equals 31 the expression
`1 << 31` shifts a signed `int` by 31 bits, which is undefined
behaviour per C11 §6.5.7¶4.  Under aggressive optimisation a
compiler is entitled to assume signed overflow never occurs and may
miscompile the loop.

Fix: use `1U << x` so the shift is performed on an unsigned operand.

## kevent11: uninitialized return value in copyout/copyin callbacks

`kevent11_copyout()` and `kevent11_copyin()` (COMPAT_FREEBSD11)
declare `int error` without initialisation and return it after a
`for`-loop controlled by `count`.  If `count == 0` the loop body
never executes and an indeterminate stack value is returned to the
caller.  The non-compat versions (`kevent_copyout`, `kevent_copyin`)
call `copyout`/`copyin` unconditionally and do not have this issue.

Fix: initialise `error = 0` so a zero-count call correctly returns
success.

Both issues were found via static analysis (cppcheck).