### PR TITLE
cdev: use proper uio helpers in example driver

### DIFF
--- a/share/examples/kld/cdev/module/cdev.c
+++ b/share/examples/kld/cdev/module/cdev.c
@@ -148,14 +148,21 @@ mydev_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int mode,
 int
 mydev_write(struct cdev *dev, struct uio *uio, int ioflag)
 {
+    size_t amt;
     int err = 0;
 
     printf("mydev_write: dev_t=%lu, uio=%p, ioflag=%d\n",
 	dev2udev(dev), uio, ioflag);
 
-    err = copyinstr(uio->uio_iov->iov_base, &buf, 512, &len);
+    amt = MIN(uio->uio_resid, sizeof(buf) - 1);
+    err = uiomove(buf, amt, uio);
     if (err != 0) {
+	len = 0;
+	buf[0] = '\0';
 	printf("Write to \"cdev\" failed.\n");
+    } else {
+	len = amt;
+	buf[len] = '\0';
     }
     return(err);
 }
@@ -173,10 +180,6 @@ mydev_read(struct cdev *dev, struct uio *uio, int ioflag)
     printf("mydev_read: dev_t=%lu, uio=%p, ioflag=%d\n",
 	dev2udev(dev), uio, ioflag);
 
-    if (len <= 0) {
-	err = -1;
-    } else {	/* copy buf to userland */
-	copystr(&buf, uio->uio_iov->iov_base, 513, &len);
-    }
+    err = uiomove_frombuf(buf, len, uio);
     return(err);
 }


### PR DESCRIPTION
The cdev example currently uses `copyinstr()` in the write path and `copystr()` in the read path.

For character-device `d_read`/`d_write` handlers, `uio(9)` documents that drivers should use `uiomove()` or related helpers to transfer data described by `struct uio`. The existing code is not only semantically wrong for `read(2)`/`write(2)`, but also triggers a compile-time error on FreeBSD 13.3 when building the example module:

```
error: incompatible pointer types passing 'char (*)[513]' to parameter of type 'const char *'
```

This change updates the example to:
- use `uiomove()` in `mydev_write()`
- null-terminate the stored buffer after successful writes
- use `uiomove_frombuf()` in `mydev_read()`

Tested on FreeBSD 13.3-RELEASE-p1 by building the example KLD successfully from `/usr/src/share/examples/kld/cdev/module`.