### PR TITLE
savecore: Create core.txt.last symlink

### DIFF
--- a/sbin/savecore/savecore.c
+++ b/sbin/savecore/savecore.c
@@ -411,6 +411,7 @@ symlinks_remove(int savedirfd)
 
 	(void)unlinkat(savedirfd, "info.last", 0);
 	(void)unlinkat(savedirfd, "key.last", 0);
+	(void)unlinkat(savedirfd, "core.txt.last", 0);
 	(void)unlinkat(savedirfd, "vmcore.last", 0);
 	(void)unlinkat(savedirfd, "vmcore.last.gz", 0);
 	(void)unlinkat(savedirfd, "vmcore.last.zst", 0);
@@ -901,6 +902,12 @@ DoLiveFile(const char *savedir, int savedirfd, const char *device)
 		    savedir, "info.last");
 	}
 
+	snprintf(linkname, sizeof(linkname), "core.txt.%d", bounds);
+	if (symlinkat(linkname, savedirfd, "core.txt.last") == -1) {
+		logmsg(LOG_WARNING, "unable to create symlink %s/%s: %m",
+		    savedir, "core.txt.last");
+	}
+
 	snprintf(linkname, sizeof(linkname), "livecore.last");
 	if (compress)
 		strcat(linkname, kdhl.compression == KERNELDUMP_COMP_ZSTD ?
@@ -1247,6 +1254,13 @@ DoFile(const char *savedir, int savedirfd, const char *device)
 			    "key.last");
 		}
 	}
+
+	snprintf(linkname, sizeof(linkname), "core.txt.%d", bounds);
+	if (symlinkat(linkname, savedirfd, "core.txt.last") == -1) {
+		logmsg(LOG_WARNING, "unable to create symlink %s/%s: %m",
+		    savedir, "core.txt.last");
+	}
+
 	if ((iscompressed && !uncompress) || compress) {
 		snprintf(linkname, sizeof(linkname), "%s.last.%s",
 		    istextdump ? "textdump.tar" :


### PR DESCRIPTION
When saving a coredump, savecore(8) maintains `.last` symlinks for info and vmcore artifacts, but not for the crashinfo text report.  Create it to point at the current `core.txt.<bounds>` file.

This makes /var/crash/core.txt.last track the same dump as info.last and vmcore.last.

Now I have `core.txt.last`:

```
$ ls -l /var/crash/
total 2689423
-rw-r--r--  1 root wheel          2 May  2 19:11 bounds
-rw-r--r--  1 root wheel        443 Apr 18 11:27 core.txt.0
-rw-r--r--  1 root wheel        443 Apr 18 11:37 core.txt.1
-rw-r--r--  1 root wheel     146891 Apr 18 11:43 core.txt.2
lrwxr-xr-x  1 root wheel         10 May  2 19:11 core.txt.last -> core.txt.2
-rw-------  1 root wheel        474 Apr 18 11:27 info.0
-rw-------  1 root wheel        474 Apr 18 11:37 info.1
-rw-------  1 root wheel        474 Apr 18 11:43 info.2
lrwxr-xr-x  1 root wheel          6 May  2 19:11 info.last -> info.2
-rw-r--r--  1 root wheel          5 Aug  8  2025 minfree
-rw-------  1 root wheel  854790144 Apr 18 11:27 vmcore.0
-rw-------  1 root wheel  854290432 Apr 18 11:37 vmcore.1
-rw-------  1 root wheel  853876736 Apr 18 11:43 vmcore.2
lrwxr-xr-x  1 root wheel          8 May  2 19:11 vmcore.last -> vmcore.2
```