### PR TITLE
linux: return EBADF for accept() on O_PATH

### DIFF
--- a/sys/compat/linux/linux_socket.c
+++ b/sys/compat/linux/linux_socket.c
@@ -31,6 +31,7 @@
 #include <sys/param.h>
 #include <sys/capsicum.h>
 #include <sys/domain.h>
+#include <sys/file.h>
 #include <sys/filedesc.h>
 #include <sys/limits.h>
 #include <sys/malloc.h>
@@ -1082,10 +1083,11 @@ linux_accept_common(struct thread *td, int s, l_uintptr_t addr,
     l_uintptr_t namelen, int flags)
 {
 	struct sockaddr_storage ss = { .ss_len = sizeof(ss) };
-	struct file *fp, *fp1;
+	struct file *fp, *headfp;
+	struct filecaps fcaps;
 	struct socket *so;
 	socklen_t len;
-	int bflags, error, error1;
+	int bflags, error;
 
 	bflags = 0;
 	fp = NULL;
@@ -1103,7 +1105,22 @@ linux_accept_common(struct thread *td, int s, l_uintptr_t addr,
 	} else
 		len = 0;
 
-	error = kern_accept4(td, s, (struct sockaddr *)&ss, bflags, &fp);
+	error = fget_cap(td, s, &cap_accept_rights, NULL, &headfp, &fcaps);
+	if (error != 0)
+		return (error);
+	if (headfp->f_ops == &path_fileops) {
+		fdrop(headfp, td);
+		filecaps_free(&fcaps);
+		return (EBADF);
+	}
+	if (headfp->f_type != DTYPE_SOCKET) {
+		fdrop(headfp, td);
+		filecaps_free(&fcaps);
+		return (ENOTSOCK);
+	}
+
+	error = kern_accept4_fp(td, headfp, &fcaps, (struct sockaddr *)&ss,
+	    bflags, &fp);
 
 	/*
 	 * Translate errno values into ones used by Linux.
@@ -1119,19 +1136,15 @@ linux_accept_common(struct thread *td, int s, l_uintptr_t addr,
 				error = EINVAL;
 			break;
 		case EINVAL:
-			error1 = getsock(td, s, &cap_accept_rights, &fp1);
-			if (error1 != 0) {
-				error = error1;
-				break;
-			}
-			so = fp1->f_data;
+			so = headfp->f_data;
 			if (so->so_type == SOCK_DGRAM)
 				error = EOPNOTSUPP;
-			fdrop(fp1, td);
 			break;
 		}
+		fdrop(headfp, td);
 		return (error);
 	}
+	fdrop(headfp, td);
 
 	if (PTRIN(addr) != NULL) {
 		len = min(ss.ss_len, len);

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -329,21 +329,15 @@ kern_accept(struct thread *td, int s, struct sockaddr *sa, struct file **fp)
 }
 
 int
-kern_accept4(struct thread *td, int s, struct sockaddr *sa, int flags,
-    struct file **fp)
+kern_accept4_fp(struct thread *td, struct file *headfp, struct filecaps *fcaps,
+    struct sockaddr *sa, int flags, struct file **fp)
 {
-	struct file *headfp, *nfp = NULL;
+	struct file *nfp = NULL;
 	struct socket *head, *so;
-	struct filecaps fcaps;
 	u_int fflag;
 	pid_t pgid;
 	int error, fd, tmp;
 
-	AUDIT_ARG_FD(s);
-	error = getsock_cap(td, s, &cap_accept_rights,
-	    &headfp, &fcaps);
-	if (error != 0)
-		return (error);
 	fflag = atomic_load_int(&headfp->f_flag);
 	head = headfp->f_data;
 	if (!SOLISTENING(head)) {
@@ -357,7 +351,7 @@ kern_accept4(struct thread *td, int s, struct sockaddr *sa, int flags,
 #endif
 	error = falloc_caps(td, &nfp, &fd,
 	    ((flags & SOCK_CLOEXEC) != 0 ? O_CLOEXEC : 0) |
-	    ((flags & SOCK_CLOFORK) != 0 ? O_CLOFORK : 0), &fcaps);
+	    ((flags & SOCK_CLOFORK) != 0 ? O_CLOFORK : 0), fcaps);
 	if (error != 0)
 		goto done;
 	SOCK_LOCK(head);
@@ -415,7 +409,7 @@ noconnection:
 	 */
 done:
 	if (nfp == NULL)
-		filecaps_free(&fcaps);
+		filecaps_free(fcaps);
 	if (fp != NULL) {
 		if (error == 0) {
 			*fp = nfp;
@@ -425,6 +419,24 @@ done:
 	}
 	if (nfp != NULL)
 		fdrop(nfp, td);
+	return (error);
+}
+
+int
+kern_accept4(struct thread *td, int s, struct sockaddr *sa, int flags,
+    struct file **fp)
+{
+	struct file *headfp;
+	struct filecaps fcaps;
+	int error;
+
+	AUDIT_ARG_FD(s);
+	error = getsock_cap(td, s, &cap_accept_rights,
+	    &headfp, &fcaps);
+	if (error != 0)
+		return (error);
+
+	error = kern_accept4_fp(td, headfp, &fcaps, sa, flags, fp);
 	fdrop(headfp, td);
 	return (error);
 }

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -89,6 +89,9 @@ int	kern_abort2(struct thread *td, const char *why, int nargs,
 	    void **uargs);
 int	kern_accept(struct thread *td, int s, struct sockaddr *sa,
 	    struct file **fp);
+int	kern_accept4_fp(struct thread *td, struct file *headfp,
+	    struct filecaps *fcaps, struct sockaddr *sa, int flags,
+	    struct file **fp);
 int	kern_accept4(struct thread *td, int s, struct sockaddr *sa,
 	    int flags, struct file **fp);
 int	kern_accessat(struct thread *td, int fd, const char *path,


### PR DESCRIPTION
Linux expects EBADF for O_PATH, not ENOTSOCK