### PR TITLE
fs/nfs: Add #ifdef guards around IPv4 specific code

### DIFF
--- a/sys/fs/nfs/nfs_commonsubs.c
+++ b/sys/fs/nfs/nfs_commonsubs.c
@@ -1089,16 +1089,19 @@ nfsaddr_match(int family, union nethostaddr *haddr, NFSSOCKADDR_T nam)
 }
 
 /*
- * Similar to the above, but takes to NFSSOCKADDR_T args.
+ * Similar to the above, but takes two NFSSOCKADDR_T args.
  */
 int
 nfsaddr2_match(NFSSOCKADDR_T nam1, NFSSOCKADDR_T nam2)
 {
+#ifdef INET
 	struct sockaddr_in *addr1, *addr2;
+#endif
 	struct sockaddr *inaddr;
 
 	inaddr = NFSSOCKADDR(nam1, struct sockaddr *);
 	switch (inaddr->sa_family) {
+#ifdef INET
 	case AF_INET:
 		addr1 = NFSSOCKADDR(nam1, struct sockaddr_in *);
 		addr2 = NFSSOCKADDR(nam2, struct sockaddr_in *);
@@ -1106,6 +1109,7 @@ nfsaddr2_match(NFSSOCKADDR_T nam1, NFSSOCKADDR_T nam2)
 		    addr1->sin_addr.s_addr == addr2->sin_addr.s_addr)
 			return (1);
 		break;
+#endif
 #ifdef INET6
 	case AF_INET6:
 		{


### PR DESCRIPTION
nfsaddr2_match() is missing #ifdef guards for IPv4 specific code and is inconsistent with nfsaddr_match().
This change is probably required for INET6-only builds.

TBH, I tested compilation with INET enabled and there may be other places that prevent a INET6-only build.
Still, nfsaddr_match() already uses #ifdef guards around INET-specific code, so it cannot hurt to align the two functions.