### PR TITLE
libc: Improve C11/C23 stdatomic conformance and GCC compatibility

### DIFF
--- a/sys/sys/stdatomic.h
+++ b/sys/sys/stdatomic.h
@@ -27,8 +27,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _STDATOMIC_H_
-#define	_STDATOMIC_H_
+#ifndef __STDC_VERSION_STDATOMIC_H__
+#define __STDC_VERSION_STDATOMIC_H__	202311L
 
 #include <sys/cdefs.h>
 #include <sys/_types.h>
@@ -421,4 +421,4 @@ atomic_flag_clear(volatile atomic_flag *__object)
 #undef __bool_locally_defined
 #endif
 
-#endif /* !_STDATOMIC_H_ */
+#endif /* !__STDC_VERSION_STDATOMIC_H__ */

--- a/sys/sys/stdatomic.h
+++ b/sys/sys/stdatomic.h
@@ -242,6 +242,12 @@ typedef _Atomic(__uintmax_t)		atomic_uintmax_t;
  */
 
 #if defined(__CLANG_ATOMICS)
+#define	atomic_store_explicit(object, desired, order)			\
+	__c11_atomic_store(object, desired, order)
+#define	atomic_load_explicit(object, order)				\
+	__c11_atomic_load(object, order)
+#define	atomic_exchange_explicit(object, desired, order)		\
+	__c11_atomic_exchange(object, desired, order)
 #define	atomic_compare_exchange_strong_explicit(object, expected,	\
     desired, success, failure)						\
 	__c11_atomic_compare_exchange_strong(object, expected, desired,	\
@@ -250,23 +256,23 @@ typedef _Atomic(__uintmax_t)		atomic_uintmax_t;
     desired, success, failure)						\
 	__c11_atomic_compare_exchange_weak(object, expected, desired,	\
 	    success, failure)
-#define	atomic_exchange_explicit(object, desired, order)		\
-	__c11_atomic_exchange(object, desired, order)
 #define	atomic_fetch_add_explicit(object, operand, order)		\
 	__c11_atomic_fetch_add(object, operand, order)
-#define	atomic_fetch_and_explicit(object, operand, order)		\
-	__c11_atomic_fetch_and(object, operand, order)
-#define	atomic_fetch_or_explicit(object, operand, order)		\
-	__c11_atomic_fetch_or(object, operand, order)
 #define	atomic_fetch_sub_explicit(object, operand, order)		\
 	__c11_atomic_fetch_sub(object, operand, order)
+#define	atomic_fetch_or_explicit(object, operand, order)		\
+	__c11_atomic_fetch_or(object, operand, order)
 #define	atomic_fetch_xor_explicit(object, operand, order)		\
 	__c11_atomic_fetch_xor(object, operand, order)
-#define	atomic_load_explicit(object, order)				\
-	__c11_atomic_load(object, order)
-#define	atomic_store_explicit(object, desired, order)			\
-	__c11_atomic_store(object, desired, order)
+#define	atomic_fetch_and_explicit(object, operand, order)		\
+	__c11_atomic_fetch_and(object, operand, order)
 #elif defined(__GNUC_ATOMICS)
+#define	atomic_store_explicit(object, desired, order)			\
+	__atomic_store_n(object, desired, order)
+#define	atomic_load_explicit(object, order)				\
+	__atomic_load_n(object, order)
+#define	atomic_exchange_explicit(object, desired, order)		\
+	__atomic_exchange_n(object, desired, order)
 #define	atomic_compare_exchange_strong_explicit(object, expected,	\
     desired, success, failure)						\
 	__atomic_compare_exchange_n(object, expected,			\
@@ -275,37 +281,23 @@ typedef _Atomic(__uintmax_t)		atomic_uintmax_t;
     desired, success, failure)						\
 	__atomic_compare_exchange_n(object, expected,			\
 	    desired, 1, success, failure)
-#define	atomic_exchange_explicit(object, desired, order)		\
-	__atomic_exchange_n(object, desired, order)
 #define	atomic_fetch_add_explicit(object, operand, order)		\
 	__atomic_fetch_add(object, operand, order)
-#define	atomic_fetch_and_explicit(object, operand, order)		\
-	__atomic_fetch_and(object, operand, order)
-#define	atomic_fetch_or_explicit(object, operand, order)		\
-	__atomic_fetch_or(object, operand, order)
 #define	atomic_fetch_sub_explicit(object, operand, order)		\
 	__atomic_fetch_sub(object, operand, order)
+#define	atomic_fetch_or_explicit(object, operand, order)		\
+	__atomic_fetch_or(object, operand, order)
 #define	atomic_fetch_xor_explicit(object, operand, order)		\
 	__atomic_fetch_xor(object, operand, order)
-#define	atomic_load_explicit(object, order)				\
-	__atomic_load_n(object, order)
-#define	atomic_store_explicit(object, desired, order)			\
-	__atomic_store_n(object, desired, order)
+#define	atomic_fetch_and_explicit(object, operand, order)		\
+	__atomic_fetch_and(object, operand, order)
 #else
 #define	__atomic_apply_stride(object, operand) \
 	(((__typeof__((object)->__val))0) + (operand))
-#define	atomic_compare_exchange_strong_explicit(object, expected,	\
-    desired, success, failure)	__extension__ ({			\
-	__typeof__(expected) __ep = (expected);				\
-	__typeof__(*__ep) __e = *__ep;					\
-	(void)(success); (void)(failure);				\
-	(_Bool)((*__ep = __sync_val_compare_and_swap(&(object)->__val,	\
-	    __e, desired)) == __e);					\
-})
-#define	atomic_compare_exchange_weak_explicit(object, expected,		\
-    desired, success, failure)						\
-	atomic_compare_exchange_strong_explicit(object, expected,	\
-		desired, success, failure)
+#define	atomic_store_explicit(object, desired, order)			\
+	((void)atomic_exchange_explicit(object, desired, order))
+#define	atomic_load_explicit(object, order)				\
+	((void)(order), __sync_fetch_and_add(&(object)->__val, 0))
 #if __has_builtin(__sync_swap)
 /* Clang provides a full-barrier atomic exchange - use it if available. */
 #define	atomic_exchange_explicit(object, desired, order)		\
@@ -324,23 +316,31 @@ __extension__ ({							\
 	__sync_synchronize();						\
 	__sync_lock_test_and_set(&(__o)->__val, __d);			\
 })
+#define	atomic_compare_exchange_strong_explicit(object, expected,	\
+    desired, success, failure)	__extension__ ({			\
+	__typeof__(expected) __ep = (expected);				\
+	__typeof__(*__ep) __e = *__ep;					\
+	(void)(success); (void)(failure);				\
+	(_Bool)((*__ep = __sync_val_compare_and_swap(&(object)->__val,	\
+	    __e, desired)) == __e);					\
+})
+#define	atomic_compare_exchange_weak_explicit(object, expected,		\
+    desired, success, failure)						\
+	atomic_compare_exchange_strong_explicit(object, expected,	\
+		desired, success, failure)
 #endif
 #define	atomic_fetch_add_explicit(object, operand, order)		\
 	((void)(order), __sync_fetch_and_add(&(object)->__val,		\
 	    __atomic_apply_stride(object, operand)))
-#define	atomic_fetch_and_explicit(object, operand, order)		\
-	((void)(order), __sync_fetch_and_and(&(object)->__val, operand))
-#define	atomic_fetch_or_explicit(object, operand, order)		\
-	((void)(order), __sync_fetch_and_or(&(object)->__val, operand))
 #define	atomic_fetch_sub_explicit(object, operand, order)		\
 	((void)(order), __sync_fetch_and_sub(&(object)->__val,		\
 	    __atomic_apply_stride(object, operand)))
+#define	atomic_fetch_or_explicit(object, operand, order)		\
+	((void)(order), __sync_fetch_and_or(&(object)->__val, operand))
 #define	atomic_fetch_xor_explicit(object, operand, order)		\
 	((void)(order), __sync_fetch_and_xor(&(object)->__val, operand))
-#define	atomic_load_explicit(object, order)				\
-	((void)(order), __sync_fetch_and_add(&(object)->__val, 0))
-#define	atomic_store_explicit(object, desired, order)			\
-	((void)atomic_exchange_explicit(object, desired, order))
+#define	atomic_fetch_and_explicit(object, operand, order)		\
+	((void)(order), __sync_fetch_and_and(&(object)->__val, operand))
 #endif
 
 /*
@@ -351,28 +351,28 @@ __extension__ ({							\
  */
 
 #ifndef _KERNEL
+#define	atomic_store(object, desired)					\
+	atomic_store_explicit(object, desired, memory_order_seq_cst)
+#define	atomic_load(object)						\
+	atomic_load_explicit(object, memory_order_seq_cst)
+#define	atomic_exchange(object, desired)				\
+	atomic_exchange_explicit(object, desired, memory_order_seq_cst)
 #define	atomic_compare_exchange_strong(object, expected, desired)	\
 	atomic_compare_exchange_strong_explicit(object, expected,	\
 	    desired, memory_order_seq_cst, memory_order_seq_cst)
 #define	atomic_compare_exchange_weak(object, expected, desired)		\
 	atomic_compare_exchange_weak_explicit(object, expected,		\
 	    desired, memory_order_seq_cst, memory_order_seq_cst)
-#define	atomic_exchange(object, desired)				\
-	atomic_exchange_explicit(object, desired, memory_order_seq_cst)
 #define	atomic_fetch_add(object, operand)				\
 	atomic_fetch_add_explicit(object, operand, memory_order_seq_cst)
-#define	atomic_fetch_and(object, operand)				\
-	atomic_fetch_and_explicit(object, operand, memory_order_seq_cst)
-#define	atomic_fetch_or(object, operand)				\
-	atomic_fetch_or_explicit(object, operand, memory_order_seq_cst)
 #define	atomic_fetch_sub(object, operand)				\
 	atomic_fetch_sub_explicit(object, operand, memory_order_seq_cst)
+#define	atomic_fetch_or(object, operand)				\
+	atomic_fetch_or_explicit(object, operand, memory_order_seq_cst)
 #define	atomic_fetch_xor(object, operand)				\
 	atomic_fetch_xor_explicit(object, operand, memory_order_seq_cst)
-#define	atomic_load(object)						\
-	atomic_load_explicit(object, memory_order_seq_cst)
-#define	atomic_store(object, desired)					\
-	atomic_store_explicit(object, desired, memory_order_seq_cst)
+#define	atomic_fetch_and(object, operand)				\
+	atomic_fetch_and_explicit(object, operand, memory_order_seq_cst)
 #endif /* !_KERNEL */
 
 /*

--- a/sys/sys/stdatomic.h
+++ b/sys/sys/stdatomic.h
@@ -270,6 +270,8 @@ typedef _Atomic(__uintmax_t)		atomic_uintmax_t;
 #define	atomic_fetch_and_explicit(object, operand, order)		\
 	__c11_atomic_fetch_and(object, operand, order)
 #elif defined(__GNUC_ATOMICS)
+#define	__atomic_apply_stride(object, operand)				\
+	(((__typeof__(*(object)))0) + (operand))
 #define	atomic_store_explicit(object, desired, order)			\
 	__atomic_store_n(object, desired, order)
 #define	atomic_load_explicit(object, order)				\
@@ -285,9 +287,11 @@ typedef _Atomic(__uintmax_t)		atomic_uintmax_t;
 	__atomic_compare_exchange_n(object, expected,			\
 	    desired, 1, success, failure)
 #define	atomic_fetch_add_explicit(object, operand, order)		\
-	__atomic_fetch_add(object, operand, order)
+	__atomic_fetch_add(object,					\
+	    __atomic_apply_stride(object, operand), order)
 #define	atomic_fetch_sub_explicit(object, operand, order)		\
-	__atomic_fetch_sub(object, operand, order)
+	__atomic_fetch_sub(object,					\
+	    __atomic_apply_stride(object, operand), order)
 #define	atomic_fetch_or_explicit(object, operand, order)		\
 	__atomic_fetch_or(object, operand, order)
 #define	atomic_fetch_xor_explicit(object, operand, order)		\

--- a/sys/sys/stdatomic.h
+++ b/sys/sys/stdatomic.h
@@ -101,9 +101,10 @@
 #endif
 
 /*
- * Clang and recent GCC both provide predefined macros for the memory
- * orderings.  If we are using a compiler that doesn't define them, use the
- * clang values - these will be ignored in the fallback path.
+ * 7.17.3 Order and consistency.
+ *
+ * The memory_order_* constants that denote the barrier behaviour of the
+ * atomic operations.
  */
 
 #ifndef __ATOMIC_RELAXED
@@ -124,13 +125,6 @@
 #ifndef __ATOMIC_SEQ_CST
 #define __ATOMIC_SEQ_CST		5
 #endif
-
-/*
- * 7.17.3 Order and consistency.
- *
- * The memory_order_* constants that denote the barrier behaviour of the
- * atomic operations.
- */
 
 typedef enum {
 	memory_order_relaxed = __ATOMIC_RELAXED,

--- a/sys/sys/stdatomic.h
+++ b/sys/sys/stdatomic.h
@@ -86,11 +86,17 @@
  * 7.17.2 Initialization.
  */
 
+#if __ISO_C_VISIBLE < 2023 || defined(__cplusplus)
 #if defined(__CLANG_ATOMICS)
 #define	ATOMIC_VAR_INIT(value)		(value)
-#define	atomic_init(obj, value)		__c11_atomic_init(obj, value)
 #else
 #define	ATOMIC_VAR_INIT(value)		{ .__val = (value) }
+#endif
+#endif
+
+#if defined(__CLANG_ATOMICS)
+#define	atomic_init(obj, value)		__c11_atomic_init(obj, value)
+#else
 #define	atomic_init(obj, value)		((void)((obj)->__val = (value)))
 #endif
 

--- a/sys/sys/stdatomic.h
+++ b/sys/sys/stdatomic.h
@@ -96,6 +96,9 @@
 
 #if defined(__CLANG_ATOMICS)
 #define	atomic_init(obj, value)		__c11_atomic_init(obj, value)
+#elif defined(__GNUC_ATOMICS)
+#define	atomic_init(obj, value)		atomic_store_explicit(obj,	\
+	    value, __ATOMIC_RELAXED)
 #else
 #define	atomic_init(obj, value)		((void)((obj)->__val = (value)))
 #endif

--- a/sys/sys/stdatomic.h
+++ b/sys/sys/stdatomic.h
@@ -141,6 +141,8 @@ typedef enum {
 	memory_order_seq_cst = __ATOMIC_SEQ_CST
 } memory_order;
 
+#define	kill_dependency(y)		(y)
+
 /*
  * 7.17.4 Fences.
  */

--- a/sys/sys/stdatomic.h
+++ b/sys/sys/stdatomic.h
@@ -377,21 +377,29 @@ __extension__ ({							\
 
 /*
  * 7.17.8 Atomic flag type and operations.
- *
- * XXX: Assume atomic_bool can be used as an atomic_flag. Is there some
- * kind of compiler built-in type we could use?
  */
 
 typedef struct {
+#if ATOMIC_BOOL_LOCK_FREE == 2
 	atomic_bool	__flag;
+#elif ATOMIC_CHAR_LOCK_FREE == 2
+	atomic_uchar	__flag;
+#else
+#error "atomic_flag is required to be lock-free"
+#endif
 } atomic_flag;
+#if __ISO_C_VISIBLE < 2023
 #define	ATOMIC_FLAG_INIT		{ ATOMIC_VAR_INIT(0) }
+#else
+#define	ATOMIC_FLAG_INIT		{ 0 }
+#endif
 
 static __inline _Bool
 atomic_flag_test_and_set_explicit(volatile atomic_flag *__object,
     memory_order __order)
 {
-	return (atomic_exchange_explicit(&__object->__flag, 1, __order));
+
+	return (atomic_exchange_explicit(&__object->__flag, 1, __order) != 0);
 }
 
 static __inline void

--- a/tools/regression/include/stdatomic/logic.c
+++ b/tools/regression/include/stdatomic/logic.c
@@ -27,6 +27,8 @@
 #include <sys/cdefs.h>
 #include <assert.h>
 #include <stdatomic.h>
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -42,7 +44,110 @@
  * especially useful for the smaller integer types, as it may be the
  * case that these operations are implemented by processing entire words
  * (e.g. on MIPS).
+ *
+ * Before the randomised loop, a small surface check exercises lock-free
+ * macros, fences, atomic_flag, atomic_bool, pointer fetch_add/fetch_sub
+ * stride, kill_dependency, atomic_is_lock_free, and when available
+ * ATOMIC_VAR_INIT / ATOMIC_FLAG_INIT (pre-C23).
  */
+
+#define	CHECK_LOCK_FREE(name)						\
+	_Static_assert((name) == 0 || (name) == 1 || (name) == 2,	\
+	    #name " out of range")
+
+CHECK_LOCK_FREE(ATOMIC_BOOL_LOCK_FREE);
+CHECK_LOCK_FREE(ATOMIC_CHAR_LOCK_FREE);
+CHECK_LOCK_FREE(ATOMIC_SHORT_LOCK_FREE);
+CHECK_LOCK_FREE(ATOMIC_INT_LOCK_FREE);
+CHECK_LOCK_FREE(ATOMIC_LONG_LOCK_FREE);
+CHECK_LOCK_FREE(ATOMIC_LLONG_LOCK_FREE);
+CHECK_LOCK_FREE(ATOMIC_POINTER_LOCK_FREE);
+#ifdef ATOMIC_CHAR8_T_LOCK_FREE
+CHECK_LOCK_FREE(ATOMIC_CHAR8_T_LOCK_FREE);
+#endif
+#ifdef ATOMIC_CHAR16_T_LOCK_FREE
+CHECK_LOCK_FREE(ATOMIC_CHAR16_T_LOCK_FREE);
+#endif
+#ifdef ATOMIC_CHAR32_T_LOCK_FREE
+CHECK_LOCK_FREE(ATOMIC_CHAR32_T_LOCK_FREE);
+#endif
+#ifdef ATOMIC_WCHAR_T_LOCK_FREE
+CHECK_LOCK_FREE(ATOMIC_WCHAR_T_LOCK_FREE);
+#endif
+
+#if defined(__STDC_VERSION_STDATOMIC_H__)
+_Static_assert(__STDC_VERSION_STDATOMIC_H__ == 202311L,
+    "__STDC_VERSION_STDATOMIC_H__");
+#endif
+
+static void
+test_surface(void)
+{
+	atomic_flag f = ATOMIC_FLAG_INIT;
+	atomic_int probe;
+	atomic_bool b;
+	_Atomic(int *) ap;
+	int arr[4];
+	int dep;
+	static const memory_order k_orders[] = {
+		memory_order_relaxed,
+		memory_order_consume,
+		memory_order_acquire,
+		memory_order_release,
+		memory_order_acq_rel,
+		memory_order_seq_cst,
+	};
+	size_t k;
+
+	dep = kill_dependency(123);
+	assert(dep == 123);
+
+	atomic_init(&probe, 0);
+	assert(atomic_is_lock_free(&probe) ==
+	    atomic_is_lock_free((atomic_int *)NULL));
+
+	for (k = 0; k < sizeof(k_orders) / sizeof(k_orders[0]); k++) {
+		atomic_thread_fence(k_orders[k]);
+		atomic_signal_fence(k_orders[k]);
+	}
+
+	assert(atomic_flag_test_and_set_explicit(&f,
+	    memory_order_seq_cst) == 0);
+	assert(atomic_flag_test_and_set_explicit(&f,
+	    memory_order_acquire) != 0);
+	atomic_flag_clear_explicit(&f, memory_order_relaxed);
+
+	atomic_init(&b, false);
+	atomic_store_explicit(&b, true, memory_order_relaxed);
+	assert(atomic_load_explicit(&b, memory_order_relaxed) == true);
+
+	memset(arr, 0, sizeof(arr));
+	atomic_init(&ap, &arr[3]);
+	atomic_fetch_sub_explicit(&ap, 2, memory_order_relaxed);
+	assert(ap == &arr[1]);
+	atomic_fetch_add_explicit(&ap, 1, memory_order_relaxed);
+	assert(ap == &arr[2]);
+}
+
+#ifdef ATOMIC_VAR_INIT
+static void
+test_atomic_var_init(void)
+{
+	atomic_int x = ATOMIC_VAR_INIT(42);
+
+	assert(atomic_load_explicit(&x, memory_order_relaxed) == 42);
+	atomic_store_explicit(&x, 7, memory_order_relaxed);
+	assert(atomic_load_explicit(&x, memory_order_relaxed) == 7);
+
+	{
+		atomic_flag f = ATOMIC_FLAG_INIT;
+
+		assert(atomic_flag_test_and_set_explicit(&f,
+		    memory_order_seq_cst) == 0);
+		atomic_flag_clear_explicit(&f, memory_order_relaxed);
+	}
+}
+#endif
 
 static inline intmax_t
 rndnum(void)
@@ -111,6 +216,10 @@ main(void)
 {
 	int i;
 
+	test_surface();
+#ifdef ATOMIC_VAR_INIT
+	test_atomic_var_init();
+#endif
 	for (i = 0; i < 1000; i++) {
 		TEST_TYPE(int8_t);
 		TEST_TYPE(uint8_t);


### PR DESCRIPTION
This series improves `stdatomic.h` conformance, compatibility, and test coverage across C11/C23 modes.

Highlights include:

- Add the missing `kill_dependency` macro
- Add the C23 atomics feature test macro
- Restrict `ATOMIC_VAR_INIT` to pre-C23 modes
- Make `atomic_flag` selection and initialisation conform to lock-free and C23 requirements
- Fix `atomic_init()` for GCC atomic objects
- Fix GCC pointer semantics for `atomic_fetch_add()` and `atomic_fetch_sub()` on atomic pointer types
- Expand regression coverage for interface semantics, compile-time assertions, and behavioural conformance

This also includes several non-functional reorganisations to align the header structure more closely with ISO C and improve maintainability.