### PR TITLE
vfs_syscalls.c: add NULL check for basep in kern_getdirentries()

### DIFF
--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -4396,7 +4396,8 @@ unionread:
 		goto unionread;
 	}
 	VOP_UNLOCK(vp);
-	*basep = loff;
+	if (basep != NULL)
+		*basep = loff;
 	if (residp != NULL)
 		*residp = auio.uio_resid;
 	td->td_retval[0] = count - auio.uio_resid;


### PR DESCRIPTION
kern_getdirentries() unconditionally dereferences the basep parameter without checking for NULL.  When called with basep == NULL, this causes a kernel page fault.  The residp parameter is already properly guarded with a NULL check in the same function, but basep was missed.

Add a NULL check for basep to match the existing pattern for residp.

Observed as a fatal page fault during boot on loongarch64:
  panic: Fatal page fault at 0xffff8000004a6e04: 0000000000000000
  ra: kern_getdirentries + 0x240