### PR TITLE
libutil++: Include <cerrno> in stringf.cc

### DIFF
--- a/lib/libutil++/libutil++.hh
+++ b/lib/libutil++/libutil++.hh
@@ -13,6 +13,7 @@
 #include <netdb.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
With modern Clang/libc++ and C++20 and later language modes, incidental transitive exposure is being reduced (see [Header Removal Policy](https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html),) making such dependencies increasingly fragile over time.

This change makes the dependency explicit and aligns the code with the standard library interface model, improving portability across current and future language modes.

No functional or behavioural change intended.