### PR TITLE
rc: fix oomprotect in case multiple pids

### DIFF
--- a/libexec/rc/rc.subr
+++ b/libexec/rc/rc.subr
@@ -1715,10 +1715,14 @@ $command $rc_flags $command_args"
 				[ -z "${rc_pid}" ] && eval $_pidcmd
 				case $_oomprotect in
 				[Aa][Ll][Ll])
-					${PROTECT} -d -i -p ${rc_pid}
+					for _v in ${rc_pid}; do
+						${PROTECT} -d -i -p ${_v}
+					done
 					;;
 				[Yy][Ee][Ss])
-					${PROTECT} -p ${rc_pid}
+					for _v in ${rc_pid}; do
+						${PROTECT} -p ${_v}
+					done
 					;;
 				esac
 			fi


### PR DESCRIPTION
Before fix:
```
Starting chronyd.
usage: protect [-i] command
       protect [-cdi] -g pgrp | -p pid
```

Since:
```
# /usr/local/etc/rc.d/chronyd status
chronyd is running as pid 76300 76433.
```

protect fail with "76300 76433" as PID.