### PR TITLE
mac: allow policies to restrict vnode-backed mmap max_prot

### DIFF
--- a/sys/security/mac/mac_framework.h
+++ b/sys/security/mac/mac_framework.h
@@ -592,6 +592,9 @@ mac_vnode_check_mmap(struct ucred *cred, struct vnode *vp, int prot,
 	return (0);
 }
 
+void	mac_vnode_check_mmap_downgrade(struct ucred *cred, struct vnode *vp,
+	    int *prot);
+
 int	mac_vnode_check_open_impl(struct ucred *cred, struct vnode *vp,
 	    accmode_t accmode);
 #ifdef MAC

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -1352,6 +1352,25 @@ vm_mmap_vnode(struct thread *td, vm_size_t objsize,
 	error = mac_vnode_check_mmap(cred, vp, (int)prot, flags);
 	if (error != 0)
 		goto done;
+
+	/*
+	 * Give MAC policies a chance to further restrict max_prot for
+	 * vnode-backed mappings while the vnode is still available.  This
+	 * lets a policy remove VM_PROT_EXECUTE from max_prot and prevent
+	 * a later mprotect(2) upgrade from making the mapping executable
+	 * without an equivalent vnode MAC check.
+	 */
+	if ((*maxprotp & VM_PROT_EXECUTE) != 0) {
+		int mac_maxprot;
+
+		mac_maxprot = (int)*maxprotp;
+		mac_vnode_check_mmap_downgrade(cred, vp, &mac_maxprot);
+		if ((mac_maxprot & (int)prot) != (int)prot) {
+			error = EACCES;
+			goto done;
+		}
+		*maxprotp = (vm_prot_t)mac_maxprot;
+	}
 #endif
 	if ((flags & MAP_SHARED) != 0) {
 		if ((va.va_flags & (SF_SNAPSHOT|IMMUTABLE|APPEND)) != 0) {


### PR DESCRIPTION
For vnode-backed mappings, MAC policies currently get a chance to check the protection requested by mmap(2). However, a mapping created without PROT_EXEC may still retain VM_PROT_EXECUTE in max_prot and later be upgraded with mprotect(PROT_EXEC):

	fd = open(path, O_RDONLY);
	addr = mmap(NULL, len, PROT_READ, MAP_PRIVATE, fd, 0);
	mprotect(addr, len, PROT_READ | PROT_EXEC);

At mprotect(2) time, the VM layer no longer has the same vnode context that was available during mmap(2). As a result, a MAC policy that intends to prevent executable mappings from a given vnode may be bypassed by first creating a non-executable mapping and then upgrading it later.

Without this enforcement point, the MAC framework does not provide policy authors with a complete mechanism to enforce vnode-based executable mapping restrictions. This can make a policy look correct while leaving a bypass path open.

Let MAC policies reduce max_prot during the vnode-backed mmap path, while the vnode is still available. This allows a policy to remove VM_PROT_EXECUTE from max_prot, causing a later mprotect(PROT_EXEC) to fail naturally in the VM layer.

If the reduced max_prot no longer contains the protection requested for the initial mmap, fail the mmap with EACCES.

This does not change behavior for policies that do not implement the downgrade hook.