### PR TITLE
libcasper: fix mandoc lint warnings in services man pages

### DIFF
--- a/lib/libcasper/services/cap_net/cap_net.3
+++ b/lib/libcasper/services/cap_net/cap_net.3
@@ -40,7 +40,7 @@
 .Nm cap_net_limit_connect ,
 .Nm cap_net_limit_init ,
 .Nm cap_net_limit_name2addr ,
-.Nm cap_net_limit_name2addr_family ,
+.Nm cap_net_limit_name2addr_family
 .Nd "library for networking in capability mode"
 .Sh LIBRARY
 .Lb libcap_net

--- a/lib/libcasper/services/cap_netdb/cap_netdb.3
+++ b/lib/libcasper/services/cap_netdb/cap_netdb.3
@@ -25,7 +25,7 @@
 .Dt CAP_NETDB 3
 .Os
 .Sh NAME
-.Nm cap_getprotobyname ,
+.Nm cap_getprotobyname
 .Nd "library for getting network proto entry in capability mode"
 .Sh LIBRARY
 .Lb libcap_netdb

--- a/lib/libcasper/services/cap_pwd/cap_pwd.3
+++ b/lib/libcasper/services/cap_pwd/cap_pwd.3
@@ -90,7 +90,7 @@ are respectively equivalent to
 .Xr setpassent 3 ,
 .Xr setpwent 3 ,
 and
-.Xr cap_endpwent 3
+.Xr endpwent 3
 except that the connection to the
 .Nm system.pwd
 service needs to be provided.


### PR DESCRIPTION
## What

Fix three real `mandoc -T lint -W warning` warnings in `lib/libcasper/services/` man pages.

## Changes

- **`cap_net.3`** — drop trailing comma on the last `.Nm` before `.Nd` (mdoc convention).
- **`cap_netdb.3`** — same: drop trailing comma on the single `.Nm` before `.Nd`.
- **`cap_pwd.3`** — change `.Xr cap_endpwent 3` to `.Xr endpwent 3`. The page documents `cap_endpwent`, so `.Xr cap_endpwent 3` is a self-reference. The surrounding text describes the cap_pwd functions as "respectively equivalent to" a list of libc functions (`getpwent`, `getpwnam`, `setpwent`, …) — the intended trailing entry is therefore `endpwent(3)`. This is the only content change in the PR.

## Verification

`mandoc -T lint -W warning` before:

```
mandoc: lib/libcasper/services/cap_net/cap_net.3:43:36: WARNING: bad NAME section content: text
mandoc: lib/libcasper/services/cap_net/cap_net.3:46:5: WARNING: unknown library name: Lb libcap_net
mandoc: lib/libcasper/services/cap_netdb/cap_netdb.3:28:24: WARNING: bad NAME section content: text
mandoc: lib/libcasper/services/cap_netdb/cap_netdb.3:31:5: WARNING: unknown library name: Lb libcap_netdb
mandoc: lib/libcasper/services/cap_pwd/cap_pwd.3:43:5: WARNING: unknown library name: Lb libcap_pwd
mandoc: lib/libcasper/services/cap_pwd/cap_pwd.3:93:5: WARNING: cross reference to self: Xr cap_endpwent 3
```

`mandoc -T lint -W warning` after:

```
mandoc: lib/libcasper/services/cap_net/cap_net.3:46:5: WARNING: unknown library name: Lb libcap_net
mandoc: lib/libcasper/services/cap_netdb/cap_netdb.3:31:5: WARNING: unknown library name: Lb libcap_netdb
mandoc: lib/libcasper/services/cap_pwd/cap_pwd.3:43:5: WARNING: unknown library name: Lb libcap_pwd
```

The three remaining `unknown library name: Lb libcap_*` warnings are intentionally **out of scope**. The `.Lb libcap_*` invocations in the pages are correct mdoc; the warnings come from mandoc's bundled library-name database not knowing these names. Fixing that belongs in mandoc upstream, not in these pages.

## Out of scope

- `cap_sysctl.3` has a `sections out of conventional order: Sh RETURN VALUES` warning. Real defect; saved for a separate, larger PR because the fix requires moving a whole section.
- The `Lb libcap_*` warnings noted above.
