### PR TITLE
crashinfo: Create core.txt.last symlink

### DIFF
--- a/usr.sbin/crashinfo/crashinfo.sh
+++ b/usr.sbin/crashinfo/crashinfo.sh
@@ -149,6 +149,7 @@ fi
 VMCORE=$CRASHDIR/vmcore.$DUMPNR
 INFO=$CRASHDIR/info.$DUMPNR
 FILE=$CRASHDIR/core.txt.$DUMPNR
+LINK=$CRASHDIR/core.txt.last
 HOSTNAME=`hostname`
 
 if $BATCH; then
@@ -342,3 +343,5 @@ echo "ddb capture buffer"
 echo
 
 ddb capture -M $VMCORE -N $KERNEL print
+
+ln -sf $(basename $FILE) $LINK


### PR DESCRIPTION
When saving a coredump, savecore(8) maintains .last symlinks for the info and vmcore artifacts, but not for the crashinfo text report.

Create it here to point at the current core.txt.<bounds> file.

This makes /var/crash/core.txt.last track the same core dump as info.last and vmcore.last.

Supersedes: https://github.com/freebsd/freebsd-src/pull/2178