### PR TITLE
hwpmc: add AMD Zen3 IBS errata workarounds (1293, 1238, 1347)

### DIFF
--- a/sys/dev/hwpmc/hwpmc_ibs.h
+++ b/sys/dev/hwpmc/hwpmc_ibs.h
@@ -149,8 +149,13 @@
 
 #define IBS_OP_DATA2			0xC0011036 /* IBS Op Data 2 */
 #define IBS_OP_DATA3			0xC0011037 /* IBS Op Data 3 */
+#define IBS_OP_DATA3_OPDCMISSOPENMEMREQSMASK					\
+	(0x3FULL << 26)		     /* DC Miss Open Mem Reqs */
+#define IBS_OP_DATA3_SWPF		(1ULL << 21) /* Software Prefetch */
+#define IBS_OP_DATA3_L2MISS		(1ULL << 20) /* L2 Cache Miss */
 #define IBS_OP_DATA3_DCPHYADDRVALID	(1ULL << 18) /* DC Physical Address */
 #define IBS_OP_DATA3_DCLINADDRVALID	(1ULL << 17) /* DC Linear Address */
+#define IBS_OP_DATA3_DCMISSNOMABALLOC	(1ULL << 16) /* DC Miss No MAB Alloc */
 #define IBS_OP_DATA3_LOCKEDOP		(1ULL << 15) /* DC Locked Op */
 #define IBS_OP_DATA3_UCMEMACCESS	(1ULL << 14) /* DC UC Memory Access */
 #define IBS_OP_DATA3_WCMEMACCESS	(1ULL << 13) /* DC WC Memory Access */

--- a/usr.sbin/pmcstat/pmcstat_log.c
+++ b/usr.sbin/pmcstat/pmcstat_log.c
@@ -48,6 +48,10 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
+#if defined(__amd64__) || defined(__i386__)
+#include <dev/hwpmc/hwpmc_ibs.h>
+#endif
+
 #include <netinet/in.h>
 
 #include <assert.h>
@@ -370,15 +374,38 @@ pmcstat_pmcindex_to_pmcr(int pmcin)
 }
 
 #if defined(__amd64__) || defined(__i386__)
+/*
+ * Set if producer kernel ran on Zen3 B0 (Family 19h Model 0x0-0xF).
+ * Affected by IBS errata #1197, #1238, #1293, #1347. Initialized from
+ * PMCLOG_TYPE_INITIALIZE pl_cpuid ("AuthenticAMD-fam-mod-step", set by
+ * hwpmc_amd.c).
+ */
+static bool pmcstat_ibs_amd_zen3_b0;
+
+static void
+pmcstat_ibs_check_errata(const char *cpuid)
+{
+	unsigned int family, model;
+
+	if (sscanf(cpuid, "AuthenticAMD-%u-%x-", &family, &model) != 2)
+		return;
+	if (family == 0x19 && model <= 0x0F)
+		pmcstat_ibs_amd_zen3_b0 = true;
+}
+
 static void
 pmcstat_print_ibs_fetch(struct pmclog_ev_callchain *cc, int offset)
 {
 	uint64_t *ibsbuf = (uint64_t *)&cc->pl_pc[offset];
 	uint64_t ctl;
+	bool show_icmiss;
 
 	ctl = ibsbuf[PMC_MPIDX_FETCH_CTL];
+
+	/* Erratum #1238: IbsIcMiss invalid on Zen3 B0. */
+	show_icmiss = !pmcstat_ibs_amd_zen3_b0;
 	PMCSTAT_PRINT_ENTRY("ibs-fetch", "%s%s%s%s",
-	    (ctl & IBS_FETCH_CTL_ICMISS) ? "icmiss " : "",
+	    (show_icmiss && (ctl & IBS_FETCH_CTL_ICMISS)) ? "icmiss " : "",
 	    (ctl & IBS_FETCH_CTL_L1TLBMISS) ? "l1tlbmiss " : "",
 	    (ctl & IBS_FETCH_CTL_OPCACHEMISS) ? "opcachemiss " : "",
 	    (ctl & IBS_FETCH_CTL_L3MISS) ? "l3miss" : "");
@@ -400,6 +427,16 @@ pmcstat_print_ibs_op(struct pmclog_ev_callchain *cc, int offset)
 
 	data = ibsbuf[PMC_MPIDX_OP_DATA];
 	data3 = ibsbuf[PMC_MPIDX_OP_DATA3];
+
+	/*
+	 * Erratum #1293 (Zen3 B0): the L2Miss and OpDcMissOpenMemReqs fields
+	 * of DATA3 (and DATA2, not displayed here) are invalid when
+	 * DcMissNoMabAlloc or SwPf is set. Mask the affected DATA3 bits.
+	 */
+	if (pmcstat_ibs_amd_zen3_b0 &&
+	    (data3 & (IBS_OP_DATA3_SWPF | IBS_OP_DATA3_DCMISSNOMABALLOC)) != 0)
+		data3 &= ~(IBS_OP_DATA3_L2MISS |
+		    IBS_OP_DATA3_OPDCMISSOPENMEMREQSMASK);
 
 	if ((data & IBS_OP_DATA_RIPINVALID) == 0) {
 		PMCSTAT_PRINT_ENTRY("ibs-op", "RIP %" PRIx64,
@@ -508,6 +545,9 @@ pmcstat_print_log(void)
 				warnx(
 "WARNING: Log version 0x%x != expected version 0x%x.",
 				    ev.pl_u.pl_i.pl_version, PMC_VERSION);
+#if defined(__amd64__) || defined(__i386__)
+			pmcstat_ibs_check_errata(ev.pl_u.pl_i.pl_cpuid);
+#endif
 			break;
 		case PMCLOG_TYPE_MAP_IN:
 			PMCSTAT_PRINT_ENTRY("map-in","%d %p \"%s\"",


### PR DESCRIPTION
## Summary

- hwpmc: add AMD Zen3 IBS errata workarounds (# 1293, # 1238, # 1347)
