### PR TITLE
libc: Add free_sized() and free_aligned_sized() as per C23

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -173,6 +173,8 @@ _Noreturn void
  */
 #if __ISO_C_VISIBLE >= 2023
 size_t	memalignment(const void *) __pure2;
+void	free_sized(void *, size_t) __noexcept;
+void	free_aligned_sized(void *, size_t, size_t) __noexcept;
 #endif /* __ISO_C_VISIBLE >= 2023 */
 
 /*

--- a/lib/libc/stdlib/malloc/Makefile.inc
+++ b/lib/libc/stdlib/malloc/Makefile.inc
@@ -1,3 +1,12 @@
 SYM_MAPS+=${LIBC_SRCTOP}/stdlib/malloc/Symbol.map
 
+.PATH: ${LIBC_SRCTOP}/stdlib/malloc
+
+MISRCS+=	free_aligned_sized.c \
+		free_sized.c
+
+MAN+=		free_sized.3
+
+MLINKS+=	free_sized.3 free_aligned_sized.3
+
 .include "${LIBC_SRCTOP}/stdlib/malloc/${OPT_LIBC_MALLOC}/Makefile.inc"

--- a/lib/libc/stdlib/malloc/Symbol.map
+++ b/lib/libc/stdlib/malloc/Symbol.map
@@ -47,6 +47,13 @@ FBSD_1.4 {
 	__mallctlbymib;
 };
 
+FBSD_1.9 {
+	free_sized;
+	free_aligned_sized;
+	__free_sized;
+	__free_aligned_sized;
+};
+
 FBSDprivate_1.0 {
 	_malloc_thread_cleanup;
 	_malloc_prefork;

--- a/lib/libc/stdlib/malloc/free_aligned_sized.c
+++ b/lib/libc/stdlib/malloc/free_aligned_sized.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Faraz Vahedi <kfv@kfv.io>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <sys/cdefs.h>
+#include <stdlib.h>
+
+void	__free(void *);
+
+void
+__free_aligned_sized(void *ptr, size_t alignment, size_t size)
+{
+
+	(void)alignment;
+	(void)size;
+	__free(ptr);
+}
+
+__weak_reference(__free_aligned_sized, free_aligned_sized);

--- a/lib/libc/stdlib/malloc/free_sized.3
+++ b/lib/libc/stdlib/malloc/free_sized.3
@@ -1,0 +1,100 @@
+.\"
+.\" Copyright (c) 2026 Faraz Vahedi <kfv@kfv.io>
+.\"
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
+.Dd May 17, 2026
+.Dt FREE_SIZED 3
+.Os
+.Sh NAME
+.Nm free_sized ,
+.Nm free_aligned_sized
+.Nd C23 sized deallocation functions
+.Sh SYNOPSIS
+.Lb libc
+.In stdlib.h
+.Ft void
+.Fn free_sized "void *ptr" "size_t size"
+.Ft void
+.Fn free_aligned_sized "void *ptr" "size_t alignment" "size_t size"
+.Sh DESCRIPTION
+The
+.Fn free_sized
+function deallocates the memory referenced by
+.Fa ptr
+that was previously allocated by
+.Xr malloc 3 ,
+.Xr realloc 3 ,
+or
+.Xr calloc 3 .
+The
+.Fa size
+argument shall equal the size passed to the allocation function.
+The result of an
+.Xr aligned_alloc 3
+may not be passed to
+.Fn free_sized .
+.Pp
+The
+.Fn free_aligned_sized
+function deallocates memory referenced by
+.Fa ptr
+that was previously allocated by
+.Xr aligned_alloc 3 .
+The
+.Fa alignment
+and
+.Fa size
+arguments shall equal the values supplied to the allocation function.
+The result of an
+.Xr malloc 3 ,
+.Xr calloc 3 ,
+or
+.Xr realloc 3
+may not be passed to
+.Fn free_aligned_sized .
+.Pp
+If
+.Fa ptr
+is neither a null pointer nor a pointer returned by the allocation functions
+described above for the corresponding deallocation function, the behaviour is
+undefined, and so is supplying a
+.Fa size
+or
+.Fa alignment
+that does not match the original allocation.
+.Sh IMPLEMENTATION NOTES
+The C standard permits an implementation to ignore the
+.Fa size
+and
+.Fa alignment
+hints.
+The current implementation forwards to
+.Xr free 3
+without validating these arguments, so behaviour remains correct for
+well-formed use.
+.Pp
+These functions will be wired to the system allocator's sized deallocation,
+once supported, as with the rest of the memory allocation API, so that
+.Fa size
+and
+.Fa alignment
+hints are used for performance and security benefits.
+That behaviour conforms to the practice recommended for each function in the
+C standard.
+.Sh SEE ALSO
+.Xr free 3 ,
+.Xr malloc 3 ,
+.Xr calloc 3 ,
+.Xr realloc 3 ,
+.Xr aligned_alloc 3 ,
+.Xr jemalloc 3
+.Sh STANDARDS
+The
+.Fn free_sized
+and
+.Fn free_aligned_sized
+functions conform to
+.St -isoC-2023 .
+.Sh AUTHOR
+.An Faraz Vahedi Aq Mt kfv@kfv.io

--- a/lib/libc/stdlib/malloc/free_sized.c
+++ b/lib/libc/stdlib/malloc/free_sized.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Faraz Vahedi <kfv@kfv.io>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <sys/cdefs.h>
+#include <stdlib.h>
+
+void	__free(void *);
+
+void
+__free_sized(void *ptr, size_t size)
+{
+
+	(void)size;
+	__free(ptr);
+}
+
+__weak_reference(__free_sized, free_sized);

--- a/lib/libc/stdlib/memory.3
+++ b/lib/libc/stdlib/memory.3
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd October 18, 2023
+.Dd May 17, 2026
 .Dt MEMORY 3
 .Os
 .Sh NAME
@@ -33,6 +33,8 @@
 .Nm alloca ,
 .Nm calloc ,
 .Nm free ,
+.Nm free_sized ,
+.Nm free_aligned_sized ,
 .Nm malloc ,
 .Nm posix_memalign ,
 .Nm realloc ,
@@ -53,6 +55,10 @@
 .Fn calloc "size_t nelem" "size_t elsize"
 .Ft void
 .Fn free "void *ptr"
+.Ft void
+.Fn free_sized "void *ptr" "size_t size"
+.Ft void
+.Fn free_aligned_sized "void *ptr" "size_t alignment" "size_t size"
 .Ft void *
 .Fn malloc "size_t size"
 .Ft int
@@ -79,6 +85,8 @@ individual manual pages.
 .Xr alloca 3 ,
 .Xr calloc 3 ,
 .Xr free 3 ,
+.Xr free_aligned_sized 3 ,
+.Xr free_sized 3 ,
 .Xr malloc 3 ,
 .Xr posix_memalign 3 ,
 .Xr realloc 3 ,
@@ -101,3 +109,10 @@ and
 .Fn posix_memalign
 functions conform to
 .St -p1003.1-2001 .
+.Pp
+The
+.Fn free_sized
+and
+.Fn free_aligned_sized
+functions conform to
+.St -isoC-2023 .


### PR DESCRIPTION
Add `free_sized()` (§7.24.3.4) and `free_aligned_sized()` (§7.24.3.5) as per C23.

For now they're simply thin wrappers around `free(3)` as the standard allows implementations to ignore the size and alignment hints (§7.24.3.4.3, §7.24.3.5.3,) so the behaviour is correct and conformant.

Once jemalloc is bumped to 5.3.1, it'd be well worth rewiring these to use the allocator's sized deallocation for the performance and security benefits.