### PR TITLE
libc: C23 conformance for <assert.h>

### DIFF
--- a/contrib/ldns/edns.c
+++ b/contrib/ldns/edns.c
@@ -10,6 +10,7 @@
  * See the file LICENSE for the license
  */
 
+#include <ldns/config.h>
 #include <ldns/ldns.h>
 
 #define LDNS_OPTIONLIST_INIT 8

--- a/include/assert.h
+++ b/include/assert.h
@@ -46,19 +46,19 @@
 #undef __assert_unreachable
 
 #ifdef NDEBUG
-#define	assert(e)	((void)0)
-#define	_assert(e)	((void)0)
+#define assert(e)	((void)0)
+#define _assert(e)	((void)0)
 #if __BSD_VISIBLE
-#define	__assert_unreachable()	__unreachable()
-#endif	/* __BSD_VISIBLE */
+#define __assert_unreachable()	__unreachable()
+#endif /* __BSD_VISIBLE */
 #else
-#define	_assert(e)	assert(e)
+#define _assert(e)	assert(e)
 
-#define	assert(e)	((e) ? (void)0 : __assert(__func__, __FILE__, \
+#define assert(e)	((e) ? (void)0 : __assert(__func__, __FILE__, \
 			    __LINE__, #e))
 #if __BSD_VISIBLE
-#define	__assert_unreachable()	assert(0 && "unreachable segment reached")
-#endif	/* __BSD_VISIBLE */
+#define __assert_unreachable()	assert(0 && "unreachable segment reached")
+#endif /* __BSD_VISIBLE */
 #endif /* NDEBUG */
 
 #ifndef _ASSERT_H_
@@ -77,7 +77,7 @@
  * _Static_assert, as keywords.
  */
 #if __ISO_C_VISIBLE >= 2011 && __ISO_C_VISIBLE < 2023 && !defined(__cplusplus)
-#define	static_assert	_Static_assert
+#define static_assert	_Static_assert
 #endif
 
 __BEGIN_DECLS

--- a/include/assert.h
+++ b/include/assert.h
@@ -46,16 +46,43 @@
 #undef __assert_unreachable
 
 #ifdef NDEBUG
-#define assert(e)	((void)0)
-#define _assert(e)	((void)0)
+#define assert(...)	((void)0)
+#define _assert(...)	((void)0)
 #if __BSD_VISIBLE
 #define __assert_unreachable()	__unreachable()
 #endif /* __BSD_VISIBLE */
 #else
-#define _assert(e)	assert(e)
-
-#define assert(e)	((e) ? (void)0 : __assert(__func__, __FILE__, \
-			    __LINE__, #e))
+#ifdef __cplusplus
+#if __cplusplus < 202002L
+/*
+ * C++ modes prior to C++20 cannot simultaneously satisfy all three
+ * desirable properties of the sanitiser:
+ *
+ *   Approach                       No double-eval  Lambda support  Arity check
+ *   -----------------------------  --------------  --------------  -----------
+ *   sizeof(cast(expression))       yes             no              yes
+ *   static_cast<bool>(expression)  no              yes             no
+ *   (void)bool(expression)         no              yes             no
+ *
+ *   NOTE: C++20 introduced lambdas in unevaluated contexts; see P0315R4.
+ *
+ * Since no approach satisfies all three below C++20, the least harmful
+ * choice is to forgo the check entirely rather than silently break one
+ * of the remaining guarantees.
+ *
+ */
+#define __assert_sanitize(...)	((void)0)
+#else
+#define __assert_sanitize(...)	(void)sizeof(((bool(*)(bool))0)(__VA_ARGS__))
+#endif /* __cplusplus < 202002L */
+#else
+#define __assert_sanitize(...)	(void)sizeof(((_Bool(*)(_Bool))0)(__VA_ARGS__))
+#endif /* __cplusplus */
+#define assert(...)	(__assert_sanitize(__VA_ARGS__),       \
+			    (__VA_ARGS__) ? (void)0 :          \
+			    __assert(__func__, __FILE__,       \
+			    __LINE__, #__VA_ARGS__))
+#define _assert(...)	assert(__VA_ARGS__)
 #if __BSD_VISIBLE
 #define __assert_unreachable()	assert(0 && "unreachable segment reached")
 #endif /* __BSD_VISIBLE */
@@ -76,7 +103,8 @@
  * C23 defines static_assert and its obsolescent alternative spelling,
  * _Static_assert, as keywords.
  */
-#if __ISO_C_VISIBLE >= 2011 && __ISO_C_VISIBLE < 2023 && !defined(__cplusplus)
+#if __ISO_C_VISIBLE >= 2011 && !defined(__cplusplus) && \
+    __STDC_VERSION__ < 202311L
 #define static_assert	_Static_assert
 #endif
 

--- a/include/assert.h
+++ b/include/assert.h
@@ -88,8 +88,8 @@
 #endif /* __BSD_VISIBLE */
 #endif /* NDEBUG */
 
-#ifndef _ASSERT_H_
-#define _ASSERT_H_
+#ifndef __STDC_VERSION_ASSERT_H__
+#define __STDC_VERSION_ASSERT_H__ 202311L
 
 /*
  * Static assertions.  In principle we could define static_assert for
@@ -112,4 +112,4 @@ __BEGIN_DECLS
 void __assert(const char *, const char *, int, const char *) __dead2;
 __END_DECLS
 
-#endif /* !_ASSERT_H_ */
+#endif /* !__STDC_VERSION_ASSERT_H__ */

--- a/include/assert.h
+++ b/include/assert.h
@@ -72,8 +72,11 @@
  * C++ template parameters may contain commas, even if not enclosed in
  * parentheses, causing the _Static_assert macro to be invoked with more
  * than two parameters.
+ *
+ * C23 defines static_assert and its obsolescent alternative spelling,
+ * _Static_assert, as keywords.
  */
-#if __ISO_C_VISIBLE >= 2011 && !defined(__cplusplus)
+#if __ISO_C_VISIBLE >= 2011 && __ISO_C_VISIBLE < 2023 && !defined(__cplusplus)
 #define	static_assert	_Static_assert
 #endif
 

--- a/include/rpcsvc/yp_prot.h
+++ b/include/rpcsvc/yp_prot.h
@@ -67,11 +67,6 @@
  * YPPROC_MAPLIST	takes (char *), returns (struct ypmaplist *).
  */
 
-#ifndef BOOL_DEFINED
-typedef u_int bool;
-#define BOOL_DEFINED
-#endif
-
 /* Program and version symbols, magic numbers */
 
 #define YPPROG		((u_long)100004)

--- a/sbin/mdmfs/mdmfs.c
+++ b/sbin/mdmfs/mdmfs.c
@@ -49,13 +49,12 @@
 #include <paths.h>
 #include <pwd.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>
-
-typedef enum { false, true } bool;
 
 struct mtpt_info {
 	uid_t		 mi_uid;

--- a/share/man/man3/assert.3
+++ b/share/man/man3/assert.3
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 20, 2021
+.Dd May 17, 2026
 .Dt ASSERT 3
 .Os
 .Sh NAME
@@ -40,15 +40,14 @@
 .Sh DESCRIPTION
 The
 .Fn assert
-macro tests the given
-.Ar expression
+macro tests the given scalar
+.Ar expression ,
 and if it is false,
-the calling process is terminated.
-A diagnostic message is written to
+a diagnostic message is written to
 .Dv stderr
 and the function
 .Xr abort 3
-is called, effectively terminating the program.
+is called, effectively terminating the calling process.
 .Pp
 If
 .Ar expression
@@ -57,6 +56,24 @@ the
 .Fn assert
 macro does nothing.
 .Pp
+The
+.Fn assert
+macro accepts a variable number of arguments.
+In all compilation modes,
+.Fn assert
+is defined as a macro with an ellipsis parameter, consistent with the
+C23 standard.
+This allows expressions containing commas to be passed directly without
+requiring an extra pair of enclosing parentheses.
+Only a single scalar expression is evaluated.
+Supplying multiple arguments is prohibited, and hence top-level comma
+operators.
+In particular, this guards against accidentally writing
+.Fn assert
+in the style of
+.Fn static_assert ,
+which would otherwise silently evaluate as always true via the comma
+operator.
 The
 .Fn assert
 macro
@@ -82,9 +99,9 @@ macro should only be used for ensuring the developer's expectations
 hold true.
 It is not appropriate for regular run-time error detection.
 .Pp
-The
+In pre-C23 compilation modes
 .Fn static_assert
-macro expands to
+is implemented as a macro and expands to
 .Fn _Static_assert ,
 and, contrarily to
 .Fn assert ,
@@ -94,8 +111,14 @@ message including the string literal message, if provided.
 The initial form of the
 .Fn _Static_assert
 containing a string literal message was introduced in C11 standard, and
-the other form with no string literal is to be implemented by C2x and
-some compilers may lack its adoption at present.
+the other form with no string literal conforms to C23 standard.
+.Pp
+In C23 and later,
+.Fn static_assert
+is a language keyword, and
+.Fn _Static_assert
+is provided as an obsolescent alternative spelling that should not be
+used for new code and development.
 .Sh EXAMPLES
 The assertion:
 .Dl "assert(1 == 0);"
@@ -111,6 +134,17 @@ Second, the code will disappear if
 .Dv NDEBUG
 is defined, changing the semantics of the program.
 .Pp
+The following example asserts that the
+.Va iov_len
+member of the compound literal, reflecting the value of
+.Va len ,
+is non-zero.
+The compound literal contains a comma that is not protected by
+parentheses, which the variadic
+.Fn assert
+macro handles transparently:
+.Dl assert((struct iovec){ buf, len }.iov_len);
+.Pp
 The following asserts that the size of the S structure is 16.
 Otherwise, it produces a diagnostic message which points at the
 constraint and includes the provided string literal:
@@ -123,14 +157,25 @@ If none is provided, it only points at the constraint.
 The
 .Fn assert
 macro conforms to
-.St -isoC-99 .
+.St -isoC-2023 .
 .Pp
 The
 .Fn static_assert
-macro conforms to
-.St -isoC-2011 .
+conforms to
+.St -isoC-2011 ,
+wherein defined as a macro, and
+.St -isoC-2023 ,
+as a language keyword, depending on the compilation mode.
 .Sh HISTORY
-An
+The
 .Nm
-macro appeared in
+macro first appeared in
 .At v7 .
+Starting with
+.Fx 15.2 ,
+it accepts a variadic argument list, allowing expressions
+containing commas, such as compound literals, to be passed
+without requiring extra enclosing parentheses.
+This conforms to
+.St -isoC-2023 ,
+but made available in all compilation modes.

--- a/share/man/man3/assert.3
+++ b/share/man/man3/assert.3
@@ -145,7 +145,9 @@ parentheses, which the variadic
 macro handles transparently:
 .Dl assert((struct iovec){ buf, len }.iov_len);
 .Pp
-The following asserts that the size of the S structure is 16.
+The following asserts that the size of the
+.Vt S
+structure is 16.
 Otherwise, it produces a diagnostic message which points at the
 constraint and includes the provided string literal:
 .Dl "static_assert(sizeof(struct S) == 16, ""size mismatch"");"


### PR DESCRIPTION
- Add `__STDC_VERSION_ASSERT_H__` feature-test macro
- Restrict `static_assert` macro definition to pre-C23 modes
- Make `assert` variadic as per C23
- Update `assert.3` accordingly