### PR TITLE
ee: add example init.ee configuration file

### DIFF
--- a/contrib/ee/ee.1
+++ b/contrib/ee/ee.1
@@ -424,6 +424,8 @@ The file \fI\/usr/share/misc/init.ee\fR is read first, then
 \fI$HOME/.init.ee\fR, then \fI.init.ee\fR, with the settings specified by the most
 recent file read taking precedence.
 .PP
+An example initialization file is provided in
+\fI/usr/share/examples/ee/init.ee\fR.
 The following items may be entered in the initialization file:
 .RS 4
 .IP \fBcase\fR

--- a/share/examples/ee/init.ee
+++ b/share/examples/ee/init.ee
@@ -1,0 +1,23 @@
+# Example init.ee for ee (easy editor)
+
+# Display
+noinfo
+nohighlight
+
+# Formatting
+noexpand
+margins
+rightmargin 72
+noautoformat
+
+# Search
+nocase
+
+# Character display
+eightbit
+
+# Key bindings
+noemacs
+
+# Printing
+printcommand lp


### PR DESCRIPTION
This change adds an example init.ee configuration file under
/usr/share/examples/ee/init.ee.

It also updates the ee(1) manual page to reference the example
configuration file.