### PR TITLE
libc: Add missing C23 feature test macros

### DIFF
--- a/include/complex.h
+++ b/include/complex.h
@@ -26,8 +26,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _COMPLEX_H
-#define	_COMPLEX_H
+#ifndef __STDC_VERSION_COMPLEX_H__
+#define __STDC_VERSION_COMPLEX_H__ 202311L
 
 #include <sys/cdefs.h>
 
@@ -135,4 +135,4 @@ float complex	ctanhf(float complex);
 
 __END_DECLS
 
-#endif /* _COMPLEX_H */
+#endif /* !__STDC_VERSION_COMPLEX_H__ */

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -26,8 +26,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _INTTYPES_H_
-#define	_INTTYPES_H_
+#ifndef __STDC_VERSION_INTTYPES_H__
+#define __STDC_VERSION_INTTYPES_H__ 202311L
 
 #include <machine/_inttypes.h>
 #include <sys/stdint.h>
@@ -59,4 +59,4 @@ uintmax_t	wcstoumax(const wchar_t * __restrict,
 		    wchar_t ** __restrict, int);
 __END_DECLS
 
-#endif /* !_INTTYPES_H_ */
+#endif /* !__STDC_VERSION_INTTYPES_H__ */

--- a/include/limits.h
+++ b/include/limits.h
@@ -29,8 +29,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIMITS_H_
-#define	_LIMITS_H_
+#ifndef __STDC_VERSION_LIMITS_H__
+#define __STDC_VERSION_LIMITS_H__ 202311L
 
 #include <sys/cdefs.h>
 
@@ -148,4 +148,4 @@
 #include <sys/syslimits.h>
 #endif
 
-#endif /* !_LIMITS_H_ */
+#endif /* !__STDC_VERSION_LIMITS_H__ */

--- a/include/rpc/xdr.h
+++ b/include/rpc/xdr.h
@@ -332,7 +332,7 @@ __BEGIN_DECLS
 extern void   xdrmem_create(XDR *, char *, u_int, enum xdr_op);
 
 /* XDR using stdio library */
-#ifdef _STDIO_H_
+#ifdef __STDC_VERSION_STDIO_H__
 extern void   xdrstdio_create(XDR *, FILE *, enum xdr_op);
 #endif
 

--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -34,8 +34,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _SETJMP_H_
-#define _SETJMP_H_
+#ifndef __STDC_VERSION_SETJMP_H__
+#define __STDC_VERSION_SETJMP_H__ 202311L
 
 #include <sys/cdefs.h>
 
@@ -58,4 +58,4 @@ int	sigsetjmp(sigjmp_buf, int) __returns_twice;
 #endif
 __END_DECLS
 
-#endif /* !_SETJMP_H_ */
+#endif /* !__STDC_VERSION_SETJMP_H__ */

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -26,9 +26,6 @@
  * SUCH DAMAGE.
  */
 
-#ifndef __STDC_VERSION_STDBOOL_H__
-#define __STDC_VERSION_STDBOOL_H__ 202311L
-
 #ifndef __bool_true_false_are_defined
 #define	__bool_true_false_are_defined	1
 
@@ -41,4 +38,3 @@
 
 #endif /* (__STDC_VERSION__ < 202311L) && !defined(__cplusplus) */
 #endif /* __bool_true_false_are_defined */
-#endif /* __STDC_VERSION_STDBOOL_H__ */

--- a/include/stddef.h
+++ b/include/stddef.h
@@ -29,8 +29,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _STDDEF_H_
-#define _STDDEF_H_
+#ifndef __STDC_VERSION_STDDEF_H__
+#define __STDC_VERSION_STDDEF_H__ 202311L
 
 #include <sys/_null.h>
 #include <sys/_offsetof.h>
@@ -77,4 +77,4 @@ typedef size_t rsize_t;
 #endif
 #endif /* __EXT1_VISIBLE */
 
-#endif /* _STDDEF_H_ */
+#endif /* !__STDC_VERSION_STDDEF_H__ */

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -32,8 +32,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef	_STDIO_H_
-#define	_STDIO_H_
+#ifndef __STDC_VERSION_STDIO_H__
+#define __STDC_VERSION_STDIO_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_null.h>
@@ -536,4 +536,4 @@ extern int __isthreaded;
 __END_DECLS
 __NULLABILITY_PRAGMA_POP
 
-#endif /* !_STDIO_H_ */
+#endif /* !__STDC_VERSION_STDIO_H__ */

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -29,8 +29,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _STDLIB_H_
-#define	_STDLIB_H_
+#ifndef __STDC_VERSION_STDLIB_H__
+#define __STDC_VERSION_STDLIB_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_null.h>
@@ -412,4 +412,4 @@ errno_t	 qsort_s(void *, rsize_t, rsize_t,
 __END_DECLS
 __NULLABILITY_PRAGMA_POP
 
-#endif /* !_STDLIB_H_ */
+#endif /* !__STDC_VERSION_STDLIB_H__ */

--- a/include/string.h
+++ b/include/string.h
@@ -29,8 +29,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _STRING_H_
-#define	_STRING_H_
+#ifndef __STDC_VERSION_STRING_H__
+#define __STDC_VERSION_STRING_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_null.h>
@@ -205,4 +205,4 @@ errno_t memset_s(void *, rsize_t, int, rsize_t);
 #endif /* __EXT1_VISIBLE */
 __END_DECLS
 
-#endif /* _STRING_H_ */
+#endif /* !__STDC_VERSION_STRING_H__ */

--- a/include/tgmath.h
+++ b/include/tgmath.h
@@ -29,8 +29,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _TGMATH_H_
-#define	_TGMATH_H_
+#ifndef __STDC_VERSION_TGMATH_H__
+#define __STDC_VERSION_TGMATH_H__ 202311L
 
 #include <complex.h>
 #include <math.h>
@@ -207,4 +207,4 @@
 #define	cproj(x)	__tg_simple(x, cproj)
 #define	creal(x)	__tg_simple(x, creal)
 
-#endif /* !_TGMATH_H_ */
+#endif /* !__STDC_VERSION_TGMATH_H__ */

--- a/include/time.h
+++ b/include/time.h
@@ -37,8 +37,8 @@
 /*
  */
 
-#ifndef _TIME_H_
-#define	_TIME_H_
+#ifndef __STDC_VERSION_TIME_H__
+#define __STDC_VERSION_TIME_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_null.h>
@@ -198,4 +198,4 @@ time_t timegm(struct tm * const);
 
 __END_DECLS
 
-#endif /* !_TIME_H_ */
+#endif /* !__STDC_VERSION_TIME_H__ */

--- a/include/uchar.h
+++ b/include/uchar.h
@@ -26,8 +26,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _UCHAR_H_
-#define	_UCHAR_H_
+#ifndef __STDC_VERSION_UCHAR_H__
+#define __STDC_VERSION_UCHAR_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_types.h>
@@ -69,4 +69,4 @@ size_t	mbrtoc32(char32_t * __restrict, const char * __restrict, size_t,
 #endif
 __END_DECLS
 
-#endif /* !_UCHAR_H_ */
+#endif /* !__STDC_VERSION_UCHAR_H__ */

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -57,8 +57,8 @@
  *	$NetBSD: wchar.h,v 1.8 2000/12/22 05:31:42 itojun Exp $
  */
 
-#ifndef _WCHAR_H_
-#define _WCHAR_H_
+#ifndef __STDC_VERSION_WCHAR_H__
+#define __STDC_VERSION_WCHAR_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_null.h>
@@ -246,4 +246,4 @@ size_t	wcslcpy(wchar_t *, const wchar_t *, size_t);
 #endif
 __END_DECLS
 
-#endif /* !_WCHAR_H_ */
+#endif /* !__STDC_VERSION_WCHAR_H__ */

--- a/include/xlocale.h
+++ b/include/xlocale.h
@@ -35,11 +35,11 @@
 __BEGIN_DECLS
 #include <xlocale/_locale.h>
 
-#ifdef _STRING_H_
+#ifdef __STDC_VERSION_STRING_H__
 #include <xlocale/_string.h>
 #endif
 
-#ifdef _INTTYPES_H_
+#ifdef __STDC_VERSION_INTTYPES_H__
 #include <xlocale/_inttypes.h>
 #endif
 
@@ -47,11 +47,11 @@ __BEGIN_DECLS
 #include <xlocale/_monetary.h>
 #endif
 
-#ifdef _STDLIB_H_
+#ifdef __STDC_VERSION_STDLIB_H__
 #include <xlocale/_stdlib.h>
 #endif
 
-#ifdef _TIME_H_
+#ifdef __STDC_VERSION_TIME_H__
 #include <xlocale/_time.h>
 #endif
 
@@ -68,11 +68,11 @@ __BEGIN_DECLS
 #include <xlocale/_ctype.h>
 #endif
 
-#ifdef _STDIO_H_
+#ifdef __STDC_VERSION_STDIO_H__
 #include <xlocale/_stdio.h>
 #endif
 
-#ifdef _WCHAR_H_
+#ifdef __STDC_VERSION_WCHAR_H__
 #include <xlocale/_wchar.h>
 #endif
 

--- a/lib/libc/xdr/xdr.3
+++ b/lib/libc/xdr/xdr.3
@@ -572,7 +572,7 @@ This routine returns the amount of memory required to encode
 using filter
 .Fa func .
 .Pp
-.It Li "#ifdef _STDIO_H_"
+.It Li "#ifdef __STDC_VERSION_STDIO_H__"
 .It Li "/* XDR using stdio library */"
 .It Xo
 .Ft void

--- a/lib/libgeom/libgeom.h
+++ b/lib/libgeom/libgeom.h
@@ -143,7 +143,7 @@ void geom_deletetree(struct gmesh *);
 
 struct gctl_req;
 
-#ifdef _STDIO_H_			/* limit #include pollution */
+#ifdef __STDC_VERSION_STDIO_H__		/* limit #include pollution */
 void gctl_dump(struct gctl_req *, FILE *);
 #endif
 void gctl_free(struct gctl_req *);

--- a/lib/libthr/thread/thr_private.h
+++ b/lib/libthr/thread/thr_private.h
@@ -890,7 +890,7 @@ int	__sys_sigwaitinfo(const sigset_t *set, siginfo_t *info);
 #endif /* _SYS_FCNTL_H_ */
 
 /* #include <time.h> */
-#ifdef	_TIME_H_
+#ifdef __STDC_VERSION_TIME_H__
 #ifndef _LIBC_PRIVATE_H_
 int	__sys_clock_nanosleep(clockid_t, int, const struct timespec *,
 	    struct timespec *);

--- a/lib/libutil/libutil.h
+++ b/lib/libutil/libutil.h
@@ -151,7 +151,7 @@ int	uu_lock_txfr(const char *_ttyname, pid_t _pid);
  * Conditionally prototype the following functions if the include
  * files upon which they depend have been included.
  */
-#ifdef _STDIO_H_
+#ifdef __STDC_VERSION_STDIO_H__
 char	*fparseln(FILE *_fp, size_t *_len, size_t *_lineno,
 	    const char _delim[3], int _flags);
 #endif

--- a/lib/msun/aarch64/fenv.h
+++ b/lib/msun/aarch64/fenv.h
@@ -28,8 +28,8 @@
 #include <arm/fenv.h>
 #else /* __arm__ */
 
-#ifndef	_FENV_H_
-#define	_FENV_H_
+#ifndef __STDC_VERSION_FENV_H__
+#define __STDC_VERSION_FENV_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_types.h>
@@ -274,6 +274,6 @@ __fegetexcept_int(void)
 
 __END_DECLS
 
-#endif	/* !_FENV_H_ */
+#endif	/* !__STDC_VERSION_FENV_H__ */
 
 #endif /* __arm__ */

--- a/lib/msun/arm/fenv.h
+++ b/lib/msun/arm/fenv.h
@@ -26,8 +26,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef	_FENV_H_
-#define	_FENV_H_
+#ifndef __STDC_VERSION_FENV_H__
+#define __STDC_VERSION_FENV_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_types.h>
@@ -300,4 +300,4 @@ __fegetexcept_int(void)
 
 __END_DECLS
 
-#endif	/* !_FENV_H_ */
+#endif	/* !__STDC_VERSION_FENV_H__ */

--- a/lib/msun/ld128/k_expl.h
+++ b/lib/msun/ld128/k_expl.h
@@ -290,7 +290,7 @@ hexpl(long double x)
 	return (lo + hi) * 2 * twopkm2;
 }
 
-#ifdef _COMPLEX_H
+#ifdef __STDC_VERSION_COMPLEX_H__
 /*
  * See ../src/k_exp.c for details.
  */
@@ -318,4 +318,4 @@ __ldexp_cexpl(long double complex z, int expt)
 	return (CMPLXL(c * exp_x * scale1 * scale2,
 	    s * exp_x * scale1 * scale2));
 }
-#endif /* _COMPLEX_H */
+#endif /* __STDC_VERSION_COMPLEX_H__ */

--- a/lib/msun/ld80/k_expl.h
+++ b/lib/msun/ld80/k_expl.h
@@ -267,7 +267,7 @@ hexpl(long double x)
 	return (lo + hi) * 2 * twopkm2;
 }
 
-#ifdef _COMPLEX_H
+#ifdef __STDC_VERSION_COMPLEX_H__
 /*
  * See ../src/k_exp.c for details.
  */
@@ -295,4 +295,4 @@ __ldexp_cexpl(long double complex z, int expt)
 	return (CMPLXL(c * exp_x * scale1 * scale2,
 	    s * exp_x * scale1 * scale2));
 }
-#endif /* _COMPLEX_H */
+#endif /* __STDC_VERSION_COMPLEX_H__ */

--- a/lib/msun/powerpc/fenv.h
+++ b/lib/msun/powerpc/fenv.h
@@ -26,8 +26,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef	_FENV_H_
-#define	_FENV_H_
+#ifndef __STDC_VERSION_FENV_H__
+#define __STDC_VERSION_FENV_H__ 202311L
 
 #include <sys/_types.h>
 #include <machine/endian.h>
@@ -309,4 +309,4 @@ fegetexcept(void)
 
 __END_DECLS
 
-#endif	/* !_FENV_H_ */
+#endif	/* !__STDC_VERSION_FENV_H__ */

--- a/lib/msun/riscv/fenv.h
+++ b/lib/msun/riscv/fenv.h
@@ -33,8 +33,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef	_FENV_H_
-#define	_FENV_H_
+#ifndef __STDC_VERSION_FENV_H__
+#define __STDC_VERSION_FENV_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_types.h>
@@ -259,4 +259,4 @@ fegetexcept(void)
 
 __END_DECLS
 
-#endif	/* !_FENV_H_ */
+#endif	/* !__STDC_VERSION_FENV_H__ */

--- a/lib/msun/src/fenv-softfloat.h
+++ b/lib/msun/src/fenv-softfloat.h
@@ -26,7 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef	_FENV_H_
+#ifndef __STDC_VERSION_FENV_H__
 #error "This file is meant to be included only by <fenv.h>."
 #endif
 

--- a/lib/msun/src/math.h
+++ b/lib/msun/src/math.h
@@ -12,8 +12,8 @@
 /*
  */
 
-#ifndef _MATH_H_
-#define	_MATH_H_
+#ifndef __STDC_VERSION_MATH_H__
+#define __STDC_VERSION_MATH_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_types.h>
@@ -551,4 +551,4 @@ long double	rsqrtl(long double);
 
 __END_DECLS
 
-#endif /* !_MATH_H_ */
+#endif /* !__STDC_VERSION_MATH_H__ */

--- a/lib/msun/src/math_private.h
+++ b/lib/msun/src/math_private.h
@@ -584,7 +584,7 @@ void _scan_nan(uint32_t *__words, int __num_words, const char *__s);
 #define	nan_mix(x, y)		(nan_mix_op((x), (y), +))
 #define	nan_mix_op(x, y, op)	(((x) + 0.0L) op ((y) + 0))
 
-#ifdef _COMPLEX_H
+#ifdef __STDC_VERSION_COMPLEX_H__
 
 /*
  * C99 specifies that complex numbers have the same representation as
@@ -657,7 +657,7 @@ CMPLXL(long double x, long double y)
 }
 #endif
 
-#endif /* _COMPLEX_H */
+#endif /* __STDC_VERSION_COMPLEX_H__ */
  
 /*
  * The rnint() family rounds to the nearest integer for a restricted range
@@ -897,7 +897,7 @@ double	__kernel_sin(double,double,int);
 double	__kernel_cos(double,double);
 double	__kernel_tan(double,double,int);
 double	__ldexp_exp(double,int);
-#ifdef _COMPLEX_H
+#ifdef __STDC_VERSION_COMPLEX_H__
 double complex __ldexp_cexp(double complex,int);
 #endif
 
@@ -915,7 +915,7 @@ float	__kernel_cosdf(double);
 float	__kernel_tandf(double,int);
 #endif
 float	__ldexp_expf(float,int);
-#ifdef _COMPLEX_H
+#ifdef __STDC_VERSION_COMPLEX_H__
 float complex __ldexp_cexpf(float complex,int);
 #endif
 

--- a/lib/msun/x86/fenv.h
+++ b/lib/msun/x86/fenv.h
@@ -26,8 +26,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef	_FENV_H_
-#define	_FENV_H_
+#ifndef __STDC_VERSION_FENV_H__
+#define __STDC_VERSION_FENV_H__ 202311L
 
 #include <sys/cdefs.h>
 #include <sys/_types.h>
@@ -359,4 +359,4 @@ __fesetenv_int(const fenv_t *__envp)
 
 __END_DECLS
 
-#endif	/* !_FENV_H_ */
+#endif	/* !__STDC_VERSION_FENV_H__ */

--- a/stand/libsa/geli/geliboot_internal.h
+++ b/stand/libsa/geli/geliboot_internal.h
@@ -28,9 +28,10 @@
 #ifndef _GELIBOOT_INTERNAL_H_
 #define _GELIBOOT_INTERNAL_H_
 
-#define _STRING_H_
+/* XXX: Perhaps we could do better for the _STANDALONE branch in g_eli.h? */
+#define __STDC_VERSION_STRING_H__	202311L
+#define __STDC_VERSION_STDIO_H__	202311L
 #define _STRINGS_H_
-#define _STDIO_H_
 
 #include <sys/endian.h>
 #include <sys/queue.h>

--- a/sys/arm/include/float.h
+++ b/sys/arm/include/float.h
@@ -32,6 +32,8 @@
 #ifndef _MACHINE_FLOAT_H_
 #define _MACHINE_FLOAT_H_ 1
 
+#define __STDC_VERSION_FLOAT_H__ 202311L
+
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS

--- a/sys/arm64/include/float.h
+++ b/sys/arm64/include/float.h
@@ -34,6 +34,8 @@
 #ifndef _MACHINE_FLOAT_H_
 #define	_MACHINE_FLOAT_H_
 
+#define __STDC_VERSION_FLOAT_H__ 202311L
+
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS

--- a/sys/powerpc/include/float.h
+++ b/sys/powerpc/include/float.h
@@ -33,6 +33,8 @@
 #ifndef _MACHINE_FLOAT_H_
 #define _MACHINE_FLOAT_H_ 1
 
+#define __STDC_VERSION_FLOAT_H__ 202311L
+
 #include <sys/cdefs.h>
 
 #ifndef _SOFT_FLOAT

--- a/sys/riscv/include/float.h
+++ b/sys/riscv/include/float.h
@@ -30,6 +30,8 @@
 #ifndef _MACHINE_FLOAT_H_
 #define	_MACHINE_FLOAT_H_
 
+#define __STDC_VERSION_FLOAT_H__ 202311L
+
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS

--- a/sys/sys/stdarg.h
+++ b/sys/sys/stdarg.h
@@ -1,6 +1,8 @@
 #ifndef __SYS_STDARG_H__
 #define	__SYS_STDARG_H__
 
+#define __STDC_VERSION_STDARG_H__ 202311L
+
 #include <sys/_stdarg.h>
 
 #endif	/* __SYS_STDARG_H__ */

--- a/sys/sys/stdint.h
+++ b/sys/sys/stdint.h
@@ -29,6 +29,8 @@
 #ifndef _SYS_STDINT_H_
 #define _SYS_STDINT_H_
 
+#define __STDC_VERSION_STDINT_H__ 202311L
+
 #include <sys/cdefs.h>
 #include <sys/_types.h>
 

--- a/sys/sys/syslimits.h
+++ b/sys/sys/syslimits.h
@@ -32,7 +32,8 @@
 #ifndef _SYS_SYSLIMITS_H_
 #define _SYS_SYSLIMITS_H_
 
-#if !defined(_STANDALONE) && !defined(_KERNEL) && !defined(_LIMITS_H_) && !defined(_SYS_PARAM_H_)
+#if !defined(_STANDALONE) && !defined(_KERNEL) && \
+    !defined(__STDC_VERSION_LIMITS_H__) && !defined(_SYS_PARAM_H_)
 #warning "No user-serviceable parts inside."
 #endif
 

--- a/sys/x86/include/float.h
+++ b/sys/x86/include/float.h
@@ -32,6 +32,8 @@
 #ifndef _MACHINE_FLOAT_H_
 #define _MACHINE_FLOAT_H_ 1
 
+#define __STDC_VERSION_FLOAT_H__ 202311L
+
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS


### PR DESCRIPTION
|   Header File   |        Feature Test Macro        |    Value    |  Conformance  |        Landed        |
|  :------------  |  :-----------------------------  |  :-------:  |  :----------  |  :-----------------  |
|  <assert.h>     |  `__STDC_VERSION_ASSERT_H__`     |  `202311L`  |  Full         |  2126cab             |
|  <complex.h>    |  `__STDC_VERSION_COMPLEX_H__`    |  `202311L`  |  Partial         |                      |
|  <fenv.h>       |  `__STDC_VERSION_FENV_H__`       |  `202311L`  |  Partial      |                      |
|  <float.h>      |  `__STDC_VERSION_FLOAT_H__`      |  `202311L`  |  Partial      |                      |
|  <inttypes.h>   |  `__STDC_VERSION_INTTYPES_H__`   |  `202311L`  |  Full      |  733ea4ee584db9b25b470ee48243135a321b4eed  |
|  <limits.h>     |  `__STDC_VERSION_LIMITS_H__`     |  `202311L`  |  Full      |  1f09e354297ce571353210c23e50ef6fc19ce382             |
|  <math.h>       |  `__STDC_VERSION_MATH_H__`       |  `202311L`  |  Partial      |                      |
|  <setjmp.h>     |  `__STDC_VERSION_SETJMP_H__`     |  `202311L`  |  Full         |  4aeed6e9d2132366fe5d7fa46d47d73be9de263b  |
|  <stdarg.h>     |  `__STDC_VERSION_STDARG_H__`     |  `202311L`  |  Partial      |                      |
|  <stdatomic.h>  |  `__STDC_VERSION_STDATOMIC_H__`  |  `202311L`  |  Full         |  85becda             |
|  <stdbit.h>     |  `__STDC_VERSION_STDBIT_H__`     |  `202311L`  |  Full         |  6296500             |
|  <stdckdint.h>  |  `__STDC_VERSION_STDCKDINT_H__`  |  `202311L`  |  Full         |  e6615b1             |
|  <stddef.h>     |  `__STDC_VERSION_STDDEF_H__`     |  `202311L`  |  Partial      |                      |
|  <stdint.h>     |  `__STDC_VERSION_STDINT_H__`     |  `202311L`  |  Full         |                      |
|  <stdio.h>      |  `__STDC_VERSION_STDIO_H__`      |  `202311L`  |  Full      | cd0727ec709bb54f8f82104f6113284a15dd3464 |
|  <stdlib.h>     |  `__STDC_VERSION_STDLIB_H__`     |  `202311L`  |  Partial      |                      |
|  <string.h>     |  `__STDC_VERSION_STRING_H__`     |  `202311L`  |  Partial      |                      |
|  <tgmath.h>     |  `__STDC_VERSION_TGMATH_H__`     |  `202311L`  |  Partial      |                      |
|  <time.h>       |  `__STDC_VERSION_TIME_H__`       |  `202311L`  |  Full         |  fc9d02cb29ed8505eeb4f90348b7318ddcfae434  |
|  <uchar.h>      |  `__STDC_VERSION_UCHAR_H__`      |  `202311L`  |  Partial      |                      |
|  <wchar.h>      |  `__STDC_VERSION_WCHAR_H__`      |  `202311L`  |  Partial      |                      |