### PR TITLE
nmdm/kern_conf: proper force-unload via destroy_dev_drain_pending()

### DIFF
--- a/sys/dev/nmdm/nmdm.c
+++ b/sys/dev/nmdm/nmdm.c
@@ -32,7 +32,7 @@
 
 #include <sys/cdefs.h>
 /*
- * Pseudo-nulmodem driver
+ * Pseudo-nullmodem driver
  * Mighty handy for use with serial console in Vmware
  */
 
@@ -115,16 +115,16 @@ nmdm_close(struct tty *tp)
 		return;
 
 	/* Shut down self. */
+	tty_lock(tp);
 	tty_rel_gone(tp);
 
 	/* Shut down second part. */
-	tty_lock(tp);
 	onp = np->np_other;
 	if (onp == NULL)
 		return;
 	otp = onp->np_tty;
+	tty_lock(otp);
 	tty_rel_gone(otp);
-	tty_lock(tp);
 }
 
 static void

--- a/sys/dev/nmdm/nmdm.c
+++ b/sys/dev/nmdm/nmdm.c
@@ -105,48 +105,66 @@ static TAILQ_HEAD(, nmdmsoftc) nmdmsoftc_list =
 static struct mtx nmdmsoftc_lock;
 MTX_SYSINIT(nmdmsoftc_lock, &nmdmsoftc_lock, "nmdmsoftc list", MTX_DEF);
 
-static void
+/*
+ * Tear down both halves of an nmdm pair.  Must be called with tp locked.
+ * Returns EBUSY (lock still held) if either side is open; returns 0 with
+ * the lock released on success.
+ */
+static int
 nmdm_destroy(struct tty *tp)
 {
-	struct nmdmpart *np;
+	struct nmdmpart *np = tty_softc(tp);
 	struct nmdmpart *onp;
 	struct tty *otp;
 
-	np = tty_softc(tp);
+	tty_assert_locked(tp);
 
-	/* Shut down self; tty_rel_gone() defers the free. */
-	tty_rel_gone(tp);
+	/* Cannot destroy while either side is still open. */
+	if (tty_opened(tp))
+		return (EBUSY);
+	onp = np->np_other;
+	if (onp != NULL && tty_opened(onp->np_tty))
+		return (EBUSY);
 
-	/* Shut down second (other) part. */
+	/* Mark self as gone; releases the shared tty lock. */
+	if (!tty_gone(tp))
+		tty_rel_gone(tp);
+	else {
+		tty_unlock(tp);
+	}
+
+	/* Both sides share ns_mtx; re-lock to operate on the other side. */
+	tty_lock(tp);
 	onp = np->np_other;
 	if (onp == NULL)
-		return;
+		return (0);
 
-	tty_lock(tp);
 	otp = onp->np_tty;
+	if (!tty_gone(otp))
+		tty_rel_gone(otp);	/* releases the lock */
+	else {
+		tty_unlock(otp);
+	}
 
-	tty_rel_gone(otp);
+	return (0);
 }
 
 static void
 nmdm_close(struct tty *tp)
 {
-	struct nmdmpart *np;
-	struct nmdmpart *onp;
-	struct tty *otp;
+	struct nmdmpart *np = tty_softc(tp);
+	struct tty *otp = np->np_other->np_tty;
 
-	np = tty_softc(tp);
-	onp = np->np_other;
-	otp = onp->np_tty;
-
-	/* If second part is opened, do not destroy ourselves. */
+	/* Defer teardown until both sides are closed. */
 	if (tty_opened(otp))
 		return;
 
-	mtx_lock(&nmdmsoftc_lock);
-	nmdm_destroy(tp);
-	tty_lock(otp);
-	mtx_unlock(&nmdmsoftc_lock);
+	/*
+	 * Neither side is open.  nmdm_destroy() releases the shared lock;
+	 * re-acquire via otp (same mutex) to restore the state callers expect.
+	 */
+	if (nmdm_destroy(tp) == 0)
+		tty_lock(otp);
 }
 
 static void
@@ -159,21 +177,23 @@ nmdm_free(void *softc)
 	taskqueue_drain(taskqueue_swi, &np->np_task);
 
 	/*
-	 * The function is called on both parts simultaneously.  We serialize
-	 * with help of ns_mtx.  The first invocation should return and
-	 * delegate freeing of resources to the second.
+	 * Both parts call nmdm_free(); the first returns after clearing
+	 * np_other and delegates cleanup to the second.  nmdmsoftc_lock is
+	 * always acquired before ns_mtx to maintain consistent lock ordering
+	 * with nmdm_unload().
 	 */
+	mtx_lock(&nmdmsoftc_lock);
 	mtx_lock(&ns->ns_mtx);
 	if (np->np_other != NULL) {
 		np->np_other->np_other = NULL;
 		mtx_unlock(&ns->ns_mtx);
+		mtx_unlock(&nmdmsoftc_lock);
 		return;
 	}
-	mtx_destroy(&ns->ns_mtx);
-
-	mtx_lock(&nmdmsoftc_lock);
 	TAILQ_REMOVE(&nmdmsoftc_list, ns, ns_list);
+	mtx_unlock(&ns->ns_mtx);
 	mtx_unlock(&nmdmsoftc_lock);
+	mtx_destroy(&ns->ns_mtx);
 
 	free(ns, M_NMDM);
 	atomic_subtract_int(&nmdm_count, 1);
@@ -449,25 +469,39 @@ nmdm_outwakeup(struct tty *tp)
 }
 
 static int
-nmdm_unload(void *data)
+nmdm_unload(void)
 {
 	struct nmdmsoftc *ns;
-	sbintime_t start_time = sbinuptime();
-	sbintime_t timeout = SBT_1S * 5; // Try to force unload for 5 seconds
+	int error;
 
+	/*
+	 * Destroy all nmdm pairs that are not in active use.  nmdmsoftc_lock
+	 * (outer) is held across tty_lock() (inner) to match the ordering in
+	 * nmdm_free(), preventing WITNESS lock-order violations.
+	 */
 	mtx_lock(&nmdmsoftc_lock);
 	TAILQ_FOREACH(ns, &nmdmsoftc_list, ns_list) {
 		tty_lock(ns->ns_part1.np_tty);
-		nmdm_destroy(ns->ns_part1.np_tty);
+		error = nmdm_destroy(ns->ns_part1.np_tty);
+		if (error != 0) {
+			/* Lock held on EBUSY; release before returning. */
+			tty_unlock(ns->ns_part1.np_tty);
+			mtx_unlock(&nmdmsoftc_lock);
+			return (EBUSY);
+		}
+		/* nmdm_destroy() released the lock on success. */
 	}
 	mtx_unlock(&nmdmsoftc_lock);
 
-	while (atomic_load_acq_int(&nmdm_count) > 0) {
-		if (sbinuptime() - start_time >= timeout) {
-			return (EBUSY);
-		}
-		pause_sbt("nmdm_unload", mstosbt(50), mstosbt(10), 0);
-	}
+	/*
+	 * tty_rel_gone() defers destruction through taskqueue_thread via
+	 * destroy_dev_sched_cb() -> tty_dealloc() -> nmdm_free().  Drain
+	 * that queue now so nmdm_count reflects the final state.
+	 */
+	destroy_dev_drain_pending();
+
+	if (atomic_load_acq_int(&nmdm_count) != 0)
+		return (EBUSY);
 
 	return (0);
 }
@@ -496,7 +530,7 @@ nmdm_modevent(module_t mod, int type, void *data)
 		break;
 
 	case MOD_UNLOAD:
-		if (nmdm_unload(data) != 0)
+		if (nmdm_unload() != 0)
 			return (EBUSY);
 
 		EVENTHANDLER_DEREGISTER(dev_clone, tag);

--- a/sys/dev/nmdm/nmdm.c
+++ b/sys/dev/nmdm/nmdm.c
@@ -95,9 +95,44 @@ struct nmdmsoftc {
 	struct nmdmpart	ns_part1;
 	struct nmdmpart	ns_part2;
 	struct mtx	ns_mtx;
+	TAILQ_ENTRY(nmdmsoftc)	ns_list;
 };
 
 static int nmdm_count = 0;
+
+static TAILQ_HEAD(, nmdmsoftc) nmdmsoftc_list =
+    TAILQ_HEAD_INITIALIZER(nmdmsoftc_list);
+static struct mtx nmdmsoftc_lock;
+MTX_SYSINIT(nmdmsoftc_lock, &nmdmsoftc_lock, "nmdmsoftc list", MTX_DEF);
+
+static void
+nmdm_destroy(struct tty *tp)
+{
+	struct nmdmpart *np;
+	struct nmdmpart *onp;
+	struct tty *otp;
+
+	np = tty_softc(tp);
+
+	if (np == NULL)
+		return;
+
+	if (tp) {
+		/* Shut down self; tty_rel_gone() defers the free. */
+		tty_lock(tp);
+		tty_rel_gone(tp);
+
+		/* Shut down second (other) part. */
+		onp = np->np_other;
+		if (onp == NULL)
+			return;
+
+		otp = onp->np_tty;
+
+		tty_lock(otp);
+		tty_rel_gone(otp);
+	}
+}
 
 static void
 nmdm_close(struct tty *tp)
@@ -114,17 +149,9 @@ nmdm_close(struct tty *tp)
 	if (tty_opened(otp))
 		return;
 
-	/* Shut down self. */
-	tty_lock(tp);
-	tty_rel_gone(tp);
-
-	/* Shut down second part. */
-	onp = np->np_other;
-	if (onp == NULL)
-		return;
-	otp = onp->np_tty;
-	tty_lock(otp);
-	tty_rel_gone(otp);
+	mtx_lock(&nmdmsoftc_lock);
+	nmdm_destroy(tp);
+	mtx_unlock(&nmdmsoftc_lock);
 }
 
 static void
@@ -148,6 +175,11 @@ nmdm_free(void *softc)
 		return;
 	}
 	mtx_destroy(&ns->ns_mtx);
+
+	mtx_lock(&nmdmsoftc_lock);
+	TAILQ_REMOVE(&nmdmsoftc_list, ns, ns_list);
+	mtx_unlock(&nmdmsoftc_lock);
+
 	free(ns, M_NMDM);
 	atomic_subtract_int(&nmdm_count, 1);
 }
@@ -223,6 +255,11 @@ nmdm_clone(void *arg, struct ucred *cred, char *name, int nameen,
 		*dev = ns->ns_part2.np_tty->t_dev;
 
 	*end = endc;
+
+	mtx_lock(&nmdmsoftc_lock);
+	TAILQ_INSERT_TAIL(&nmdmsoftc_list, ns, ns_list);
+	mtx_unlock(&nmdmsoftc_lock);
+
 	atomic_add_int(&nmdm_count, 1);
 }
 
@@ -416,6 +453,29 @@ nmdm_outwakeup(struct tty *tp)
 	taskqueue_enqueue(taskqueue_swi, &np->np_task);
 }
 
+static int
+nmdm_unload(void *data)
+{
+	struct nmdmsoftc *ns;
+	sbintime_t start_time = sbinuptime();
+	sbintime_t timeout = SBT_1S * 5; // Try to force unload for 5 seconds
+
+	mtx_lock(&nmdmsoftc_lock);
+	TAILQ_FOREACH(ns, &nmdmsoftc_list, ns_list) {
+		nmdm_destroy(ns->ns_part1.np_tty);
+	}
+	mtx_unlock(&nmdmsoftc_lock);
+
+	while (atomic_load_acq_int(&nmdm_count) > 0) {
+		if (sbinuptime() - start_time >= timeout) {
+			return (EBUSY);
+		}
+		pause_sbt("nmdm_unload", mstosbt(50), mstosbt(10), 0);
+	}
+
+	return (0);
+}
+
 /*
  * Module handling
  */
@@ -424,8 +484,8 @@ nmdm_modevent(module_t mod, int type, void *data)
 {
 	static eventhandler_tag tag;
 
-        switch(type) {
-        case MOD_LOAD: 
+	switch (type) {
+	case MOD_LOAD:
 		tag = EVENTHANDLER_REGISTER(dev_clone, nmdm_clone, 0, 1000);
 		if (tag == NULL)
 			return (ENOMEM);
@@ -434,10 +494,17 @@ nmdm_modevent(module_t mod, int type, void *data)
 	case MOD_SHUTDOWN:
 		break;
 
-	case MOD_UNLOAD:
-		if (nmdm_count != 0)
+	case MOD_QUIESCE:
+		if (atomic_load_acq_int(&nmdm_count) != 0)
 			return (EBUSY);
+		break;
+
+	case MOD_UNLOAD:
+		if (nmdm_unload(data) != 0)
+			return (EBUSY);
+
 		EVENTHANDLER_DEREGISTER(dev_clone, tag);
+		mtx_destroy(&nmdmsoftc_lock);
 		break;
 
 	default:

--- a/sys/dev/nmdm/nmdm.c
+++ b/sys/dev/nmdm/nmdm.c
@@ -114,24 +114,18 @@ nmdm_destroy(struct tty *tp)
 
 	np = tty_softc(tp);
 
-	if (np == NULL)
+	/* Shut down self; tty_rel_gone() defers the free. */
+	tty_rel_gone(tp);
+
+	/* Shut down second (other) part. */
+	onp = np->np_other;
+	if (onp == NULL)
 		return;
 
-	if (tp) {
-		/* Shut down self; tty_rel_gone() defers the free. */
-		tty_lock(tp);
-		tty_rel_gone(tp);
+	tty_lock(tp);
+	otp = onp->np_tty;
 
-		/* Shut down second (other) part. */
-		onp = np->np_other;
-		if (onp == NULL)
-			return;
-
-		otp = onp->np_tty;
-
-		tty_lock(otp);
-		tty_rel_gone(otp);
-	}
+	tty_rel_gone(otp);
 }
 
 static void
@@ -151,6 +145,7 @@ nmdm_close(struct tty *tp)
 
 	mtx_lock(&nmdmsoftc_lock);
 	nmdm_destroy(tp);
+	tty_lock(otp);
 	mtx_unlock(&nmdmsoftc_lock);
 }
 
@@ -462,6 +457,7 @@ nmdm_unload(void *data)
 
 	mtx_lock(&nmdmsoftc_lock);
 	TAILQ_FOREACH(ns, &nmdmsoftc_list, ns_list) {
+		tty_lock(ns->ns_part1.np_tty);
 		nmdm_destroy(ns->ns_part1.np_tty);
 	}
 	mtx_unlock(&nmdmsoftc_lock);

--- a/sys/kern/kern_conf.c
+++ b/sys/kern/kern_conf.c
@@ -1538,6 +1538,20 @@ destroy_dev_drain(struct cdevsw *csw)
 	dev_unlock();
 }
 
+/*
+ * Flush all pending deferred destroy_dev() operations.  Drivers that call
+ * tty_rel_gone() or destroy_dev_sched*() and need a synchronous teardown
+ * should call this after scheduling destruction and before checking whether
+ * their devices are gone.
+ */
+void
+destroy_dev_drain_pending(void)
+{
+
+	taskqueue_drain(taskqueue_thread, &dev_dtr_task);
+	taskqueue_drain(taskqueue_thread, &dev_dtr_task_giant);
+}
+
 #include "opt_ddb.h"
 #ifdef DDB
 #include <sys/kernel.h>

--- a/sys/sys/conf.h
+++ b/sys/sys/conf.h
@@ -279,6 +279,7 @@ void	destroy_dev(struct cdev *_dev);
 int	destroy_dev_sched(struct cdev *dev);
 int	destroy_dev_sched_cb(struct cdev *dev, void (*cb)(void *), void *arg);
 void	destroy_dev_drain(struct cdevsw *csw);
+void	destroy_dev_drain_pending(void);
 void	dev_copyname(struct cdev *dev, char *path, size_t len);
 struct cdevsw *dev_refthread(struct cdev *_dev, int *_ref);
 struct cdevsw *devvn_refthread(struct vnode *vp, struct cdev **devp, int *_ref);


### PR DESCRIPTION
This is a follow-up to #1367, addressing the feedback from @kevans91 that was never completed.

The original PR fixed a bug where accidentally-created nmdm devices (e.g. via `ls /dev/nmdmAA`) would prevent the module from unloading, and added `kldunload -f` support. It was not merged because the unload path used a 5-second busy-wait instead of proper plumbing through the tty/cdev layers, and had a lock-ordering issue.

This PR makes two additional changes on top of the original three commits:

**`kern_conf: add destroy_dev_drain_pending()`**
Adds a new KPI that synchronously drains the `taskqueue_thread` tasks responsible for deferred `destroy_dev_sched*()`/`tty_rel_gone()` teardown. This is the `tty_drain_freed → destroy_dev_drain_pending → taskqueue_drain` plumbing @kevans91 described.

**`nmdm: replace force-unload timeout with destroy_dev_drain_pending()`**
- Replaces the 5-second polling loop with a call to `destroy_dev_drain_pending()` after scheduling destruction of all idle pairs.
- `nmdm_destroy()` now returns `EBUSY` immediately (lock still held) if either side is open, so `nmdm_unload()` fails fast for pairs that won't go away.
- `nmdm_free()` now acquires `nmdmsoftc_lock` before `ns_mtx`, matching `nmdm_unload()`'s ordering and eliminating the WITNESS lock-order violation. `nmdm_close()` no longer needs `nmdmsoftc_lock` at all.
