### PR TITLE
Fix dangling dev->driver pointer when unloading a driver with probed-but-not-attached devices

### DIFF
--- a/sys/kern/subr_bus.c
+++ b/sys/kern/subr_bus.c
@@ -804,6 +804,12 @@ devclass_driver_deleted(devclass_t busclass, devclass_t dc, driver_t *driver)
 			    dev->parent->devclass == busclass) {
 				if ((error = device_detach(dev)) != 0)
 					return (error);
+				/*
+				 * Clear driver associated with this device, if
+				 * any remain from non-fully attached devices.
+				 */
+				if (dev->driver == driver)
+					(void)device_set_driver(dev, NULL);
 				if (device_frozen) {
 					dev->flags &= ~DF_DONENOMATCH;
 					dev->flags |= DF_NEEDNOMATCH;


### PR DESCRIPTION
**Problem**

When a driver module is unloaded, `devclass_driver_deleted()` calls `device_detach()` for each device using that driver. However, `device_detach()` is a no-op if the device is not in `DS_ATTACHED` state — it returns 0 immediately without clearing `dev->driver`.

This occurs whenever a device was successfully probed (setting `dev->driver` into module memory and transitioning to `DS_ALIVE`) but attach was never reached — most commonly because `device_attach()` returned early on a `resource_disabled()` hint check. After `kldunload`, `dev->driver` is a dangling pointer into freed module pages.

A subsequent `sysctl hw.bus.devices` query (e.g. from `devmatch`) calls `sysctl_devices()`, which dereferences `dev->driver->name` — triggering a page fault and kernel panic.

This affects any loadable driver whose probe succeeds but whose attach is blocked by hints. The entire HID leaf driver family (`hms`, `hkbd`, `hcons`, `hmt`, `hpen`, `hgame`, `hidraw`, `bcm5974`, `appleir`, `hconf`, `hsctrl`, `ietp`, `ps4dshock`, `u2f`, `wmt`, `xb360gp`) is in this category, as none perform their own `resource_disabled()` check in probe.

**Fix**

After `device_detach()` returns in `devclass_driver_deleted()`, check whether `dev->driver` still points at the departing driver and call `device_set_driver(dev, NULL)` to release it before the module is freed.

**Reproducer**

```
hint.hms.0.disabled="1"   # in /boot/device.hints
```
Boot, then `kldunload hms` (or wait for `devmatch` to run). Kernel panics in `sysctl_devices()` with a page fault at the address where `hms.ko` was mapped.
