### PR TITLE
arch.7: remove powerpcspe

### DIFF
--- a/share/man/man7/arch.7
+++ b/share/man/man7/arch.7
@@ -234,7 +234,6 @@ Machine-dependent type sizes:
 .It armv7       Ta 4 Ta  4 Ta  8 Ta 8
 .It i386        Ta 4 Ta  4 Ta 12 Ta 4
 .It powerpc     Ta 4 Ta  4 Ta  8 Ta 8
-.It powerpcspe  Ta 4 Ta  4 Ta  8 Ta 8
 .It powerpc64   Ta 8 Ta  8 Ta  8 Ta 8
 .It powerpc64le Ta 8 Ta  8 Ta  8 Ta 8
 .It riscv64     Ta 8 Ta  8 Ta 16 Ta 8
@@ -252,7 +251,6 @@ is 8 bytes on all supported architectures except i386.
 .It armv7       Ta little Ta unsigned
 .It i386        Ta little Ta   signed
 .It powerpc     Ta big    Ta unsigned
-.It powerpcspe  Ta big    Ta unsigned
 .It powerpc64   Ta big    Ta unsigned
 .It powerpc64le Ta little Ta unsigned
 .It riscv64     Ta little Ta   signed
@@ -267,7 +265,6 @@ is 8 bytes on all supported architectures except i386.
 .It armv7       Ta 4K, 1M
 .It i386        Ta 4K, 2M (PAE), 4M
 .It powerpc     Ta 4K
-.It powerpcspe  Ta 4K
 .It powerpc64   Ta 4K
 .It powerpc64le Ta 4K
 .It riscv64     Ta 4K, 2M, 1G
@@ -283,7 +280,6 @@ is 8 bytes on all supported architectures except i386.
 .It armv7          Ta 0xbfc00000         Ta 3GiB
 .It i386           Ta 0xffc00000         Ta 4GiB
 .It powerpc        Ta 0xfffff000         Ta 4GiB
-.It powerpcspe     Ta 0x7ffff000         Ta 2GiB
 .It powerpc64      Ta 0x000fffffc0000000 Ta 4PiB
 .It powerpc64le    Ta 0x000fffffc0000000 Ta 4PiB
 .It riscv64 (Sv39) Ta 0x0000004000000000 Ta 256GiB
@@ -339,7 +335,6 @@ currently supports Sv39 and Sv48 and defaults to using Sv39.
 .It armv7       Ta hard Ta hard, double precision
 .It i386        Ta hard Ta hard, 80 bit
 .It powerpc     Ta hard Ta hard, double precision
-.It powerpcspe  Ta hard Ta hard, double precision
 .It powerpc64   Ta hard Ta hard, double precision
 .It powerpc64le Ta hard Ta hard, double precision
 .It riscv64     Ta hard Ta hard, quad precision
@@ -374,7 +369,7 @@ or similar things like boot sequences.
 .It amd64 Ta amd64 Ta amd64
 .It arm Ta arm Ta armv7
 .It i386 Ta i386 Ta i386
-.It powerpc Ta powerpc Ta powerpc, powerpcspe, powerpc64, powerpc64le
+.It powerpc Ta powerpc Ta powerpc, powerpc64, powerpc64le
 .It riscv Ta riscv Ta riscv64, riscv64c
 .El
 .Ss Predefined Macros
@@ -427,7 +422,6 @@ Architecture-specific macros:
 .It armv7       Ta Dv __arm__ , Dv __ARM_ARCH >= 7
 .It i386        Ta Dv __i386__
 .It powerpc     Ta Dv __powerpc__
-.It powerpcspe  Ta Dv __powerpc__ , Dv __SPE__
 .It powerpc64   Ta Dv __powerpc__ , Dv __powerpc64__
 .It powerpc64le Ta Dv __powerpc__ , Dv __powerpc64__
 .It riscv64     Ta Dv __riscv , Dv __riscv_xlen == 64


### PR DESCRIPTION
Unlike powerpc, powerpcspe binaries cannot run through lib32 on powerpc64 since powerpc64 doesn't have SPE instructions.

Signed-off-by: Minsoo Choo <minsoo@minsoo.io>

Fixes:		072f54bf9ff3 ("arch.7: Move i386, powerpc, and powerpcspe to the discontinued arch list")

Edit: subject to stable/15 mfc