### PR TITLE
ukbd: fix SET_REPORT wValue always using report ID 0 for LED output

### DIFF
--- a/sys/dev/usb/input/ukbd.c
+++ b/sys/dev/usb/input/ukbd.c
@@ -959,7 +959,6 @@ ukbd_set_leds_callback(struct usb_xfer *xfer, usb_error_t error)
 
 		req.bmRequestType = UT_WRITE_CLASS_INTERFACE;
 		req.bRequest = UR_SET_REPORT;
-		USETW2(req.wValue, UHID_OUTPUT_REPORT, 0);
 		req.wIndex[0] = sc->sc_iface_no;
 		req.wIndex[1] = 0;
 		req.wLength[1] = 0;
@@ -1001,6 +1000,8 @@ ukbd_set_leds_callback(struct usb_xfer *xfer, usb_error_t error)
 		/* if no leds, nothing to do */
 		if (!any)
 			break;
+
+		USETW2(req.wValue, UHID_OUTPUT_REPORT, id);
 
 		/* range check output report length */
 		len = sc->sc_led_size;


### PR DESCRIPTION
ukbd_set_leds_callback() built the SET_REPORT control request with USETW2(req.wValue, UHID_OUTPUT_REPORT, 0) before the loop that determines the actual HID report ID from sc_id_numlock, sc_id_scrolllock, or sc_id_capslock.  The data payload was already correctly prefixed with the real report ID when id != 0, but the control request's wValue told the device to set report ID 0, which does not exist on devices that use non-zero report IDs for LED output.

Apple Internal Keyboard / Trackpad (0x05ac:0x0274) uses report ID 1 for LED output.  The mismatch caused the device to STALL every SET_REPORT request, so the capslock LED could never be updated.

Move the USETW2 call to after the LED-detection loop so that wValue carries the correct report ID.

This fixes https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=279690.