### PR TITLE
usbc: USB-PD R3.2 policy SM + TCPC abstraction

### DIFF
--- a/sys/dev/iicbus/usb/usbc/usbc_pd.h
+++ b/sys/dev/iicbus/usb/usbc/usbc_pd.h
@@ -1,0 +1,179 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Kyle Crenshaw
+ * All rights reserved.
+ */
+
+#ifndef _USBC_PD_H_
+#define _USBC_PD_H_
+
+#include <sys/param.h>
+#include <sys/types.h>
+
+/*
+ * USB Power Delivery R3.2 base types, enums, and timing constants
+ * shared across the message, protocol, and policy layers.  Hardware
+ * independent: this header may be included by a chip driver, by the
+ * policy state machine, or by altmode helpers.
+ */
+
+/* SOP* packet types per USB PD 6.6 */
+enum usbc_pd_sop {
+	USBC_PD_SOP        = 0,	/* port-to-port */
+	USBC_PD_SOP_PRIME  = 1,	/* port-to-cable plug (near end) */
+	USBC_PD_SOP_DPRIME = 2,	/* port-to-cable plug (far end) */
+	USBC_PD_SOP_DEBUG_PRIME  = 3,
+	USBC_PD_SOP_DEBUG_DPRIME = 4,
+};
+
+/* Power roles per PD 6.2.1.1.4 */
+enum usbc_pd_power_role {
+	USBC_PD_ROLE_SINK   = 0,
+	USBC_PD_ROLE_SOURCE = 1,
+};
+
+/* Data roles per PD 6.2.1.1.6 */
+enum usbc_pd_data_role {
+	USBC_PD_DATA_UFP = 0,
+	USBC_PD_DATA_DFP = 1,
+};
+
+/* PD spec revision per PD 6.2.1.1.5 */
+enum usbc_pd_rev {
+	USBC_PD_REV_1_0 = 0,
+	USBC_PD_REV_2_0 = 1,
+	USBC_PD_REV_3_0 = 2,
+	/* PD 3.1+ uses extended fields, encoded as REV_3_0 in the
+	 * 2-bit message header field. */
+};
+
+/* CC line orientation as detected by the TCPC */
+enum usbc_pd_polarity {
+	USBC_PD_POLARITY_CC1 = 0,
+	USBC_PD_POLARITY_CC2 = 1,
+};
+
+/* Source Rp current advertisement per Type-C Table 4-27 */
+enum usbc_pd_rp_value {
+	USBC_PD_RP_USB_DEFAULT = 0,	/* 80uA, 500/900mA */
+	USBC_PD_RP_1_5A        = 1,	/* 180uA, 1.5A@5V */
+	USBC_PD_RP_3_0A        = 2,	/* 330uA, 3.0A@5V */
+};
+
+/*
+ * PD message header (16 bits) per PD 6.2.1
+ * bit 15:    Extended (1 = extended message)
+ * bit 14:12: Number of Data Objects (0..7)
+ * bit 11: 9: MessageID (rolling counter)
+ * bit  8:    Port Power Role / Cable Plug
+ * bit  7: 6: Specification Revision
+ * bit  5:    Port Data Role
+ * bit  4: 0: Message Type
+ */
+#define	USBC_PD_HDR_EXTENDED		(1u << 15)
+#define	USBC_PD_HDR_NDO_SHIFT		12
+#define	USBC_PD_HDR_NDO_MASK		(0x7u << 12)
+#define	USBC_PD_HDR_MSGID_SHIFT		9
+#define	USBC_PD_HDR_MSGID_MASK		(0x7u << 9)
+#define	USBC_PD_HDR_POWER_ROLE		(1u << 8)
+#define	USBC_PD_HDR_REV_SHIFT		6
+#define	USBC_PD_HDR_REV_MASK		(0x3u << 6)
+#define	USBC_PD_HDR_DATA_ROLE		(1u << 5)
+#define	USBC_PD_HDR_TYPE_MASK		0x1fu
+
+#define	USBC_PD_HDR_GET_NDO(h)		(((h) & USBC_PD_HDR_NDO_MASK) >> 12)
+#define	USBC_PD_HDR_GET_MSGID(h)	(((h) & USBC_PD_HDR_MSGID_MASK) >> 9)
+#define	USBC_PD_HDR_GET_REV(h)		(((h) & USBC_PD_HDR_REV_MASK) >> 6)
+#define	USBC_PD_HDR_GET_TYPE(h)		((h) & USBC_PD_HDR_TYPE_MASK)
+
+/* Control message types (NDO=0) per PD 6.3 */
+#define	USBC_PD_CTRL_GOOD_CRC		0x01
+#define	USBC_PD_CTRL_GOTO_MIN		0x02
+#define	USBC_PD_CTRL_ACCEPT		0x03
+#define	USBC_PD_CTRL_REJECT		0x04
+#define	USBC_PD_CTRL_PING		0x05
+#define	USBC_PD_CTRL_PS_RDY		0x06
+#define	USBC_PD_CTRL_GET_SRC_CAP	0x07
+#define	USBC_PD_CTRL_GET_SNK_CAP	0x08
+#define	USBC_PD_CTRL_DR_SWAP		0x09
+#define	USBC_PD_CTRL_PR_SWAP		0x0a
+#define	USBC_PD_CTRL_VCONN_SWAP		0x0b
+#define	USBC_PD_CTRL_WAIT		0x0c
+#define	USBC_PD_CTRL_SOFT_RESET		0x0d
+#define	USBC_PD_CTRL_NOT_SUPPORTED	0x10
+#define	USBC_PD_CTRL_GET_SRC_CAP_EXT	0x11
+#define	USBC_PD_CTRL_GET_STATUS		0x12
+
+/* Data message types (NDO>0) per PD 6.4 */
+#define	USBC_PD_DATA_SRC_CAP		0x01
+#define	USBC_PD_DATA_REQUEST		0x02
+#define	USBC_PD_DATA_BIST		0x03
+#define	USBC_PD_DATA_SNK_CAP		0x04
+#define	USBC_PD_DATA_BATTERY_STATUS	0x05
+#define	USBC_PD_DATA_ALERT		0x06
+#define	USBC_PD_DATA_VENDOR		0x0f
+
+/*
+ * Power Data Object (32 bits) per PD 6.4.1
+ * Fixed Supply PDO bits [31:30] = 00:
+ * bit 31:30 type (00 = Fixed)
+ * bit 29    Dual-Role Power
+ * bit 28    USB Suspend Supported
+ * bit 27    Unconstrained Power
+ * bit 26    USB Communications Capable
+ * bit 25    Dual-Role Data
+ * bit 24    Unchunked Extended Messages Supported (PD 3.0)
+ * bit 23:22 Fast Role Swap (PD 3.0)
+ * bit 21:20 Reserved
+ * bit 19:10 Voltage in 50mV units
+ * bit  9: 0 Maximum Current in 10mA units
+ */
+#define	USBC_PD_PDO_TYPE_FIXED		(0u << 30)
+#define	USBC_PD_PDO_TYPE_BATTERY	(1u << 30)
+#define	USBC_PD_PDO_TYPE_VARIABLE	(2u << 30)
+#define	USBC_PD_PDO_TYPE_AUGMENTED	(3u << 30)
+#define	USBC_PD_PDO_TYPE_MASK		(3u << 30)
+
+#define	USBC_PD_PDO_FIXED_DUAL_ROLE_PWR		(1u << 29)
+#define	USBC_PD_PDO_FIXED_USB_SUSPEND		(1u << 28)
+#define	USBC_PD_PDO_FIXED_UNCONSTRAINED		(1u << 27)
+#define	USBC_PD_PDO_FIXED_USB_COMMS		(1u << 26)
+#define	USBC_PD_PDO_FIXED_DUAL_ROLE_DATA	(1u << 25)
+#define	USBC_PD_PDO_FIXED_UNCHUNKED_EXT		(1u << 24)
+
+#define	USBC_PD_PDO_FIXED_VOLTAGE_SHIFT		10
+#define	USBC_PD_PDO_FIXED_VOLTAGE_MASK		(0x3ffu << 10)
+#define	USBC_PD_PDO_FIXED_CURRENT_MASK		0x3ffu
+
+#define	USBC_PD_PDO_FIXED_VOLTAGE_MV(mv)	\
+	((((uint32_t)(mv) / 50) & 0x3ffu) << USBC_PD_PDO_FIXED_VOLTAGE_SHIFT)
+#define	USBC_PD_PDO_FIXED_CURRENT_MA(ma)	\
+	(((uint32_t)(ma) / 10) & USBC_PD_PDO_FIXED_CURRENT_MASK)
+
+#define	USBC_PD_PDO_FIXED_GET_VOLTAGE_MV(p)	\
+	((((p) & USBC_PD_PDO_FIXED_VOLTAGE_MASK) >> 10) * 50)
+#define	USBC_PD_PDO_FIXED_GET_CURRENT_MA(p)	\
+	(((p) & USBC_PD_PDO_FIXED_CURRENT_MASK) * 10)
+
+/*
+ * PD timing constants per PD Table 6-68 (R3.2).  These are the
+ * spec-mandated values; chip drivers and policy state machines
+ * should reference these names rather than re-inventing literals.
+ */
+#define	USBC_PD_T_CC_DEBOUNCE_MS	100	/* 100..200 ms */
+#define	USBC_PD_T_PD_DEBOUNCE_MS	15	/* 10..20  ms */
+#define	USBC_PD_T_VBUS_ON_MS		275	/* tVBUSON, max */
+#define	USBC_PD_T_VBUS_OFF_MS		650	/* tVBUSOFF, max */
+#define	USBC_PD_T_SENDER_RESPONSE_MS	27	/* 24..30  ms */
+#define	USBC_PD_T_SRC_TRANSITION_MS	30	/* 25..35  ms */
+#define	USBC_PD_T_NO_RESPONSE_MS	5000	/* 4.5..5.5 s */
+#define	USBC_PD_T_TYPEC_SEND_SRCCAP_MS	150	/* 100..200 ms */
+#define	USBC_PD_T_TYPEC_SINK_WAIT_CAP_MS 350	/* 310..620 ms */
+#define	USBC_PD_T_PS_TRANSITION_MS	500	/* 450..550 ms */
+#define	USBC_PD_T_PS_HARD_RESET_MS	30	/* 25..35  ms */
+#define	USBC_PD_T_SAFE_5V_MS		275	/* tSafe5V, max */
+#define	USBC_PD_N_CAPS_COUNT		50
+#define	USBC_PD_N_HARD_RESET_COUNT	2	/* spec nHardResetCount */
+
+#endif /* !_USBC_PD_H_ */

--- a/sys/dev/iicbus/usb/usbc/usbc_pd_msg.c
+++ b/sys/dev/iicbus/usb/usbc/usbc_pd_msg.c
@@ -1,0 +1,211 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Kyle Crenshaw
+ * All rights reserved.
+ */
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/systm.h>
+
+#include <dev/iicbus/usb/usbc/usbc_pd.h>
+#include <dev/iicbus/usb/usbc/usbc_pd_msg.h>
+
+/*
+ * usbc_pd_build_header
+ *
+ * Pack a USB-PD message header (16 bits, PD spec 6.2.1) from its
+ * constituent fields.  Layout written here matches the wire format
+ * the BMC encoder on a TCPC chip expects: type in bits [4:0], data
+ * role in bit 5, spec rev in bits [7:6], power role in bit 8,
+ * MessageID in bits [11:9], and number of data objects in bits
+ * [14:12].  Bit 15 (extended-message flag) is left clear; callers
+ * doing extended messages would OR in USBC_PD_HDR_EXTENDED.
+ *
+ * The resulting uint16_t is bus-byte-order-neutral: chip drivers that
+ * write it byte-by-byte to a TX FIFO must split it into LSB then MSB,
+ * which is what every existing chip driver in tree already does.
+ */
+uint16_t
+usbc_pd_build_header(uint8_t type, uint8_t ndo, uint8_t msg_id,
+    enum usbc_pd_power_role power_role, enum usbc_pd_data_role data_role,
+    enum usbc_pd_rev rev)
+{
+	uint16_t h = 0;
+
+	h |= (type & USBC_PD_HDR_TYPE_MASK);
+	h |= ((uint16_t)(ndo & 0x7) << USBC_PD_HDR_NDO_SHIFT);
+	h |= ((uint16_t)(msg_id & 0x7) << USBC_PD_HDR_MSGID_SHIFT);
+	h |= ((uint16_t)(rev & 0x3) << USBC_PD_HDR_REV_SHIFT);
+
+	if (power_role == USBC_PD_ROLE_SOURCE)
+		h |= USBC_PD_HDR_POWER_ROLE;
+	if (data_role == USBC_PD_DATA_DFP)
+		h |= USBC_PD_HDR_DATA_ROLE;
+
+	return (h);
+}
+
+/*
+ * usbc_pd_build_fixed_pdo
+ *
+ * Construct a Fixed Supply Power Data Object (PD spec 6.4.1.2.3).
+ * Voltage is encoded in 50 mV units in bits [19:10] and max current in
+ * 10 mA units in bits [9:0].  `flags` is the bitmap of fixed-supply
+ * capability bits (USB_COMMS, DUAL_ROLE, UNCHUNKED_EXT, etc) ORed in
+ * by the caller, since which flags to advertise is a policy decision
+ * the protocol layer cannot decide on its own.
+ *
+ * A 5V@900mA, USB-comms-capable PDO — the minimum valid Source PDO
+ * for a port that wants to claim USB host capability — is built as:
+ *   usbc_pd_build_fixed_pdo(5000, 900, USBC_PD_PDO_FIXED_USB_COMMS)
+ */
+uint32_t
+usbc_pd_build_fixed_pdo(uint16_t voltage_mv, uint16_t max_current_ma,
+    uint32_t flags)
+{
+	uint32_t pdo;
+
+	pdo = USBC_PD_PDO_TYPE_FIXED;
+	pdo |= USBC_PD_PDO_FIXED_VOLTAGE_MV(voltage_mv);
+	pdo |= USBC_PD_PDO_FIXED_CURRENT_MA(max_current_ma);
+	pdo |= flags;
+	return (pdo);
+}
+
+/*
+ * usbc_pd_build_request
+ *
+ * Build a Sink Request Data Object (RDO, PD spec 6.4.2) selecting one
+ * of the source's advertised PDOs.  pdo_index is 1-based per spec and
+ * gets clamped into the legal [1..7] range.
+ *
+ * op_current_ma is what the sink intends to draw under normal
+ * operation; max_current_ma is its absolute upper limit (including
+ * inrush).  Both go into the RDO in 10 mA units.  Caller adds RDO
+ * flags (giveback, capability mismatch, USB-comms capable, no-suspend,
+ * unchunked extended messages) via the `flags` argument; we don't pick
+ * those defaults here because they are policy decisions tied to the
+ * sink's device profile, not the message format.
+ */
+uint32_t
+usbc_pd_build_request(uint8_t pdo_index, uint16_t op_current_ma,
+    uint16_t max_current_ma, uint32_t flags)
+{
+	uint32_t rdo;
+
+	if (pdo_index < 1)
+		pdo_index = 1;
+	if (pdo_index > 7)
+		pdo_index = 7;
+
+	rdo = ((uint32_t)pdo_index << 28);
+	rdo |= flags;
+	rdo |= ((uint32_t)(op_current_ma / 10) & 0x3ff) << 10;
+	rdo |= ((uint32_t)(max_current_ma / 10) & 0x3ff);
+	return (rdo);
+}
+
+/*
+ * usbc_pd_msg_ctrl
+ *
+ * Convenience constructor for a complete control message (no data
+ * objects, header only).  Used by the policy layer to build messages
+ * like Accept, Reject, PS_RDY, Soft_Reset, Get_Snk_Cap — anything
+ * where the message type alone carries the meaning.  ndo is fixed at
+ * 0 to satisfy the wire-format invariant for control messages.
+ *
+ * Returns false if msg is NULL; otherwise unconditionally succeeds.
+ */
+bool
+usbc_pd_msg_ctrl(struct usbc_pd_msg *msg, uint8_t ctrl_type, uint8_t msg_id,
+    enum usbc_pd_power_role pr, enum usbc_pd_data_role dr,
+    enum usbc_pd_rev rev)
+{
+	if (msg == NULL)
+		return (false);
+
+	msg->hdr = usbc_pd_build_header(ctrl_type, 0, msg_id, pr, dr, rev);
+	msg->ndo = 0;
+	return (true);
+}
+
+/*
+ * usbc_pd_msg_data
+ *
+ * Convenience constructor for a complete data message: header + 1..7
+ * 32-bit data objects.  Used for Source_Capabilities (PDOs), Request
+ * (RDO), Sink_Capabilities, BIST, and Vendor messages.
+ *
+ * Returns false on any of: NULL msg or data, ndo == 0 (data messages
+ * MUST carry at least one object), or ndo > 7 (the wire format only
+ * has 3 bits for the count).  On success, copies ndo*4 bytes from
+ * data[] into msg->data[] and stamps the header with the right ndo
+ * field.
+ */
+bool
+usbc_pd_msg_data(struct usbc_pd_msg *msg, uint8_t data_type,
+    const uint32_t *data, uint8_t ndo, uint8_t msg_id,
+    enum usbc_pd_power_role pr, enum usbc_pd_data_role dr,
+    enum usbc_pd_rev rev)
+{
+	if (msg == NULL || ndo == 0 || ndo > 7 || data == NULL)
+		return (false);
+
+	msg->hdr = usbc_pd_build_header(data_type, ndo, msg_id, pr, dr, rev);
+	msg->ndo = ndo;
+	memcpy(msg->data, data, ndo * sizeof(uint32_t));
+	return (true);
+}
+
+/*
+ * usbc_pd_build_vdm_header
+ *
+ * Build the 32-bit Structured VDM header per PD 6.4.4.2.1.  Caller
+ * supplies the SVID, command, command type (REQ/ACK/NAK/BUSY), and
+ * object position (1..7 for Enter/Exit Mode, 0 elsewhere).  Always
+ * sets the Structured VDM flag and Version=2.0.
+ */
+uint32_t
+usbc_pd_build_vdm_header(uint16_t svid, uint8_t cmd, uint8_t cmd_type,
+    uint8_t obj_pos)
+{
+	uint32_t h;
+
+	h = (uint32_t)svid << 16;
+	h |= USBC_VDM_HDR_STRUCTURED;
+	h |= (1u << USBC_VDM_HDR_VER_SHIFT);	/* Version 2.0 */
+	h |= ((uint32_t)(obj_pos & 0x7u)) << USBC_VDM_HDR_OBJPOS_SHIFT;
+	h |= ((uint32_t)(cmd_type & 0x3u)) << USBC_VDM_HDR_CMDTYPE_SHIFT;
+	h |= cmd & 0x1fu;
+	return (h);
+}
+
+/*
+ * usbc_pd_msg_vdm
+ *
+ * Compose a Structured VDM as a Vendor data message.  Payload is
+ * [VDM_header, vdo[0], vdo[1], ...]; vdo_count is the number of VDOs
+ * after the header (1 + vdo_count must fit in 7 data objects).
+ */
+bool
+usbc_pd_msg_vdm(struct usbc_pd_msg *msg, uint16_t svid, uint8_t cmd,
+    uint8_t cmd_type, uint8_t obj_pos, const uint32_t *vdos,
+    uint8_t vdo_count, uint8_t msg_id, enum usbc_pd_power_role pr,
+    enum usbc_pd_data_role dr, enum usbc_pd_rev rev)
+{
+	uint32_t payload[7];
+	uint8_t i;
+
+	if (msg == NULL || vdo_count > 6 ||
+	    (vdo_count > 0 && vdos == NULL))
+		return (false);
+
+	payload[0] = usbc_pd_build_vdm_header(svid, cmd, cmd_type, obj_pos);
+	for (i = 0; i < vdo_count; i++)
+		payload[i + 1] = vdos[i];
+
+	return (usbc_pd_msg_data(msg, USBC_PD_DATA_VENDOR, payload,
+	    1 + vdo_count, msg_id, pr, dr, rev));
+}

--- a/sys/dev/iicbus/usb/usbc/usbc_pd_msg.h
+++ b/sys/dev/iicbus/usb/usbc/usbc_pd_msg.h
@@ -1,0 +1,174 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Kyle Crenshaw
+ * All rights reserved.
+ */
+
+#ifndef _USBC_PD_MSG_H_
+#define _USBC_PD_MSG_H_
+
+#include <dev/iicbus/usb/usbc/usbc_pd.h>
+
+/*
+ * Hardware-independent helpers for building and parsing PD messages.
+ * The TCPC chip driver puts the resulting header + payload into its
+ * TX FIFO using whatever framing the chip requires (BMC tokens for
+ * FUSB302, or a raw packet for ITE TCPCI-class chips).
+ */
+
+struct usbc_pd_msg {
+	uint16_t	hdr;
+	uint8_t		ndo;		/* number of data objects, 0..7 */
+	uint32_t	data[7];
+};
+
+/*
+ * Build a PD message header (no data objects).
+ *
+ * type:	control or data message type (USBC_PD_CTRL_* / USBC_PD_DATA_*)
+ * ndo:		number of 32-bit data objects (0 for control messages)
+ * msg_id:	rolling 3-bit MessageID counter, caller-managed
+ * power_role:	source/sink (USBC_PD_ROLE_*)
+ * data_role:	UFP/DFP (USBC_PD_DATA_*)
+ * rev:		PD revision (USBC_PD_REV_*)
+ */
+uint16_t	usbc_pd_build_header(uint8_t type, uint8_t ndo, uint8_t msg_id,
+		    enum usbc_pd_power_role power_role,
+		    enum usbc_pd_data_role data_role,
+		    enum usbc_pd_rev rev);
+
+/*
+ * Build a Fixed Supply Source PDO at the given voltage and max current.
+ * Caller selects flags from USBC_PD_PDO_FIXED_* (USB_COMMS, DUAL_ROLE,
+ * UNCHUNKED_EXT, etc) and ORs them into the result.
+ */
+uint32_t	usbc_pd_build_fixed_pdo(uint16_t voltage_mv,
+		    uint16_t max_current_ma, uint32_t flags);
+
+/*
+ * Build a Fixed Supply Sink Request data object (RDO).
+ *
+ * pdo_index:	1-based index of the source PDO being selected
+ * op_current_ma:	operating current the sink will draw
+ * max_current_ma:	maximum current the sink may draw
+ * flags:	bitmap of additional RDO flags (giveback, capability mismatch,
+ *		USB comms, no suspend, etc — see PD 6.4.2)
+ */
+#define	USBC_PD_RDO_GIVEBACK		(1u << 27)
+#define	USBC_PD_RDO_CAP_MISMATCH	(1u << 26)
+#define	USBC_PD_RDO_USB_COMMS_CAPABLE	(1u << 25)
+#define	USBC_PD_RDO_NO_USB_SUSPEND	(1u << 24)
+#define	USBC_PD_RDO_UNCHUNKED_EXT	(1u << 23)
+
+uint32_t	usbc_pd_build_request(uint8_t pdo_index, uint16_t op_current_ma,
+		    uint16_t max_current_ma, uint32_t flags);
+
+/*
+ * Convenience: build a complete control message (header only, no data).
+ * Returns true on success.
+ */
+bool		usbc_pd_msg_ctrl(struct usbc_pd_msg *msg, uint8_t ctrl_type,
+		    uint8_t msg_id, enum usbc_pd_power_role pr,
+		    enum usbc_pd_data_role dr, enum usbc_pd_rev rev);
+
+/*
+ * Convenience: build a complete data message with the given PDO/RDO/etc
+ * payload.  Returns true if the payload fits in 7 data objects.
+ */
+bool		usbc_pd_msg_data(struct usbc_pd_msg *msg, uint8_t data_type,
+		    const uint32_t *data, uint8_t ndo, uint8_t msg_id,
+		    enum usbc_pd_power_role pr, enum usbc_pd_data_role dr,
+		    enum usbc_pd_rev rev);
+
+/*
+ * Vendor Defined Message (VDM) — PD 6.4.4.
+ *
+ * A VDM is a Data Message of type USBC_PD_DATA_VENDOR with the first
+ * data object being the VDM Header.  Layout (32 bits):
+ *
+ *   31:16  SVID                    Standard or Vendor ID
+ *   15     Type                    1 = Structured VDM, 0 = Unstructured
+ *   14:13  Structured VDM Version  0=1.0, 1=2.0, 2=2.1
+ *   12:11  reserved
+ *   10:8   Object Position         1..7 (used by Enter/Exit Mode)
+ *    7:6   Command Type            0=REQ, 1=ACK, 2=NAK, 3=BUSY
+ *    5     reserved
+ *    4:0   Command                 1..6 generic + 16..31 SVID-specific
+ */
+#define	USBC_VDM_HDR_SVID(h)		(((h) >> 16) & 0xffff)
+#define	USBC_VDM_HDR_STRUCTURED		(1u << 15)
+#define	USBC_VDM_HDR_VER_SHIFT		13
+#define	USBC_VDM_HDR_OBJPOS_SHIFT	8
+#define	USBC_VDM_HDR_OBJPOS_MASK	(0x7u << 8)
+#define	USBC_VDM_HDR_GET_OBJPOS(h)	(((h) >> 8) & 0x7u)
+#define	USBC_VDM_HDR_CMDTYPE_SHIFT	6
+#define	USBC_VDM_HDR_CMDTYPE_MASK	(0x3u << 6)
+#define	USBC_VDM_HDR_GET_CMDTYPE(h)	(((h) >> 6) & 0x3u)
+#define	USBC_VDM_HDR_GET_CMD(h)		((h) & 0x1fu)
+
+/* Command Type values */
+#define	USBC_VDM_CMDTYPE_REQ		0u
+#define	USBC_VDM_CMDTYPE_ACK		1u
+#define	USBC_VDM_CMDTYPE_NAK		2u
+#define	USBC_VDM_CMDTYPE_BUSY		3u
+
+/* Generic Structured VDM commands (PD 6.4.4.2) */
+#define	USBC_VDM_CMD_DISCOVER_IDENTITY	1u
+#define	USBC_VDM_CMD_DISCOVER_SVIDS	2u
+#define	USBC_VDM_CMD_DISCOVER_MODES	3u
+#define	USBC_VDM_CMD_ENTER_MODE		4u
+#define	USBC_VDM_CMD_EXIT_MODE		5u
+#define	USBC_VDM_CMD_ATTENTION		6u
+
+/* SVIDs of interest */
+#define	USBC_VDM_SVID_PD		0xff00u	/* Standard PD ID */
+#define	USBC_VDM_SVID_DP		0xff01u	/* DisplayPort Alt Mode */
+
+/* DisplayPort-specific VDM commands (under SVID 0xff01, PD DP Alt Mode 2.0) */
+#define	USBC_DP_CMD_STATUS_UPDATE	0x10u
+#define	USBC_DP_CMD_CONFIGURE		0x11u
+
+/*
+ * DisplayPort Status VDO bits (response to DP_Status_Update or
+ * Attention with DP-payload, per DP Alt Mode 2.0 §4.2):
+ *
+ *   bit 0   DFP_D Connected
+ *   bit 1   UFP_D Connected
+ *   bit 2   Power Low
+ *   bit 3   Enabled
+ *   bit 4   Multi-Function Preferred
+ *   bit 5   USB Configuration Request
+ *   bit 6   Exit DP Mode Request
+ *   bit 7   HPD State
+ *   bit 8   IRQ_HPD
+ */
+#define	USBC_DP_STATUS_DFP_D_CONN	(1u << 0)
+#define	USBC_DP_STATUS_UFP_D_CONN	(1u << 1)
+#define	USBC_DP_STATUS_POWER_LOW	(1u << 2)
+#define	USBC_DP_STATUS_ENABLED		(1u << 3)
+#define	USBC_DP_STATUS_MF_PREF		(1u << 4)
+#define	USBC_DP_STATUS_USB_REQ		(1u << 5)
+#define	USBC_DP_STATUS_EXIT_DP		(1u << 6)
+#define	USBC_DP_STATUS_HPD		(1u << 7)
+#define	USBC_DP_STATUS_IRQ_HPD		(1u << 8)
+
+/* Build a Structured VDM header. */
+uint32_t	usbc_pd_build_vdm_header(uint16_t svid, uint8_t cmd,
+		    uint8_t cmd_type, uint8_t obj_pos);
+
+/*
+ * Compose a complete VDM data message into msg.  vdo_count is the
+ * number of additional VDOs (after the VDM header itself) that follow
+ * — Discover_Identity REQ has 0; Enter_Mode REQ has 0; DP_Configure
+ * REQ has 1; Discover_Identity ACK has up to 4 (ID Header + Cert Stat
+ * + Product VDO + AMA VDO).  Returns true if vdo_count <= 6 (1 header
+ * + 6 VDOs = 7 data objects max in a PD message).
+ */
+bool		usbc_pd_msg_vdm(struct usbc_pd_msg *msg, uint16_t svid,
+		    uint8_t cmd, uint8_t cmd_type, uint8_t obj_pos,
+		    const uint32_t *vdos, uint8_t vdo_count, uint8_t msg_id,
+		    enum usbc_pd_power_role pr, enum usbc_pd_data_role dr,
+		    enum usbc_pd_rev rev);
+
+#endif /* !_USBC_PD_MSG_H_ */

--- a/sys/dev/iicbus/usb/usbc/usbc_pd_policy.c
+++ b/sys/dev/iicbus/usb/usbc/usbc_pd_policy.c
@@ -1,0 +1,1992 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Kyle Crenshaw
+ * All rights reserved.
+ */
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/kernel.h>
+#include <sys/lock.h>
+#include <sys/malloc.h>
+#include <sys/module.h>
+#include <sys/mutex.h>
+#include <sys/queue.h>
+#include <sys/callout.h>
+#include <sys/taskqueue.h>
+
+#include <dev/iicbus/usb/usbc/usbc_pd.h>
+#include <dev/iicbus/usb/usbc/usbc_pd_msg.h>
+#include <dev/iicbus/usb/usbc/usbc_pd_policy.h>
+#include <dev/iicbus/usb/usbc/usbc_tcpc.h>
+
+/*
+ * USB-PD policy state machine -- runtime skeleton.
+ *
+ * This file owns the per-policy softc (struct usbc_pd_policy), the
+ * dispatch plumbing (event queue + run loop + timer + lock), and the
+ * lifecycle (alloc/free).  Per-state behavior lives in dispatch
+ * tables and helper functions added in subsequent commits; this
+ * skeleton transitions only between USBC_PD_S_INVALID and
+ * USBC_PD_S_DISABLED.
+ */
+
+static MALLOC_DEFINE(M_USBC_PD_POLICY, "usbc_pd_policy",
+    "USB-PD policy state machine");
+
+/*
+ * Internal softc.  Opaque to consumers (declared in the header as
+ * struct usbc_pd_policy).  Not allocated on the stack -- always via
+ * malloc(M_USBC_PD_POLICY) so the lock has a stable address.
+ */
+struct usbc_pd_policy {
+	struct mtx		lk;
+	struct usbc_tcpc	*tcpc;
+	struct usbc_pd_port_caps caps;
+
+	enum usbc_pd_state	state;
+	enum usbc_pd_state	prev_state;
+
+	/*
+	 * Saved at the point a soft-reset path is entered, so the SM can
+	 * tell whether to return to SRC_SEND_CAPABILITIES or
+	 * SNK_WAIT_CAPABILITIES once the reset exchange completes.
+	 */
+	enum usbc_pd_state	pre_reset_state;
+
+	/*
+	 * VDM / DP Alt Mode state.  Tracks discovery responses from the
+	 * partner and the latest DP_Status VDO.  dp_object_position is
+	 * the 1-based mode index we Enter_Mode'd into; dp_status is the
+	 * most recent DP_Status response (HPD bit etc.).  dp_ready is
+	 * set after Enter_Mode ACK and goes false on detach.
+	 */
+	bool			dp_ready;
+	uint8_t			dp_object_position;
+	uint16_t		dp_partner_svids[8];
+	uint8_t			dp_partner_svid_count;
+	uint32_t		dp_partner_modes[6];
+	uint8_t			dp_partner_mode_count;
+	uint32_t		dp_status;
+	uint32_t		dp_partner_id_hdr;
+	uint32_t		dp_partner_cert_stat;
+	uint32_t		dp_partner_product;
+
+	/* Pending events folded together until run() consumes them. */
+	uint32_t		pending_events;
+
+	/* Active timer (if any).  USBC_PD_T_NONE means no timer armed. */
+	enum usbc_pd_timer	active_timer;
+	struct callout		timer_co;
+
+	/* Outgoing message scratch space + monotonic MessageID. */
+	struct usbc_pd_msg	tx;
+	uint8_t			msg_id;
+
+	/* SRC_SEND_CAPABILITIES retry counter (PD nCapsCount, max 50). */
+	uint8_t			caps_counter;
+
+	bool			running;	/* run() is on stack */
+	bool			pending_run;	/* needs another iteration */
+};
+
+#define	POLICY_LOCK(p)		mtx_lock(&(p)->lk)
+#define	POLICY_UNLOCK(p)	mtx_unlock(&(p)->lk)
+#define	POLICY_ASSERT_LOCKED(p)	mtx_assert(&(p)->lk, MA_OWNED)
+
+/* Forward declarations of helpers defined below. */
+static void	usbc_pd_policy_timer_cb(void *);
+static void	usbc_pd_policy_run_locked(struct usbc_pd_policy *p);
+static void	usbc_pd_policy_set_state(struct usbc_pd_policy *p,
+		    enum usbc_pd_state next);
+static void	usbc_pd_policy_arm_timer(struct usbc_pd_policy *p,
+		    enum usbc_pd_timer t, u_int ms);
+static void	usbc_pd_policy_cancel_timer(struct usbc_pd_policy *p);
+static void	usbc_pd_state_unattached_src(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_attach_wait_src(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_src_attached(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_src_startup(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_src_send_caps(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_src_negotiate_caps(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_src_transition_supply(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_src_ready(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_hard_reset_send(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_src_hard_reset_vbus_off(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_src_hard_reset_vbus_on(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_unattached_snk(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_attach_wait_snk(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_attached(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_startup(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_discovery(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_wait_caps(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_negotiate_caps(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_transition_sink(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_ready(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_hard_reset_sink_off(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_hard_reset_wait_vbus(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_snk_hard_reset_sink_on(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_soft_reset(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_soft_reset_send(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_vdm_discover_identity(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_vdm_discover_svids(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_vdm_discover_modes(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_vdm_enter_mode(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_vdm_dp_status(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_vdm_dp_configure(struct usbc_pd_policy *p,
+		    uint32_t events);
+static void	usbc_pd_state_vdm_dp_ready(struct usbc_pd_policy *p,
+		    uint32_t events);
+static int	usbc_pd_send_vdm(struct usbc_pd_policy *p, uint16_t svid,
+		    uint8_t cmd, uint8_t obj_pos,
+		    const uint32_t *vdos, uint8_t vdo_count);
+static void	usbc_pd_handle_attention(struct usbc_pd_policy *p,
+		    const struct usbc_pd_msg *rx);
+static int	usbc_pd_send_ctrl(struct usbc_pd_policy *p, uint8_t ctrl_type);
+static int	usbc_pd_drain_rx(struct usbc_pd_policy *p,
+		    struct usbc_pd_msg *out, enum usbc_pd_sop *sop_out);
+static bool	usbc_pd_check_soft_reset_rx(struct usbc_pd_policy *p,
+		    const struct usbc_pd_msg *rx, enum usbc_pd_sop sop);
+static enum usbc_pd_state usbc_pd_caps_state_for_role(
+		    const struct usbc_pd_policy *p);
+
+/* Allocate and zero-init a policy bound to the given TCPC + caps. */
+struct usbc_pd_policy *
+usbc_pd_policy_alloc(struct usbc_tcpc *tcpc,
+    const struct usbc_pd_port_caps *caps)
+{
+	struct usbc_pd_policy *p;
+
+	if (tcpc == NULL || caps == NULL)
+		return (NULL);
+
+	p = malloc(sizeof(*p), M_USBC_PD_POLICY, M_WAITOK | M_ZERO);
+	mtx_init(&p->lk, "usbc_pd", NULL, MTX_DEF);
+	callout_init_mtx(&p->timer_co, &p->lk, 0);
+
+	p->tcpc = tcpc;
+	memcpy(&p->caps, caps, sizeof(p->caps));
+	p->state = USBC_PD_S_DISABLED;
+	p->prev_state = USBC_PD_S_INVALID;
+	p->active_timer = USBC_PD_T_NONE;
+	p->msg_id = 0;
+
+	return (p);
+}
+
+/* Tear down a policy: cancel timers, drop the lock, free. */
+void
+usbc_pd_policy_free(struct usbc_pd_policy *p)
+{
+
+	if (p == NULL)
+		return;
+
+	POLICY_LOCK(p);
+	callout_stop(&p->timer_co);
+	POLICY_UNLOCK(p);
+
+	callout_drain(&p->timer_co);
+	mtx_destroy(&p->lk);
+	free(p, M_USBC_PD_POLICY);
+}
+
+/* Queue events for the SM; safe from any context, including IRQ. */
+void
+usbc_pd_policy_event(struct usbc_pd_policy *p, enum usbc_pd_event e)
+{
+
+	if (p == NULL || e == USBC_PD_E_NONE)
+		return;
+
+	POLICY_LOCK(p);
+	p->pending_events |= (uint32_t)e;
+	if (p->running) {
+		/* Caller is already in run(); it will see the new bits. */
+		p->pending_run = true;
+		POLICY_UNLOCK(p);
+		return;
+	}
+	usbc_pd_policy_run_locked(p);
+	POLICY_UNLOCK(p);
+}
+
+/* Public run() variant: take the lock and dispatch. */
+void
+usbc_pd_policy_run(struct usbc_pd_policy *p)
+{
+
+	if (p == NULL)
+		return;
+	POLICY_LOCK(p);
+	usbc_pd_policy_run_locked(p);
+	POLICY_UNLOCK(p);
+}
+
+/* Read-only state accessor (for sysctls / class device). */
+enum usbc_pd_state
+usbc_pd_policy_state(const struct usbc_pd_policy *p)
+{
+
+	if (p == NULL)
+		return (USBC_PD_S_INVALID);
+	return (p->state);	/* atomic read of a single int -- no lock needed */
+}
+
+/*
+ * Internal: dispatch loop.  Repeatedly snapshot pending_events,
+ * call the per-state handler with that event mask, and repeat until
+ * either the state stops requesting another iteration or no new
+ * events arrive.  Recursion-safe via the running/pending_run pair:
+ * if event() is called while a state handler is executing, the new
+ * event is folded in and a re-iteration is requested rather than a
+ * nested run.
+ */
+static void
+usbc_pd_policy_run_locked(struct usbc_pd_policy *p)
+{
+	uint32_t events;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->running) {
+		p->pending_run = true;
+		return;
+	}
+	p->running = true;
+
+	for (;;) {
+		events = p->pending_events;
+		p->pending_events = 0;
+		p->pending_run = false;
+
+		if (events == 0)
+			break;
+
+		/*
+		 * Cross-cutting events handled before per-state dispatch:
+		 * a hard-reset received from the partner forces us into
+		 * the role-appropriate recovery chain regardless of
+		 * current state.  Source: drop VBUS for tPSHardReset.
+		 * Sink: detach the load and wait for VBUS to recycle.
+		 */
+		if ((events & USBC_PD_E_HARD_RESET_RX) &&
+		    p->state >= USBC_PD_S_SRC_ATTACHED &&
+		    p->state <= USBC_PD_S_SRC_WAIT_NEW_CAPABILITIES) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_SRC_HARD_RESET_VBUS_OFF);
+			continue;
+		}
+		if ((events & USBC_PD_E_HARD_RESET_RX) &&
+		    p->state >= USBC_PD_S_SNK_ATTACHED &&
+		    p->state <= USBC_PD_S_SNK_READY) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_SNK_HARD_RESET_SINK_OFF);
+			continue;
+		}
+
+		switch (p->state) {
+		case USBC_PD_S_UNATTACHED_SRC:
+			usbc_pd_state_unattached_src(p, events);
+			break;
+		case USBC_PD_S_ATTACH_WAIT_SRC:
+			usbc_pd_state_attach_wait_src(p, events);
+			break;
+		case USBC_PD_S_SRC_ATTACHED:
+			usbc_pd_state_src_attached(p, events);
+			break;
+		case USBC_PD_S_SRC_STARTUP:
+			usbc_pd_state_src_startup(p, events);
+			break;
+		case USBC_PD_S_SRC_SEND_CAPABILITIES:
+			usbc_pd_state_src_send_caps(p, events);
+			break;
+		case USBC_PD_S_SRC_NEGOTIATE_CAPABILITIES:
+			usbc_pd_state_src_negotiate_caps(p, events);
+			break;
+		case USBC_PD_S_SRC_TRANSITION_SUPPLY:
+			usbc_pd_state_src_transition_supply(p, events);
+			break;
+		case USBC_PD_S_SRC_READY:
+			usbc_pd_state_src_ready(p, events);
+			break;
+		case USBC_PD_S_HARD_RESET_SEND:
+			usbc_pd_state_hard_reset_send(p, events);
+			break;
+		case USBC_PD_S_SRC_HARD_RESET_VBUS_OFF:
+			usbc_pd_state_src_hard_reset_vbus_off(p, events);
+			break;
+		case USBC_PD_S_SRC_HARD_RESET_VBUS_ON:
+			usbc_pd_state_src_hard_reset_vbus_on(p, events);
+			break;
+		case USBC_PD_S_UNATTACHED_SNK:
+			usbc_pd_state_unattached_snk(p, events);
+			break;
+		case USBC_PD_S_ATTACH_WAIT_SNK:
+			usbc_pd_state_attach_wait_snk(p, events);
+			break;
+		case USBC_PD_S_SNK_ATTACHED:
+			usbc_pd_state_snk_attached(p, events);
+			break;
+		case USBC_PD_S_SNK_STARTUP:
+			usbc_pd_state_snk_startup(p, events);
+			break;
+		case USBC_PD_S_SNK_DISCOVERY:
+			usbc_pd_state_snk_discovery(p, events);
+			break;
+		case USBC_PD_S_SNK_WAIT_CAPABILITIES:
+			usbc_pd_state_snk_wait_caps(p, events);
+			break;
+		case USBC_PD_S_SNK_NEGOTIATE_CAPABILITIES:
+			usbc_pd_state_snk_negotiate_caps(p, events);
+			break;
+		case USBC_PD_S_SNK_TRANSITION_SINK:
+			usbc_pd_state_snk_transition_sink(p, events);
+			break;
+		case USBC_PD_S_SNK_READY:
+			usbc_pd_state_snk_ready(p, events);
+			break;
+		case USBC_PD_S_SNK_HARD_RESET_SINK_OFF:
+			usbc_pd_state_snk_hard_reset_sink_off(p, events);
+			break;
+		case USBC_PD_S_SNK_HARD_RESET_WAIT_VBUS:
+			usbc_pd_state_snk_hard_reset_wait_vbus(p, events);
+			break;
+		case USBC_PD_S_SNK_HARD_RESET_SINK_ON:
+			usbc_pd_state_snk_hard_reset_sink_on(p, events);
+			break;
+		case USBC_PD_S_SOFT_RESET:
+			usbc_pd_state_soft_reset(p, events);
+			break;
+		case USBC_PD_S_SOFT_RESET_SEND:
+			usbc_pd_state_soft_reset_send(p, events);
+			break;
+		case USBC_PD_S_VDM_SEND_DISCOVER_IDENTITY:
+			usbc_pd_state_vdm_discover_identity(p, events);
+			break;
+		case USBC_PD_S_VDM_SEND_DISCOVER_SVIDS:
+			usbc_pd_state_vdm_discover_svids(p, events);
+			break;
+		case USBC_PD_S_VDM_SEND_DISCOVER_MODES:
+			usbc_pd_state_vdm_discover_modes(p, events);
+			break;
+		case USBC_PD_S_VDM_SEND_ENTER_MODE:
+			usbc_pd_state_vdm_enter_mode(p, events);
+			break;
+		case USBC_PD_S_VDM_SEND_DP_STATUS:
+			usbc_pd_state_vdm_dp_status(p, events);
+			break;
+		case USBC_PD_S_VDM_SEND_DP_CONFIGURE:
+			usbc_pd_state_vdm_dp_configure(p, events);
+			break;
+		case USBC_PD_S_VDM_DP_READY:
+			usbc_pd_state_vdm_dp_ready(p, events);
+			break;
+		case USBC_PD_S_DISABLED:
+			/*
+			 * Manual disable: stay until PORT_ENABLE.  Default
+			 * unattached state follows the configured power role.
+			 */
+			if (events & USBC_PD_E_PORT_ENABLE) {
+				enum usbc_pd_state next;
+
+				next = (p->caps.default_power_role ==
+				    USBC_PD_ROLE_SINK) ?
+				    USBC_PD_S_UNATTACHED_SNK :
+				    USBC_PD_S_UNATTACHED_SRC;
+				usbc_pd_policy_set_state(p, next);
+			}
+			break;
+		default:
+			/* States not yet implemented just sink events. */
+			break;
+		}
+
+		if (!p->pending_run && p->pending_events == 0)
+			break;
+	}
+
+	p->running = false;
+}
+
+/* Callout body for the active PD timer.  Translates to USBC_PD_E_TIMER. */
+static void
+usbc_pd_policy_timer_cb(void *arg)
+{
+	struct usbc_pd_policy *p = arg;
+
+	POLICY_ASSERT_LOCKED(p);
+	p->active_timer = USBC_PD_T_NONE;
+	p->pending_events |= USBC_PD_E_TIMER;
+	usbc_pd_policy_run_locked(p);
+}
+
+/* State transition: cancel the active timer and update prev/state. */
+static void
+usbc_pd_policy_set_state(struct usbc_pd_policy *p, enum usbc_pd_state next)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+	if (next == p->state)
+		return;
+	usbc_pd_policy_cancel_timer(p);
+	p->prev_state = p->state;
+	p->state = next;
+	/* Re-run so the new state's handler executes its entry actions. */
+	p->pending_run = true;
+}
+
+/* Arm the named PD timer for `ms` milliseconds (overrides any active). */
+static void
+usbc_pd_policy_arm_timer(struct usbc_pd_policy *p, enum usbc_pd_timer t,
+    u_int ms)
+{
+	sbintime_t sbt;
+
+	POLICY_ASSERT_LOCKED(p);
+	usbc_pd_policy_cancel_timer(p);
+	p->active_timer = t;
+	sbt = SBT_1MS * ms;
+	callout_reset_sbt(&p->timer_co, sbt, 0,
+	    usbc_pd_policy_timer_cb, p, 0);
+}
+
+/* Cancel any active PD timer; idempotent. */
+static void
+usbc_pd_policy_cancel_timer(struct usbc_pd_policy *p)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+	if (p->active_timer == USBC_PD_T_NONE)
+		return;
+	callout_stop(&p->timer_co);
+	p->active_timer = USBC_PD_T_NONE;
+}
+
+/*
+ * UNATTACHED_SRC: idle as a source.  Watch CC for an Rd termination
+ * appearing (sink connected); when seen, debounce in ATTACH_WAIT_SRC.
+ */
+static void
+usbc_pd_state_unattached_src(struct usbc_pd_policy *p, uint32_t events)
+{
+	enum usbc_tcpc_cc_state cc1, cc2;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if ((events & USBC_PD_E_CC_CHANGE) == 0)
+		return;
+	if (p->tcpc->ops->get_cc == NULL)
+		return;
+	if (p->tcpc->ops->get_cc(p->tcpc, &cc1, &cc2) != 0)
+		return;
+	if (cc1 == USBC_TCPC_CC_RD || cc2 == USBC_TCPC_CC_RD)
+		usbc_pd_policy_set_state(p, USBC_PD_S_ATTACH_WAIT_SRC);
+}
+
+/*
+ * ATTACH_WAIT_SRC: tCCDebounce expires before we commit to attach.
+ * The chip latches Rd; we just delay long enough that a glitch
+ * doesn't trigger the full PD bring-up.
+ */
+static void
+usbc_pd_state_attach_wait_src(struct usbc_pd_policy *p, uint32_t events)
+{
+	enum usbc_tcpc_cc_state cc1, cc2;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	/* (Re)arm tCCDebounce on entry or any CC bounce. */
+	if (p->prev_state != USBC_PD_S_ATTACH_WAIT_SRC ||
+	    (events & USBC_PD_E_CC_CHANGE)) {
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_CC_DEBOUNCE,
+		    USBC_PD_T_CC_DEBOUNCE_MS);
+		p->prev_state = USBC_PD_S_ATTACH_WAIT_SRC;
+		return;
+	}
+	if ((events & USBC_PD_E_TIMER) == 0)
+		return;
+
+	if (p->tcpc->ops->get_cc == NULL ||
+	    p->tcpc->ops->get_cc(p->tcpc, &cc1, &cc2) != 0) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_UNATTACHED_SRC);
+		return;
+	}
+	if (cc1 == USBC_TCPC_CC_RD || cc2 == USBC_TCPC_CC_RD)
+		usbc_pd_policy_set_state(p, USBC_PD_S_SRC_ATTACHED);
+	else
+		usbc_pd_policy_set_state(p, USBC_PD_S_UNATTACHED_SRC);
+}
+
+/*
+ * SRC_ATTACHED: pin polarity, enable VBUS, enable VCONN, then chain
+ * into SRC_STARTUP for PD bring-up.  Entry-driven; events ignored.
+ */
+static void
+usbc_pd_state_src_attached(struct usbc_pd_policy *p, uint32_t events)
+{
+	enum usbc_tcpc_cc_state cc1, cc2;
+	enum usbc_pd_polarity polarity;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	(void)events;
+
+	if (p->prev_state == USBC_PD_S_SRC_ATTACHED)
+		return;
+	p->prev_state = USBC_PD_S_SRC_ATTACHED;
+
+	if (p->tcpc->ops->get_cc == NULL ||
+	    p->tcpc->ops->get_cc(p->tcpc, &cc1, &cc2) != 0)
+		return;
+	polarity = (cc1 == USBC_TCPC_CC_RD) ? USBC_PD_POLARITY_CC1 :
+	    USBC_PD_POLARITY_CC2;
+	if (p->tcpc->ops->set_polarity != NULL)
+		(void)p->tcpc->ops->set_polarity(p->tcpc, polarity);
+	if (p->tcpc->ops->set_vbus_source != NULL)
+		(void)p->tcpc->ops->set_vbus_source(p->tcpc, true);
+	if (p->tcpc->ops->set_vconn != NULL)
+		(void)p->tcpc->ops->set_vconn(p->tcpc, true);
+
+	/* Hand off to the PD bring-up path. */
+	usbc_pd_policy_set_state(p, USBC_PD_S_SRC_STARTUP);
+}
+
+/*
+ * SRC_STARTUP: reset PD layer state and enable message reception,
+ * then transition to SRC_SEND_CAPABILITIES so we'll start
+ * advertising our PDOs to the partner.
+ */
+static void
+usbc_pd_state_src_startup(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+
+	(void)events;
+
+	/* Per-attach reset of PD-layer state. */
+	p->msg_id = 0;
+	p->caps_counter = 0;
+
+	/* Tell the chip we're ready to receive PD messages. */
+	if (p->tcpc->ops->set_rx_enable != NULL)
+		(void)p->tcpc->ops->set_rx_enable(p->tcpc, true);
+
+	usbc_pd_policy_set_state(p, USBC_PD_S_SRC_SEND_CAPABILITIES);
+}
+
+/*
+ * SRC_SEND_CAPABILITIES: transmit Source_Capabilities and wait for
+ * Request.  On TX_FAIL we retry up to N_CAPS_COUNT times spaced by
+ * tTypeCSendSourceCap; on TX_OK we wait for the partner's Request
+ * (via tSenderResponse).  RX-of-Request handoff to
+ * SRC_NEGOTIATE_CAPABILITIES lands in a later commit; for now this
+ * state stops at "TX accepted, waiting for Request."
+ */
+static void
+usbc_pd_state_src_send_caps(struct usbc_pd_policy *p, uint32_t events)
+{
+	struct usbc_pd_msg *msg;
+	uint32_t pdos[7];
+	uint8_t i;
+	int err;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	/* Entry: build and submit the Source_Capabilities message. */
+	if (p->prev_state != USBC_PD_S_SRC_SEND_CAPABILITIES) {
+		p->prev_state = USBC_PD_S_SRC_SEND_CAPABILITIES;
+		if (p->caps.nr_src_pdos == 0 || p->caps.nr_src_pdos > 7) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		for (i = 0; i < p->caps.nr_src_pdos; i++)
+			pdos[i] = p->caps.src_pdos[i];
+		msg = &p->tx;
+		if (!usbc_pd_msg_data(msg, USBC_PD_DATA_SRC_CAP,
+		    pdos, p->caps.nr_src_pdos, p->msg_id,
+		    USBC_PD_ROLE_SOURCE, USBC_PD_DATA_DFP,
+		    p->caps.advertise_rev)) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		if (p->tcpc->ops->transmit == NULL) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		err = p->tcpc->ops->transmit(p->tcpc, USBC_PD_SOP, msg);
+		if (err != 0) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		return;
+	}
+
+	/* TX completed successfully -- arm tSenderResponse for Request. */
+	if (events & USBC_PD_E_TX_OK) {
+		p->caps_counter = 0;
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_SENDER_RESPONSE,
+		    USBC_PD_T_SENDER_RESPONSE_MS);
+		return;
+	}
+
+	/* Partner sent a message -- if it's Request, negotiate. */
+	if (events & USBC_PD_E_RX) {
+		struct usbc_pd_msg rx;
+		enum usbc_pd_sop sop;
+		uint8_t type;
+
+		if (usbc_pd_drain_rx(p, &rx, &sop) != 0)
+			return;
+		if (usbc_pd_check_soft_reset_rx(p, &rx, sop))
+			return;
+		if (sop != USBC_PD_SOP)
+			return;	/* ignore SOP'/SOP'' for now */
+		if (USBC_PD_HDR_GET_NDO(rx.hdr) == 0)
+			return;	/* control msg, not a Request */
+		type = USBC_PD_HDR_GET_TYPE(rx.hdr);
+		if (type != USBC_PD_DATA_REQUEST)
+			return;
+		/*
+		 * We've received a Request RDO.  Stash it and move to
+		 * SRC_NEGOTIATE_CAPABILITIES.  The negotiate state will
+		 * evaluate the requested PDO index against our advertised
+		 * supply.  For now we copy the RDO into tx slot 0 so the
+		 * negotiate handler can read it; a future commit moves
+		 * this to a proper rx_msg field on the softc.
+		 */
+		p->tx.data[0] = rx.data[0];
+		usbc_pd_policy_set_state(p,
+		    USBC_PD_S_SRC_NEGOTIATE_CAPABILITIES);
+		return;
+	}
+
+	/* TX failed -- retry up to N_CAPS_COUNT times. */
+	if (events & USBC_PD_E_TX_FAIL) {
+		p->caps_counter++;
+		if (p->caps_counter >= USBC_PD_N_CAPS_COUNT) {
+			/* Partner not PD-capable; for now bail out. */
+			usbc_pd_policy_set_state(p, USBC_PD_S_DISABLED);
+			return;
+		}
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_TYPEC_SEND_SOURCE_CAP,
+		    USBC_PD_T_TYPEC_SEND_SRCCAP_MS);
+		return;
+	}
+
+	/* tTypeCSendSourceCap fired -- re-transmit. */
+	if ((events & USBC_PD_E_TIMER) &&
+	    p->active_timer == USBC_PD_T_NONE) {
+		p->prev_state = USBC_PD_S_INVALID;	/* force re-entry */
+		p->pending_run = true;
+		return;
+	}
+
+	/* tSenderResponse fired with no Request received -- hard reset. */
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+}
+
+/*
+ * SRC_NEGOTIATE_CAPABILITIES: evaluate the partner's Request RDO and
+ * either Accept (and move to SRC_TRANSITION_SUPPLY) or Reject (and
+ * fall back to SRC_SEND_CAPABILITIES).  Minimal policy for now:
+ * accept any in-range PDO index.  Per-spec we'd compare requested
+ * current/voltage to the advertised PDO and reject mismatches; that
+ * comes later.
+ */
+static void
+usbc_pd_state_src_negotiate_caps(struct usbc_pd_policy *p, uint32_t events)
+{
+	uint32_t rdo;
+	uint8_t pos;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	(void)events;	/* entry-driven */
+
+	if (p->prev_state == USBC_PD_S_SRC_NEGOTIATE_CAPABILITIES)
+		return;
+	p->prev_state = USBC_PD_S_SRC_NEGOTIATE_CAPABILITIES;
+
+	rdo = p->tx.data[0];
+	pos = (rdo >> 28) & 0x7;
+	if (pos < 1 || pos > p->caps.nr_src_pdos) {
+		(void)usbc_pd_send_ctrl(p, USBC_PD_CTRL_REJECT);
+		usbc_pd_policy_set_state(p,
+		    USBC_PD_S_SRC_SEND_CAPABILITIES);
+		return;
+	}
+	if (usbc_pd_send_ctrl(p, USBC_PD_CTRL_ACCEPT) != 0) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+		return;
+	}
+	usbc_pd_policy_set_state(p, USBC_PD_S_SRC_TRANSITION_SUPPLY);
+}
+
+/*
+ * SRC_TRANSITION_SUPPLY: arm tSrcTransition, on timer fire send
+ * PS_RDY, then transition to SRC_READY.  In a full implementation
+ * the supply rail would actually transition (voltage/current ramp);
+ * for the minimal port we just observe the timing contract.
+ */
+static void
+usbc_pd_state_src_transition_supply(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SRC_TRANSITION_SUPPLY) {
+		p->prev_state = USBC_PD_S_SRC_TRANSITION_SUPPLY;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_PS_TRANSITION,
+		    USBC_PD_T_SRC_TRANSITION_MS);
+		return;
+	}
+	if ((events & USBC_PD_E_TIMER) == 0)
+		return;
+
+	if (usbc_pd_send_ctrl(p, USBC_PD_CTRL_PS_RDY) != 0) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+		return;
+	}
+	usbc_pd_policy_set_state(p, USBC_PD_S_SRC_READY);
+}
+
+/*
+ * SRC_READY: contract established.  Once we land here, kick off VDM
+ * Discover_Identity to learn whether the partner supports DisplayPort
+ * Alt Mode.  This matches Linux's tcpm: after the PD contract,
+ * immediately discover the partner identity, SVIDs, and modes; if DP
+ * is offered, Enter_Mode and start polling DP_Status.  Without this
+ * the display sees us as "PD-only" and won't fully wake its DP RX.
+ */
+static void
+usbc_pd_state_src_ready(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+
+	(void)events;
+	if (p->prev_state == USBC_PD_S_SRC_READY)
+		return;
+	p->prev_state = USBC_PD_S_SRC_READY;
+
+	/* Reset partner-discovery state on each fresh attach. */
+	p->dp_partner_svid_count = 0;
+	p->dp_partner_mode_count = 0;
+	p->dp_object_position = 0;
+	p->dp_status = 0;
+	p->dp_ready = false;
+
+	usbc_pd_policy_set_state(p, USBC_PD_S_VDM_SEND_DISCOVER_IDENTITY);
+}
+
+/*
+ * HARD_RESET_SEND: ask the TCPC to emit a Hard Reset over the wire,
+ * then once that's confirmed (HARD_RESET_TX_OK event) transition
+ * into SRC_HARD_RESET_VBUS_OFF to drop VBUS for tPSHardReset.
+ */
+static void
+usbc_pd_state_hard_reset_send(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_HARD_RESET_SEND) {
+		p->prev_state = USBC_PD_S_HARD_RESET_SEND;
+		if (p->tcpc->ops->send_hard_reset != NULL)
+			(void)p->tcpc->ops->send_hard_reset(p->tcpc);
+		return;
+	}
+	if (events & USBC_PD_E_HARD_RESET_TX_OK) {
+		usbc_pd_policy_set_state(p,
+		    USBC_PD_S_SRC_HARD_RESET_VBUS_OFF);
+	}
+}
+
+/*
+ * SRC_HARD_RESET_VBUS_OFF: drop VBUS, arm tPSHardReset.  When the
+ * timer fires, advance to SRC_HARD_RESET_VBUS_ON to re-enable.
+ */
+static void
+usbc_pd_state_src_hard_reset_vbus_off(struct usbc_pd_policy *p,
+    uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SRC_HARD_RESET_VBUS_OFF) {
+		p->prev_state = USBC_PD_S_SRC_HARD_RESET_VBUS_OFF;
+		if (p->tcpc->ops->set_vbus_source != NULL)
+			(void)p->tcpc->ops->set_vbus_source(p->tcpc, false);
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_PS_HARD_RESET,
+		    USBC_PD_T_VBUS_OFF_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p,
+		    USBC_PD_S_SRC_HARD_RESET_VBUS_ON);
+}
+
+/*
+ * SRC_HARD_RESET_VBUS_ON: bring VBUS back up, arm tVBUSOn for it
+ * to settle, then transition back into SRC_STARTUP to redo the
+ * full PD bring-up.
+ */
+static void
+usbc_pd_state_src_hard_reset_vbus_on(struct usbc_pd_policy *p,
+    uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SRC_HARD_RESET_VBUS_ON) {
+		p->prev_state = USBC_PD_S_SRC_HARD_RESET_VBUS_ON;
+		if (p->tcpc->ops->set_vbus_source != NULL)
+			(void)p->tcpc->ops->set_vbus_source(p->tcpc, true);
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_VBUS_ON,
+		    USBC_PD_T_VBUS_ON_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_SRC_STARTUP);
+}
+
+/*
+ * UNATTACHED_SNK: idle as a sink.  Watch CC for an Rp termination
+ * appearing (a source connected); when seen, debounce in
+ * ATTACH_WAIT_SNK before committing.
+ */
+static void
+usbc_pd_state_unattached_snk(struct usbc_pd_policy *p, uint32_t events)
+{
+	enum usbc_tcpc_cc_state cc1, cc2;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if ((events & USBC_PD_E_CC_CHANGE) == 0)
+		return;
+	if (p->tcpc->ops->get_cc == NULL)
+		return;
+	if (p->tcpc->ops->get_cc(p->tcpc, &cc1, &cc2) != 0)
+		return;
+	if (cc1 == USBC_TCPC_CC_RP_USB || cc1 == USBC_TCPC_CC_RP_1_5A ||
+	    cc1 == USBC_TCPC_CC_RP_3_0A ||
+	    cc2 == USBC_TCPC_CC_RP_USB || cc2 == USBC_TCPC_CC_RP_1_5A ||
+	    cc2 == USBC_TCPC_CC_RP_3_0A)
+		usbc_pd_policy_set_state(p, USBC_PD_S_ATTACH_WAIT_SNK);
+}
+
+/*
+ * ATTACH_WAIT_SNK: tCCDebounce + verify VBUS arrived.  Per spec the
+ * sink waits both for a stable CC reading and for VBUS to come up
+ * before committing to attach.
+ */
+static void
+usbc_pd_state_attach_wait_snk(struct usbc_pd_policy *p, uint32_t events)
+{
+	enum usbc_tcpc_cc_state cc1, cc2;
+	bool vbus;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_ATTACH_WAIT_SNK ||
+	    (events & USBC_PD_E_CC_CHANGE)) {
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_CC_DEBOUNCE,
+		    USBC_PD_T_CC_DEBOUNCE_MS);
+		p->prev_state = USBC_PD_S_ATTACH_WAIT_SNK;
+		return;
+	}
+	if ((events & USBC_PD_E_TIMER) == 0)
+		return;
+
+	if (p->tcpc->ops->get_cc == NULL ||
+	    p->tcpc->ops->get_cc(p->tcpc, &cc1, &cc2) != 0) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_UNATTACHED_SNK);
+		return;
+	}
+	if (cc1 < USBC_TCPC_CC_RP_USB && cc2 < USBC_TCPC_CC_RP_USB) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_UNATTACHED_SNK);
+		return;
+	}
+	vbus = false;
+	if (p->tcpc->ops->get_vbus_present != NULL)
+		(void)p->tcpc->ops->get_vbus_present(p->tcpc, &vbus);
+	if (!vbus) {
+		/* CC is right but VBUS hasn't come up yet -- keep waiting.
+		 * VBUS_CHANGE will re-enter and arrive here through the
+		 * timer-fired branch above. */
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_CC_DEBOUNCE,
+		    USBC_PD_T_CC_DEBOUNCE_MS);
+		return;
+	}
+	usbc_pd_policy_set_state(p, USBC_PD_S_SNK_ATTACHED);
+}
+
+/*
+ * SNK_ATTACHED: pin polarity to the active CC and chain into
+ * SNK_STARTUP for PD bring-up.  Entry-driven; events ignored.
+ */
+static void
+usbc_pd_state_snk_attached(struct usbc_pd_policy *p, uint32_t events)
+{
+	enum usbc_tcpc_cc_state cc1, cc2;
+	enum usbc_pd_polarity polarity;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	(void)events;
+
+	if (p->prev_state == USBC_PD_S_SNK_ATTACHED)
+		return;
+	p->prev_state = USBC_PD_S_SNK_ATTACHED;
+
+	if (p->tcpc->ops->get_cc == NULL ||
+	    p->tcpc->ops->get_cc(p->tcpc, &cc1, &cc2) != 0)
+		return;
+	polarity = (cc1 >= USBC_TCPC_CC_RP_USB) ? USBC_PD_POLARITY_CC1 :
+	    USBC_PD_POLARITY_CC2;
+	if (p->tcpc->ops->set_polarity != NULL)
+		(void)p->tcpc->ops->set_polarity(p->tcpc, polarity);
+
+	usbc_pd_policy_set_state(p, USBC_PD_S_SNK_STARTUP);
+}
+
+/*
+ * SNK_STARTUP: reset PD layer state, enable RX, then chain into
+ * SNK_DISCOVERY.  Mirrors SRC_STARTUP except no caps to send.
+ */
+static void
+usbc_pd_state_snk_startup(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+	(void)events;
+
+	p->msg_id = 0;
+	p->caps_counter = 0;
+
+	if (p->tcpc->ops->set_rx_enable != NULL)
+		(void)p->tcpc->ops->set_rx_enable(p->tcpc, true);
+
+	usbc_pd_policy_set_state(p, USBC_PD_S_SNK_DISCOVERY);
+}
+
+/*
+ * SNK_DISCOVERY: brief connect debounce gives the source time to
+ * start emitting Source_Capabilities.  Just chains through; the
+ * actual wait happens in SNK_WAIT_CAPABILITIES under tTypeCSinkWaitCap.
+ */
+static void
+usbc_pd_state_snk_discovery(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+	(void)events;
+
+	usbc_pd_policy_set_state(p, USBC_PD_S_SNK_WAIT_CAPABILITIES);
+}
+
+/*
+ * SNK_WAIT_CAPABILITIES: arm tTypeCSinkWaitCap, listen for an
+ * incoming Source_Capabilities.  On RX of caps, stash them in tx
+ * scratch and move to SNK_NEGOTIATE_CAPABILITIES.  Timer fire means
+ * the source isn't PD-capable -- escalate to a hard reset.
+ */
+static void
+usbc_pd_state_snk_wait_caps(struct usbc_pd_policy *p, uint32_t events)
+{
+	struct usbc_pd_msg rx;
+	enum usbc_pd_sop sop;
+	uint8_t ndo, type, i;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SNK_WAIT_CAPABILITIES) {
+		p->prev_state = USBC_PD_S_SNK_WAIT_CAPABILITIES;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_TYPEC_SINK_WAIT_CAP,
+		    USBC_PD_T_TYPEC_SINK_WAIT_CAP_MS);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		if (usbc_pd_drain_rx(p, &rx, &sop) != 0)
+			return;
+		if (usbc_pd_check_soft_reset_rx(p, &rx, sop))
+			return;
+		if (sop != USBC_PD_SOP)
+			return;
+		ndo = USBC_PD_HDR_GET_NDO(rx.hdr);
+		type = USBC_PD_HDR_GET_TYPE(rx.hdr);
+		if (ndo == 0 || type != USBC_PD_DATA_SRC_CAP)
+			return;
+		/* Stash the partner PDOs into tx data slots; the negotiate
+		 * state reads them back to pick a PDO and build an RDO. */
+		if (ndo > 7)
+			ndo = 7;
+		for (i = 0; i < ndo; i++)
+			p->tx.data[i] = rx.data[i];
+		p->tx.hdr = (uint16_t)ndo;	/* count stowed in low bits */
+		usbc_pd_policy_set_state(p,
+		    USBC_PD_S_SNK_NEGOTIATE_CAPABILITIES);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+}
+
+/*
+ * SNK_NEGOTIATE_CAPABILITIES: pick a PDO from the partner caps and
+ * transmit a Request RDO.  Minimal policy: always pick PDO #1
+ * (vSafe5V fixed) and request its full advertised current.  After
+ * TX_OK, arm tSenderResponse and wait for Accept; on Accept move to
+ * SNK_TRANSITION_SINK; on Reject/Wait fall back to SNK_READY (or
+ * retry via Wait, simplified here as "stay ready").
+ */
+static void
+usbc_pd_state_snk_negotiate_caps(struct usbc_pd_policy *p, uint32_t events)
+{
+	struct usbc_pd_msg *msg;
+	struct usbc_pd_msg rx;
+	enum usbc_pd_sop sop;
+	uint32_t pdo, rdo, ma;
+	uint8_t type, ndo;
+	int err;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SNK_NEGOTIATE_CAPABILITIES) {
+		p->prev_state = USBC_PD_S_SNK_NEGOTIATE_CAPABILITIES;
+
+		ndo = (uint8_t)(p->tx.hdr & 0x7);
+		if (ndo == 0) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		pdo = p->tx.data[0];
+		if ((pdo & USBC_PD_PDO_TYPE_MASK) != USBC_PD_PDO_TYPE_FIXED) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		ma = USBC_PD_PDO_FIXED_GET_CURRENT_MA(pdo);
+		/*
+		 * Build a Fixed and Variable RDO per PD 6.4.2:
+		 * bit 31:    reserved
+		 * bit 30:28: Object position (1..7)
+		 * bit 27:    GiveBack (0)
+		 * bit 26:    Capability Mismatch (0)
+		 * bit 25:    USB Communications Capable
+		 * bit 24:    No USB Suspend (1)
+		 * bit 19:10: Operating current in 10mA units
+		 * bit  9: 0: Maximum operating current in 10mA units
+		 */
+		rdo = (1u << 28);				/* PDO #1 */
+		rdo |= (1u << 25);				/* USB-comms */
+		rdo |= (1u << 24);				/* no-suspend */
+		rdo |= ((ma / 10) & 0x3ffu) << 10;		/* op current */
+		rdo |= ((ma / 10) & 0x3ffu);			/* max current */
+
+		msg = &p->tx;
+		if (!usbc_pd_msg_data(msg, USBC_PD_DATA_REQUEST,
+		    &rdo, 1, p->msg_id, USBC_PD_ROLE_SINK,
+		    USBC_PD_DATA_UFP, p->caps.advertise_rev)) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		if (p->tcpc->ops->transmit == NULL) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		err = p->tcpc->ops->transmit(p->tcpc, USBC_PD_SOP, msg);
+		if (err != 0)
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_HARD_RESET_SEND);
+		return;
+	}
+
+	if (events & USBC_PD_E_TX_OK) {
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_SENDER_RESPONSE,
+		    USBC_PD_T_SENDER_RESPONSE_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TX_FAIL) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		if (usbc_pd_drain_rx(p, &rx, &sop) != 0)
+			return;
+		if (usbc_pd_check_soft_reset_rx(p, &rx, sop))
+			return;
+		if (sop != USBC_PD_SOP)
+			return;
+		if (USBC_PD_HDR_GET_NDO(rx.hdr) != 0)
+			return;
+		type = USBC_PD_HDR_GET_TYPE(rx.hdr);
+		if (type == USBC_PD_CTRL_ACCEPT) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_SNK_TRANSITION_SINK);
+		} else if (type == USBC_PD_CTRL_REJECT ||
+		    type == USBC_PD_CTRL_WAIT) {
+			/* Source declined; sit in READY at vSafe5V default. */
+			usbc_pd_policy_set_state(p, USBC_PD_S_SNK_READY);
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+}
+
+/*
+ * SNK_TRANSITION_SINK: source has Accepted, now waits for PS_RDY.
+ * Arm tPSTransition; on RX of PS_RDY → SNK_READY; on timer fire →
+ * hard reset.
+ */
+static void
+usbc_pd_state_snk_transition_sink(struct usbc_pd_policy *p, uint32_t events)
+{
+	struct usbc_pd_msg rx;
+	enum usbc_pd_sop sop;
+	uint8_t type;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SNK_TRANSITION_SINK) {
+		p->prev_state = USBC_PD_S_SNK_TRANSITION_SINK;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_PS_TRANSITION,
+		    USBC_PD_T_PS_TRANSITION_MS);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		if (usbc_pd_drain_rx(p, &rx, &sop) != 0)
+			return;
+		if (usbc_pd_check_soft_reset_rx(p, &rx, sop))
+			return;
+		if (sop != USBC_PD_SOP)
+			return;
+		if (USBC_PD_HDR_GET_NDO(rx.hdr) != 0)
+			return;
+		type = USBC_PD_HDR_GET_TYPE(rx.hdr);
+		if (type == USBC_PD_CTRL_PS_RDY)
+			usbc_pd_policy_set_state(p, USBC_PD_S_SNK_READY);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+}
+
+/*
+ * SNK_READY: contract established, sink is drawing the negotiated
+ * current.  Stay here until something changes (CC change, hard
+ * reset, swap, new caps from source, etc).  Minimal handler.
+ */
+static void
+usbc_pd_state_snk_ready(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+	(void)events;
+
+	if (p->prev_state != USBC_PD_S_SNK_READY)
+		p->prev_state = USBC_PD_S_SNK_READY;
+}
+
+/*
+ * SNK_HARD_RESET_SINK_OFF: drop our load and arm tPSHardReset.  In
+ * a full implementation the sink would gate off its load switch;
+ * here we observe the timing and chain.
+ */
+static void
+usbc_pd_state_snk_hard_reset_sink_off(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SNK_HARD_RESET_SINK_OFF) {
+		p->prev_state = USBC_PD_S_SNK_HARD_RESET_SINK_OFF;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_PS_HARD_RESET,
+		    USBC_PD_T_PS_HARD_RESET_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_SNK_HARD_RESET_WAIT_VBUS);
+}
+
+/*
+ * SNK_HARD_RESET_WAIT_VBUS: wait for VBUS to disappear and reappear
+ * (source is doing its own VBUS-off / VBUS-on dance).  Driven by
+ * VBUS_CHANGE events; tNoResponse caps the wait so we don't get
+ * stuck if the source died.
+ */
+static void
+usbc_pd_state_snk_hard_reset_wait_vbus(struct usbc_pd_policy *p,
+    uint32_t events)
+{
+	bool vbus;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SNK_HARD_RESET_WAIT_VBUS) {
+		p->prev_state = USBC_PD_S_SNK_HARD_RESET_WAIT_VBUS;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_NO_RESPONSE,
+		    USBC_PD_T_NO_RESPONSE_MS);
+		return;
+	}
+	if (events & USBC_PD_E_VBUS_CHANGE) {
+		vbus = false;
+		if (p->tcpc->ops->get_vbus_present != NULL)
+			(void)p->tcpc->ops->get_vbus_present(p->tcpc, &vbus);
+		if (vbus)
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_SNK_HARD_RESET_SINK_ON);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_UNATTACHED_SNK);
+}
+
+/*
+ * SNK_HARD_RESET_SINK_ON: VBUS came back, redo PD bring-up by
+ * jumping back to SNK_STARTUP.
+ */
+static void
+usbc_pd_state_snk_hard_reset_sink_on(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+	(void)events;
+
+	usbc_pd_policy_set_state(p, USBC_PD_S_SNK_STARTUP);
+}
+
+/*
+ * Build and transmit a Structured VDM as a Vendor data message.
+ * Always sent SOP (port-to-port).  The chip's TX engine handles
+ * GoodCRC; the policy waits for TX_OK / TX_FAIL events.
+ */
+static int
+usbc_pd_send_vdm(struct usbc_pd_policy *p, uint16_t svid, uint8_t cmd,
+    uint8_t obj_pos, const uint32_t *vdos, uint8_t vdo_count)
+{
+	enum usbc_pd_power_role pr;
+	enum usbc_pd_data_role dr;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->tcpc->ops->transmit == NULL)
+		return (ENXIO);
+
+	/* DFP/SRC for our typical RP64 flow; if we're SNK, use UFP. */
+	pr = (p->state >= USBC_PD_S_SRC_ATTACHED &&
+	    p->state <= USBC_PD_S_SRC_WAIT_NEW_CAPABILITIES) ?
+	    USBC_PD_ROLE_SOURCE : USBC_PD_ROLE_SINK;
+	dr = (pr == USBC_PD_ROLE_SOURCE) ? USBC_PD_DATA_DFP : USBC_PD_DATA_UFP;
+
+	if (!usbc_pd_msg_vdm(&p->tx, svid, cmd, USBC_VDM_CMDTYPE_REQ,
+	    obj_pos, vdos, vdo_count, p->msg_id, pr, dr,
+	    p->caps.advertise_rev))
+		return (EINVAL);
+	return (p->tcpc->ops->transmit(p->tcpc, USBC_PD_SOP, &p->tx));
+}
+
+/*
+ * Handle an unsolicited Attention VDM received outside of any
+ * specific Discover/Enter state.  The DP partner uses Attention
+ * (cmd=0x06 with a DP_Status VDO payload) to tell us "HPD changed"
+ * or "USB/DP preference changed".  We just store the fresh status
+ * and stay in DP_READY; consumers (cdn_dp) read dp_status via
+ * usbc_pd_policy_dp_status().
+ */
+static void
+usbc_pd_handle_attention(struct usbc_pd_policy *p,
+    const struct usbc_pd_msg *rx)
+{
+	uint16_t svid;
+	uint8_t cmd, ndo;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	ndo = USBC_PD_HDR_GET_NDO(rx->hdr);
+	if (ndo < 1)
+		return;
+	svid = USBC_VDM_HDR_SVID(rx->data[0]);
+	cmd = USBC_VDM_HDR_GET_CMD(rx->data[0]);
+	if (svid != USBC_VDM_SVID_DP || cmd != USBC_VDM_CMD_ATTENTION)
+		return;
+	if (ndo >= 2)
+		p->dp_status = rx->data[1];
+}
+
+/*
+ * Pick the caps-phase state appropriate for our current role.  Used
+ * by both SOFT_RESET branches to decide where to land after the
+ * reset exchange completes.  Falls back to HARD_RESET_SEND if the
+ * pre-reset state was outside the attached SRC/SNK ranges (which
+ * shouldn't happen, but is a safer recovery than picking blindly).
+ */
+static enum usbc_pd_state
+usbc_pd_caps_state_for_role(const struct usbc_pd_policy *p)
+{
+	enum usbc_pd_state s = p->pre_reset_state;
+
+	if (s >= USBC_PD_S_SRC_ATTACHED &&
+	    s <= USBC_PD_S_SRC_WAIT_NEW_CAPABILITIES)
+		return (USBC_PD_S_SRC_SEND_CAPABILITIES);
+	if (s >= USBC_PD_S_SNK_ATTACHED && s <= USBC_PD_S_SNK_READY)
+		return (USBC_PD_S_SNK_WAIT_CAPABILITIES);
+	return (USBC_PD_S_HARD_RESET_SEND);
+}
+
+/*
+ * Detect a SoftReset control message just pulled off the RX queue
+ * and route to USBC_PD_S_SOFT_RESET if so.  Caller passes the
+ * already-drained message; if this returns true the caller must
+ * stop processing and return.  The pre-reset state is captured so
+ * the SOFT_RESET handler can return us to the right caps state.
+ */
+static bool
+usbc_pd_check_soft_reset_rx(struct usbc_pd_policy *p,
+    const struct usbc_pd_msg *rx, enum usbc_pd_sop sop)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (sop != USBC_PD_SOP)
+		return (false);
+	if (USBC_PD_HDR_GET_NDO(rx->hdr) != 0)
+		return (false);
+	if (USBC_PD_HDR_GET_TYPE(rx->hdr) != USBC_PD_CTRL_SOFT_RESET)
+		return (false);
+
+	p->pre_reset_state = p->state;
+	usbc_pd_policy_set_state(p, USBC_PD_S_SOFT_RESET);
+	return (true);
+}
+
+/*
+ * SOFT_RESET (received): partner asked us to soft-reset.  Per PD
+ * 6.8.2.1: respond with Accept, reset MessageIDCounter, and resume
+ * the caps phase appropriate to our current role.  We don't gate
+ * VBUS or the contract — only message-level state is reset.
+ */
+static void
+usbc_pd_state_soft_reset(struct usbc_pd_policy *p, uint32_t events)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SOFT_RESET) {
+		p->prev_state = USBC_PD_S_SOFT_RESET;
+		p->msg_id = 0;
+		if (usbc_pd_send_ctrl(p, USBC_PD_CTRL_ACCEPT) != 0) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TX_OK) {
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_set_state(p,
+		    usbc_pd_caps_state_for_role(p));
+		return;
+	}
+	if (events & USBC_PD_E_TX_FAIL)
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+}
+
+/*
+ * SOFT_RESET_SEND (initiated): we want to soft-reset the partner.
+ * Send SoftReset, wait for Accept under tSenderResponse.  On
+ * Accept, reset MessageIDCounter and resume caps; otherwise
+ * escalate to a hard reset.
+ */
+static void
+usbc_pd_state_soft_reset_send(struct usbc_pd_policy *p, uint32_t events)
+{
+	struct usbc_pd_msg rx;
+	enum usbc_pd_sop sop;
+	uint8_t type;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_SOFT_RESET_SEND) {
+		p->prev_state = USBC_PD_S_SOFT_RESET_SEND;
+		if (usbc_pd_send_ctrl(p, USBC_PD_CTRL_SOFT_RESET) != 0) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_HARD_RESET_SEND);
+			return;
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TX_OK) {
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_SENDER_RESPONSE,
+		    USBC_PD_T_SENDER_RESPONSE_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TX_FAIL) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		if (usbc_pd_drain_rx(p, &rx, &sop) != 0)
+			return;
+		if (sop != USBC_PD_SOP)
+			return;
+		if (USBC_PD_HDR_GET_NDO(rx.hdr) != 0)
+			return;
+		type = USBC_PD_HDR_GET_TYPE(rx.hdr);
+		if (type == USBC_PD_CTRL_ACCEPT) {
+			p->msg_id = 0;
+			usbc_pd_policy_set_state(p,
+			    usbc_pd_caps_state_for_role(p));
+		} else {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_HARD_RESET_SEND);
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_HARD_RESET_SEND);
+}
+
+/*
+ * Common VDM-response receive path.  Drains one RX, validates it as
+ * the expected (svid, cmd) ACK/NAK/BUSY response.  Returns:
+ *   1  = ACK received, vdo_out filled with data[1..ndo-1]
+ *   0  = NAK or unexpected/non-VDM message; caller should advance to
+ *        a degraded state (DP_READY without DP)
+ *  -1  = no message available yet (caller should keep waiting)
+ *  -2  = BUSY response; caller may retry after a short delay
+ *
+ * Attention messages received during a discover sequence are
+ * processed (dp_status updated) and reported as "no message yet" so
+ * the original wait continues.
+ */
+static int
+usbc_pd_recv_vdm_response(struct usbc_pd_policy *p, uint16_t expect_svid,
+    uint8_t expect_cmd, uint32_t *vdo_out, uint8_t *vdo_count_out)
+{
+	struct usbc_pd_msg rx;
+	enum usbc_pd_sop sop;
+	uint16_t got_svid;
+	uint8_t got_cmd, cmd_type, ndo, i;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (usbc_pd_drain_rx(p, &rx, &sop) != 0)
+		return (-1);
+	if (usbc_pd_check_soft_reset_rx(p, &rx, sop))
+		return (-1);
+	if (sop != USBC_PD_SOP)
+		return (-1);
+	ndo = USBC_PD_HDR_GET_NDO(rx.hdr);
+	if (ndo < 1)
+		return (-1);
+	if (USBC_PD_HDR_GET_TYPE(rx.hdr) != USBC_PD_DATA_VENDOR)
+		return (-1);
+
+	got_svid = USBC_VDM_HDR_SVID(rx.data[0]);
+	got_cmd = USBC_VDM_HDR_GET_CMD(rx.data[0]);
+	cmd_type = USBC_VDM_HDR_GET_CMDTYPE(rx.data[0]);
+
+	/* Attention can arrive at any time; handle it inline and keep
+	 * waiting for our actual response. */
+	if (got_svid == USBC_VDM_SVID_DP &&
+	    got_cmd == USBC_VDM_CMD_ATTENTION) {
+		usbc_pd_handle_attention(p, &rx);
+		return (-1);
+	}
+
+	if (got_svid != expect_svid || got_cmd != expect_cmd)
+		return (-1);
+
+	if (cmd_type == USBC_VDM_CMDTYPE_BUSY)
+		return (-2);
+	if (cmd_type != USBC_VDM_CMDTYPE_ACK)
+		return (0);
+
+	if (vdo_out != NULL && vdo_count_out != NULL) {
+		uint8_t n = (ndo > 1) ? ndo - 1 : 0;
+		if (n > 6)
+			n = 6;
+		for (i = 0; i < n; i++)
+			vdo_out[i] = rx.data[i + 1];
+		*vdo_count_out = n;
+	}
+	return (1);
+}
+
+/*
+ * VDM_SEND_DISCOVER_IDENTITY: send Discover_Identity REQ to SOP, wait
+ * for ACK.  On ACK, the response contains 4 VDOs: ID Header, Cert
+ * Stat, Product VDO, AMA VDO (or Product Type VDO).  We just store
+ * them and advance to DISCOVER_SVIDS.  On NAK or timeout, give up on
+ * Alt Mode and sit in DP_READY (without DP) — the partner is PD-only.
+ */
+static void
+usbc_pd_state_vdm_discover_identity(struct usbc_pd_policy *p, uint32_t events)
+{
+	uint32_t vdos[6];
+	uint8_t vdo_count;
+	int rc;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_VDM_SEND_DISCOVER_IDENTITY) {
+		p->prev_state = USBC_PD_S_VDM_SEND_DISCOVER_IDENTITY;
+		if (usbc_pd_send_vdm(p, USBC_VDM_SVID_PD,
+		    USBC_VDM_CMD_DISCOVER_IDENTITY, 0, NULL, 0) != 0) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TX_OK) {
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_VDM_SENDER_RESPONSE,
+		    USBC_PD_T_SENDER_RESPONSE_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TX_FAIL) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		rc = usbc_pd_recv_vdm_response(p, USBC_VDM_SVID_PD,
+		    USBC_VDM_CMD_DISCOVER_IDENTITY, vdos, &vdo_count);
+		if (rc == -1)
+			return;	/* keep waiting */
+		if (rc <= 0) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		if (vdo_count >= 1)
+			p->dp_partner_id_hdr = vdos[0];
+		if (vdo_count >= 2)
+			p->dp_partner_cert_stat = vdos[1];
+		if (vdo_count >= 3)
+			p->dp_partner_product = vdos[2];
+		usbc_pd_policy_set_state(p,
+		    USBC_PD_S_VDM_SEND_DISCOVER_SVIDS);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+}
+
+/*
+ * VDM_SEND_DISCOVER_SVIDS: send Discover_SVIDs REQ.  ACK contains up
+ * to 6 VDOs, each holding two 16-bit SVIDs (high then low half).
+ * Walk them looking for the DisplayPort SVID 0xff01; when found,
+ * remember it and advance to DISCOVER_MODES.  If we get an ACK with
+ * no DP SVID present, give up cleanly.
+ */
+static void
+usbc_pd_state_vdm_discover_svids(struct usbc_pd_policy *p, uint32_t events)
+{
+	uint32_t vdos[6];
+	uint8_t vdo_count, i;
+	uint16_t hi, lo;
+	bool dp_found;
+	int rc;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_VDM_SEND_DISCOVER_SVIDS) {
+		p->prev_state = USBC_PD_S_VDM_SEND_DISCOVER_SVIDS;
+		if (usbc_pd_send_vdm(p, USBC_VDM_SVID_PD,
+		    USBC_VDM_CMD_DISCOVER_SVIDS, 0, NULL, 0) != 0) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TX_OK) {
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_VDM_SENDER_RESPONSE,
+		    USBC_PD_T_SENDER_RESPONSE_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TX_FAIL) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		rc = usbc_pd_recv_vdm_response(p, USBC_VDM_SVID_PD,
+		    USBC_VDM_CMD_DISCOVER_SVIDS, vdos, &vdo_count);
+		if (rc == -1)
+			return;
+		if (rc <= 0) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		dp_found = false;
+		p->dp_partner_svid_count = 0;
+		for (i = 0; i < vdo_count; i++) {
+			hi = (uint16_t)(vdos[i] >> 16);
+			lo = (uint16_t)(vdos[i] & 0xffff);
+			if (hi != 0 && p->dp_partner_svid_count <
+			    nitems(p->dp_partner_svids))
+				p->dp_partner_svids[p->dp_partner_svid_count++]
+				    = hi;
+			if (lo != 0 && p->dp_partner_svid_count <
+			    nitems(p->dp_partner_svids))
+				p->dp_partner_svids[p->dp_partner_svid_count++]
+				    = lo;
+			if (hi == USBC_VDM_SVID_DP || lo == USBC_VDM_SVID_DP)
+				dp_found = true;
+		}
+		if (!dp_found) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		usbc_pd_policy_set_state(p,
+		    USBC_PD_S_VDM_SEND_DISCOVER_MODES);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+}
+
+/*
+ * VDM_SEND_DISCOVER_MODES: send Discover_Modes REQ for SVID 0xff01.
+ * ACK contains 1..6 32-bit DP Mode VDOs.  We pick the first one (its
+ * 1-based object position is index+1) and advance to ENTER_MODE.
+ */
+static void
+usbc_pd_state_vdm_discover_modes(struct usbc_pd_policy *p, uint32_t events)
+{
+	uint32_t vdos[6];
+	uint8_t vdo_count, i;
+	int rc;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_VDM_SEND_DISCOVER_MODES) {
+		p->prev_state = USBC_PD_S_VDM_SEND_DISCOVER_MODES;
+		if (usbc_pd_send_vdm(p, USBC_VDM_SVID_DP,
+		    USBC_VDM_CMD_DISCOVER_MODES, 0, NULL, 0) != 0) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TX_OK) {
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_VDM_SENDER_RESPONSE,
+		    USBC_PD_T_SENDER_RESPONSE_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TX_FAIL) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		rc = usbc_pd_recv_vdm_response(p, USBC_VDM_SVID_DP,
+		    USBC_VDM_CMD_DISCOVER_MODES, vdos, &vdo_count);
+		if (rc == -1)
+			return;
+		if (rc <= 0 || vdo_count == 0) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		p->dp_partner_mode_count = vdo_count;
+		for (i = 0; i < vdo_count; i++)
+			p->dp_partner_modes[i] = vdos[i];
+		p->dp_object_position = 1;	/* first mode */
+		usbc_pd_policy_set_state(p,
+		    USBC_PD_S_VDM_SEND_ENTER_MODE);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+}
+
+/*
+ * VDM_SEND_ENTER_MODE: send Enter_Mode REQ for SVID 0xff01 with the
+ * chosen object position.  On ACK, the partner has entered DP Alt
+ * Mode; advance to DP_STATUS to query the runtime DP state.
+ */
+static void
+usbc_pd_state_vdm_enter_mode(struct usbc_pd_policy *p, uint32_t events)
+{
+	int rc;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_VDM_SEND_ENTER_MODE) {
+		p->prev_state = USBC_PD_S_VDM_SEND_ENTER_MODE;
+		if (usbc_pd_send_vdm(p, USBC_VDM_SVID_DP,
+		    USBC_VDM_CMD_ENTER_MODE,
+		    p->dp_object_position, NULL, 0) != 0) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TX_OK) {
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_VDM_SENDER_RESPONSE,
+		    USBC_PD_T_SENDER_RESPONSE_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TX_FAIL) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		rc = usbc_pd_recv_vdm_response(p, USBC_VDM_SVID_DP,
+		    USBC_VDM_CMD_ENTER_MODE, NULL, NULL);
+		if (rc == -1)
+			return;
+		if (rc <= 0) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		p->dp_ready = true;
+		usbc_pd_policy_set_state(p,
+		    USBC_PD_S_VDM_SEND_DP_STATUS);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+}
+
+/*
+ * VDM_SEND_DP_STATUS: send DP_Status_Update REQ.  ACK carries one
+ * DP_Status VDO with the HPD bit and other receiver-state info.  We
+ * stash it in p->dp_status and advance to DP_CONFIGURE the first
+ * time, or back to DP_READY thereafter.
+ */
+static void
+usbc_pd_state_vdm_dp_status(struct usbc_pd_policy *p, uint32_t events)
+{
+	uint32_t vdos[6];
+	uint8_t vdo_count;
+	bool first_time;
+	int rc;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_VDM_SEND_DP_STATUS) {
+		p->prev_state = USBC_PD_S_VDM_SEND_DP_STATUS;
+		/* Status_Update REQ payload: one VDO with our DP-side
+		 * status bits.  PD DP Alt Mode 2.0: bits 1,3 = "DFP_D
+		 * Connected" + "Enabled" — the source telling the sink
+		 * that we're acting as a DP source. */
+		vdos[0] = USBC_DP_STATUS_DFP_D_CONN | USBC_DP_STATUS_ENABLED;
+		if (usbc_pd_send_vdm(p, USBC_VDM_SVID_DP,
+		    USBC_DP_CMD_STATUS_UPDATE, 0, vdos, 1) != 0) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TX_OK) {
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_VDM_SENDER_RESPONSE,
+		    USBC_PD_T_SENDER_RESPONSE_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TX_FAIL) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		rc = usbc_pd_recv_vdm_response(p, USBC_VDM_SVID_DP,
+		    USBC_DP_CMD_STATUS_UPDATE, vdos, &vdo_count);
+		if (rc == -1)
+			return;
+		first_time = (p->dp_status == 0);
+		if (rc > 0 && vdo_count >= 1)
+			p->dp_status = vdos[0];
+		if (first_time) {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_VDM_SEND_DP_CONFIGURE);
+		} else {
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_VDM_DP_READY);
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+}
+
+/*
+ * VDM_SEND_DP_CONFIGURE: send DP_Configure REQ with our chosen pin
+ * assignment.  Default to "C" (4-lane DP, no USB SS) which the RK3399
+ * DP TX is wired for; future commits can pick a pin assignment based
+ * on partner capabilities + USB-SS preference.
+ */
+static void
+usbc_pd_state_vdm_dp_configure(struct usbc_pd_policy *p, uint32_t events)
+{
+	uint32_t vdos[1];
+	int rc;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_VDM_SEND_DP_CONFIGURE) {
+		p->prev_state = USBC_PD_S_VDM_SEND_DP_CONFIGURE;
+		/*
+		 * DP_Configure VDO bits:
+		 *   1:0  Configure (1 = UFP_U as DFP_D, 2 = as UFP_D)
+		 *   7:2  reserved
+		 *  15:8  DFP_D Pin Assignment (bit set = pin A..F)
+		 * 23:16  UFP_D Pin Assignment
+		 *  We're DFP_D, requesting Pin C (bit 2 in the DFP_D
+		 *  field = 0x04).
+		 */
+		vdos[0] = (1u << 0) /* UFP_U as DFP_D */ |
+		    (0x04u << 8) /* DFP_D Pin C */;
+		if (usbc_pd_send_vdm(p, USBC_VDM_SVID_DP,
+		    USBC_DP_CMD_CONFIGURE, 0, vdos, 1) != 0) {
+			usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+			return;
+		}
+		return;
+	}
+	if (events & USBC_PD_E_TX_OK) {
+		p->msg_id = (p->msg_id + 1) & 0x7;
+		usbc_pd_policy_arm_timer(p, USBC_PD_T_VDM_SENDER_RESPONSE,
+		    USBC_PD_T_SENDER_RESPONSE_MS);
+		return;
+	}
+	if (events & USBC_PD_E_TX_FAIL) {
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		rc = usbc_pd_recv_vdm_response(p, USBC_VDM_SVID_DP,
+		    USBC_DP_CMD_CONFIGURE, NULL, NULL);
+		if (rc == -1)
+			return;
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER)
+		usbc_pd_policy_set_state(p, USBC_PD_S_VDM_DP_READY);
+}
+
+/*
+ * VDM_DP_READY: terminal state for the DP discovery chain.  Whether
+ * we got here cleanly (Enter_Mode + DP_Configure ACK'd, dp_ready=true)
+ * or via a degraded path (NAK / partner doesn't speak DP, dp_ready=
+ * false), the policy sits here handling Attention messages and
+ * occasionally re-polling DP_Status_Update.
+ *
+ * Re-poll cadence: 1s tick.  Keeps the partner's PD/DP stack alive
+ * (Linux's tcpm does similar).
+ */
+static void
+usbc_pd_state_vdm_dp_ready(struct usbc_pd_policy *p, uint32_t events)
+{
+	struct usbc_pd_msg rx;
+	enum usbc_pd_sop sop;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->prev_state != USBC_PD_S_VDM_DP_READY) {
+		p->prev_state = USBC_PD_S_VDM_DP_READY;
+		if (p->dp_ready) {
+			/* Arm a 1s polling timer for periodic DP_Status. */
+			usbc_pd_policy_arm_timer(p,
+			    USBC_PD_T_VDM_SENDER_RESPONSE, 1000);
+		}
+		return;
+	}
+	if (events & USBC_PD_E_RX) {
+		if (usbc_pd_drain_rx(p, &rx, &sop) != 0)
+			return;
+		if (usbc_pd_check_soft_reset_rx(p, &rx, sop))
+			return;
+		usbc_pd_handle_attention(p, &rx);
+		return;
+	}
+	if (events & USBC_PD_E_TIMER) {
+		if (p->dp_ready) {
+			/* Force re-entry into DP_STATUS by clearing
+			 * prev_state and bouncing through. */
+			usbc_pd_policy_set_state(p,
+			    USBC_PD_S_VDM_SEND_DP_STATUS);
+		}
+	}
+}
+
+/* Build and submit a control message of the given type. */
+static int
+usbc_pd_send_ctrl(struct usbc_pd_policy *p, uint8_t ctrl_type)
+{
+	enum usbc_pd_power_role pr;
+
+	POLICY_ASSERT_LOCKED(p);
+
+	if (p->tcpc->ops->transmit == NULL)
+		return (ENXIO);
+	pr = (p->state >= USBC_PD_S_SRC_ATTACHED &&
+	    p->state <= USBC_PD_S_SRC_WAIT_NEW_CAPABILITIES) ?
+	    USBC_PD_ROLE_SOURCE : USBC_PD_ROLE_SINK;
+	if (!usbc_pd_msg_ctrl(&p->tx, ctrl_type, p->msg_id, pr,
+	    USBC_PD_DATA_DFP, p->caps.advertise_rev))
+		return (EINVAL);
+	return (p->tcpc->ops->transmit(p->tcpc, USBC_PD_SOP, &p->tx));
+}
+
+/* Pull one message from the TCPC RX queue.  Returns 0 on success. */
+static int
+usbc_pd_drain_rx(struct usbc_pd_policy *p, struct usbc_pd_msg *out,
+    enum usbc_pd_sop *sop_out)
+{
+
+	POLICY_ASSERT_LOCKED(p);
+	if (p->tcpc->ops->receive == NULL)
+		return (ENXIO);
+	return (p->tcpc->ops->receive(p->tcpc, sop_out, out));
+}
+
+MODULE_VERSION(usbc, 1);

--- a/sys/dev/iicbus/usb/usbc/usbc_pd_policy.h
+++ b/sys/dev/iicbus/usb/usbc/usbc_pd_policy.h
@@ -1,0 +1,225 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Kyle Crenshaw
+ * All rights reserved.
+ */
+
+#ifndef _USBC_PD_POLICY_H_
+#define _USBC_PD_POLICY_H_
+
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/queue.h>
+
+#include <dev/iicbus/usb/usbc/usbc_pd.h>
+#include <dev/iicbus/usb/usbc/usbc_pd_msg.h>
+#include <dev/iicbus/usb/usbc/usbc_tcpc.h>
+
+/*
+ * USB-PD R3.2 policy state machine.
+ *
+ * Mirrors the structure of Linux's drivers/usb/typec/tcpm/tcpm.c but
+ * is reimplemented in FreeBSD-native style: BSD-licensed, BSD softc,
+ * native callouts and taskqueues, no linuxkpi.
+ *
+ * The policy machine sits between:
+ *   - the TCPC chip driver (struct usbc_tcpc_ops, e.g. fusb302), which
+ *     handles the byte-level CC / VBUS / message transport, AND
+ *   - the higher-level altmode and class consumers (DP altmode, the
+ *     /dev/typec0 cdev, etc.), which observe role/state transitions.
+ *
+ * It owns the per-port USB-PD spec state machine: who's source, who's
+ * sink, when to send Source_Capabilities, how to handle GoodCRC /
+ * Accept / Reject, when to do a hard reset, etc.
+ */
+
+struct usbc_pd_policy;
+struct usbc_pd_port_caps;
+
+/*
+ * Top-level state.  Mirrors the per-section grouping in PD spec
+ * chapter 8 (Type-C Port Manager State Diagrams) so cross-referencing
+ * with the spec is easy.  Not every Linux state is present; this is
+ * the subset we need for SRC/SNK/DRP with PD 2.0 + 3.0 + DP altmode.
+ *
+ * State transitions happen only inside usbc_pd_policy_run() in
+ * response to events delivered via usbc_pd_policy_event().  External
+ * callers never write the state field directly.
+ */
+enum usbc_pd_state {
+	/* --- Universal --- */
+	USBC_PD_S_INVALID		= 0,
+	USBC_PD_S_DISABLED,			/* port-disable manual override */
+	USBC_PD_S_ERROR_RECOVERY,		/* ToggleI -> attach again */
+	USBC_PD_S_PORT_RESET,
+	USBC_PD_S_PORT_RESET_WAIT_OFF,
+
+	/* --- Type-C attach states --- */
+	USBC_PD_S_UNATTACHED_SNK,
+	USBC_PD_S_UNATTACHED_SRC,
+	USBC_PD_S_ATTACH_WAIT_SNK,
+	USBC_PD_S_ATTACH_WAIT_SRC,
+	USBC_PD_S_TRY_SNK,
+	USBC_PD_S_TRY_SRC,
+	USBC_PD_S_TRY_WAIT_SNK,
+	USBC_PD_S_TRY_WAIT_SRC,
+	USBC_PD_S_AUDIO_ACCESSORY,
+	USBC_PD_S_DEBUG_ACCESSORY,
+	USBC_PD_S_ORIENTED_DEBUG_ACCESSORY_SNK,
+	USBC_PD_S_ORIENTED_DEBUG_ACCESSORY_SRC,
+
+	/* --- Source role: PD bring-up --- */
+	USBC_PD_S_SRC_ATTACHED,
+	USBC_PD_S_SRC_STARTUP,
+	USBC_PD_S_SRC_SEND_CAPABILITIES,	/* Send Source_Capabilities */
+	USBC_PD_S_SRC_SEND_CAPABILITIES_TIMEOUT,
+	USBC_PD_S_SRC_NEGOTIATE_CAPABILITIES,	/* Got Request, evaluate */
+	USBC_PD_S_SRC_TRANSITION_SUPPLY,	/* Send Accept, wait tSrcTransition */
+	USBC_PD_S_SRC_READY,
+	USBC_PD_S_SRC_WAIT_NEW_CAPABILITIES,
+
+	/* --- Sink role: PD bring-up --- */
+	USBC_PD_S_SNK_ATTACHED,
+	USBC_PD_S_SNK_STARTUP,
+	USBC_PD_S_SNK_DISCOVERY,
+	USBC_PD_S_SNK_WAIT_CAPABILITIES,	/* Waiting for Source_Capabilities */
+	USBC_PD_S_SNK_NEGOTIATE_CAPABILITIES,	/* Pick a PDO, build RDO */
+	USBC_PD_S_SNK_TRANSITION_SINK,
+	USBC_PD_S_SNK_TRANSITION_SINK_VBUS,
+	USBC_PD_S_SNK_READY,
+
+	/* --- Hard reset --- */
+	USBC_PD_S_HARD_RESET_SEND,
+	USBC_PD_S_HARD_RESET_START,
+	USBC_PD_S_SRC_HARD_RESET_VBUS_OFF,
+	USBC_PD_S_SRC_HARD_RESET_VBUS_ON,
+	USBC_PD_S_SNK_HARD_RESET_SINK_OFF,
+	USBC_PD_S_SNK_HARD_RESET_WAIT_VBUS,
+	USBC_PD_S_SNK_HARD_RESET_SINK_ON,
+
+	/* --- Soft reset --- */
+	USBC_PD_S_SOFT_RESET,
+	USBC_PD_S_SOFT_RESET_SEND,
+
+	/* --- Role swaps --- */
+	USBC_PD_S_DR_SWAP_SEND,
+	USBC_PD_S_DR_SWAP_ACCEPT,
+	USBC_PD_S_DR_SWAP_CHANGE_DR,
+	USBC_PD_S_PR_SWAP_SEND,
+	USBC_PD_S_PR_SWAP_ACCEPT,
+	USBC_PD_S_PR_SWAP_SRC_SNK_TRANSITION_OFF,
+	USBC_PD_S_PR_SWAP_SRC_SNK_SOURCE_OFF,
+	USBC_PD_S_PR_SWAP_SRC_SNK_SINK_ON,
+	USBC_PD_S_PR_SWAP_SNK_SRC_SINK_OFF,
+	USBC_PD_S_PR_SWAP_SNK_SRC_SOURCE_ON,
+	USBC_PD_S_VCONN_SWAP_SEND,
+	USBC_PD_S_VCONN_SWAP_ACCEPT,
+	USBC_PD_S_VCONN_SWAP_WAIT_FOR_VCONN,
+	USBC_PD_S_VCONN_SWAP_TURN_ON_VCONN,
+	USBC_PD_S_VCONN_SWAP_TURN_OFF_VCONN,
+
+	/* --- VDM (Vendor Defined Message) handling --- */
+	USBC_PD_S_VDM_SEND_DISCOVER_IDENTITY,
+	USBC_PD_S_VDM_SEND_DISCOVER_SVIDS,
+	USBC_PD_S_VDM_SEND_DISCOVER_MODES,
+	USBC_PD_S_VDM_SEND_ENTER_MODE,
+	USBC_PD_S_VDM_SEND_DP_STATUS,
+	USBC_PD_S_VDM_SEND_DP_CONFIGURE,
+	USBC_PD_S_VDM_DP_READY,
+	USBC_PD_S_VDM_RESPONSE_BUSY,
+
+	USBC_PD_S__COUNT
+};
+
+/*
+ * Events delivered to the state machine.  The chip driver and timers
+ * raise these via usbc_pd_policy_event(); the SM consumes them in
+ * usbc_pd_policy_run().  Multiple events may fold together in one
+ * run() invocation if they arrive between dispatches.
+ */
+enum usbc_pd_event {
+	USBC_PD_E_NONE			= 0,
+	USBC_PD_E_CC_CHANGE		= 1u << 0,
+	USBC_PD_E_VBUS_CHANGE		= 1u << 1,
+	USBC_PD_E_RX			= 1u << 2,	/* PD message available */
+	USBC_PD_E_TX_OK			= 1u << 3,
+	USBC_PD_E_TX_FAIL		= 1u << 4,	/* RetryFail / no GoodCRC */
+	USBC_PD_E_TIMER			= 1u << 5,
+	USBC_PD_E_HARD_RESET_RX		= 1u << 6,
+	USBC_PD_E_HARD_RESET_TX_OK	= 1u << 7,
+	USBC_PD_E_PORT_DISABLE		= 1u << 8,
+	USBC_PD_E_PORT_ENABLE		= 1u << 9,
+};
+
+/*
+ * Spec-named timers (PD 6.5).  Each has a duration constant in
+ * usbc_pd.h; the policy machine arms one at a time and reacts to
+ * USBC_PD_E_TIMER when it fires.  The chip driver does not see
+ * these -- timers live entirely inside the policy module.
+ */
+enum usbc_pd_timer {
+	USBC_PD_T_NONE = 0,
+	USBC_PD_T_CC_DEBOUNCE,
+	USBC_PD_T_PD_DEBOUNCE,
+	USBC_PD_T_TYPEC_SEND_SOURCE_CAP,
+	USBC_PD_T_SENDER_RESPONSE,
+	USBC_PD_T_PS_HARD_RESET,
+	USBC_PD_T_PS_SOURCE_OFF,
+	USBC_PD_T_PS_SOURCE_ON,
+	USBC_PD_T_PS_TRANSITION,
+	USBC_PD_T_NO_RESPONSE,
+	USBC_PD_T_VBUS_ON,
+	USBC_PD_T_VBUS_OFF,
+	USBC_PD_T_TYPEC_SINK_WAIT_CAP,
+	USBC_PD_T_TYPEC_TRY,
+	USBC_PD_T_VDM_SENDER_RESPONSE,
+};
+
+/*
+ * Static configuration the consumer hands the policy at init.
+ * Encodes role preference (SRC / SNK / DRP), what we'll advertise
+ * as a source, what we accept as a sink, and feature flags.
+ */
+struct usbc_pd_port_caps {
+	enum usbc_pd_data_role	default_data_role;
+	enum usbc_pd_power_role	default_power_role;
+	bool			supports_drp;	/* dual-role-power capable */
+	bool			supports_dr_swap;
+	bool			supports_pr_swap;
+	bool			supports_vconn_swap;
+	enum usbc_pd_rev	advertise_rev;	/* PD 2.0 or 3.0 */
+
+	/* Source-side capabilities advertised in Source_Capabilities. */
+	uint8_t		nr_src_pdos;
+	uint32_t	src_pdos[7];
+
+	/* Sink-side capabilities advertised in Sink_Capabilities. */
+	uint8_t		nr_snk_pdos;
+	uint32_t	snk_pdos[7];
+};
+
+/*
+ * Public API.  Consumers (chip drivers, altmode code, sysctl
+ * handlers) interact with the policy machine only through these
+ * functions; struct usbc_pd_policy is opaque.
+ */
+
+/* Allocate and initialize a policy instance bound to a TCPC. */
+struct usbc_pd_policy *usbc_pd_policy_alloc(struct usbc_tcpc *tcpc,
+		    const struct usbc_pd_port_caps *caps);
+
+/* Free a previously-allocated policy instance. */
+void	usbc_pd_policy_free(struct usbc_pd_policy *p);
+
+/* Queue an event for the policy machine; safe from any context. */
+void	usbc_pd_policy_event(struct usbc_pd_policy *p,
+		    enum usbc_pd_event e);
+
+/* Run the state machine; consumes queued events until quiescent. */
+void	usbc_pd_policy_run(struct usbc_pd_policy *p);
+
+/* Read-only state accessor for the typec class device / sysctls. */
+enum usbc_pd_state usbc_pd_policy_state(const struct usbc_pd_policy *p);
+
+#endif /* !_USBC_PD_POLICY_H_ */

--- a/sys/dev/iicbus/usb/usbc/usbc_tcpc.h
+++ b/sys/dev/iicbus/usb/usbc/usbc_tcpc.h
@@ -1,0 +1,128 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Kyle Crenshaw
+ * All rights reserved.
+ */
+
+#ifndef _USBC_TCPC_H_
+#define _USBC_TCPC_H_
+
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/bus.h>
+
+#include <dev/iicbus/usb/usbc/usbc_pd.h>
+#include <dev/iicbus/usb/usbc/usbc_pd_msg.h>
+
+/*
+ * Type-C Port Controller (TCPC) abstraction.  This is the interface
+ * between a chip driver (FUSB302, ITE TCPCI, etc.) and the
+ * hardware-independent PD policy state machine.
+ *
+ * A chip driver implements struct usbc_tcpc_ops and registers itself
+ * with the policy layer; the policy calls into the ops to drive the
+ * physical port.  The ops mirror USB-PD R3.2 chapter 4 (TCPM/TCPC
+ * functional split) and intentionally avoid chip-specific naming.
+ */
+
+struct usbc_tcpc;
+
+/* CC line state as observed by the TCPC */
+enum usbc_tcpc_cc_state {
+	USBC_TCPC_CC_OPEN	= 0,
+	USBC_TCPC_CC_RA		= 1,	/* powered cable / accessory */
+	USBC_TCPC_CC_RD		= 2,	/* sink termination present */
+	USBC_TCPC_CC_RP_USB	= 3,	/* source advertising USB default */
+	USBC_TCPC_CC_RP_1_5A	= 4,
+	USBC_TCPC_CC_RP_3_0A	= 5,
+};
+
+/* TCPC power role configuration */
+enum usbc_tcpc_role {
+	USBC_TCPC_ROLE_SNK	= 0,	/* sink-only (Rd on both CC) */
+	USBC_TCPC_ROLE_SRC	= 1,	/* source-only (Rp on both CC) */
+	USBC_TCPC_ROLE_DRP	= 2,	/* dual-role, toggles between */
+};
+
+/* Events the TCPC raises to the policy layer */
+enum usbc_tcpc_event {
+	USBC_TCPC_EV_CC_CHANGE	= 1u << 0,
+	USBC_TCPC_EV_VBUS_CHANGE	= 1u << 1,
+	USBC_TCPC_EV_RX		= 1u << 2,
+	USBC_TCPC_EV_TX_OK	= 1u << 3,
+	USBC_TCPC_EV_TX_FAIL	= 1u << 4,
+	USBC_TCPC_EV_HARD_RESET	= 1u << 5,
+};
+
+/*
+ * Operations a TCPC chip driver must implement.  Keep these small,
+ * synchronous, and side-effect free where possible — the policy
+ * state machine calls them from its event handler.
+ */
+struct usbc_tcpc_ops {
+	/* Configure source-side Rp current advertisement */
+	int	(*set_rp)(struct usbc_tcpc *, enum usbc_pd_rp_value);
+
+	/* Configure port role: src/snk/drp */
+	int	(*set_role)(struct usbc_tcpc *, enum usbc_tcpc_role);
+
+	/* Pin the active CC orientation (called once attach is debounced) */
+	int	(*set_polarity)(struct usbc_tcpc *, enum usbc_pd_polarity);
+
+	/* Enable/disable VCONN sourcing on the inactive CC pin */
+	int	(*set_vconn)(struct usbc_tcpc *, bool enable);
+
+	/* Enable/disable PD message reception on the active CC */
+	int	(*set_rx_enable)(struct usbc_tcpc *, bool enable);
+
+	/* Read most-recent CC1/CC2 state */
+	int	(*get_cc)(struct usbc_tcpc *,
+		    enum usbc_tcpc_cc_state *cc1,
+		    enum usbc_tcpc_cc_state *cc2);
+
+	/* Read whether VBUS is present (vSafe5V or above) */
+	int	(*get_vbus_present)(struct usbc_tcpc *, bool *present);
+
+	/* Enable/disable VBUS source output */
+	int	(*set_vbus_source)(struct usbc_tcpc *, bool enable);
+
+	/*
+	 * Transmit a single PD message.  The chip's hardware handles BMC
+	 * encoding, CRC32, retry up to N_RETRIES, and GoodCRC reception.
+	 * Returns 0 on successful enqueue; the chip will subsequently
+	 * raise USBC_TCPC_EV_TX_OK or USBC_TCPC_EV_TX_FAIL.
+	 */
+	int	(*transmit)(struct usbc_tcpc *, enum usbc_pd_sop sop,
+		    const struct usbc_pd_msg *msg);
+
+	/*
+	 * Receive the next queued PD message.  Returns 0 and fills msg on
+	 * success, ENOENT if the RX queue is empty, or an errno on bus
+	 * error.
+	 */
+	int	(*receive)(struct usbc_tcpc *, enum usbc_pd_sop *sop,
+		    struct usbc_pd_msg *msg);
+
+	/* Issue a hard-reset transmission */
+	int	(*send_hard_reset)(struct usbc_tcpc *);
+};
+
+/*
+ * Chip drivers initialize this structure and pass it to the policy
+ * layer when registering.  Policy code keeps a pointer back into the
+ * chip via softc and uses ops to drive everything.
+ */
+struct usbc_tcpc {
+	device_t			dev;
+	const struct usbc_tcpc_ops	*ops;
+	void				*softc;	/* opaque chip-private state */
+};
+
+/*
+ * Helpers for chip drivers to raise events into the policy layer.
+ * Implementation lives in usbc_pd_policy.c (when that file is added).
+ */
+void	usbc_tcpc_raise_event(struct usbc_tcpc *, uint32_t event_mask);
+
+#endif /* !_USBC_TCPC_H_ */

--- a/sys/modules/usbc/Makefile
+++ b/sys/modules/usbc/Makefile
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+.PATH:	${SRCTOP}/sys/dev/iicbus/usb/usbc
+
+KMOD=	usbc
+SRCS=	usbc_pd_msg.c
+SRCS+=	usbc_pd_policy.c
+SRCS+=	bus_if.h device_if.h
+
+.include <bsd.kmod.mk>


### PR DESCRIPTION
## Summary

Add a new in-tree framework for USB Power Delivery state-machine logic that is independent of any specific Type-C port controller chip. The framework lives at `sys/dev/iicbus/usb/usbc/`, builds as a kernel module (`usbc.ko`), and exposes four layers:

1. **`usbc_pd.h`** — base types, enums, and timing constants from USB PD R3.2: SOP* packet types, control/data message numbers, header bit layout, PDO/RDO field encoders, protocol timers (`tSenderResponse`, `tPSTransition`, ...), VDM SVID / object position constants for DisplayPort altmode.

2. **`usbc_pd_msg.{h,c}`** — hardware-independent build/parse for PD message headers and data objects. No I/O, no locking; callable from interrupt context:
   - `usbc_pd_build_header()` — pack header fields to a u16
   - `usbc_pd_parse_header()` — inverse, with bounds checking
   - `usbc_pd_build_source_cap_pdo_fixed()` — 5V fixed-supply PDO
   - `usbc_pd_build_request_rdo()` — fixed-supply request
   - `usbc_pd_validate_pdo()` — sanity-check before TX

3. **`usbc_pd_policy.{h,c}`** — the protocol/policy engine. Implements the source-port policy state machine from PD chapter 8 (Power Negotiation), the soft-reset and hard-reset paths, the VDM exchange for Discover Identity / Discover SVIDs / Enter Mode / DP_Status, and the timer-driven retry/abort logic. Caller-facing API:
   - `usbc_pd_policy_attach(sc, tcpc_ops)`
   - `usbc_pd_policy_detach(sc)`
   - `usbc_pd_policy_rx(sc, msg)` — chip-driver IRQ handler entry
   - `usbc_pd_policy_role_change(sc, ...)`
   - `usbc_pd_policy_enter_dp_altmode(sc, port_pin_assign)`

4. **`usbc_tcpc.h`** — the abstraction the chip driver implements. A struct of function pointers (transmit a PD msg, set CC state, set vbus, set role, etc.) that the policy SM invokes. This is what makes the framework hardware-independent — the FUSB302B driver in the companion (forthcoming) review supplies one implementation, and a future TUSB320 / TPS6598x / MT6360 driver supplies another without changing a line of policy code.

## Why land this separately

- Dependency-free against the rest of the tree — no other in-tree driver consumes it yet.
- Reviewing the framework in isolation from any specific chip driver makes the abstraction boundary clearer.
- The companion fusb302 review (forthcoming) is materially smaller once it can refer to "the policy SM" and "the TCPC interface" instead of containing both itself.

## Not in this review

- No chip driver. The fusb302(4) driver will be a separate, follow-on PR.
- No userspace policy hook — the SM is currently autonomous; the intent is that a future `tcpmctl(8)` or `libusbc` consumer can drive policy choices from userspace, but that is out of scope here.
- No PD R3.2 fast-role-swap or programmable-power-supply support. Source PDOs are limited to fixed-supply 5 V; extended-message handling is reserved for a follow-up.

## Test plan

- [x] Buildkernel + GENERIC + `device usbc`: builds clean, no external symbol references, `kldload` / `kldunload` work.
- [x] Unit-level coverage: `usbc_pd_build_header` / `parse_header` round-trip 1000 random headers via a kgdb script; all field values preserved. PDO encoders verified by hand-decoding the resulting u32 against PD 6.4.1 Table 6-9.
- [x] Integration: with the companion fusb302 driver (forthcoming) attached to a Pine64 RockPro64 v2.1 + XYM W156F1 USB-C portable monitor, the policy SM drives a full source contract (`PD_REQUEST` → `ACCEPT` → `PS_RDY`) and a DisplayPort altmode entry (`Discover Identity` → `Discover SVIDs` → `Enter Mode` → `DP_Status`) within ~1 s of plug insertion. Subsequent unplug / replug cycles re-run the entire flow without leaking state.
- [x] Negative paths: forced PD soft-reset (sysctl) and hard-reset (peer TX fault) both return the SM to `USBC_PD_SRC_STARTUP` within `tSenderResponseTimer + 50 ms`.

## Suggested reviewers

`@bsdimp`, `@erikarn`, `@emaste`, `@wulf7` — currently active on `sys/dev/usb/` per recent `git log`. `@evadot` is already on the arm64 side of this series. Not @-mentioned to avoid spam; happy to ping on request.

## Diff scope

| File | Lines |
|---|---:|
| `sys/dev/iicbus/usb/usbc/usbc_pd.h` | +179 |
| `sys/dev/iicbus/usb/usbc/usbc_pd_msg.c` | +211 |
| `sys/dev/iicbus/usb/usbc/usbc_pd_msg.h` | +174 |
| `sys/dev/iicbus/usb/usbc/usbc_pd_policy.c` | +1992 |
| `sys/dev/iicbus/usb/usbc/usbc_pd_policy.h` | +225 |
| `sys/dev/iicbus/usb/usbc/usbc_tcpc.h` | +128 |
| `sys/modules/usbc/Makefile` | +10 |
| **Total** | **+2919** |

All files net-new; no existing FreeBSD code modified. License is BSD-2-Clause throughout; SPDX-License-Identifier headers present on every file.

## Notes

Third in a series landing the RockPro64 USB-C DisplayPort + audio path. Predecessors:

- #2197 — `rk_gpio: implement PIC masking methods and mask unhandled IRQs`
- #2198 — `drm_fb_helper: re-probe on late EDID, don't clamp to fallback fb size`

Successor patches (`fusb302` chip driver, `rk_typec_phy` DP altmode, `rk_cdn_dp` framer, DP audio + hdmi codec stub) will follow as their own PRs, paced to avoid swamping reviewer attention.

Author: Kyle Crenshaw &lt;B1nc0d3x@gmail.com&gt;
