### PR TITLE
 lib/libc/gen/fts.3: use 'options' consistently in fts_set() return description

### DIFF
--- a/lib/libc/gen/fts.3
+++ b/lib/libc/gen/fts.3
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd October 6, 2025
+.Dd May 21, 2026
 .Dt FTS 3
 .Os
 .Sh NAME
@@ -893,7 +893,7 @@ to an appropriate non-zero value.
 The
 .Fn fts_set
 function returns 0 on success and \-1 if its
-.Fa instr
+.Fa options
 argument is invalid.
 .Pp
 The


### PR DESCRIPTION
The RETURN VALUES section used "instr" to describe the fts_set()
argument, while the SYNOPSIS and all other references use "options".
Fix the inconsistency.

Reported during GSoC 2026 code review by Alan Somers.
Reviewed by: asomers
Sponsored by: Google LLC (GSoC 2026)