### PR TITLE
ipfilter: Fix NULL pointer dereferences when processing ICMPv6 error packets

### DIFF
--- a/sys/netpfil/ipfilter/netinet/fil.c
+++ b/sys/netpfil/ipfilter/netinet/fil.c
@@ -890,6 +890,8 @@ ipf_pr_icmp6(fr_info_t *fin)
 		ip6_t *ip6;
 
 		icmp6 = fin->fin_dp;
+		if (icmp6 == NULL)
+			return;
 
 		fin->fin_data[0] = *(u_short *)icmp6;
 
@@ -1198,6 +1200,8 @@ ipf_pr_icmp(fr_info_t *fin)
 	}
 
 	icmp = fin->fin_dp;
+	if (icmp == NULL)
+		return;
 
 	fin->fin_data[0] = *(u_short *)icmp;
 	fin->fin_data[1] = icmp->icmp_id;

--- a/sys/netpfil/ipfilter/netinet/fil.c
+++ b/sys/netpfil/ipfilter/netinet/fil.c
@@ -916,6 +916,9 @@ ipf_pr_icmp6(fr_info_t *fin)
 			if (fin->fin_plen < ICMP6ERR_IPICMPHLEN)
 				break;
 
+			if (fin->fin_m == NULL)
+				break;
+
 			if (M_LEN(fin->fin_m) < fin->fin_plen) {
 				if (ipf_coalesce(fin) != 1)
 					return;

--- a/sys/netpfil/ipfilter/netinet/ip_state.c
+++ b/sys/netpfil/ipfilter/netinet/ip_state.c
@@ -4364,9 +4364,13 @@ ipf_checkicmp6matchingstate(fr_info_t *fin)
 	}
 
 	ic6 = fin->fin_dp;
+	if (ic6 == NULL) {
+		SBUMPD(ipf_state_stats, iss_icmp6_miss);
+		return (NULL);
+	}
 
 	oip6 = (ip6_t *)((char *)ic6 + ICMPERR_ICMPHLEN);
-	if (fin->fin_plen < sizeof(*oip6)) {
+	if (fin->fin_dlen < ICMPERR_ICMPHLEN + sizeof(*oip6)) {
 		SBUMPD(ipf_state_stats, iss_icmp_short);
 		return (NULL);
 	}
@@ -4408,6 +4412,10 @@ ipf_checkicmp6matchingstate(fr_info_t *fin)
 
 	if (oip6->ip6_nxt == IPPROTO_ICMPV6) {
 		oic = ofin.fin_dp;
+		if (oic == NULL) {
+			SBUMPD(ipf_state_stats, iss_icmp6_miss);
+			return (NULL);
+		}
 		/*
 		 * an ICMP error can only be generated as a result of an
 		 * ICMP query, not as the response on an ICMP error


### PR DESCRIPTION
Fix kernel panic due to unchecked `M_LEN(fin->fin_m)` on synthetic ICMPv6 inner-packet parse with `fin_m == NULL`, plus dead length check replaced with `fin_dlen` validation.

Malformed/truncated ICMPv6 error packets are now rejected earlier. Valid packets meeting RFC-minimum encapsulation are unaffected.

@cschuber - this has been assigned to you for a while, so I took a shot at fixing it. Happy to defer if you'd prefer to handle it

### Root Cause

When `ipf_checkicmp6matchingstate()` processes an ICMPv6 error packet, it creates a synthesized `fr_info_t` structure (`ofin`) with `fin_m` explicitly set to NULL (with the comment "if dereferenced, panic XXX"). It then calls `ipf_makefrip()` which eventually reaches `ipf_pr_icmp6()`. This function calls `M_LEN(fin->fin_m)` without checking if `fin_m` is NULL, causing a kernel panic.

Additionally, the original length check (`fin->fin_plen < sizeof(ip6_t)`) was unreachable after the earlier `ICMP6ERR_MINPKTLEN` gate and therefore non-functional.

### Fixes

1. **fil.c: ipf_pr_icmp6() / ipf_pr_icmp()** - Add NULL check for `fin->fin_dp` before dereferencing
2. **fil.c: ipf_pr_icmp6()** - Add NULL check for `fin->fin_m` before calling `M_LEN()`
3. **ip_state.c: ipf_checkicmp6matchingstate()** - Add NULL checks for `ic6` and `oic` pointers
4. **ip_state.c: ipf_checkicmp6matchingstate()** - Fix length validation (original check was dead code)

### Testing

- [Reproducer](https://bugs.freebsd.org/bugzilla/attachment.cgi?id=262288) from PR 288333 no longer causes kernel panic
- Module builds and loads cleanly
- No regressions observed

### Problem Report

[PR 288333](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=288333)