### PR TITLE
syslogd: fix memory leak in casper_ttymsg()

### DIFF
--- a/usr.sbin/syslogd/syslogd_cap_log.c
+++ b/usr.sbin/syslogd/syslogd_cap_log.c
@@ -128,19 +128,19 @@ cap_ttymsg(cap_channel_t *chan, struct iovec *iov, int iovcnt,
 int
 casper_ttymsg(nvlist_t *nvlin, nvlist_t *nvlout)
 {
-	char **nvlstrs;
+	const char * const *nvlstrs;
 	struct iovec *iov;
 	size_t iovcnt;
 	int tmout;
 	const char *line;
 
-	nvlstrs = nvlist_take_string_array(nvlin, "iov_strs", &iovcnt);
+	nvlstrs = nvlist_get_string_array(nvlin, "iov_strs", &iovcnt);
 	assert(iovcnt <= TTYMSG_IOV_MAX);
 	iov = calloc(iovcnt, sizeof(*iov));
 	if (iov == NULL)
 		err(EXIT_FAILURE, "calloc");
 	for (size_t i = 0; i < iovcnt; ++i) {
-		iov[i].iov_base = nvlstrs[i];
+		iov[i].iov_base = __DECONST(char *, nvlstrs[i]);
 		iov[i].iov_len = strlen(nvlstrs[i]);
 	}
 	line = nvlist_get_string(nvlin, "line");
@@ -187,25 +187,23 @@ int
 casper_wallmsg(nvlist_t *nvlin)
 {
 	const struct filed *f;
-	char **nvlstrs;
+	const char * const *nvlstrs;
 	struct iovec *iov;
 	size_t sz;
 
 	f = nvlist_get_binary(nvlin, "filed", &sz);
 	assert(sz == sizeof(*f));
-	nvlstrs = nvlist_take_string_array(nvlin, "iov_strs", &sz);
+	nvlstrs = nvlist_get_string_array(nvlin, "iov_strs", &sz);
 	assert(sz <= TTYMSG_IOV_MAX);
 	iov = calloc(sz, sizeof(*iov));
 	if (iov == NULL)
 		err(EXIT_FAILURE, "calloc");
 	for (size_t i = 0; i < sz; ++i) {
-		iov[i].iov_base = nvlstrs[i];
+		iov[i].iov_base = __DECONST(char *, nvlstrs[i]);
 		iov[i].iov_len = strlen(nvlstrs[i]);
 	}
 	wallmsg(f, iov, sz);
 
-	for (size_t i = 0; i < sz; ++i)
-		free(iov[i].iov_base);
 	free(iov);
 	return (0);
 }


### PR DESCRIPTION
nvlist_take_string_array(9) takes ownership of the array and its
strings. casper_ttymsg() freed neither, leaking memory on every
F_CONSOLE and F_TTY message. On long-running systems with high
error-rate syslog traffic routed to /dev/console, syslogd.casper grew
to hundreds of MB.

Use nvlist_get_string_array(9) to borrow the array instead. Update
casper_wallmsg() similarly.

PR: 295488
Fixes: 61a29eca550b ("syslogd: Log messages using libcasper")
Signed-off-by: Pat Maddox <pat@patmaddox.com>