### PR TITLE
libc: Suppress <stdalign.h> content for C23 and later

### DIFF
--- a/include/stdalign.h
+++ b/include/stdalign.h
@@ -26,6 +26,8 @@
  * SUCH DAMAGE.
  */
 
+#if __STDC_VERSION__ < 202311L
+
 #ifndef __alignas_is_defined
 #define	__alignas_is_defined	1
 
@@ -45,3 +47,5 @@
 #endif
 
 #endif /* !__alignof_is_defined */
+
+#endif /* __STDC_VERSION__ < 202311L */


### PR DESCRIPTION
C23 deprecates `<stdalign.h>` and specifies that the header shall provide no content (§7.15.1).