### PR TITLE
stand+kern: pass ELF header and phdrs from loader to kernel via metadata

### DIFF
--- a/stand/common/load_elf.c
+++ b/stand/common/load_elf.c
@@ -482,6 +482,23 @@ __elfN(loadfile_raw)(char *filename, uint64_t dest,
 	/* save exec header as metadata */
 	file_addmetadata(fp, MODINFOMD_ELFHDR, sizeof(*ehdr), ehdr);
 
+	/*
+	 * Save the program header table too.  The kernel walks PT_LOAD
+	 * entries to set per-segment protections via preload_protect(),
+	 * but on architectures whose default kmod ldscript places the
+	 * ELF header outside every PT_LOAD (e.g. aarch64, where
+	 * CONSTANT(COMMONPAGESIZE)=0x10000 pushes PT_LOAD[0] to file
+	 * offset 0x10000), the loader's PT_LOAD copy loop never lands
+	 * the header at the module's load address.  Caching the phdrs
+	 * as metadata lets the kernel locate them regardless of the
+	 * on-disk layout of the module.
+	 */
+	if (ehdr->e_phnum != 0 && ehdr->e_phoff != 0 &&
+	    ehdr->e_phoff + ehdr->e_phnum * sizeof(Elf_Phdr) <= ef.firstlen)
+		file_addmetadata(fp, MODINFOMD_PHDR,
+		    ehdr->e_phnum * sizeof(Elf_Phdr),
+		    ef.firstpage + ehdr->e_phoff);
+
 	/* Load OK, return module pointer */
 	*result = (struct preloaded_file *)fp;
 	err = 0;

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -811,8 +811,31 @@ preload_protect1(elf_file_t ef, vm_prot_t prot, bool reset)
 	int error;
 
 	error = 0;
-	hdr = (Elf_Ehdr *)ef->address;
-	phdr = (Elf_Phdr *)(ef->address + hdr->e_phoff);
+	/*
+	 * Read the Elf header and the program header table from the
+	 * metadata copies the loader saved (MODINFOMD_ELFHDR /
+	 * MODINFOMD_PHDR).
+	 *
+	 * Dereferencing ef->address as Elf_Ehdr works by coincidence on
+	 * amd64 (CONSTANT(COMMONPAGESIZE)=0x1000 keeps the header inside
+	 * PT_LOAD[0]).  On aarch64 (COMMONPAGESIZE=0x10000) the default
+	 * lld kmod layout pushes PT_LOAD[0] to file offset 0x10000, so
+	 * the ELF header and program headers fall outside every PT_LOAD,
+	 * are never copied to memory by __elfN(loadimage)(), and the
+	 * deref reads .plt/.text bytes — yielding a garbage e_phoff and
+	 * an unmappable phdr pointer.
+	 *
+	 * Falls back to the legacy in-place layout for modules whose
+	 * loader pre-dates MODINFOMD_PHDR.
+	 */
+	hdr = (Elf_Ehdr *)preload_search_info(ef->modptr,
+	    MODINFO_METADATA | MODINFOMD_ELFHDR);
+	phdr = (Elf_Phdr *)preload_search_info(ef->modptr,
+	    MODINFO_METADATA | MODINFOMD_PHDR);
+	if (hdr == NULL || phdr == NULL) {
+		hdr = (Elf_Ehdr *)ef->address;
+		phdr = (Elf_Phdr *)(ef->address + hdr->e_phoff);
+	}
 	phlimit = phdr + hdr->e_phnum;
 	for (; phdr < phlimit; phdr++) {
 		if (phdr->p_type != PT_LOAD)

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -260,6 +260,7 @@ void linker_kldload_unbusy(int flags);
 #define MODINFOMD_FONT		0x000e		/* Console font */
 #define MODINFOMD_SPLASH	0x000f		/* Console splash screen */
 #define MODINFOMD_SHTDWNSPLASH	0x0010		/* Console shutdown splash screen */
+#define MODINFOMD_PHDR		0x0011		/* ELF program header table */
 #define MODINFOMD_NOCOPY	0x8000		/* don't copy this metadata to the kernel */
 
 #define MODINFOMD_DEPLIST	(0x4001 | MODINFOMD_NOCOPY)	/* depends on */


### PR DESCRIPTION
## Summary

`preload_protect()` walks PT_LOAD entries of a preloaded module to set
per-segment page protections.  It locates the Elf header by dereferencing
`ef->address` as `Elf_Ehdr *` and reads the program header table at
`ef->address + e_phoff`.

That works by coincidence on amd64.  `CONSTANT(COMMONPAGESIZE)=0x1000` keeps
the file's `PT_LOAD[0]` aligned starting at file offset 0, so lld places the
Elf header inside the first segment and `__elfN(loadimage)()` copies it to
`ef->address` along with everything else.

On aarch64 `COMMONPAGESIZE=0x10000`.  The default lld kmod layout pushes
`PT_LOAD[0]` to file offset `0x10000`, leaving the Elf header at file offset 0
**outside every PT_LOAD**.  `__elfN(loadimage)()` never copies it to memory.
`preload_protect()` then reads `.plt` / `.text` bytes as Elf_Ehdr, gets a
garbage `e_phoff`, and faults trying to deref the resulting phdr pointer.

Concrete panic, from a recent reproducer (out-of-tree `virtio_drm.ko`
preloaded via `/boot/loader.conf`, FreeBSD-arm64 under QEMU virt):

    panic: vm_fault failed: 0xffff00000058283c error 1   (preload_protect+0x54)
    x8  = 0xffff000001461000   (ef->address — module base)
    x9  = 0xf9443a1190000070   (e_phoff read from [x8 + 32])
    x21 = ef->address + x9     (faults on translation, far == x21)

Reproduces with any module whose first PT_LOAD has `p_offset > 0`.  Default
aarch64 lld layout produces this for virtually every kmod, so the failure
mode is generic, not specific to one driver.

An ldscript that forces `FILEHDR PHDRS` into `PT_LOAD[0]` is not a fix on its
own — the loader still only copies PT_LOAD content, and lld additionally
rewrites such headers in-place which doesn't match what
`link_elf_link_preload()` reads.

## Fix

Route the Elf header and the program header table loader→kernel as preload
metadata instead of computing them from `ef->address`:

  - **`sys/sys/linker.h`** — allocate `MODINFOMD_PHDR` (`0x0011`) alongside
    the existing `MODINFOMD_ELFHDR` slot.

  - **`stand/common/load_elf.c`**, `__elfN(loadfile_raw)()` — after the
    existing `MODINFOMD_ELFHDR` save, also stash the phdr table from
    `ef.firstpage` when it falls within `ef.firstlen` (the first page of
    the file is already buffered during `loadimage()`'s header scan, so
    this requires no extra I/O).

  - **`sys/kern/link_elf.c`**, `preload_protect1()` — pull both via
    `preload_search_info(ef->modptr, MODINFO_METADATA | MODINFOMD_*)`.
    Fall back to the legacy `ef->address`-deref when either is absent,
    so a new kernel paired with an old loader still works (legacy compat
    path is just the pre-patch code).

amd64 is unchanged behaviourally — the metadata path replaces an equivalent
computation; the result is identical to dereferencing `ef->address`.
aarch64 modules that previously panicked on `preload_protect()` now load
cleanly via `/boot/loader.conf` preload.

Diff size: +43 / -2 across three files.

## Test plan

  - [x] amd64 GENERIC: no regression in module preload.
  - [x] aarch64 GENERIC under QEMU virt, FreeBSD-15.0-RELEASE-p4 base:
        out-of-tree `virtio_drm.ko` listed in `/boot/loader.conf` as
        `virtio_drm_load="YES"`.  Pre-patch: panics at
        `preload_protect+0x54` on every boot.  Post-patch: module loads
        at the same `0xffff000001461000` that used to fault, reaches
        userland, `kldstat -n virtio_drm` shows it initialised.
  - [x] aarch64 with new kernel + old (unpatched) loader: legacy fallback
        path verified — boot still works, preload still panics for the
        same upstream reason it always did.  (Same behaviour as before;
        confirms compat path is wired correctly.)

## Suggested reviewers

Per recent committers to `sys/kern/link_elf.c`, `stand/common/load_elf.c`,
and `sys/sys/linker.h`:

  - @markjdb (link_elf.c, linker.h)
  - @bsdimp (load_elf.c, linker.h)
  - @mhorne61 (link_elf.c)
  - @bsdjhb (link_elf.c, load_elf.c)