### PR TITLE
bhyveload: add a small ring buffer to the cb_putc function.

### DIFF
--- a/usr.sbin/bhyveload/bhyveload.c
+++ b/usr.sbin/bhyveload/bhyveload.c
@@ -57,6 +57,7 @@
 #include <sys/stat.h>
 #include <sys/disk.h>
 #include <sys/queue.h>
+#include <sys/uio.h>
 
 #include <machine/specialreg.h>
 #include <machine/vmm.h>
@@ -88,6 +89,10 @@
 #define	BSP	0
 
 #define	NDISKS	32
+
+#define BUF_SIZE 256
+#define PRODUCE(u, p, n)  {(u) += (n); (p) = ((p) + (n)) % BUF_SIZE; }
+#define CONSUME(u, c, n)  {(u) -= (n); (c) = ((c) + (n)) % BUF_SIZE; }
 
 /*
  * Reason for our loader reload and reentry, though these aren't really used
@@ -125,9 +130,35 @@ static void cb_exit(void *arg, int v);
 static void
 cb_putc(void *arg __unused, int ch)
 {
-	char c = ch;
+	static char buf[BUF_SIZE];
+	static uint cons = 0, prod = 0, used = 0;
+	struct iovec iov[2];
+	uint niov;
+	ssize_t rc;
 
-	(void) write(consout_fd, &c, 1);
+	/* If the buffer is full, discard one character. */
+	if (used == BUF_SIZE)
+		CONSUME(used, cons, 1);
+
+	buf[prod] = ch;
+	PRODUCE(used, prod, 1);
+
+	if (prod > cons) {
+		iov[0].iov_base = &buf[cons];
+		iov[0].iov_len = prod - cons;
+		niov = 1;
+	} else {
+		iov[0].iov_base = &buf[cons];
+		iov[0].iov_len = BUF_SIZE - cons;
+		iov[1].iov_base = buf;
+		iov[1].iov_len = prod;
+		niov = 2;
+	}
+
+	if ((rc = writev(consout_fd, iov, niov)) < 0)
+		return;
+
+	CONSUME(used, cons, rc);
 }
 
 static int


### PR DESCRIPTION
While bhyveload opens an nmdm device as a console, I often see that the boot loader messages are partly missing on my console. I investigated the bhyloveload with truss(1), I found that write(2) system call returns EGAIN while missing the message. The console output descriptor is opened with O_NONBLOCK. So, the write(2) system call may return the EAGAIN. It is described in the manual. An application should accept and handle the error case.

I added a small ring buffer for the output characters and retry writing in the error case. I see about 150 characters are missing with my debug message, so the 256-byte buffer is enough for me.