### PR TITLE
cut(1), rev(1): add Capsicum sandboxing

### DIFF
--- a/usr.bin/cut/Makefile
+++ b/usr.bin/cut/Makefile
@@ -2,6 +2,12 @@
 
 PROG=	cut
 
+.if ${MK_CASPER} != "no" && !defined(BOOTSTRAPPING)
+LIBADD+=	casper
+LIBADD+=	cap_fileargs
+CFLAGS+=	-DWITH_CASPER
+.endif
+
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests
 

--- a/usr.bin/cut/cut.c
+++ b/usr.bin/cut/cut.c
@@ -32,9 +32,13 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/capsicum.h>
+
+#include <capsicum_helpers.h>
 #include <ctype.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <locale.h>
 #include <stdio.h>
@@ -42,6 +46,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <wchar.h>
+
+#include <libcasper.h>
+#include <casper/cap_fileargs.h>
 
 static int	bflag;
 static int	cflag;
@@ -69,9 +76,11 @@ int
 main(int argc, char *argv[])
 {
 	FILE *fp;
+	fileargs_t *fa;
 	int (*fcn)(FILE *, const char *);
 	int ch, rval;
 	size_t n;
+	cap_rights_t rights;
 
 	setlocale(LC_ALL, "");
 
@@ -131,13 +140,23 @@ main(int argc, char *argv[])
 	else if (bflag)
 		fcn = nflag && MB_CUR_MAX > 1 ? b_n_cut : b_cut;
 
+	fa = fileargs_init(argc, argv, O_RDONLY, 0,
+	    cap_rights_init(&rights, CAP_FSTAT, CAP_FCNTL, CAP_READ), FA_OPEN);
+	if (fa == NULL)
+		err(1, "unable to init casper");
+	caph_cache_catpages();
+	if (caph_limit_stdio() < 0)
+		err(1, "unable to limit stdio");
+	if (caph_enter_casper() < 0)
+		err(1, "unable to enter capability mode");
+
 	rval = 0;
 	if (*argv)
 		for (; *argv; ++argv) {
 			if (strcmp(*argv, "-") == 0)
 				rval |= fcn(stdin, "stdin");
 			else {
-				if (!(fp = fopen(*argv, "r"))) {
+				if (!(fp = fileargs_fopen(fa, *argv, "r"))) {
 					warn("%s", *argv);
 					rval = 1;
 					continue;
@@ -148,6 +167,7 @@ main(int argc, char *argv[])
 		}
 	else
 		rval = fcn(stdin, "stdin");
+	fileargs_free(fa);
 	exit(rval);
 }
 

--- a/usr.bin/rev/Makefile
+++ b/usr.bin/rev/Makefile
@@ -1,3 +1,11 @@
+.include <src.opts.mk>
+
 PROG=	rev
+
+.if ${MK_CASPER} != "no"
+LIBADD+=	casper
+LIBADD+=	cap_fileargs
+CFLAGS+=	-DWITH_CASPER
+.endif
 
 .include <bsd.prog.mk>

--- a/usr.bin/rev/rev.c
+++ b/usr.bin/rev/rev.c
@@ -30,15 +30,21 @@
  */
 
 #include <sys/types.h>
+#include <sys/capsicum.h>
 
+#include <capsicum_helpers.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <wchar.h>
+
+#include <libcasper.h>
+#include <casper/cap_fileargs.h>
 
 static void usage(void) __dead2;
 
@@ -48,8 +54,10 @@ main(int argc, char *argv[])
 	const char *filename;
 	wchar_t *p, *t;
 	FILE *fp;
+	fileargs_t *fa;
 	size_t len;
 	int ch, rval;
+	cap_rights_t rights;
 
 	setlocale(LC_ALL, "");
 
@@ -63,12 +71,22 @@ main(int argc, char *argv[])
 	argc -= optind;
 	argv += optind;
 
+	fa = fileargs_init(argc, argv, O_RDONLY, 0,
+	    cap_rights_init(&rights, CAP_FSTAT, CAP_FCNTL, CAP_READ), FA_OPEN);
+	if (fa == NULL)
+		err(1, "unable to init casper");
+	caph_cache_catpages();
+	if (caph_limit_stdio() < 0)
+		err(1, "unable to limit stdio");
+	if (caph_enter_casper() < 0)
+		err(1, "unable to enter capability mode");
+
 	fp = stdin;
 	filename = "stdin";
 	rval = 0;
 	do {
 		if (*argv) {
-			if ((fp = fopen(*argv, "r")) == NULL) {
+			if ((fp = fileargs_fopen(fa, *argv, "r")) == NULL) {
 				warn("%s", *argv);
 				rval = 1;
 				++argv;
@@ -90,6 +108,7 @@ main(int argc, char *argv[])
 		}
 		(void)fclose(fp);
 	} while(*argv);
+	fileargs_free(fa);
 	exit(rval);
 }
 


### PR DESCRIPTION
Open file arguments through Casper's cap_fileargs service and enter capability mode after limiting stdio rights, so cut(1) and rev(1) run sandboxed.

cut(1) is a bootstrap tool, so the Makefile drops the Casper libraries and -DWITH_CASPER while BOOTSTRAPPING; <casper/cap_fileargs.h> then resolves fileargs_*() to plain fopen(3), matching wc(1)/head(1).