### PR TITLE
aq(4): Fix OOB write in RSS table packing (no link / panic)

### DIFF
--- a/sys/dev/aq/aq_hw.c
+++ b/sys/dev/aq/aq_hw.c
@@ -878,8 +878,14 @@ aq_hw_rss_set(struct aq_hw_s *self,
 	memset(bitary, 0, sizeof(bitary));
 
 	for (i = HW_ATL_RSS_INDIRECTION_TABLE_MAX; i--;) {
-		(*(uint32_t *)(bitary + ((i * 3U) / 16U))) |=
-			((rss_table[i]) << ((i * 3U) & 0xFU));
+		uint32_t bit_pos = i * 3U;
+		uint32_t word = bit_pos / 16U;
+		uint32_t shift = bit_pos % 16U;
+		uint32_t val = (uint32_t)(rss_table[i] & 0x7U) << shift;
+
+		bitary[word] |= (uint16_t)val;
+		if ((val >> 16) && word + 1U < ARRAY_SIZE(bitary))
+			bitary[word + 1U] |= (uint16_t)(val >> 16);
 	}
 
 	for (i = ARRAY_SIZE(bitary); i--;) {

--- a/sys/dev/aq/aq_hw.h
+++ b/sys/dev/aq/aq_hw.h
@@ -197,6 +197,8 @@ struct aq_hw {
 
 #define HW_ATL_RSS_INDIRECTION_TABLE_MAX  64U
 #define HW_ATL_RSS_HASHKEY_SIZE           40U
+/* Redirection-table entries are 3 bits wide, so RSS spans <= 8 queues. */
+#define HW_ATL_RSS_QUEUES_MAX             8U
 
 /* PCI core control register */
 #define AQ_HW_PCI_REG_CONTROL_6_ADR 0x1014U

--- a/sys/dev/aq/aq_main.c
+++ b/sys/dev/aq/aq_main.c
@@ -464,10 +464,14 @@ aq_if_attach_post(if_ctx_t ctx)
 	}
 
 	aq_add_stats_sysctls(softc);
-	/* RSS */
+	/*
+	 * RSS: modulo over min(rings, 8) queues.  Ring count isn't always a
+	 * power of two, so an AND mask would starve queues; HW caps RSS at 8.
+	 */
 	arc4rand(softc->rss_key, HW_ATL_RSS_HASHKEY_SIZE, 0);
+	uint32_t rss_qs = MIN(softc->rx_rings_count, HW_ATL_RSS_QUEUES_MAX);
 	for (int i = ARRAY_SIZE(softc->rss_table); i--;){
-		softc->rss_table[i] = i & (softc->rx_rings_count - 1);
+		softc->rss_table[i] = i % rss_qs;
 	}
 exit:
 	AQ_DBG_EXIT(rc);


### PR DESCRIPTION
Fix an out-of-bounds stack write in aq_hw_rss_set().  RSS table entries are 3 bits (8 queues max), but with more than 8 RX rings rss_table[] holds larger values; the 32-bit write then spills one uint16_t past bitary[] and corrupts the stack, so the NIC never links or the kernel panics. Mask each value to 3 bits and pack 16 bits at a time to keep the write in bounds.

Confirmed on AQC107 (firmware 3.1.88) under FreeBSD 15.0-RELEASE: with the OOB write the interface attached but stayed "no carrier"; removed, link negotiates 1000baseT full-duplex and passes traffic.

cc @emaste 