### PR TITLE
bsdinstall: Disable setuid and devices on /home ZFS dataset

### DIFF
--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -159,6 +159,9 @@ f_isset ZFSBOOT_DATASETS || ZFSBOOT_DATASETS="
 	# Don't mount /usr so that 'base' files go to the BEROOT
 	/usr		mountpoint=/usr,canmount=off
 
+	# Objects tree
+	/usr/obj	setuid=off
+
 	# Ports tree
 	/usr/ports	setuid=off
 

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -151,7 +151,7 @@ f_isset ZFSBOOT_DATASETS || ZFSBOOT_DATASETS="
 	/$ZFSBOOT_BEROOT_NAME/$ZFSBOOT_BOOTFS_NAME	mountpoint=/
 
 	# Home directories separated so they are common to all BEs
-	/home		mountpoint=/home
+	/home		mountpoint=/home,setuid=off,devices=off
 
 	# Create /tmp and allow exec but not setuid
 	/tmp		mountpoint=/tmp,exec=on,setuid=off


### PR DESCRIPTION
Home directories are user-writable and should not contain setuid binaries.

Fixes: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295583

Also create a separate ZFS dataset for /usr/obj
    
    /usr/obj should not be part of a boot environment.  It can hold several
    gigabytes of build artifacts that unnecessarily increase its size.
    Keeping it separate allows it to be managed independently.
