### PR TITLE
socket: Add missing so_rerror handling cases

### DIFF
--- a/lib/libsys/getsockopt.2
+++ b/lib/libsys/getsockopt.2
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 21, 2026
+.Dd May 26, 2026
 .Dt GETSOCKOPT 2
 .Os
 .Sh NAME
@@ -517,6 +517,9 @@ returns any pending error on the socket and clears
 the error status.
 It may be used to check for asynchronous errors on connected
 datagram sockets or for other asynchronous errors.
+Note that more than one error may be pending on the socket when
+.Dv SO_RERROR
+is set.
 .Dv SO_RERROR
 indicates that receive buffer overflows should be handled as errors.
 Historically receive buffer overflows have been ignored and programs

--- a/sys/dev/cxgbe/nvmf/nvmf_che.c
+++ b/sys/dev/cxgbe/nvmf/nvmf_che.c
@@ -1946,11 +1946,8 @@ nvmf_che_receive(void *arg)
 	SOCKBUF_LOCK(&so->so_rcv);
 	while (!qp->rx_shutdown) {
 		/* Wait for a PDU. */
-		if (so->so_error != 0 || so->so_rerror != 0) {
-			if (so->so_error != 0)
-				error = so->so_error;
-			else
-				error = so->so_rerror;
+		if (soerror(so)) {
+			error = soerror(so);
 			SOCKBUF_UNLOCK(&so->so_rcv);
 		error:
 			nvmf_qpair_error(&qp->qp, error);

--- a/sys/dev/nvmf/nvmf_tcp.c
+++ b/sys/dev/nvmf/nvmf_tcp.c
@@ -1092,11 +1092,8 @@ nvmf_tcp_receive(void *arg)
 	SOCKBUF_LOCK(&so->so_rcv);
 	while (!qp->rx_shutdown) {
 		/* Wait until there is enough data for the next step. */
-		if (so->so_error != 0 || so->so_rerror != 0) {
-			if (so->so_error != 0)
-				error = so->so_error;
-			else
-				error = so->so_rerror;
+		if (soerror(so)) {
+			error = soerror(so);
 			SOCKBUF_UNLOCK(&so->so_rcv);
 		error:
 			m_freem(m);

--- a/sys/kern/uipc_socket.c
+++ b/sys/kern/uipc_socket.c
@@ -1631,10 +1631,9 @@ solisten_dequeue(struct socket *head, struct socket **ret, int flags)
 			return (error);
 		}
 	}
-	if (head->so_error) {
-		error = head->so_error;
-		head->so_error = 0;
-	} else if ((head->so_state & SS_NBIO) && TAILQ_EMPTY(&head->sol_comp))
+	if (soerror(head))
+		error = soerrorfetch(head);
+	else if ((head->so_state & SS_NBIO) && TAILQ_EMPTY(&head->sol_comp))
 		error = EWOULDBLOCK;
 	else
 		error = 0;
@@ -2163,7 +2162,7 @@ soconnectat(int fd, struct socket *so, struct sockaddr *nam, struct thread *td)
 		 * Prevent accumulated error from previous connection from
 		 * biting us.
 		 */
-		so->so_error = 0;
+		so->so_error = so->so_rerror = 0;
 		if (fd == AT_FDCWD) {
 			error = so->so_proto->pr_connect(so, nam, td);
 		} else {
@@ -3321,14 +3320,18 @@ restart:
 	SOCKBUF_LOCK_ASSERT(&so->so_rcv);
 
 	/* Abort if socket has reported problems. */
-	if (so->so_error) {
+	if (so->so_error || so->so_rerror) {
 		if (sbavail(sb) > 0)
 			goto deliver;
 		if (oresid > uio->uio_resid)
 			goto out;
-		error = so->so_error;
-		if (!(flags & MSG_PEEK))
-			so->so_error = 0;
+		error = (so->so_error ? so->so_error : so->so_rerror);
+		if ((flags & MSG_PEEK) == 0) {
+			if (so->so_error)
+				so->so_error = 0;
+			else
+				so->so_rerror = 0;
+		}
 		goto out;
 	}
 
@@ -3579,6 +3582,12 @@ soreceive_dgram(struct socket *so, struct sockaddr **psa, struct uio *uio,
 		if (so->so_error) {
 			error = so->so_error;
 			so->so_error = 0;
+			SOCKBUF_UNLOCK(&so->so_rcv);
+			return (error);
+		}
+		if (so->so_rerror) {
+			error = so->so_rerror;
+			so->so_rerror = 0;
 			SOCKBUF_UNLOCK(&so->so_rcv);
 			return (error);
 		}

--- a/sys/kern/uipc_usrreq.c
+++ b/sys/kern/uipc_usrreq.c
@@ -1696,7 +1696,7 @@ uipc_sopoll_stream_or_seqpacket(struct socket *so, int events,
 			revents = 0;
 		else if (!TAILQ_EMPTY(&so->sol_comp))
 			revents = events & (POLLIN | POLLRDNORM);
-		else if (so->so_error)
+		else if (soerror(so))
 			revents = (events & (POLLIN | POLLRDNORM)) | POLLHUP;
 		else {
 			selrecord(td, &so->so_rdsel);
@@ -1711,7 +1711,7 @@ uipc_sopoll_stream_or_seqpacket(struct socket *so, int events,
 		if (events & (POLLIN | POLLRDNORM | POLLRDHUP)) {
 			SOCK_RECVBUF_LOCK(so);
 			if (sbavail(&so->so_rcv) >= so->so_rcv.sb_lowat ||
-			    so->so_error || so->so_rerror)
+			    soerror(so))
 				revents |= events & (POLLIN | POLLRDNORM);
 			if (so->so_rcv.sb_state & SBS_CANTRCVMORE)
 				revents |= events &
@@ -2268,10 +2268,9 @@ uipc_soreceive_dgram(struct socket *so, struct sockaddr **psa, struct uio *uio,
 	while ((m = so->so_rcv.uxdg_peeked) == NULL &&
 	    (sb = TAILQ_FIRST(&so->so_rcv.uxdg_conns)) == NULL &&
 	    (m = STAILQ_FIRST(&so->so_rcv.uxdg_mb)) == NULL) {
-		if (so->so_error) {
-			error = so->so_error;
-			if (!(flags & MSG_PEEK))
-				so->so_error = 0;
+		if (soerror(so)) {
+			error = flags & MSG_PEEK ? soerror(so) :
+			    soerrorfetch(so);
 			SOCK_RECVBUF_UNLOCK(so);
 			SOCK_IO_RECV_UNLOCK(so);
 			return (error);

--- a/sys/sys/socketvar.h
+++ b/sys/sys/socketvar.h
@@ -362,6 +362,23 @@ soeventmtx(struct socket *so, const sb_which which)
 #define	_soreadable(so) \
 	(soreadabledata(so) || ((so)->so_rcv.sb_state & SBS_CANTRCVMORE))
 
+#define soerror(so) \
+	((so)->so_error ? (so)->so_error : (so)->so_rerror)
+static inline int
+soerrorfetch(struct socket *so)
+{
+	int error;
+
+	if (so->so_error) {
+		error = so->so_error;
+		so->so_error = 0;
+	} else {
+		error = so->so_rerror;
+		so->so_rerror = 0;
+	}
+	return (error);
+}
+
 static inline bool
 soreadable(struct socket *so)
 {


### PR DESCRIPTION
Also wrap the logic into `soerror()` and `soerrorfetch()` to help handle
`so_error` and `so_rerror` consistently.

My tests regarding this patch are quite limited: the problem was discovered in
a very specific context were a lot of interfaces were created which triggered a
lot of requests sent to a `PF_ROUTE` socket.

And I didn't find any Kuya test regarding `SO_ERROR` and the fact, that since
`so_rerror` was introduced, it may be necessary to call it twice to pop all the
errors currently bound to the socket.

Also, I was unable to find a way to simulate something that looks like an mbuf
starvation to trigger the use of `so_rerror`, so feel free to give me some hints
if possible to add tests ;)