### PR TITLE
bsdinstall: Create separate dataset for /root

### DIFF
--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -153,6 +153,9 @@ f_isset ZFSBOOT_DATASETS || ZFSBOOT_DATASETS="
 	# Home directories separated so they are common to all BEs
 	/home		mountpoint=/home
 
+	# Home directory for root
+	/root		mountpoint=/root
+
 	# Create /tmp and allow exec but not setuid
 	/tmp		mountpoint=/tmp,exec=on,setuid=off
 


### PR DESCRIPTION
Otherwise there could be data loss in ZFS boot environment rollbacks.

Fixes: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295619