### PR TITLE
bcm2835_sdhci: Clean up DMA resources on attach failure

### DIFF
--- a/sys/arm/broadcom/bcm2835/bcm2835_sdhci.c
+++ b/sys/arm/broadcom/bcm2835/bcm2835_sdhci.c
@@ -365,6 +365,7 @@ bcm_sdhci_attach(device_t dev)
 	return (0);
 
 fail:
+	bcm_dma_free(sc->sc_dma_ch);
 	if (sc->sc_intrhand)
 		bus_teardown_intr(dev, sc->sc_irq_res, sc->sc_intrhand);
 	if (sc->sc_irq_res)


### PR DESCRIPTION
bcm_sdhci_attach() allocates a DMA channel with bcm_dma_allocate() before creating the bus_dma tag and map.  If a later initialization step fails, the common error path releases the interrupt and memory resources, but leaves the DMA channel allocated.

Call bcm_dma_free() for cleanup, as it already performs the required internal checks and can therefore be invoked directly.