### PR TITLE
libc: Guard mergesort() allocation size arithmetic

### DIFF
--- a/lib/libc/stdlib/merge.c
+++ b/lib/libc/stdlib/merge.c
@@ -49,6 +49,7 @@
 #include <sys/param.h>
 
 #include <errno.h>
+#include <stdckdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -109,7 +110,7 @@ mergesort_b(void *base, size_t nmemb, size_t size, cmp_t cmp)
 mergesort(void *base, size_t nmemb, size_t size, cmp_t cmp)
 #endif
 {
-	size_t i;
+	size_t i, nbytes, asize;
 	int sense;
 	int big, iflag;
 	u_char *f1, *f2, *t, *b, *tp2, *q, *l1, *l2;
@@ -123,16 +124,21 @@ mergesort(void *base, size_t nmemb, size_t size, cmp_t cmp)
 	if (nmemb == 0)
 		return (0);
 
+	if (ckd_mul(&nbytes, nmemb, size) || ckd_add(&asize, nbytes, PSIZE)) {
+		errno = EINVAL;
+		return (-1);
+	}
+
 	iflag = 0;
 	if (__is_aligned(size, ISIZE) && __is_aligned(base, ISIZE))
 		iflag = 1;
 
-	if ((list2 = malloc(nmemb * size + PSIZE)) == NULL)
+	if ((list2 = malloc(asize)) == NULL)
 		return (-1);
 
 	list1 = base;
 	setup(list1, list2, nmemb, size, cmp);
-	last = list2 + nmemb * size;
+	last = list2 + nbytes;
 	i = big = 0;
 	while (*EVAL(list2) != last) {
 	    l2 = list1;
@@ -227,10 +233,10 @@ COPY:	    			b = t;
 	    tp2 = list1;	/* swap list1, list2 */
 	    list1 = list2;
 	    list2 = tp2;
-	    last = list2 + nmemb*size;
+	    last = list2 + nbytes;
 	}
 	if (base == list2) {
-		memmove(list2, list1, nmemb*size);
+		memmove(list2, list1, nbytes);
 		list2 = list1;
 	}
 	free(list2);

--- a/lib/libc/stdlib/qsort.3
+++ b/lib/libc/stdlib/qsort.3
@@ -29,7 +29,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd October 25, 2024
+.Dd June 2, 2026
 .Dt QSORT 3
 .Os
 .Sh NAME
@@ -362,13 +362,21 @@ functions succeed unless:
 .It Bq Er EINVAL
 The
 .Fa size
-argument is zero, or,
+argument is zero,
 the
 .Fa size
 argument to
 .Fn mergesort
 is less than
-.Dq "sizeof(void *) / 2" .
+.Dq "sizeof(void *) / 2" ,
+or
+the
+.Fa nmemb
+and
+.Fa size
+arguments to
+.Fn mergesort
+describe an unrepresentable buffer size.
 .It Bq Er ENOMEM
 The
 .Fn heapsort


### PR DESCRIPTION
`mergesort()` used unchecked `size_t` arithmetic for allocation and subsequent range calculations. For large inputs, `nmemb * size` could wrap, leading to `stack-buffer-underflow` and out-of-bounds access.

### Diff

- Add an overflow guard in `mergesort()` to reject combinations that would overflow `nmemb * size + PSIZE`.
- Return `-1` with `errno = EINVAL` for invalid size combinations instead of proceeding with unsafe pointer/length arithmetic.

### Note

- No ABI/API changes.
- Normal sorting semantics are unchanged for valid inputs.