### PR TITLE
glxsb: Free DMA resources on attach failure

### DIFF
--- a/sys/dev/glxsb/glxsb.c
+++ b/sys/dev/glxsb/glxsb.c
@@ -305,7 +305,7 @@ glxsb_attach(device_t dev)
 	    taskqueue_thread_enqueue, &sc->sc_tq);
 	if (sc->sc_tq == NULL) {
 		device_printf(dev, "cannot create task queue\n");
-		goto fail0;
+		goto fail_dma;
 	}
 	if (taskqueue_start_threads(&sc->sc_tq, 1, PI_NET, "%s taskq",
 	    device_get_nameunit(dev)) != 0) {
@@ -330,6 +330,8 @@ glxsb_attach(device_t dev)
 
 fail1:
 	taskqueue_free(sc->sc_tq);
+fail_dma:
+	glxsb_dma_free(sc, &sc->sc_dma);
 fail0:
 	bus_release_resource(dev, SYS_RES_MEMORY, sc->sc_rid, sc->sc_sr);
 	return (ENXIO);


### PR DESCRIPTION
If glxsb_dma_alloc() succeeds and a later attach step fails, glxsb_attach() releases the memory resource but does not free the DMA tag, map, and buffer.

Add an attach failure path that frees the DMA resources after they have been successfully allocated.