### PR TITLE
mrsas: Free event log info DMA resources on timeout

### DIFF
--- a/sys/dev/mrsas/mrsas.c
+++ b/sys/dev/mrsas/mrsas.c
@@ -597,9 +597,10 @@ mrsas_get_seq_num(struct mrsas_softc *sc,
 	 * Copy the data back into callers buffer
 	 */
 	memcpy(eli, sc->el_info_mem, sizeof(struct mrsas_evt_log_info));
-	mrsas_free_evt_log_info_cmd(sc);
 
 dcmd_timeout:
+	mrsas_free_evt_log_info_cmd(sc);
+
 	if (do_ocr)
 		sc->do_timedout_reset = MFI_DCMD_TIMEOUT_OCR;
 	else


### PR DESCRIPTION
mrsas_get_seq_num() allocates event log info DMA resources before issuing MR_DCMD_CTRL_EVENT_GET_INFO. If mrsas_issue_blocked_cmd() returns ETIMEDOUT, the function jumps to dcmd_timeout before calling mrsas_free_evt_log_info_cmd(), leaving those resources allocated.

Move mrsas_free_evt_log_info_cmd() to the common exit path so the resources are released on both the successful path and the DCMD timeout path.