### PR TITLE
nat64lsn: Fix type confusion panic when using wrong NAT64 instance type

### DIFF
--- a/sys/netpfil/ipfw/nat64/nat64lsn.c
+++ b/sys/netpfil/ipfw/nat64/nat64lsn.c
@@ -1731,7 +1731,8 @@ ipfw_nat64lsn(struct ip_fw_chain *ch, struct ip_fw_args *args,
 	if (cmd->opcode != O_EXTERNAL_ACTION ||
 	    insntod(cmd, kidx)->kidx != V_nat64lsn_eid ||
 	    icmd->opcode != O_EXTERNAL_INSTANCE ||
-	    (i = NAT64_LOOKUP(ch, icmd)) == NULL)
+	    (i = NAT64_LOOKUP(ch, icmd)) == NULL ||
+	    i->no.etlv != IPFW_TLV_NAT64LSN_NAME)
 		return (IP_FW_DENY);
 
 	*done = 1;	/* terminate the search */


### PR DESCRIPTION
When an ipfw rule references a NAT64 instance by name using 'nat64lsn', the kernel looks up the instance in the shared srvstate[] array without verifying the instance type.  If the named instance is instead a nat64clat or nat64stl instance, the code incorrectly casts the instance to nat64lsn_instance and dereferences the ->cfg pointer, which causes a kernel panic.

The root cause is that all NAT64 instance types share the same srvstate[] array but have different struct layouts.  For nat64lsn_instance, the field after 'no' is a pointer to nat64lsn_cfg.  For nat64clat_cfg, the same offset contains an embedded nat64_config struct.

Fixed by adding a type check after NAT64_LOOKUP() to verify that the instance's etlv matches IPFW_TLV_NAT64LSN_NAME before proceeding. If the type doesn't match, return IP_FW_DENY to reject the packet safely rather than crashing.

Tested with the official reproducer from the bug report on FreeBSD 16.0-CURRENT, no kernel panic with the change.

PR: [292023](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=292023)
