### PR TITLE
bnxt_re: Free GSI QP header buffers on QP1 create failure

### DIFF
--- a/sys/dev/bnxt/bnxt_re/ib_verbs.c
+++ b/sys/dev/bnxt/bnxt_re/ib_verbs.c
@@ -2332,6 +2332,7 @@ static int bnxt_re_create_gsi_qp(struct bnxt_re_qp *qp, struct bnxt_re_pd *pd)
 	rc = bnxt_qplib_create_qp1(res, qplqp);
 	if (rc) {
 		dev_err(rdev_to_dev(rdev), "create HW QP1 failed!\n");
+		bnxt_qplib_free_hdr_buf(res, qplqp);
 		goto out;
 	}
 


### PR DESCRIPTION
bnxt_re_create_gsi_qp() allocates SQ/RQ header buffers with bnxt_qplib_alloc_hdr_buf() before creating the hardware QP1. If bnxt_qplib_create_qp1() fails, the function returns without freeing those header buffers, leaking the memory owned by qplqp->sq_hdr_buf and qplqp->rq_hdr_buf.

Free the header buffers on the QP1 create error path before returning.