### PR TITLE
fsck_msdosfs: don't report FSERROR for a lost chain that was cleared

### DIFF
--- a/sbin/fsck_msdosfs/fat.c
+++ b/sbin/fsck_msdosfs/fat.c
@@ -1258,6 +1258,7 @@ checklost(struct fat_descriptor *fat)
 	cl_t head;
 	int mod = FSOK;
 	int dosfs, ret;
+	bool reconnect_failed;
 	size_t chains, chainlength;
 	struct bootblock *boot;
 
@@ -1283,19 +1284,32 @@ checklost(struct fat_descriptor *fat)
 			continue;
 		}
 		if (fat_is_cl_head(fat, head)) {
+			reconnect_failed = false;
 			ret = checkchain(fat, head, &chainlength);
 			if (ret != FSERROR && chainlength > 0) {
 				pwarn("Lost cluster chain at cluster %u\n"
 				    "%zd Cluster(s) lost\n",
 				    head, chainlength);
-				mod |= ret = reconnect(fat, head,
+				ret = reconnect(fat, head,
 				    chainlength);
+				/*
+				 * Defer folding a reconnect() failure into
+				 * mod: if the lost chain is cleared below, it
+				 * has been resolved and must not be reported as
+				 * an unrecovered error (FSERROR).
+				 */
+				if (ret == FSERROR)
+					reconnect_failed = true;
+				else
+					mod |= ret;
 			}
 			if (mod & FSFATAL)
 				break;
 			if (ret == FSERROR && ask(0, "Clear")) {
 				clearchain(fat, head);
 				mod |= FSFATMOD;
+			} else if (reconnect_failed) {
+				mod |= FSERROR;
 			}
 			chains--;
 		}


### PR DESCRIPTION
While looking into why an SD card had to be re-inserted twice before it
would mount, I traced it to a stale FSERROR exit code from fsck_msdosfs.

In checklost(), when a lost cluster chain is found but reconnect() fails
(LOST.DIR full in my case), reconnect() returns FSERROR and the old code
ORs it into `mod` right away via `mod |= ret = reconnect(...)`. If the
following Clear succeeds, clearchain() frees the chain and sets FSFATMOD,
but the FSERROR bit is still set, so checkfilesys() returns 8 on a volume
that is actually clean. A mounter that keys off the exit code rejects it
on the first pass; the second pass returns 0 only because the first run
already repaired it.

The fix defers folding a reconnect() failure into `mod` until we know
whether the chain gets cleared. Cleared -> resolved, don't report FSERROR.
Not cleared -> keep FSERROR as before. FSFATAL still takes `ret != FSERROR`
so the `mod & FSFATAL` break is unchanged.

The patch now tracks whether FSERROR came from reconnect(), so the change is
limited to the reconnect-failure fallback path. FSERROR returned by checkchain()
keeps the old behavior.

Tested on arm64. Same corrupted FAT16 image (orphan chains + full LOST.DIR,
`fsck_msdos -p -f -y`): old binary returns 8 then 0 on a re-run, patched
returns 0 on the first run, and the repair output is identical between the
two. Also ran it over 135 randomly generated images (varying chain counts,
lengths, and a partly-full LOST.DIR so some chains reconnect and some get
cleared in the same run) and the patched binary never returned 8.
