### PR TITLE
mvs: free DMA slots on channel attach failure

### DIFF
--- a/sys/dev/mvs/mvs.c
+++ b/sys/dev/mvs/mvs.c
@@ -209,6 +209,7 @@ err1:
 err0:
 	bus_release_resource(dev, SYS_RES_MEMORY, ch->unit, ch->r_mem);
 	mtx_unlock(&ch->mtx);
+	mvs_slotsfree(dev);
 	mtx_destroy(&ch->mtx);
 	return (error);
 }


### PR DESCRIPTION
mvs_ch_attach() allocates per-slot DMA maps with mvs_slotsalloc() before several later attach steps can fail.  The detach path frees those maps with mvs_slotsfree(), but attach failure does not reach mvs_ch_detach(), so the maps are leaked on the error path.

Call mvs_slotsfree() before destroying the channel mutex in the common attach failure path.