### PR TITLE
arm: allwinner: Fix A10 INTC MMIO resource cleanup

### DIFF
--- a/sys/arm/allwinner/a10/a10_intc.c
+++ b/sys/arm/allwinner/a10/a10_intc.c
@@ -330,7 +330,7 @@ a10_aintc_attach(device_t dev)
 	    &rid, RF_ACTIVE);
 	if (!sc->aintc_res) {
 		device_printf(dev, "could not allocate resource\n");
-		goto error;
+		return (ENXIO);
 	}
 
 	sc->aintc_bst = rman_get_bustag(sc->aintc_res);
@@ -351,7 +351,7 @@ a10_aintc_attach(device_t dev)
 
 	if (a10_intr_pic_attach(sc) != 0) {
 		device_printf(dev, "could not attach PIC\n");
-		return (ENXIO);
+		goto error;
 	}
 
 	return (0);


### PR DESCRIPTION
Do not jump to the resource release path when bus_alloc_resource_any() fails, since no MMIO resource was allocated. If a10_intr_pic_attach() fails after the MMIO resource has been allocated, release it before returning.