### PR TITLE
bnxt: clean up PCI mappings on attach mapping failure

### DIFF
--- a/sys/dev/bnxt/bnxt_en/if_bnxt.c
+++ b/sys/dev/bnxt/bnxt_en/if_bnxt.c
@@ -2479,7 +2479,7 @@ bnxt_attach_pre(if_ctx_t ctx)
 	if (bnxt_pci_mapping(softc)) {
 		device_printf(softc->dev, "PCI mapping failed\n");
 		rc = ENXIO;
-		goto pci_map_fail;
+		goto free_pci_map;
 	}
 
 	softc->pdev = kzalloc(sizeof(*softc->pdev), GFP_KERNEL);
@@ -2842,7 +2842,6 @@ pci_attach_fail:
 	softc->pdev = NULL;
 free_pci_map:
 	bnxt_pci_mapping_free(softc);
-pci_map_fail:
 	pci_disable_busmaster(softc->dev);
 	return (rc);
 }


### PR DESCRIPTION
If bnxt_pci_mapping() succeeds in mapping BAR0 but fails while mapping BAR2, bnxt_attach_pre() previously skipped bnxt_pci_mapping_free() and only disabled bus mastering. Route the failure path through free_pci_map so any partially mapped PCI BAR resources are released.

Remove the now-unused pci_map_fail label.