### PR TITLE
nat64: Fix type confusion panic when using wrong NAT64 instance types

### DIFF
--- a/sys/netpfil/ipfw/nat64/nat64clat.c
+++ b/sys/netpfil/ipfw/nat64/nat64clat.c
@@ -214,7 +214,8 @@ ipfw_nat64clat(struct ip_fw_chain *chain, struct ip_fw_args *args,
 	if (cmd->opcode != O_EXTERNAL_ACTION ||
 	    insntod(cmd, kidx)->kidx != V_nat64clat_eid ||
 	    icmd->opcode != O_EXTERNAL_INSTANCE ||
-	    (cfg = NAT64_LOOKUP(chain, icmd)) == NULL)
+	    (cfg = NAT64_LOOKUP(chain, icmd)) == NULL ||
+	    cfg->no.etlv != IPFW_TLV_NAT64CLAT_NAME)
 		return (0);
 
 	switch (args->f_id.addr_type) {

--- a/sys/netpfil/ipfw/nat64/nat64stl.c
+++ b/sys/netpfil/ipfw/nat64/nat64stl.c
@@ -217,7 +217,8 @@ ipfw_nat64stl(struct ip_fw_chain *chain, struct ip_fw_args *args,
 	if (cmd->opcode != O_EXTERNAL_ACTION ||
 	    insntod(cmd, kidx)->kidx != V_nat64stl_eid ||
 	    icmd->opcode != O_EXTERNAL_INSTANCE ||
-	    (cfg = NAT64_LOOKUP(chain, icmd)) == NULL)
+	    (cfg = NAT64_LOOKUP(chain, icmd)) == NULL ||
+	    cfg->no.etlv != IPFW_TLV_NAT64STL_NAME)
 		return (0);
 
 	switch (args->f_id.addr_type) {


### PR DESCRIPTION
When an ipfw rule references a NAT64 instance by name, the kernel looks up the instance in the shared srvstate[] array without verifying the instance type. If the named instance is not the expected one, the code casts the instance to the wrong type and will eventually cause a kernel panic.

The root cause is that all NAT64 instance types share the same srvstate[] array but have different struct layouts. 

Fixed by adding a type check after NAT64_LOOKUP() to verify that the instance's etlv matches the expected type before proceeding. If the type doesn't match, return IP_FW_DENY to reject the packet safely rather than crashing.

Tested with the reproducers from the bug report on FreeBSD 16.0-CURRENT, no kernel panic with the changes.

PR: [295794](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295794)