### PR TITLE
Add support for Linux-compatible Unix abstract sockets

### DIFF
--- a/sys/kern/uipc_usrreq.c
+++ b/sys/kern/uipc_usrreq.c
@@ -65,8 +65,10 @@
 #include <sys/fcntl.h>
 #include <sys/file.h>
 #include <sys/filedesc.h>
+#include <sys/hash.h>
 #include <sys/jail.h>
 #include <sys/kernel.h>
+#include <sys/libkern.h>
 #include <sys/lock.h>
 #include <sys/malloc.h>
 #include <sys/mbuf.h>
@@ -77,6 +79,7 @@
 #include <sys/proc.h>
 #include <sys/protosw.h>
 #include <sys/queue.h>
+#include <sys/refcount.h>
 #include <sys/resourcevar.h>
 #include <sys/rwlock.h>
 #include <sys/socket.h>
@@ -288,12 +291,75 @@ static struct mtx	unp_defers_lock;
 #define	UNP_PCB_LOCK_ASSERT(unp)	mtx_assert(&(unp)->unp_mtx, MA_OWNED)
 #define	UNP_PCB_UNLOCK_ASSERT(unp)	mtx_assert(&(unp)->unp_mtx, MA_NOTOWNED)
 
+/*
+ * Abstract namespace.
+ *
+ * Sockets bound with sun_path[0] == '\0' live in a kernel-only hash table
+ * keyed by (prison, socket type, sun_path). No filesystem objects created.
+ * Names are length-delimited, not NUL-terminated, thus treated as opaque byte
+ * sequences.
+ *
+ * Bindings are prison-local (pointer identity, not prison_check() visibility).
+ * Parent jails cannot see child bindings. This mirrors Linux's per-netns model.
+ *
+ * Lifetime: Each binding owns a heap-allocated struct unp_absent which is on
+ * the hash table while the socket is alive and abstract-bound. The unpcb has a
+ * back-pointer to its entry; both pointer and table linkage are protected by
+ * unp_abstract_mtx.
+ *
+ * Lock order: unp_abstract_mtx is acquired before any per-pcb mutex.  Lookup
+ * acquires the hash mtx, validates unp_socket under the pcb mtx, takes refs,
+ * then drops both.
+ */
+struct unp_absent {
+	LIST_ENTRY(unp_absent) link;	/* (h) hash bucket linkage */
+	struct unpcb	*unp;		/* (c) owning unpcb */
+	struct prison	*pr;		/* (c) prison; refcount held */
+	int		 so_type;	/* (c) socket type */
+	int		 pathlen;	/* (c) length incl. leading NUL */
+	char		 path[];	/* (c) raw sun_path bytes */
+};
+LIST_HEAD(unp_abshead, unp_absent);
+
+static struct unp_abshead	*unp_abstract_hashtbl;
+static u_long			 unp_abstract_hashmask;
+static struct mtx		 unp_abstract_mtx;
+MTX_SYSINIT(unp_abstract, &unp_abstract_mtx, "unp_abstract", MTX_DEF);
+static MALLOC_DEFINE(M_UNPABS, "unpabs", "abstract Unix socket entries");
+
+/*
+ * Hash an abstract socket name to a bucket index using the tuple
+ * (prison, socket type, raw sun_path bytes).  The same fields are compared
+ * while walking the bucket so the hash only improves distribution.
+ *
+ * Linux also hashes the socket type so different socket types may bind the
+ * same abstract name.
+ */
+static inline uint32_t
+unp_abs_hashkey(const struct prison *pr, int so_type, const char *path,
+    int pathlen)
+{
+	uintptr_t prp;
+	uint32_t h;
+
+	prp = (uintptr_t)pr;
+	h = hash32_buf(&prp, sizeof(prp), HASHINIT);
+	h = hash32_buf(&so_type, sizeof(so_type), h);
+	h = hash32_buf(path, pathlen, h);
+
+	return (h);
+}
+
+#define UNP_ABS_BUCKET(pr, so_type, path, pathlen)		\
+	(&unp_abstract_hashtbl[unp_abs_hashkey((pr), (so_type),	\
+	(path), (pathlen)) & unp_abstract_hashmask])
+
 static int	uipc_connect2(struct socket *, struct socket *);
 static int	uipc_ctloutput(struct socket *, struct sockopt *);
 static int	unp_connect(struct socket *, struct sockaddr *,
 		    struct thread *);
 static int	unp_connectat(int, struct socket *, struct sockaddr *,
-		    struct thread *, bool);
+		    struct thread *, bool, struct socket **, struct unpcb **);
 static void	unp_connect2(struct socket *, struct socket *, bool);
 static void	unp_disconnect(struct unpcb *unp, struct unpcb *unp2);
 static void	unp_dispose(struct socket *so);
@@ -559,6 +625,175 @@ common:
 	return (0);
 }
 
+/*
+ * Look up an abstract binding in pr's namespace.  On hit, returns true with
+ * (*unpp, *sop) populated; caller owns one unp_pcb_hold() reference and one
+ * socket reference.  Both are released by unp_connectat() except on the
+ * abstract return_locked datagram success path, where they are handed to
+ * uipc_sosend_dgram() via abs_so / abs_unp and dropped after pair unlock.
+ */
+static bool
+unp_abstract_lookup(struct prison *pr, int so_type, const char *path,
+    int pathlen, struct unpcb **unpp, struct socket **sop)
+{
+	struct unp_absent *abs;
+	struct unp_abshead *bucket;
+	struct unpcb *unp;
+	struct socket *so;
+
+	bucket = UNP_ABS_BUCKET(pr, so_type, path, pathlen);
+	mtx_lock(&unp_abstract_mtx);
+	LIST_FOREACH(abs, bucket, link) {
+		if (abs->pr != pr || abs->so_type != so_type ||
+		    abs->pathlen != pathlen ||
+		    memcmp(abs->path, path, pathlen) != 0)
+			continue;
+
+		unp = abs->unp;
+		UNP_PCB_LOCK(unp);
+		so = unp->unp_socket;
+		if (so == NULL) {
+			UNP_PCB_UNLOCK(unp);
+			continue;
+		}
+		if (!refcount_acquire_if_not_zero(&so->so_count)) {
+			UNP_PCB_UNLOCK(unp);
+			continue;
+		}
+		unp_pcb_hold(unp);
+		UNP_PCB_UNLOCK(unp);
+		mtx_unlock(&unp_abstract_mtx);
+		*unpp = unp;
+		*sop = so;
+		return (true);
+	}
+	mtx_unlock(&unp_abstract_mtx);
+	return (false);
+}
+
+/*
+ * Bind unp into the abstract namespace.
+ *
+ * Lock acquisition order is hash -> pcb across the commit critical section.
+ * The collision scan and insert happen under the hash lock; the pcb lock is
+ * taken inside it to publish the binding atomically.
+ */
+static int
+unp_bind_abstract(struct socket *so, struct sockaddr *nam, int pathlen,
+    struct thread *td)
+{
+	struct sockaddr_un *soun = (struct sockaddr_un *)nam;
+	struct sockaddr_un *new_addr;
+	struct unp_absent *abs, *cur;
+	struct unp_abshead *bucket;
+	struct unpcb *unp;
+	struct prison *pr;
+
+	unp = sotounpcb(so);
+
+	UNP_PCB_LOCK(unp);
+	if (unp->unp_addr != NULL) {
+		UNP_PCB_UNLOCK(unp);
+		return (EINVAL);
+	}
+	if ((unp->unp_flags & UNP_BINDING) != 0) {
+		UNP_PCB_UNLOCK(unp);
+		return (EALREADY);
+	}
+	unp->unp_flags |= UNP_BINDING;
+	UNP_PCB_UNLOCK(unp);
+
+	pr = td->td_ucred->cr_prison;
+	prison_hold(pr);
+
+	abs = malloc(sizeof(*abs) + pathlen, M_UNPABS, M_WAITOK | M_ZERO);
+	abs->unp = unp;
+	abs->pr = pr;
+	abs->so_type = so->so_type;
+	abs->pathlen = pathlen;
+	memcpy(abs->path, soun->sun_path, pathlen);
+
+	new_addr = (struct sockaddr_un *)sodupsockaddr(nam, M_WAITOK);
+
+	bucket = UNP_ABS_BUCKET(pr, so->so_type, soun->sun_path, pathlen);
+	mtx_lock(&unp_abstract_mtx);
+	LIST_FOREACH(cur, bucket, link) {
+		if (cur->pr != pr || cur->so_type != so->so_type ||
+		    cur->pathlen != pathlen ||
+		    memcmp(cur->path, soun->sun_path, pathlen) != 0)
+			continue;
+
+		mtx_unlock(&unp_abstract_mtx);
+		free(new_addr, M_SONAME);
+		free(abs, M_UNPABS);
+		prison_free(pr);
+		UNP_PCB_LOCK(unp);
+		unp->unp_flags &= ~UNP_BINDING;
+		UNP_PCB_UNLOCK(unp);
+		return (EADDRINUSE);
+	}
+	LIST_INSERT_HEAD(bucket, abs, link);
+	UNP_PCB_LOCK(unp);
+	unp->unp_absent = abs;
+	unp->unp_addr = new_addr;
+	unp->unp_flags &= ~UNP_BINDING;
+	UNP_PCB_UNLOCK(unp);
+	mtx_unlock(&unp_abstract_mtx);
+	return (0);
+}
+
+/*
+ * Autobind: assign a kernel-chosen abstract name of the form \0NNNNN
+ * (NUL marker + 5 lowercase hex digits).
+ */
+static int
+unp_bind_abstract_auto(struct socket *so, struct thread *td)
+{
+	struct sockaddr_un sun;
+	uint32_t n, start;
+	int error;
+
+	memset(&sun, 0, sizeof(sun));
+	sun.sun_family = AF_UNIX;
+	sun.sun_len = offsetof(struct sockaddr_un, sun_path) + 6;
+	sun.sun_path[0] = '\0';
+
+	start = arc4random() & 0xfffff;
+	n = start;
+	do {
+		(void)snprintf(sun.sun_path + 1, 6, "%05x", n);
+		error = unp_bind_abstract(so, (struct sockaddr *)&sun, 6, td);
+		if (error != EADDRINUSE)
+			return (error);
+		n = (n + 1) & 0xfffff;
+	} while (n != start);
+
+	return (EADDRINUSE);
+}
+
+static void
+unp_abstract_detach(struct unpcb *unp)
+{
+	struct unp_absent *abs;
+
+	UNP_PCB_UNLOCK_ASSERT(unp);
+
+	mtx_lock(&unp_abstract_mtx);
+	UNP_PCB_LOCK(unp);
+	abs = unp->unp_absent;
+	if (abs != NULL) {
+		LIST_REMOVE(abs, link);
+		unp->unp_absent = NULL;
+	}
+	UNP_PCB_UNLOCK(unp);
+	mtx_unlock(&unp_abstract_mtx);
+
+	if (abs != NULL) {
+		prison_free(abs->pr);
+		free(abs, M_UNPABS);
+	}
+}
+
 static int
 uipc_bindat(int fd, struct socket *so, struct sockaddr *nam, struct thread *td)
 {
@@ -584,6 +819,12 @@ uipc_bindat(int fd, struct socket *so, struct sockaddr *nam, struct thread *td)
 	namelen = soun->sun_len - offsetof(struct sockaddr_un, sun_path);
 	if (namelen <= 0)
 		return (EINVAL);
+
+	if (soun->sun_path[0] == '\0') {
+		if (namelen == 1)
+		    return (unp_bind_abstract_auto(so, td));
+		return (unp_bind_abstract(so, nam, namelen, td));
+	}
 
 	/*
 	 * We don't allow simultaneous bind() calls on a single UNIX domain
@@ -711,7 +952,7 @@ uipc_connectat(int fd, struct socket *so, struct sockaddr *nam,
 	int error;
 
 	KASSERT(td == curthread, ("uipc_connectat: td != curthread"));
-	error = unp_connectat(fd, so, nam, td, false);
+	error = unp_connectat(fd, so, nam, td, false, NULL, NULL);
 	return (error);
 }
 
@@ -762,7 +1003,8 @@ uipc_chmod(struct socket *so, mode_t mode, struct ucred *cred __unused,
 	error = 0;
 	unp = sotounpcb(so);
 	UNP_PCB_LOCK(unp);
-	if (unp->unp_vnode != NULL || (unp->unp_flags & UNP_BINDING) != 0)
+	if (unp->unp_vnode != NULL || (unp->unp_flags & UNP_BINDING) != 0 ||
+	    unp->unp_absent != NULL)
 		error = EINVAL;
 	else
 		unp->unp_mode = mode;
@@ -819,6 +1061,9 @@ uipc_detach(struct socket *so)
 	unp->unp_gencnt = ++unp_gencnt;
 	--unp_count;
 	UNP_LINK_WUNLOCK();
+
+	if (unp->unp_absent != NULL)
+		unp_abstract_detach(unp);
 
 	UNP_PCB_UNLOCK_ASSERT(unp);
  restart:
@@ -934,7 +1179,7 @@ uipc_listen(struct socket *so, int backlog, struct thread *td)
 	UNP_PCB_LOCK(unp);
 	if (unp->unp_conn != NULL || (unp->unp_flags & UNP_CONNECTING) != 0)
 		error = EINVAL;
-	else if (unp->unp_vnode == NULL)
+	else if (unp->unp_vnode == NULL && unp->unp_absent == NULL)
 		error = EDESTADDRREQ;
 	if (error != 0) {
 		UNP_PCB_UNLOCK(unp);
@@ -1957,6 +2202,8 @@ uipc_sosend_dgram(struct socket *so, struct sockaddr *addr, struct uio *uio,
 	struct sockbuf *sb;
 	struct mchain cmc = MCHAIN_INITIALIZER(&cmc);
 	struct mbuf *f;
+	struct socket *abs_so = NULL;	/* abstract listener ref to drop */
+	struct unpcb *abs_unp = NULL;	/* abstract listener pcb hold */
 	u_int cc, ctl, mbcnt;
 	u_int dcc __diagused, dctl __diagused, dmbcnt __diagused;
 	int error;
@@ -2034,7 +2281,8 @@ uipc_sosend_dgram(struct socket *so, struct sockaddr *addr, struct uio *uio,
 	SOCK_SENDBUF_UNLOCK(so);
 
 	if (addr != NULL) {
-		if ((error = unp_connectat(AT_FDCWD, so, addr, td, true)))
+		if ((error = unp_connectat(AT_FDCWD, so, addr, td, true,
+		    &abs_so, &abs_unp)))
 			goto out3;
 		UNP_PCB_LOCK_ASSERT(unp);
 		unp2 = unp->unp_conn;
@@ -2147,6 +2395,20 @@ uipc_sosend_dgram(struct socket *so, struct sockaddr *addr, struct uio *uio,
 		unp_disconnect(unp, unp2);
 	else
 		unp_pcb_unlock_pair(unp, unp2);
+
+	/*
+	 * Drop abstract listener refs after pair unlock.
+	 *
+	 * Both pointers are NULL for non-abstract sends or when
+	 * unp_connectat() failed.
+	 */
+	if (abs_so != NULL)
+		sorele(abs_so);
+	if (abs_unp != NULL) {
+		UNP_PCB_LOCK(abs_unp);
+		if (unp_pcb_rele(abs_unp) == false)
+			UNP_PCB_UNLOCK(abs_unp);
+	}
 
 	td->td_ru.ru_msgsnd++;
 
@@ -2847,24 +3109,27 @@ static int
 unp_connect(struct socket *so, struct sockaddr *nam, struct thread *td)
 {
 
-	return (unp_connectat(AT_FDCWD, so, nam, td, false));
+	return (unp_connectat(AT_FDCWD, so, nam, td, false, NULL, NULL));
 }
 
 static int
 unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
-    struct thread *td, bool return_locked)
+    struct thread *td, bool return_locked, struct socket **abs_so,
+    struct unpcb **abs_unp)
 {
 	struct mtx *vplock;
 	struct sockaddr_un *soun;
 	struct vnode *vp;
 	struct socket *so2;
+	struct socket *so2_abs_ref;	/* abstract: socket reference held */
 	struct unpcb *unp, *unp2, *unp3;
+	struct unpcb *unp2_abs_ref;	/* abstract: unpcb reference held */
 	struct nameidata nd;
 	char buf[SOCK_MAXADDRLEN];
 	struct sockaddr *sa;
 	cap_rights_t rights;
 	int error, len;
-	bool connreq;
+	bool abstract, connreq;
 
 	CURVNET_ASSERT_SET();
 
@@ -2876,8 +3141,12 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 	if (len <= 0)
 		return (EINVAL);
 	soun = (struct sockaddr_un *)nam;
-	bcopy(soun->sun_path, buf, len);
-	buf[len] = 0;
+	abstract = soun->sun_path[0] == '\0';
+
+	if (!abstract) {
+		bcopy(soun->sun_path, buf, len);
+		buf[len] = 0;
+	}
 
 	error = 0;
 	unp = sotounpcb(so);
@@ -2921,42 +3190,56 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 		sa = malloc(sizeof(struct sockaddr_un), M_SONAME, M_WAITOK);
 	else
 		sa = NULL;
-	NDINIT_ATRIGHTS(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF | EMPTYPATH,
-	    UIO_SYSSPACE, buf, fd, cap_rights_init_one(&rights, CAP_CONNECTAT));
-	error = namei(&nd);
-	if (error)
-		vp = NULL;
-	else
-		vp = nd.ni_vp;
-	ASSERT_VOP_LOCKED(vp, "unp_connect");
-	if (error)
-		goto bad;
-	NDFREE_PNBUF(&nd);
 
-	if (vp->v_type != VSOCK) {
-		error = ENOTSOCK;
-		goto bad;
-	}
+	vp = NULL;
+	if (abstract) {
+		if (!unp_abstract_lookup(td->td_ucred->cr_prison,
+		    so->so_type, soun->sun_path, len, &unp2, &so2)) {
+			error = ECONNREFUSED;
+			goto bad;
+		}
+		unp2_abs_ref = unp2;
+		so2_abs_ref = so2;
+	} else {
+		NDINIT_ATRIGHTS(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF |
+		    EMPTYPATH, UIO_SYSSPACE, buf, fd,
+		    cap_rights_init_one(&rights, CAP_CONNECTAT));
+		error = namei(&nd);
+		if (error)
+			vp = NULL;
+		else
+			vp = nd.ni_vp;
+		ASSERT_VOP_LOCKED(vp, "unp_connect");
+		if (error)
+			goto bad;
+		NDFREE_PNBUF(&nd);
+
+		if (vp->v_type != VSOCK) {
+			error = ENOTSOCK;
+			goto bad;
+		}
 #ifdef MAC
-	error = mac_vnode_check_open(td->td_ucred, vp, VWRITE | VREAD);
-	if (error)
-		goto bad;
+		error = mac_vnode_check_open(td->td_ucred, vp, VWRITE | VREAD);
+		if (error)
+			goto bad;
 #endif
-	error = VOP_ACCESS(vp, VWRITE, td->td_ucred, td);
-	if (error)
-		goto bad;
+		error = VOP_ACCESS(vp, VWRITE, td->td_ucred, td);
+		if (error)
+			goto bad;
 
-	unp = sotounpcb(so);
-	KASSERT(unp != NULL, ("unp_connect: unp == NULL"));
+		unp = sotounpcb(so);
+		KASSERT(unp != NULL, ("unp_connect: unp == NULL"));
 
-	vplock = mtx_pool_find(unp_vp_mtxpool, vp);
-	mtx_lock(vplock);
-	VOP_UNP_CONNECT(vp, &unp2);
-	if (unp2 == NULL) {
-		error = ECONNREFUSED;
-		goto bad2;
+		vplock = mtx_pool_find(unp_vp_mtxpool, vp);
+		mtx_lock(vplock);
+		VOP_UNP_CONNECT(vp, &unp2);
+		if (unp2 == NULL) {
+			error = ECONNREFUSED;
+			goto bad2;
+		}
+		so2 = unp2->unp_socket;
 	}
-	so2 = unp2->unp_socket;
+
 	if (so->so_type != so2->so_type) {
 		error = EPROTOTYPE;
 		goto bad2;
@@ -3011,7 +3294,25 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 	if (!return_locked)
 		unp_pcb_unlock_pair(unp, unp2);
 bad2:
-	mtx_unlock(vplock);
+	if (abstract) {
+		if (error == 0 && return_locked && !connreq) {
+			KASSERT(abs_so != NULL && abs_unp != NULL,
+			    ("%s: abstract return_locked without ref handoff",
+			    __func__));
+			*abs_so = so2_abs_ref;
+			*abs_unp = unp2_abs_ref;
+			so2_abs_ref = NULL;
+			unp2_abs_ref = NULL;
+		}
+		if (so2_abs_ref != NULL)
+			sorele(so2_abs_ref);
+		if (unp2_abs_ref != NULL) {
+			UNP_PCB_LOCK(unp2_abs_ref);
+			if (unp_pcb_rele(unp2_abs_ref) == false)
+				UNP_PCB_UNLOCK(unp2_abs_ref);
+		}
+	} else
+		mtx_unlock(vplock);
 bad:
 	if (vp != NULL) {
 		/*
@@ -3643,6 +3944,8 @@ unp_init(void *arg __unused)
 	LIST_INIT(&unp_dhead);
 	LIST_INIT(&unp_shead);
 	LIST_INIT(&unp_sphead);
+	unp_abstract_hashtbl = hashinit(MAX(maxsockets / 16, 16),
+	    M_UNPABS, &unp_abstract_hashmask);
 	SLIST_INIT(&unp_defers);
 	TIMEOUT_TASK_INIT(taskqueue_thread, &unp_gc_task, 0, unp_gc, NULL);
 	TASK_INIT(&unp_defer_task, 0, unp_process_defers, NULL);

--- a/sys/sys/unpcb.h
+++ b/sys/sys/unpcb.h
@@ -67,10 +67,12 @@ typedef uint64_t unp_gen_t;
  * (a) Atomic
  * (c) Constant
  * (g) Locked using linkage lock
+ * (h) Locked using the abstract-namespace hash lock
  * (l) Locked using list lock
  * (p) Locked using pcb lock
  */
 LIST_HEAD(unp_head, unpcb);
+struct unp_absent;
 
 struct unpcb {
 	/* Cache line 1 */
@@ -95,6 +97,7 @@ struct unpcb {
 	ino_t	unp_ino;		/* (g) fake inode number */
 	mode_t  unp_mode;		/* (g) initial pre-bind() mode */
 	LIST_ENTRY(unpcb) unp_dead;	/* (g) link in dead list */
+	struct unp_absent *unp_absent;	/* (h) abstract namespace binding */
 } __aligned(CACHE_LINE_SIZE);
 
 /*

--- a/tests/sys/kern/Makefile
+++ b/tests/sys/kern/Makefile
@@ -68,6 +68,9 @@ TEST_METADATA.unix_passfd_stream+=	is_exclusive="true"
 ATF_TESTS_C+=	unix_seqpacket_test
 TEST_METADATA.unix_seqpacket_test+=	timeout="15"
 ATF_TESTS_C+=	unix_stream
+ATF_TESTS_C+=	unix_abstract
+TEST_METADATA.unix_abstract+=	is_exclusive="true"
+TEST_METADATA.unix_abstract+=	timeout="60"
 ATF_TESTS_C+=	waitpid_nohang
 ATF_TESTS_C+=	pdeathsig
 ATF_TESTS_C+=	sigsys
@@ -117,6 +120,7 @@ LIBADD.ktrace_test+=			sysdecode
 LIBADD.unix_passfd_dgram+=		jail
 LIBADD.unix_passfd_stream+=		jail
 LIBADD.unix_stream+=			pthread
+LIBADD.unix_abstract+=			jail pthread
 
 NETBSD_ATF_TESTS_C+=	lockf_test
 NETBSD_ATF_TESTS_C+=	mqueue_test

--- a/tests/sys/kern/unix_abstract.c
+++ b/tests/sys/kern/unix_abstract.c
@@ -1,0 +1,555 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2025 Ricardo Branco <rbranco@suse.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/* Tests for the Linux-style abstract AF_UNIX namespace. */
+
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+
+#include <atf-c.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static socklen_t
+mkabstract(struct sockaddr_un *sun, const void *name, size_t namelen)
+{
+	ATF_REQUIRE(namelen + 1 <= sizeof(sun->sun_path));
+	memset(sun, 0, sizeof(*sun));
+	sun->sun_family = AF_UNIX;
+	sun->sun_path[0] = '\0';
+	if (namelen > 0)
+		memcpy(&sun->sun_path[1], name, namelen);
+	sun->sun_len = offsetof(struct sockaddr_un, sun_path) + 1 + namelen;
+	return (sun->sun_len);
+}
+
+ATF_TC_WITHOUT_HEAD(bind_and_close);
+ATF_TC_BODY(bind_and_close, tc)
+{
+	struct sockaddr_un sun;
+	socklen_t slen;
+	int s;
+
+	s = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s >= 0);
+	slen = mkabstract(&sun, "test", sizeof("test") - 1);
+	ATF_REQUIRE_EQ(0, bind(s, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(0, close(s));
+}
+
+ATF_TC_WITHOUT_HEAD(bind_then_unlink_does_nothing);
+ATF_TC_BODY(bind_then_unlink_does_nothing, tc)
+{
+	struct sockaddr_un sun;
+	socklen_t slen;
+	int s;
+
+	/*
+	 * Abstract bindings are not in the filesystem; unlink(2) on a
+	 * pathname collision should not affect them.  We just confirm
+	 * binding succeeds even when the corresponding character bytes
+	 * happen to look like a path.
+	 */
+	s = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s >= 0);
+	slen = mkabstract(&sun, "/tmp/foobar", sizeof("/tmp/foobar") - 1);
+	ATF_REQUIRE_EQ(0, bind(s, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(-1, access("/tmp/foobar", F_OK));
+	ATF_REQUIRE_EQ(ENOENT, errno);
+	close(s);
+}
+
+ATF_TC_WITHOUT_HEAD(bind_duplicate_returns_eaddrinuse);
+ATF_TC_BODY(bind_duplicate_returns_eaddrinuse, tc)
+{
+	struct sockaddr_un sun;
+	socklen_t slen;
+	int s1, s2;
+
+	s1 = socket(AF_UNIX, SOCK_STREAM, 0);
+	s2 = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s1 >= 0 && s2 >= 0);
+	slen = mkabstract(&sun, "dup_name", sizeof("dup_name") - 1);
+	ATF_REQUIRE_EQ(0, bind(s1, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(-1, bind(s2, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(EADDRINUSE, errno);
+	close(s1);
+	close(s2);
+}
+
+ATF_TC_WITHOUT_HEAD(bind_after_close_succeeds);
+ATF_TC_BODY(bind_after_close_succeeds, tc)
+{
+	struct sockaddr_un sun;
+	socklen_t slen;
+	int s1, s2;
+
+	s1 = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s1 >= 0);
+	slen = mkabstract(&sun, "rebind_name", sizeof("rebind_name") - 1);
+	ATF_REQUIRE_EQ(0, bind(s1, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(0, close(s1));
+
+	/*
+	 * Auto-cleanup property: the binding should vanish when the last
+	 * reference closes, leaving the name immediately re-bindable.
+	 */
+	s2 = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s2 >= 0);
+	ATF_REQUIRE_EQ(0, bind(s2, (struct sockaddr *)&sun, slen));
+	close(s2);
+}
+
+ATF_TC_WITHOUT_HEAD(bind_embedded_nuls_in_name);
+ATF_TC_BODY(bind_embedded_nuls_in_name, tc)
+{
+	struct sockaddr_un sun1, sun2;
+	socklen_t slen1, slen2;
+	int s1, s2;
+
+	/*
+	 * Names with embedded NULs are distinct byte sequences: "a\0b" and
+	 * "a\0c" must not collide.  This exercises the "do not use string
+	 * functions on abstract names" invariant.
+	 */
+	s1 = socket(AF_UNIX, SOCK_STREAM, 0);
+	s2 = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s1 >= 0 && s2 >= 0);
+	slen1 = mkabstract(&sun1, "a\0b", sizeof("a\0b") - 1);
+	slen2 = mkabstract(&sun2, "a\0c", sizeof("a\0c") - 1);
+	ATF_REQUIRE_EQ(0, bind(s1, (struct sockaddr *)&sun1, slen1));
+	ATF_REQUIRE_EQ(0, bind(s2, (struct sockaddr *)&sun2, slen2));
+	close(s1);
+	close(s2);
+}
+
+ATF_TC_WITHOUT_HEAD(bind_filesystem_name_does_not_collide);
+ATF_TC_BODY(bind_filesystem_name_does_not_collide, tc)
+{
+	struct sockaddr_un fs_sun, abs_sun;
+	socklen_t abs_slen;
+	int sf, sa;
+
+	/*
+	 * Pathname and abstract namespaces are disjoint: binding "foo" in
+	 * the filesystem must not prevent binding "\0foo" in abstract.
+	 */
+	memset(&fs_sun, 0, sizeof(fs_sun));
+	fs_sun.sun_family = AF_UNIX;
+	snprintf(fs_sun.sun_path, sizeof(fs_sun.sun_path),
+	    "test_fs_collide_%u.sock", (unsigned)getpid());
+	fs_sun.sun_len = SUN_LEN(&fs_sun);
+	(void)unlink(fs_sun.sun_path);
+
+	sf = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(sf >= 0);
+	ATF_REQUIRE_EQ(0, bind(sf, (struct sockaddr *)&fs_sun, fs_sun.sun_len));
+
+	sa = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(sa >= 0);
+	abs_slen = mkabstract(&abs_sun, fs_sun.sun_path,
+	    strlen(fs_sun.sun_path));
+	ATF_REQUIRE_EQ(0, bind(sa, (struct sockaddr *)&abs_sun, abs_slen));
+
+	close(sa);
+	close(sf);
+	unlink(fs_sun.sun_path);
+}
+
+ATF_TC_WITHOUT_HEAD(getsockname_roundtrip);
+ATF_TC_BODY(getsockname_roundtrip, tc)
+{
+	struct sockaddr_un bound, got;
+	socklen_t blen, glen;
+	int s;
+
+	s = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s >= 0);
+	blen = mkabstract(&bound, "rtrip", sizeof("rtrip") - 1);
+	ATF_REQUIRE_EQ(0, bind(s, (struct sockaddr *)&bound, blen));
+
+	glen = sizeof(got);
+	memset(&got, 0xa5, sizeof(got));
+	ATF_REQUIRE_EQ(0, getsockname(s, (struct sockaddr *)&got, &glen));
+	ATF_REQUIRE_EQ(blen, glen);
+	ATF_REQUIRE_EQ(AF_UNIX, got.sun_family);
+	ATF_REQUIRE_EQ(0, got.sun_path[0]);
+	ATF_REQUIRE_EQ(0, memcmp(got.sun_path, bound.sun_path,
+	    blen - offsetof(struct sockaddr_un, sun_path)));
+	close(s);
+}
+
+ATF_TC_WITHOUT_HEAD(stream_connect_econnrefused_on_missing);
+ATF_TC_BODY(stream_connect_econnrefused_on_missing, tc)
+{
+	struct sockaddr_un sun;
+	socklen_t slen;
+	int s;
+
+	s = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s >= 0);
+	slen = mkabstract(&sun, "not_bound", sizeof("not_bound") - 1);
+	ATF_REQUIRE_EQ(-1, connect(s, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(ECONNREFUSED, errno);
+	close(s);
+}
+
+ATF_TC_WITHOUT_HEAD(stream_connect_accept);
+ATF_TC_BODY(stream_connect_accept, tc)
+{
+	struct sockaddr_un sun;
+	char buf[5];
+	socklen_t slen;
+	int ls, cs, as;
+
+	ls = socket(AF_UNIX, SOCK_STREAM, 0);
+	cs = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(ls >= 0 && cs >= 0);
+	slen = mkabstract(&sun, "stream_listen", sizeof("stream_listen") - 1);
+	ATF_REQUIRE_EQ(0, bind(ls, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(0, listen(ls, 1));
+	ATF_REQUIRE_EQ(0, connect(cs, (struct sockaddr *)&sun, slen));
+	as = accept(ls, NULL, NULL);
+	ATF_REQUIRE(as >= 0);
+	ATF_REQUIRE_EQ(5, write(cs, "hello", 5));
+	ATF_REQUIRE_EQ(5, read(as, buf, 5));
+	ATF_REQUIRE_EQ(0, memcmp(buf, "hello", 5));
+	close(as);
+	close(cs);
+	close(ls);
+}
+
+ATF_TC_WITHOUT_HEAD(seqpacket_connect_accept);
+ATF_TC_BODY(seqpacket_connect_accept, tc)
+{
+	struct sockaddr_un sun;
+	char buf[16];
+	socklen_t slen;
+	int ls, cs, as;
+	ssize_t n;
+
+	ls = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+	cs = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+	ATF_REQUIRE(ls >= 0 && cs >= 0);
+	slen = mkabstract(&sun, "seqpacket", sizeof("seqpacket") - 1);
+	ATF_REQUIRE_EQ(0, bind(ls, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(0, listen(ls, 1));
+	ATF_REQUIRE_EQ(0, connect(cs, (struct sockaddr *)&sun, slen));
+	as = accept(ls, NULL, NULL);
+	ATF_REQUIRE(as >= 0);
+	ATF_REQUIRE_EQ(7, write(cs, "datagram", 7));
+	n = read(as, buf, sizeof(buf));
+	ATF_REQUIRE_EQ(7, n);
+	close(as);
+	close(cs);
+	close(ls);
+}
+
+ATF_TC_WITHOUT_HEAD(dgram_connect_send);
+ATF_TC_BODY(dgram_connect_send, tc)
+{
+	struct sockaddr_un sun;
+	char buf[8];
+	socklen_t slen;
+	int rs, cs;
+
+	rs = socket(AF_UNIX, SOCK_DGRAM, 0);
+	cs = socket(AF_UNIX, SOCK_DGRAM, 0);
+	ATF_REQUIRE(rs >= 0 && cs >= 0);
+	slen = mkabstract(&sun, "dgram_recv", sizeof("dgram_recv") - 1);
+	ATF_REQUIRE_EQ(0, bind(rs, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(0, connect(cs, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(4, send(cs, "ping", 4, 0));
+	ATF_REQUIRE_EQ(4, recv(rs, buf, sizeof(buf), 0));
+	ATF_REQUIRE_EQ(0, memcmp(buf, "ping", 4));
+	close(cs);
+	close(rs);
+}
+
+ATF_TC_WITHOUT_HEAD(dgram_unconnected_sendto);
+ATF_TC_BODY(dgram_unconnected_sendto, tc)
+{
+	struct sockaddr_un sun;
+	char buf[8];
+	socklen_t slen;
+	int rs, cs;
+
+	rs = socket(AF_UNIX, SOCK_DGRAM, 0);
+	cs = socket(AF_UNIX, SOCK_DGRAM, 0);
+	ATF_REQUIRE(rs >= 0 && cs >= 0);
+	slen = mkabstract(&sun, "dgram_unconn", sizeof("dgram_unconn") - 1);
+	ATF_REQUIRE_EQ(0, bind(rs, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(4, sendto(cs, "ping", 4, 0,
+	    (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(4, recv(rs, buf, sizeof(buf), 0));
+	ATF_REQUIRE_EQ(0, memcmp(buf, "ping", 4));
+	close(cs);
+	close(rs);
+}
+
+ATF_TC_WITHOUT_HEAD(dgram_unconnected_sendto_loop);
+ATF_TC_BODY(dgram_unconnected_sendto_loop, tc)
+{
+	struct sockaddr_un sun;
+	char buf[8];
+	socklen_t slen;
+	int rs, cs;
+
+	rs = socket(AF_UNIX, SOCK_DGRAM, 0);
+	cs = socket(AF_UNIX, SOCK_DGRAM, 0);
+	ATF_REQUIRE(rs >= 0 && cs >= 0);
+	slen = mkabstract(&sun, "dgram_loop", sizeof("dgram_loop") - 1);
+	ATF_REQUIRE_EQ(0, bind(rs, (struct sockaddr *)&sun, slen));
+	for (int i = 0; i < 4096; i++) {
+		ATF_REQUIRE_EQ(4, sendto(cs, "ping", 4, 0,
+		    (struct sockaddr *)&sun, slen));
+		ATF_REQUIRE_EQ(4, recv(rs, buf, sizeof(buf), 0));
+	}
+	close(cs);
+	close(rs);
+}
+
+ATF_TC_WITHOUT_HEAD(stream_peer_address);
+ATF_TC_BODY(stream_peer_address, tc)
+{
+	struct sockaddr_un bound, peer;
+	socklen_t blen, plen;
+	int ls, cs, as;
+
+	ls = socket(AF_UNIX, SOCK_STREAM, 0);
+	cs = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(ls >= 0 && cs >= 0);
+	blen = mkabstract(&bound, "peer_addr", sizeof("peer_addr") - 1);
+	ATF_REQUIRE_EQ(0, bind(ls, (struct sockaddr *)&bound, blen));
+	ATF_REQUIRE_EQ(0, listen(ls, 1));
+	ATF_REQUIRE_EQ(0, connect(cs, (struct sockaddr *)&bound, blen));
+	as = accept(ls, NULL, NULL);
+	ATF_REQUIRE(as >= 0);
+
+	plen = sizeof(peer);
+	memset(&peer, 0, sizeof(peer));
+	ATF_REQUIRE_EQ(0, getpeername(cs, (struct sockaddr *)&peer, &plen));
+	ATF_REQUIRE_EQ(blen, plen);
+	ATF_REQUIRE_EQ(0, peer.sun_path[0]);
+	ATF_REQUIRE_EQ(0, memcmp(peer.sun_path, bound.sun_path,
+	    blen - offsetof(struct sockaddr_un, sun_path)));
+
+	close(as);
+	close(cs);
+	close(ls);
+}
+
+/*
+ * Auto-cleanup: a listener that exits without closing should free the
+ * binding when the kernel reaps the fd.
+ */
+ATF_TC_WITHOUT_HEAD(child_exit_releases_binding);
+ATF_TC_BODY(child_exit_releases_binding, tc)
+{
+	struct sockaddr_un sun;
+	socklen_t slen;
+	pid_t pid;
+	int s, status;
+
+	slen = mkabstract(&sun, "child_releases", sizeof("child_releases") - 1);
+
+	pid = fork();
+	ATF_REQUIRE(pid >= 0);
+	if (pid == 0) {
+		s = socket(AF_UNIX, SOCK_STREAM, 0);
+		if (s < 0)
+			_exit(1);
+		if (bind(s, (struct sockaddr *)&sun, slen) != 0)
+			_exit(2);
+		_exit(0);	/* fd reaped on exit; binding should vanish */
+	}
+	ATF_REQUIRE_EQ(pid, waitpid(pid, &status, 0));
+	ATF_REQUIRE(WIFEXITED(status));
+	ATF_REQUIRE_EQ(0, WEXITSTATUS(status));
+
+	/* Parent should now be able to bind the same name. */
+	s = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s >= 0);
+	ATF_REQUIRE_EQ(0, bind(s, (struct sockaddr *)&sun, slen));
+	close(s);
+}
+
+/*
+ * The same abstract name may be bound simultaneously by sockets of
+ * different so_type within one prison.  Linux behaves this way (the
+ * abstract namespace hash key includes sk_type), so Linuxulator
+ * compatibility requires we match it.  Same name, same type still
+ * collides with EADDRINUSE.
+ */
+ATF_TC_WITHOUT_HEAD(type_independence);
+ATF_TC_BODY(type_independence, tc)
+{
+	struct sockaddr_un sun;
+	socklen_t slen;
+	int s_stream, s_dgram, s_seq, s_stream2;
+
+	slen = mkabstract(&sun, "type_indep", sizeof("type_indep") - 1);
+
+	s_stream = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s_stream >= 0);
+	ATF_REQUIRE_EQ(0, bind(s_stream, (struct sockaddr *)&sun, slen));
+
+	s_dgram = socket(AF_UNIX, SOCK_DGRAM, 0);
+	ATF_REQUIRE(s_dgram >= 0);
+	ATF_CHECK_EQ_MSG(0, bind(s_dgram, (struct sockaddr *)&sun, slen),
+	    "SOCK_DGRAM bind to same name as SOCK_STREAM should succeed: %s",
+	    strerror(errno));
+
+	s_seq = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+	ATF_REQUIRE(s_seq >= 0);
+	ATF_CHECK_EQ_MSG(0, bind(s_seq, (struct sockaddr *)&sun, slen),
+	    "SOCK_SEQPACKET bind to same name should succeed: %s",
+	    strerror(errno));
+
+	/* Same name, same type: must still collide. */
+	s_stream2 = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s_stream2 >= 0);
+	ATF_REQUIRE_EQ(-1, bind(s_stream2, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(EADDRINUSE, errno);
+
+	close(s_stream);
+	close(s_dgram);
+	close(s_seq);
+	close(s_stream2);
+}
+
+ATF_TC_WITHOUT_HEAD(chmod_rejected);
+ATF_TC_BODY(chmod_rejected, tc)
+{
+	struct sockaddr_un sun;
+	socklen_t slen;
+	int s;
+
+	s = socket(AF_UNIX, SOCK_STREAM, 0);
+	ATF_REQUIRE(s >= 0);
+	slen = mkabstract(&sun, "chmod_test", sizeof("chmod_test") - 1);
+	ATF_REQUIRE_EQ(0, bind(s, (struct sockaddr *)&sun, slen));
+	ATF_REQUIRE_EQ(-1, fchmod(s, 0600));
+	ATF_REQUIRE_EQ(EINVAL, errno);
+	close(s);
+}
+
+/*
+ * Autobind: bind(2) with a length-1 abstract address (just the NUL marker,
+ * no following bytes) triggers kernel-assigned name selection.  The kernel
+ * picks a unique \0NNNNN name (NUL + 5 lowercase hex digits), binds the
+ * socket to it, and getsockname(2) returns the assigned address.  Two
+ * autobinds within the same prison and socket type must produce distinct
+ * names.  The assigned address is usable for datagram exchange.
+ */
+ATF_TC_WITHOUT_HEAD(autobind);
+ATF_TC_BODY(autobind, tc)
+{
+	struct sockaddr_un trigger, bound, bound2;
+	socklen_t blen;
+	int s1, s2, cs, i;
+	char buf[1];
+
+	/*
+	 * Autobind trigger: sun_path[0] == '\0' and namelen == 1.
+	 * sun_len = offsetof(sun_path) + 1.
+	 */
+	memset(&trigger, 0, sizeof(trigger));
+	trigger.sun_family = AF_UNIX;
+	trigger.sun_len = offsetof(struct sockaddr_un, sun_path) + 1;
+
+	s1 = socket(AF_UNIX, SOCK_DGRAM, 0);
+	ATF_REQUIRE(s1 >= 0);
+	ATF_REQUIRE_EQ(0, bind(s1, (struct sockaddr *)&trigger,
+	    trigger.sun_len));
+
+	/* getsockname must return a 6-byte abstract name: \0 + 5 hex digits. */
+	blen = sizeof(bound);
+	ATF_REQUIRE_EQ(0, getsockname(s1, (struct sockaddr *)&bound, &blen));
+	ATF_REQUIRE_EQ((socklen_t)(offsetof(struct sockaddr_un, sun_path) + 6),
+	    blen);
+	ATF_REQUIRE_EQ('\0', bound.sun_path[0]);
+	for (i = 1; i <= 5; i++)
+		ATF_REQUIRE_MSG(isxdigit((unsigned char)bound.sun_path[i]),
+		    "sun_path[%d] = 0x%02x is not a hex digit", i,
+		    (unsigned char)bound.sun_path[i]);
+
+	/* Second autobind must produce a distinct name (same type, same prison). */
+	s2 = socket(AF_UNIX, SOCK_DGRAM, 0);
+	ATF_REQUIRE(s2 >= 0);
+	ATF_REQUIRE_EQ(0, bind(s2, (struct sockaddr *)&trigger,
+	    trigger.sun_len));
+	blen = sizeof(bound2);
+	ATF_REQUIRE_EQ(0, getsockname(s2, (struct sockaddr *)&bound2, &blen));
+	ATF_REQUIRE_MSG(
+	    memcmp(bound.sun_path, bound2.sun_path, 6) != 0,
+	    "two autobinds produced the same name");
+
+	/* The assigned address is reachable: another socket can send to it. */
+	blen = offsetof(struct sockaddr_un, sun_path) + 6;
+	cs = socket(AF_UNIX, SOCK_DGRAM, 0);
+	ATF_REQUIRE(cs >= 0);
+	ATF_REQUIRE_EQ(1, sendto(cs, "x", 1, 0,
+	    (struct sockaddr *)&bound, blen));
+	ATF_REQUIRE_EQ(1, recv(s1, buf, sizeof(buf), 0));
+	ATF_REQUIRE_EQ('x', buf[0]);
+
+	close(cs);
+	close(s1);
+	close(s2);
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+	ATF_TP_ADD_TC(tp, bind_and_close);
+	ATF_TP_ADD_TC(tp, bind_then_unlink_does_nothing);
+	ATF_TP_ADD_TC(tp, bind_duplicate_returns_eaddrinuse);
+	ATF_TP_ADD_TC(tp, bind_after_close_succeeds);
+	ATF_TP_ADD_TC(tp, bind_embedded_nuls_in_name);
+	ATF_TP_ADD_TC(tp, bind_filesystem_name_does_not_collide);
+	ATF_TP_ADD_TC(tp, getsockname_roundtrip);
+	ATF_TP_ADD_TC(tp, stream_connect_econnrefused_on_missing);
+	ATF_TP_ADD_TC(tp, stream_connect_accept);
+	ATF_TP_ADD_TC(tp, seqpacket_connect_accept);
+	ATF_TP_ADD_TC(tp, dgram_connect_send);
+	ATF_TP_ADD_TC(tp, dgram_unconnected_sendto);
+	ATF_TP_ADD_TC(tp, dgram_unconnected_sendto_loop);
+	ATF_TP_ADD_TC(tp, stream_peer_address);
+	ATF_TP_ADD_TC(tp, child_exit_releases_binding);
+	ATF_TP_ADD_TC(tp, type_independence);
+	ATF_TP_ADD_TC(tp, chmod_rejected);
+	ATF_TP_ADD_TC(tp, autobind);
+	return (atf_no_error());
+}


### PR DESCRIPTION
From the Linux's [unix(7) manpage](https://man7.org/linux/man-pages/man7/unix.7.html):

> an abstract socket address is distinguished (from a  pathname socket) by the fact that sun_path[0] is a null byte ('\0').  The socket's address in this namespace is given by the additional bytes in sun_path that are covered by the specified length of the address structure.  (Null bytes in the name have no special significance.)  The name has no connection with filesystem pathnames.  (...)

Also:

> Socket permissions have no meaning for abstract sockets: the process umask(2) has no effect when binding an abstract socket, and changing the ownership and permissions of the object (via fchown(2) and fchmod(2)) has no effect on the accessibility of the socket. Abstract sockets automatically disappear when all open references to the socket are closed.

This PR adds support for Linux-compatible Unix abstract sockets.

It passes some tests but before I continue feel free to dismiss this as a Linuxism now.  ;)

TODO
- [x] Add tests. 
- [ ] Add introspection via sysctls?
- [ ] Update commands such as fstat(1).  Please suggest others.
- [ ] Update manpages.
- [ ] Update the Linuxulator (in another PR).
