### PR TITLE
linuxulator: improve getxattr() error handling

### DIFF
--- a/sys/compat/linux/linux_xattr.c
+++ b/sys/compat/linux/linux_xattr.c
@@ -26,8 +26,10 @@
  */
 
 #include <sys/param.h>
+#include <sys/capsicum.h>
 #include <sys/extattr.h>
 #include <sys/fcntl.h>
+#include <sys/file.h>
 #include <sys/namei.h>
 #include <sys/proc.h>
 #include <sys/syscallsubr.h>
@@ -132,11 +134,20 @@ listxattr(struct thread *td, struct listxattr_args *args)
 {
 	char attrname[LINUX_XATTR_NAME_MAX + 1];
 	char *data, *prefix, *key;
+	cap_rights_t rights;
+	struct file *fp = NULL;
 	struct uio auio;
 	struct iovec aiov;
 	unsigned char keylen;
 	size_t sz, cnt, rs, prefixlen, pairlen;
 	int attrnamespace, error;
+
+	if (args->path == NULL) {
+		error = getvnode(td, args->fd,
+		    cap_rights_init_one(&rights, CAP_EXTATTR_LIST), &fp);
+		if (error != 0)
+			return (error);
+	}
 
 	if (args->size != 0)
 		sz = min(LINUX_XATTR_LIST_MAX, args->size);
@@ -162,7 +173,7 @@ listxattr(struct thread *td, struct listxattr_args *args)
 			error = kern_extattr_list_path(td, args->path,
 			    attrnamespace, &auio, args->follow, UIO_USERSPACE);
 		else
-			error = kern_extattr_list_fd(td, args->fd,
+			error = kern_extattr_list_fp(td, fp,
 			    attrnamespace, &auio);
 		rs = sz - auio.uio_resid;
 		if (error == EPERM)
@@ -204,6 +215,8 @@ listxattr(struct thread *td, struct listxattr_args *args)
 	if (error == 0)
 		td->td_retval[0] = cnt;
 	free(data, M_LINUX);
+	if (fp != NULL)
+		fdrop(fp, td);
 	return (error_to_xattrerror(attrnamespace, error));
 }
 
@@ -253,18 +266,33 @@ static int
 removexattr(struct thread *td, struct removexattr_args *args)
 {
 	char attrname[LINUX_XATTR_NAME_MAX + 1];
+	struct file *fp = NULL;
+	cap_rights_t rights;
 	int attrnamespace, error;
+
+	if (args->path == NULL) {
+		error = getvnode(td, args->fd,
+		    cap_rights_init_one(&rights, CAP_EXTATTR_DELETE), &fp);
+		if (error != 0)
+			return (error);
+	}
 
 	error = xattr_to_extattr(args->name, &attrnamespace, attrname);
 	if (error != 0)
-		return (error);
+		goto out_err;
 	if (args->path != NULL)
 		error = kern_extattr_delete_path(td, args->path, attrnamespace,
 		    attrname, args->follow, UIO_USERSPACE);
 	else
-		error = kern_extattr_delete_fd(td, args->fd, attrnamespace,
+		error = kern_extattr_delete_fp(td, fp, attrnamespace,
 		    attrname);
+	if (fp != NULL)
+		fdrop(fp, td);
 	return (error_to_xattrerror(attrnamespace, error));
+out_err:
+	if (fp != NULL)
+		fdrop(fp, td);
+	return (error);
 }
 
 int
@@ -310,17 +338,30 @@ static int
 getxattr(struct thread *td, struct getxattr_args *args)
 {
 	char attrname[LINUX_XATTR_NAME_MAX + 1];
+	struct file *fp = NULL;
+	cap_rights_t rights;
 	int attrnamespace, error;
+
+	if (args->path == NULL) {
+		error = getvnode(td, args->fd,
+		    cap_rights_init_one(&rights, CAP_EXTATTR_GET), &fp);
+		if (error != 0)
+			return (error);
+	}
 
 	error = xattr_to_extattr(args->name, &attrnamespace, attrname);
 	if (error != 0)
-		return (error);
+		goto out_err;
 	if (args->path != NULL)
 		error = kern_extattr_get_path(td, args->path, attrnamespace,
 		    attrname, args->value, args->size, args->follow, UIO_USERSPACE);
 	else
-		error = kern_extattr_get_fd(td, args->fd, attrnamespace,
+		error = kern_extattr_get_fp(td, fp, attrnamespace,
 		    attrname, args->value, args->size);
+
+out_err:
+	if (fp != NULL)
+		fdrop(fp, td);
 	return (error == EPERM ? ENOATTR : error);
 }
 
@@ -373,14 +414,28 @@ static int
 setxattr(struct thread *td, struct setxattr_args *args)
 {
 	char attrname[LINUX_XATTR_NAME_MAX + 1];
+	struct file *fp = NULL;
+	cap_rights_t rights;
 	int attrnamespace, error;
 
+	if (args->path == NULL) {
+		if ((args->flags & LINUX_XATTR_FLAGS) != 0)
+			cap_rights_init(&rights, CAP_EXTATTR_GET, CAP_EXTATTR_SET);
+		else
+			cap_rights_init_one(&rights, CAP_EXTATTR_SET);
+		error = getvnode(td, args->fd, &rights, &fp);
+		if (error != 0)
+			return (error);
+	}
+
 	if ((args->flags & ~(LINUX_XATTR_FLAGS)) != 0 ||
-	    args->flags == (LINUX_XATTR_FLAGS))
-		return (EINVAL);
+	    args->flags == (LINUX_XATTR_FLAGS)) {
+		error = EINVAL;
+		goto out_err;
+	}
 	error = xattr_to_extattr(args->name, &attrnamespace, attrname);
 	if (error != 0)
-		return (error);
+		goto out_err;
 
 	if ((args->flags & (LINUX_XATTR_FLAGS)) != 0 ) {
 		if (args->path != NULL)
@@ -388,7 +443,7 @@ setxattr(struct thread *td, struct setxattr_args *args)
 			    attrnamespace, attrname, NULL, args->size,
 			    args->follow, UIO_USERSPACE);
 		else
-			error = kern_extattr_get_fd(td, args->fd,
+			error = kern_extattr_get_fp(td, fp,
 			    attrnamespace, attrname, NULL, args->size);
 		if ((args->flags & LINUX_XATTR_CREATE) != 0) {
 			if (error == 0)
@@ -404,11 +459,17 @@ setxattr(struct thread *td, struct setxattr_args *args)
 		    attrname, args->value, args->size, args->follow,
 		    UIO_USERSPACE);
 	else
-		error = kern_extattr_set_fd(td, args->fd, attrnamespace,
+		error = kern_extattr_set_fp(td, fp, attrnamespace,
 		    attrname, args->value, args->size);
 out:
+	if (fp != NULL)
+		fdrop(fp, td);
 	td->td_retval[0] = 0;
 	return (error_to_xattrerror(attrnamespace, error));
+out_err:
+	if (fp != NULL)
+		fdrop(fp, td);
+	return (error);
 }
 
 int

--- a/sys/compat/linux/linux_xattr.c
+++ b/sys/compat/linux/linux_xattr.c
@@ -33,6 +33,9 @@
 #include <sys/namei.h>
 #include <sys/proc.h>
 #include <sys/syscallsubr.h>
+#include <sys/vnode.h>
+
+#include <security/mac/mac_framework.h>
 
 #ifdef COMPAT_LINUX32
 #include <machine/../linux32/linux.h>
@@ -334,11 +337,83 @@ linux_fremovexattr(struct thread *td, struct linux_fremovexattr_args *args)
 	return (removexattr(td, &eargs));
 }
 
+/*-
+ * Linux-specific atomic extended attribute get on a vnode.
+ *
+ * Probes the attribute size and reads the data under a single vnode lock,
+ * preventing a TOCTOU race and returning ERANGE when the buffer is too
+ * small (matching Linux getxattr(2) semantics).
+ */
+static int
+linux_extattr_get_vp(struct vnode *vp, int attrnamespace, const char *attrname,
+    void *data, size_t nbytes, struct thread *td)
+{
+	struct uio auio;
+	struct iovec aiov;
+	size_t size;
+	int error;
+
+	if (nbytes > IOSIZE_MAX)
+		return (EINVAL);
+
+	vn_lock(vp, LK_SHARED | LK_RETRY);
+
+#ifdef MAC
+	error = mac_vnode_check_getextattr(td->td_ucred, vp, attrnamespace,
+	    attrname);
+	if (error != 0)
+		goto done;
+#endif
+
+	/*
+	 * Probe the attribute size first under the vnode lock;
+	 */
+	error = VOP_GETEXTATTR(vp, attrnamespace, attrname, NULL,
+	    &size, td->td_ucred, td);
+	if (error != 0)
+		goto done;
+
+	/*
+	 * The caller only wants the size, so we are done after this.
+	 */
+	if (data == NULL || nbytes == 0) {
+		td->td_retval[0] = size;
+		goto done;
+	}
+	/*
+	 * If the buffer is too small, return ERANGE
+	 * so the caller can retry (Linux getxattr semantics).
+	 */
+	if (size > nbytes) {
+		error = ERANGE;
+		goto done;
+	}
+	/* Buffer is large enough; read the value. */
+	aiov.iov_base = data;
+	aiov.iov_len = nbytes;
+	auio.uio_iov = &aiov;
+	auio.uio_iovcnt = 1;
+	auio.uio_offset = 0;
+	auio.uio_resid = nbytes;
+	auio.uio_rw = UIO_READ;
+	auio.uio_segflg = UIO_USERSPACE;
+	auio.uio_td = td;
+	error = VOP_GETEXTATTR(vp, attrnamespace, attrname, &auio, NULL,
+		td->td_ucred, td);
+	if (error == 0)
+		td->td_retval[0] = nbytes - auio.uio_resid;
+done:
+	VOP_UNLOCK(vp);
+	return (error);
+}
+
 static int
 getxattr(struct thread *td, struct getxattr_args *args)
 {
 	char attrname[LINUX_XATTR_NAME_MAX + 1];
 	struct file *fp = NULL;
+	struct nameidata nd;
+	struct vnode *vp;
 	cap_rights_t rights;
 	int attrnamespace, error;
 
@@ -347,22 +422,30 @@ getxattr(struct thread *td, struct getxattr_args *args)
 		    cap_rights_init_one(&rights, CAP_EXTATTR_GET), &fp);
 		if (error != 0)
 			return (error);
+		vp = fp->f_vnode;
+	} else {
+		NDINIT_ATRIGHTS(&nd, LOOKUP, args->follow, UIO_USERSPACE,
+		    args->path, AT_FDCWD,
+		    cap_rights_init_one(&rights, CAP_EXTATTR_GET));
+		error = namei(&nd);
+		if (error != 0)
+			return (error);
+		NDFREE_PNBUF(&nd);
+		vp = nd.ni_vp;
 	}
 
 	error = xattr_to_extattr(args->name, &attrnamespace, attrname);
-	if (error != 0)
-		goto out_err;
-	if (args->path != NULL)
-		error = kern_extattr_get_path(td, args->path, attrnamespace,
-		    attrname, args->value, args->size, args->follow, UIO_USERSPACE);
-	else
-		error = kern_extattr_get_fp(td, fp, attrnamespace,
-		    attrname, args->value, args->size);
+	if (error == 0) {
+		error = linux_extattr_get_vp(vp, attrnamespace, attrname,
+			args->value, args->size, td);
+	}
 
-out_err:
-	if (fp != NULL)
+	if (fp != NULL) {
 		fdrop(fp, td);
-	return (error == EPERM ? ENOATTR : error);
+	} else {
+		vrele(nd.ni_vp);
+	}
+	return (error == EPERM || error == EOPNOTSUPP ? ENOATTR : error);
 }
 
 int

--- a/sys/kern/vfs_extattr.c
+++ b/sys/kern/vfs_extattr.c
@@ -241,6 +241,15 @@ sys_extattr_set_fd(struct thread *td, struct extattr_set_fd_args *uap)
 }
 
 int
+kern_extattr_set_fp(struct thread *td, struct file *fp, int attrnamespace,
+    const char *attrname, void *data, size_t nbytes)
+{
+
+	return (extattr_set_vp(fp->f_vnode, attrnamespace, attrname, data,
+	    nbytes, td));
+}
+
+int
 kern_extattr_set_fd(struct thread *td, int fd, int attrnamespace,
     const char *attrname, void *data, size_t nbytes)
 {
@@ -257,8 +266,8 @@ kern_extattr_set_fd(struct thread *td, int fd, int attrnamespace,
 	if (error)
 		return (error);
 
-	error = extattr_set_vp(fp->f_vnode, attrnamespace,
-	    attrname, data, nbytes, td);
+	error = kern_extattr_set_fp(td, fp, attrnamespace, attrname, data,
+	    nbytes);
 	fdrop(fp, td);
 
 	return (error);
@@ -429,6 +438,15 @@ sys_extattr_get_fd(struct thread *td, struct extattr_get_fd_args *uap)
 }
 
 int
+kern_extattr_get_fp(struct thread *td, struct file *fp, int attrnamespace,
+    const char *attrname, void *data, size_t nbytes)
+{
+
+	return (extattr_get_vp(fp->f_vnode, attrnamespace, attrname, data,
+	    nbytes, td));
+}
+
+int
 kern_extattr_get_fd(struct thread *td, int fd, int attrnamespace,
     const char *attrname, void *data, size_t nbytes)
 {
@@ -445,8 +463,8 @@ kern_extattr_get_fd(struct thread *td, int fd, int attrnamespace,
 	if (error)
 		return (error);
 
-	error = extattr_get_vp(fp->f_vnode, attrnamespace,
-	    attrname, data, nbytes, td);
+	error = kern_extattr_get_fp(td, fp, attrnamespace, attrname, data,
+	    nbytes);
 
 	fdrop(fp, td);
 	return (error);
@@ -585,6 +603,14 @@ sys_extattr_delete_fd(struct thread *td, struct extattr_delete_fd_args *uap)
 }
 
 int
+kern_extattr_delete_fp(struct thread *td, struct file *fp, int attrnamespace,
+    const char *attrname)
+{
+
+	return (extattr_delete_vp(fp->f_vnode, attrnamespace, attrname, td));
+}
+
+int
 kern_extattr_delete_fd(struct thread *td, int fd, int attrnamespace,
     const char *attrname)
 {
@@ -601,8 +627,7 @@ kern_extattr_delete_fd(struct thread *td, int fd, int attrnamespace,
 	if (error)
 		return (error);
 
-	error = extattr_delete_vp(fp->f_vnode, attrnamespace,
-	    attrname, td);
+	error = kern_extattr_delete_fp(td, fp, attrnamespace, attrname);
 	fdrop(fp, td);
 	return (error);
 }
@@ -754,6 +779,14 @@ sys_extattr_list_fd(struct thread *td, struct extattr_list_fd_args *uap)
 }
 
 int
+kern_extattr_list_fp(struct thread *td, struct file *fp, int attrnamespace,
+    struct uio *auiop)
+{
+
+	return (extattr_list_vp(fp->f_vnode, attrnamespace, auiop, td));
+}
+
+int
 kern_extattr_list_fd(struct thread *td, int fd, int attrnamespace,
     struct uio *auiop)
 {
@@ -768,7 +801,7 @@ kern_extattr_list_fd(struct thread *td, int fd, int attrnamespace,
 	if (error)
 		return (error);
 
-	error = extattr_list_vp(fp->f_vnode, attrnamespace, auiop, td);
+	error = kern_extattr_list_fp(td, fp, attrnamespace, auiop);
 
 	fdrop(fp, td);
 	return (error);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -139,21 +139,31 @@ int	kern_execve(struct thread *td, struct image_args *args,
 void	kern_exit(struct thread *, int, int);
 int	kern_extattr_delete_fd(struct thread *td, int fd, int attrnamespace,
 	    const char *attrname);
+int	kern_extattr_delete_fp(struct thread *td, struct file *fp,
+	    int attrnamespace, const char *attrname);
 int	kern_extattr_delete_path(struct thread *td, const char *path,
 	    int attrnamespace, const char *attrname, int follow,
 	    enum uio_seg pathseg);
 int	kern_extattr_get_fd(struct thread *td, int fd, int attrnamespace,
 	    const char *attrname, void *data, size_t nbytes);
+int	kern_extattr_get_fp(struct thread *td, struct file *fp,
+	    int attrnamespace, const char *attrname, void *data,
+	    size_t nbytes);
 int	kern_extattr_get_path(struct thread *td, const char *path,
 	    int attrnamespace, const char *attrname, void *data,
 	    size_t nbytes, int follow, enum uio_seg pathseg);
 int	kern_extattr_list_fd(struct thread *td, int fd, int attrnamespace,
 	    struct uio *auiop);
+int	kern_extattr_list_fp(struct thread *td, struct file *fp,
+	    int attrnamespace, struct uio *auiop);
 int	kern_extattr_list_path(struct thread *td, const char *path,
 	    int attrnamespace, struct uio *auiop, int follow,
 	    enum uio_seg pathseg);
 int	kern_extattr_set_fd(struct thread *td, int fd, int attrnamespace,
 	    const char *attrname, void *data, size_t nbytes);
+int	kern_extattr_set_fp(struct thread *td, struct file *fp,
+	    int attrnamespace, const char *attrname, void *data,
+	    size_t nbytes);
 int	kern_extattr_set_path(struct thread *td, const char *path,
 	    int attrnamespace, const char *attrname, void *data,
 	    size_t nbytes, int follow, enum uio_seg pathseg);


### PR DESCRIPTION
- Return ERANGE for short getxattr buffers: when the caller provides a buffer smaller than the xattr value, linux_getxattr() and linux_lgetxattr() should set the return value to the full size of the attribute and return ERANGE, matching Linux behavior. This fixes the LTP getxattr01 test.
- Return ENODATA for getxattr on unsupported file types: for file types that do not support extended attributes (fifo, char device, block device, UNIX domain socket), the FreeBSD VFS layer returns EOPNOTSUPP via vop_eopnotsupp(). Map this to ENOATTR so that the Linux errno translation produces ENODATA (61), matching Linux behavior. This fixes the LTP getxattr02 test.