### PR TITLE
iflib: Fix panic when netmap VALE drops packets to iflib driver

### DIFF
--- a/sys/net/iflib.c
+++ b/sys/net/iflib.c
@@ -1051,6 +1051,13 @@ iflib_netmap_txsync(struct netmap_kring *kring, int flags)
 			}
 
 			if (!(slot->flags & NS_MOREFRAG)) {
+				/*
+				 * Ensure a packet made only of zero-length
+				 * slots still emits one descriptor.
+				 */
+				if (seg_idx == 0)
+					seg_idx = 1;
+
 				pi.ipi_len = pkt_len;
 				pi.ipi_nsegs = seg_idx;
 				pi.ipi_pidx = nic_i_start;
@@ -1062,8 +1069,10 @@ iflib_netmap_txsync(struct netmap_kring *kring, int flags)
 				DBG_COUNTER_INC(tx_encap);
 
 				/* Update transmit counters */
-				tx_bytes += pi.ipi_len;
-				tx_pkts++;
+				if (pkt_len > 0) {
+					tx_bytes += pi.ipi_len;
+					tx_pkts++;
+				}
 
 				/* Reinit per-packet info for the next one. */
 				flags = seg_idx = pkt_len = 0;


### PR DESCRIPTION
When a netmap VALE switch drops packets destined for an iflib-based network driver (e.g., vmxnet3, igb, em), the kernel panics with a page fault in the driver's `isc_txd_encap()` function.

The crash occurs because:

1. `nm_vale_flush()` drops oversized packets by setting `slot->len = 0`
2. `iflib_netmap_txsync()` processes the zero-length slot but `seg_idx` stays 0 since `len == 0`
3. `isc_txd_encap()` is called with `pi->ipi_nsegs = 0`
4. The driver loops zero times but unconditionally sets the EOP flag on an uninitialized descriptor pointer

To fix, we ensure at least one segment (seg_idx = 1) for zero-length packets. The segment already has a valid address from the PNMB call and ds_len = 0, written unconditionally at loop top before the if (len) guard. This keeps the netmap and NIC ring indices in lockstep (both advance together at loop bottom), and the driver writes a valid zero-length descriptor with EOP instead of accessing invalid memory.

We also skip the transmit counter update (IFCOUNTER_OPACKETS/OBYTES) when pkt_len == 0, so packets VALE intended to drop are not reported as transmitted.

The fix is in iflib rather than individual drivers because all iflib drivers assume `nsegs > 0`, and we want to protect all drivers with a single fix. 

Tested on FreeBSD 16.0-CURRENT using the reproducer script from the bug report.

PR: [294726](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=294726)