### PR TITLE
libc: Fix assert() sanitiser for C++ contextual bool conversion

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -73,7 +73,10 @@
  */
 #define __assert_sanitize(...)	((void)0)
 #else
-#define __assert_sanitize(...)	(void)sizeof(((bool(*)(bool))0)(__VA_ARGS__))
+char __assert_sanitize_arity(auto &&);
+#define __assert_sanitize(...)                                 \
+	((void)sizeof(__assert_sanitize_arity(__VA_ARGS__)),   \
+	 (void)sizeof((__VA_ARGS__) ? 1 : 1))
 #endif /* __cplusplus < 202002L */
 #else
 #define __assert_sanitize(...)	(void)sizeof(((_Bool(*)(_Bool))0)(__VA_ARGS__))

--- a/include/assert.h
+++ b/include/assert.h
@@ -46,8 +46,8 @@
 #undef __assert_unreachable
 
 #ifdef NDEBUG
-#define assert(e)	((void)0)
-#define _assert(e)	((void)0)
+#define assert(...)	((void)0)
+#define _assert(...)	((void)0)
 #if __BSD_VISIBLE
 #define __assert_unreachable()	__unreachable()
 #endif /* __BSD_VISIBLE */

--- a/include/assert.h
+++ b/include/assert.h
@@ -53,38 +53,15 @@
 #endif /* __BSD_VISIBLE */
 #else
 #ifdef __cplusplus
-#if __cplusplus < 202002L
-/*
- * C++ modes prior to C++20 cannot simultaneously satisfy all three
- * desirable properties of the sanitiser:
- *
- *   Approach                       No double-eval  Lambda support  Arity check
- *   -----------------------------  --------------  --------------  -----------
- *   sizeof(cast(expression))       yes             no              yes
- *   static_cast<bool>(expression)  no              yes             no
- *   (void)bool(expression)         no              yes             no
- *
- *   NOTE: C++20 introduced lambdas in unevaluated contexts; see P0315R4.
- *
- * Since no approach satisfies all three below C++20, the least harmful
- * choice is to forgo the check entirely rather than silently break one
- * of the remaining guarantees.
- *
- */
-#define __assert_sanitize(...)	((void)0)
+#define assert(...)	((void)(bool(__VA_ARGS__) ? ((void)0) :           \
+			    __assert(__func__, __FILE__, __LINE__,        \
+			    #__VA_ARGS__)))
 #else
-char __assert_sanitize_arity(auto &&);
-#define __assert_sanitize(...)                                 \
-	((void)sizeof(__assert_sanitize_arity(__VA_ARGS__)),   \
-	 (void)sizeof((__VA_ARGS__) ? 1 : 1))
-#endif /* __cplusplus < 202002L */
-#else
-#define __assert_sanitize(...)	(void)sizeof(((_Bool(*)(_Bool))0)(__VA_ARGS__))
-#endif /* __cplusplus */
-#define assert(...)	(__assert_sanitize(__VA_ARGS__),       \
-			    (__VA_ARGS__) ? (void)0 :          \
-			    __assert(__func__, __FILE__,       \
+#define assert(...)	((void)sizeof(((_Bool(*)(_Bool))0)(__VA_ARGS__)), \
+			    (__VA_ARGS__) ? (void)0 :                     \
+			    __assert(__func__, __FILE__,                  \
 			    __LINE__, #__VA_ARGS__))
+#endif /* __cplusplus */
 #define _assert(...)	assert(__VA_ARGS__)
 #if __BSD_VISIBLE
 #define __assert_unreachable()	assert(0 && "unreachable segment reached")


### PR DESCRIPTION
Reported by: [dim@](https://github.com/freebsd/freebsd-src/pull/2203#issuecomment-4624496419), [aokblast@](https://reviews.freebsd.org/D57449)

Cc: @clausecker, @DimitryAndric, @aokblast 