### PR TITLE
Pause failpoint: replace mtx_sleep with tsleep

### DIFF
--- a/sys/kern/kern_fail.c
+++ b/sys/kern/kern_fail.c
@@ -176,7 +176,6 @@ struct fail_point_setting {
 	STAILQ_ENTRY(fail_point_setting) fs_garbage_link;
 	struct fail_point_entry_queue fp_entry_queue;
 	struct fail_point * fs_parent;
-	struct mtx feq_mtx; /* Gives fail_point_pause something to do.  */
 };
 
 /**
@@ -248,7 +247,6 @@ fail_point_setting_new(struct fail_point *fp)
 	fs_new = fs_malloc();
 	fs_new->fs_parent = fp;
 	TAILQ_INIT(&fs_new->fp_entry_queue);
-	mtx_init(&fs_new->feq_mtx, "fail point entries", NULL, MTX_SPIN);
 
 	fail_point_setting_garbage_append(fs_new);
 
@@ -407,14 +405,13 @@ fail_point_drain(struct fail_point *fp, int expected_ref)
 }
 
 static inline void
-fail_point_pause(struct fail_point *fp, enum fail_point_return_code *pret,
-        struct mtx *mtx_sleep)
+fail_point_pause(struct fail_point *fp, enum fail_point_return_code *pret)
 {
 
 	if (fp->fp_pre_sleep_fn)
 		fp->fp_pre_sleep_fn(fp->fp_pre_sleep_arg);
 
-	msleep_spin(FP_PAUSE_CHANNEL(fp), mtx_sleep, "failpt", 0);
+	tsleep(FP_PAUSE_CHANNEL(fp), 0, "failpt", 0);
 
 	if (fp->fp_post_sleep_fn)
 		fp->fp_post_sleep_fn(fp->fp_post_sleep_arg);
@@ -624,9 +621,7 @@ fail_point_eval_nontrivial(struct fail_point *fp, int *return_value)
 			 * The sysctl layer actually truncates all entries after
 			 * a pause for this reason.
 			 */
-			mtx_lock_spin(&fp_setting->feq_mtx);
-			fail_point_pause(fp, &ret, &fp_setting->feq_mtx);
-			mtx_unlock_spin(&fp_setting->feq_mtx);
+			fail_point_pause(fp, &ret);
 			break;
 
 		case FAIL_POINT_YIELD:


### PR DESCRIPTION
Change sleep mechanism when a failpoint pauses, from mtx_sleep to tsleep.

Eliminates panic when triggering a paused failpoint after re-setting the failpoint to pause (address of feq_mtx changes by setting FP a second time).

# Test Plan

## Panic reproduction steps
Testing against 15.0-STABLE:
```
Term 1:
sysctl debug.fail_point.test_fail_point=pause
sysctl debug.fail_point.test_trigger_fail_point => thread pauses

Term 2:
sysctl debug.fail_point.test_fail_point=pause
sysctl debug.fail_point.test_trigger_fail_point  => panic

freebsd-test:~ # panic: Assertion lock == sq->sq_lock failed at /home/mrk/freebsd/dev/stable/15/sys/kern/subr_sleepqueue.c:369
cpuid = 1
time = 1779166451
KDB: stack backtrace:
db_trace_self_wrapper() at db_trace_self_wrapper+0x2b/frame 0xfffffe00467488f0
vpanic() at vpanic+0x136/frame 0xfffffe0046748a20
panic() at panic+0x43/frame 0xfffffe0046748a80
sleepq_add() at sleepq_add+0x3e8/frame 0xfffffe0046748ad0
msleep_spin_sbt() at msleep_spin_sbt+0xdb/frame 0xfffffe0046748b50
fail_point_eval_nontrivial() at fail_point_eval_nontrivial+0x1b1/frame 0xfffffe0046748bc0
sysctl_test_fail_point() at sysctl_test_fail_point+0x2a/frame 0xfffffe0046748be0
sysctl_root_handler_locked() at sysctl_root_handler_locked+0x9c/frame 0xfffffe0046748c30
sysctl_root() at sysctl_root+0x22f/frame 0xfffffe0046748cb0
userland_sysctl() at userland_sysctl+0x1b6/frame 0xfffffe0046748d50
sys___sysctl() at sys___sysctl+0x65/frame 0xfffffe0046748e00
amd64_syscall() at amd64_syscall+0x169/frame 0xfffffe0046748f30
fast_syscall_common() at fast_syscall_common+0xf8/frame 0xfffffe0046748f30
--- syscall (202, FreeBSD ELF64, __sysctl), rip = 0x385fa099ea4a, rsp = 0x385f9d2e83c8, rbp = 0x385f9d2e8410 ---
KDB: enter: panic
[ thread pid 1161 tid 100082 ]
Stopped at      kdb_enter+0x33: movq    $0,0x15ea952(%rip)
db>
```

## Manual testing with fix
- panic scenario no longer panics
- able to cancel a paused failpoint