### PR TITLE
bhyve: add Arrow Lake to the GVT-d device table

### DIFF
--- a/usr.sbin/bhyve/amd64/pci_gvt-d.c
+++ b/usr.sbin/bhyve/amd64/pci_gvt-d.c
@@ -187,6 +187,7 @@ static const struct igd_device igd_devices[] = {
 	INTEL_RPLS_IDS(IGD_DEVICE, &igd_ops_gen11),
 	INTEL_RPLU_IDS(IGD_DEVICE, &igd_ops_gen11),
 	INTEL_RPLP_IDS(IGD_DEVICE, &igd_ops_gen11),
+	INTEL_ARL_IDS(IGD_DEVICE, &igd_ops_gen11),
 };
 
 static const struct igd_ops *


### PR DESCRIPTION
igd_devices[] is used to determine which BDSM register layout passed-through PCI devices should use.

The table ended at Raptor Lake, so get_igd_ops() returned an error and consequently broke PCI passthrough for newer devices.

BDSM (Base Data Stolen Memory) changes for gen 11 graphics were added in 9eddbaa5bba20c1a276d4711a4e9271e5f200ee1



Tested by passing the integrated GPU of an Arrow Lake-S system
(PCI 8086:7d67) through to a Linux guest on an ASUS Pro WS W880-ACE SE.
Meteor Lake and Lunar Lake use the identical code path and were added
alongside but not individually tested on hardware.

MFC after:	1 week