### PR TITLE
rtld: Check for -1 as an-end-of-section marker instead of 1

### DIFF
--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -3166,7 +3166,8 @@ objlist_call_fini(Objlist *list, Obj_Entry *root, RtldLockState *lockstate)
 				for (index = elm->obj->fini_array_num - 1;
 				    index >= 0; index--) {
 					if (fini_addr[index] != 0 &&
-					    fini_addr[index] != 1) {
+					    fini_addr[index] != 1 &&
+					    fini_addr[index] != (Elf_Addr)-1) {
 				dbg("calling fini function for %s at %p",
 						    elm->obj->path,
 						    (void *)fini_addr[index]);
@@ -3272,7 +3273,8 @@ objlist_call_init(Objlist *list, RtldLockState *lockstate)
 			for (index = 0; index < elm->obj->init_array_num;
 			    index++) {
 				if (init_addr[index] != 0 &&
-				    init_addr[index] != 1) {
+				    init_addr[index] != 1 &&
+				    init_addr[index] != (Elf_Addr)-1) {
 				dbg("calling init function for %s at %p",
 					    elm->obj->path,
 					    (void *)init_addr[index]);


### PR DESCRIPTION
rtld calls functions in the .init_array section one at a time, until it finds a distinguished sentinel value. The C runtime does the same thing (in crtend.c). However, that checks for the sentinel -1 and not 1 . If one is using a linker that unifies .ctors and .init_array, then rtld will miss the sentinel value. I believe the author of this code intended to write -1 instead of 1. Indeed, changing the branch to check for -1 prevents rtld from attempting to call a non-existent function.