### PR TITLE
hwpmc: Disable AMD PMCs if in an unsupported VM

### DIFF
--- a/sys/dev/hwpmc/hwpmc_amd.c
+++ b/sys/dev/hwpmc/hwpmc_amd.c
@@ -869,6 +869,8 @@ amd_pcpu_fini(struct pmc_mdep *md, int cpu)
 struct pmc_mdep *
 pmc_amd_initialize(void)
 {
+	int status;
+	uint64_t reg;
 	struct pmc_classdep *pcd;
 	struct pmc_mdep *pmc_mdep;
 	enum pmc_cputype cputype;
@@ -903,6 +905,36 @@ pmc_amd_initialize(void)
 		printf("pmc: Unknown AMD CPU %x %d-%d.\n", cpu_id, family,
 		    model);
 		return (NULL);
+	}
+
+	/*
+	 * Unforunately, there is no way to communicate that the original four
+	 * core counters are disabled through CPUIDs alone.  We attempt to
+	 * write and read back the MSR to validate it is working.
+	 *
+	 * Referenced the BIOS and Kernel Developer Guide for AMD Athlon 64 and
+	 * AMD Opteron Processors 26094 Rev. 3.24 January, 2005 to ensure these
+	 * fields are valid.
+	 */
+	if ((amd_feature2 & AMDID2_PCXC) == 0) {
+		status = wrmsr_safe(AMD_PMC_EVSEL_0, AMD_PMC_OS | AMD_PMC_USR);
+		if (status != 0) {
+			printf("hwpmc: AMD evsel 0 wrmsr failed!\n");
+			return (NULL);
+		}
+
+		status = rdmsr_safe(AMD_PMC_EVSEL_0, &reg);
+		if (status != 0) {
+			printf("hwpmc: AMD evsel 0 rdmsr failed!\n");
+			return (NULL);
+		}
+
+		if (reg == 0) {
+			printf("hwpmc: AMD evsel returned invalid value! You may be in a VM without PMC support.\n");
+			return (NULL);
+		}
+
+		wrmsr(AMD_PMC_EVSEL_0, 0);
 	}
 
 	/*


### PR DESCRIPTION
AMD does not have a CPUID bit to indicate the lack of K8 PMCs.  If all other PMC features are not present we should test an event selector to see if it stores and returns a value.  If the VM is implemented correctly, this should result in a #GP on the initial wrmsr_safe.  Bhyve and a few other VMs ignore writes, so I got one step further and test that it retains the OS and USR bits.

Tested on Zen 5 native and a Zen 5 Bhyve virtual machine.  This code should not run on any recent hardware, except in a VM, as it checks that the core counter extension is missing.

Reported by: Sandipan Das
Sponsored by: Netflix