### PR TITLE
axgbe: Remove leftover RSS default from xgbe_default_config()

### DIFF
--- a/sys/dev/axgbe/if_axgbe_pci.c
+++ b/sys/dev/axgbe/if_axgbe_pci.c
@@ -1387,7 +1387,6 @@ xgbe_default_config(struct xgbe_prv_data *pdata)
         pdata->pause_autoneg = 1;
         pdata->phy_speed = SPEED_UNKNOWN;
         pdata->power_down = 0;
-        pdata->enable_rss = 1;
 }
 
 static int


### PR DESCRIPTION
Since 2b8df53 this is a sysctl toggle and the default is managed in axgbe_sysctl_init() already along with the other toggles.