### PR TITLE
axgbe: Reset PHY RX data path when mailbox command times out

### DIFF
--- a/sys/dev/axgbe/xgbe-phy-v2.c
+++ b/sys/dev/axgbe/xgbe-phy-v2.c
@@ -2304,6 +2304,9 @@ xgbe_phy_perform_ratechange(struct xgbe_prv_data *pdata, unsigned int cmd,
 
 	axgbe_printf(3, "firmware mailbox command did not complete\n");
 
+	/* Reset on error */
+	xgbe_phy_rx_reset(pdata);
+
 reenable_pll:
 	xgbe_phy_pll_ctrl(pdata, true);
 }


### PR DESCRIPTION
This is a leftover of 2b8df53, which included the ported Linux commit https://github.com/torvalds/linux/commit/30b7edc82ec82578f4f5e6706766f0a9535617d3.