### PR TITLE
bluetooth/ath3kfw: added support for "Qualcomm Atheros Communications  Dell Wireless 1802 Bluetooth 4.0 LE" (0cf3:e006)

### DIFF
--- a/usr.sbin/bluetooth/ath3kfw/main.c
+++ b/usr.sbin/bluetooth/ath3kfw/main.c
@@ -83,6 +83,7 @@ static struct ath3k_devid ath3k_list[] = {
 	{ .vendor_id = 0x0CF3, .product_id = 0x817a, .is_3012 = 1 },
 	{ .vendor_id = 0x0cf3, .product_id = 0xe004, .is_3012 = 1 },
 	{ .vendor_id = 0x0cf3, .product_id = 0xe005, .is_3012 = 1 },
+	{ .vendor_id = 0x0cf3, .product_id = 0xe006, .is_3012 = 1 },
 	{ .vendor_id = 0x0cf3, .product_id = 0xe003, .is_3012 = 1 },
 	{ .vendor_id = 0x13d3, .product_id = 0x3362, .is_3012 = 1 },
 	{ .vendor_id = 0x13d3, .product_id = 0x3375, .is_3012 = 1 },


### PR DESCRIPTION
This is a Wifi-Bluetooth combo. The bluetooth chip is confirmed to be AR3012 compatible. That's what the [Linux ath3k driver](https://github.com/torvalds/linux/blob/e21ee273e6fa3879aec9a27251cfce98156e07c4/drivers/bluetooth/ath3k.c#L99) loads as well.

It has been tested with the firmware files from the [linux-firmware](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git) repository as the [https://www.freshports.org/comms/ath3k-firmware/](comms/ath3k-firmware) port appears to be discontinued.
I got it to work both with a BT keyboard and a [BLE mouse](https://github.com/rhaberkorn/FreeBSD-BLE).

Currently I have to load the firmware after startup. The following devd clause does **not** work:

```
attach 100 {
       match "vendor" "0x0cf3";
       match "product" "0xe006";
       action "sleep 2 && ath3kfw -d $device-name -f /usr/share/firmware/ath3k";
}
```

Afterwards, wifi wouldn't work properly.
Apparently it interferes with the wifi driver initialization (ath). ath is compiled into the generic 15.0-RELEASE-p5 kernel.
Perhaps the firmware file loading should be performed as part of an ath3k kernel module to avoid this kind of race condition.