### PR TITLE
Efficient failpoint enabled check

### DIFF
--- a/sys/kern/kern_fail.c
+++ b/sys/kern/kern_fail.c
@@ -337,6 +337,9 @@ fail_point_swap_settings(struct fail_point *fp,
 	fp_setting_old = fp->fp_setting;
 	fp->fp_setting = fp_setting_new;
 
+	if (fp->fp_enabled)
+		*fp->fp_enabled = fp->fp_setting != NULL;
+
 	return (fp_setting_old);
 }
 
@@ -482,6 +485,7 @@ fail_point_init(struct fail_point *fp, const char *fmt, ...)
 
 	fp->fp_name = name;
 	fp->fp_location = "";
+	fp->fp_enabled = NULL;
 	fp->fp_flags |= FAIL_POINT_DYNAMIC_NAME;
 	fp->fp_pre_sleep_fn = NULL;
 	fp->fp_pre_sleep_arg = NULL;
@@ -520,6 +524,8 @@ fail_point_destroy(struct fail_point *fp)
 		fp->fp_name = NULL;
 	}
 	fp->fp_flags = 0;
+	if (fp->fp_enabled)
+		*fp->fp_enabled = false;
 	if (fp->fp_callout) {
 		fp_free(fp->fp_callout);
 		fp->fp_callout = NULL;

--- a/sys/sys/fail.h
+++ b/sys/sys/fail.h
@@ -71,6 +71,7 @@ struct fail_point {
 	                             * unfreed fail_point_setting
 	                             */
 	struct fail_point_setting * volatile fp_setting;
+	bool *fp_enabled;
 	int fp_flags;
 
 	/**< Function to call before sleep or pause */
@@ -98,7 +99,7 @@ struct fail_point {
 
 __BEGIN_DECLS
 
-/* Private failpoint eval function -- use fail_point_eval() instead. */
+/* Private failpoint eval function -- use fail_point_eval/_fast() instead. */
 enum fail_point_return_code fail_point_eval_nontrivial(struct fail_point *,
         int *ret);
 
@@ -192,19 +193,39 @@ fail_point_eval(struct fail_point *fp, int *ret)
 	return (fail_point_eval_nontrivial(fp, ret));
 }
 
+/**
+ * Fast-variant of failpoint evaluation.
+ * fp_enabled caches fp->fp_setting != NULL in the static
+ * fail point context. Not consistent in all edge cases.
+ */
+static inline enum fail_point_return_code
+fail_point_eval_fast(struct fail_point *fp, bool *fp_enabled, int *ret)
+{
+
+	if (__predict_true(!*fp_enabled))
+		return (FAIL_POINT_RC_CONTINUE);
+	else
+		return (fail_point_eval_nontrivial(fp, ret));
+}
+
 __END_DECLS
 
 /* Declare a fail_point and its sysctl in a function. */
-#define KFAIL_POINT_DECLARE(name) \
-    extern struct fail_point _FAIL_POINT_NAME(name)
 #define _FAIL_POINT_NAME(name) _fail_point_##name
+#define _FAIL_POINT_NAME_ENABLED(name) _fail_point_##name##_enabled
+#define KFAIL_POINT_DECLARE(name) \
+    extern struct fail_point _FAIL_POINT_NAME(name); \
+    extern bool _FAIL_POINT_NAME_ENABLED(name)
 #define _FAIL_POINT_LOCATION() "(" __FILE__ ":" __XSTRING(__LINE__) ")"
 #define KFAIL_POINT_DEFINE(parent, name, flags) \
-	struct fail_point _FAIL_POINT_NAME(name) = { \
+	bool _FAIL_POINT_NAME_ENABLED(name) __section("fail_point") = false; \
+	static struct fail_point _FAIL_POINT_NAME(name) = \
+	{ \
 	        .fp_name = #name, \
 	        .fp_location = _FAIL_POINT_LOCATION(), \
 	        .fp_ref_cnt = 0, \
 	        .fp_setting = NULL, \
+	        .fp_enabled = &_FAIL_POINT_NAME_ENABLED(name), \
 	        .fp_flags = (flags), \
 	        .fp_pre_sleep_fn = NULL, \
 	        .fp_pre_sleep_arg = NULL, \
@@ -226,7 +247,9 @@ __END_DECLS
 	int RETURN_VALUE; \
  \
 	if (__predict_false(cond && \
-	        fail_point_eval(&_FAIL_POINT_NAME(name), &RETURN_VALUE))) { \
+	        fail_point_eval_fast(&_FAIL_POINT_NAME(name), \
+		    &_FAIL_POINT_NAME_ENABLED(name), \
+		    &RETURN_VALUE))) { \
  \
 		code; \
  \


### PR DESCRIPTION
Cache the failpoint-enabled setting in a boolean tagged against a failpoint-specific section to optimize the failpoint-enable check.

## `objdump` output shows the failpoint-enabled booleans co-located in a unique section of the address space and only use a single bit in memory:
```
****************************************************
static failpoint cached enablement symbol address in separate section:
****************************************************

Disassembly of section fail_point:

ffffffff823b3458 <random_fortuna_pre_read._fail_point_random_fortuna_pre_read_enabled>:
ffffffff823b3458: 00 00                 addb    %al, (%rax)

ffffffff823b3459 <nfscl_loadattrcache._fail_point_nfscl_force_fileid_warning_enabled>:
ffffffff823b3459: 00 00                 addb    %al, (%rax)

ffffffff823b345a <sysctl_test_fail_point._fail_point_test_fail_point_enabled>:
ffffffff823b345a: 00 00                 addb    %al, (%rax)

ffffffff823b345b <sysctl_root_handler_locked._fail_point_sysctl_running_enabled>:
ffffffff823b345b: 00 00                 addb    %al, (%rax)

ffffffff823b345c <vn_fill_kinfo_vnode._fail_point_fill_kinfo_vnode__random_path_enabled>:
ffffffff823b345c: 00 00                 addb    %al, (%rax)

ffffffff823b345d <nlm_do_granted._fail_point_nlm_deny_grant_enabled>:
ffffffff823b345d: 00                    <unknown>
```

## Testing

```
**************************
Test:
- set failpoint to sleep for 500ms 3 times then confirm automatically disabled:
**************************

root@freebsd-test:~ # sysctl debug.fail_point.test_fail_point="3*sleep(500)"
debug.fail_point.test_fail_point: off -> 3*sleep(500)

root@freebsd-test:~ # time sysctl -B10 debug.fail_point.test_trigger_fail_point
        0.52 real         0.00 user         0.00 sys

root@freebsd-test:~ # sysctl debug.fail_point.test_fail_point
debug.fail_point.test_fail_point: 2*sleep(500)

root@freebsd-test:~ # time sysctl -B10 debug.fail_point.test_trigger_fail_point
        0.53 real         0.00 user         0.00 sys

root@freebsd-test:~ # sysctl debug.fail_point.test_fail_point
debug.fail_point.test_fail_point: 1*sleep(500)

root@freebsd-test:~ # time sysctl -B10 debug.fail_point.test_trigger_fail_point
        0.50 real         0.00 user         0.00 sys

root@freebsd-test:~ # sysctl debug.fail_point.test_fail_point
debug.fail_point.test_fail_point: off

root@freebsd-test:~ # time sysctl -B10 debug.fail_point.test_trigger_fail_point
        0.00 real         0.00 user         0.00 sys
```

```
**************************
Demonstrate callstack in fail_point_eval_fast
**************************

root@freebsd-test:~ # sysctl debug.fail_point.test_fail_point="sleep(500)"
debug.fail_point.test_fail_point: off -> sleep(500)
root@freebsd-test:~ # time sysctl -B10 debug.fail_point.test_trigger_fail_point
load: 0.25  cmd: sysctl 1275 [failpt] 0.28r 0.00u 0.00s 0% 2356k
#0 0xffffffff810f32de at mi_switch+0x31e
#1 0xffffffff81176ccf at sleepq_switch+0x28f
#2 0xffffffff81176ff4 at sleepq_timedwait+0x84
#3 0xffffffff810f23c2 at _sleep+0x572
#4 0xffffffff81062664 at fail_point_sleep+0xa4
#5 0xffffffff81062463 at fail_point_eval_nontrivial+0x223
#6 0xffffffff810640bf at fail_point_eval_fast+0x3f
#7 0xffffffff8106402a at sysctl_test_fail_point+0x3a
#8 0xffffffff810f9aad at sysctl_root_handler_locked+0xdd
#9 0xffffffff810f872b at sysctl_root+0x32b
#10 0xffffffff810f9270 at userland_sysctl+0x300
#11 0xffffffff810f8ece at sys___sysctl+0xee
#12 0xffffffff8190df19 at syscallenter+0x609
#13 0xffffffff8190d5fe at amd64_syscall+0x7e
#14 0xffffffff818cc1fb at fast_syscall_common+0xf8
```
