### PR TITLE
fts: remove chdir, use openat for directory traversal

### DIFF
--- a/lib/libc/gen/fts.c
+++ b/lib/libc/gen/fts.c
@@ -343,7 +343,6 @@ int
 fts_close(FTS *sp)
 {
 	FTSENT *freep, *p;
-	int saved_errno;
 
 	/*
 	 * This still works if we haven't read anything -- the dummy structure
@@ -377,20 +376,6 @@ fts_close(FTS *sp)
 #endif /* __BLOCKS__ */
 	}
 
-	/* Return to original directory, save errno if necessary. */
-	if (!ISSET(FTS_NOCHDIR)) {
-		saved_errno = fchdir(sp->fts_rfd) ? errno : 0;
-		(void)_close(sp->fts_rfd);
-
-		/* Set errno and return. */
-		if (saved_errno != 0) {
-			/* Free up the stream pointer. */
-			free(sp);
-			errno = saved_errno;
-			return (-1);
-		}
-	}
-
 	/* Free up the stream pointer. */
 	free(sp);
 	return (0);
@@ -410,7 +395,6 @@ fts_read(FTS *sp)
 	FTSENT *p, *tmp;
 	int instr;
 	char *t;
-	int saved_errno;
 
 	/* If finished or unrecoverable error, return NULL. */
 	if (sp->fts_cur == NULL || ISSET(FTS_STOP))
@@ -438,14 +422,6 @@ fts_read(FTS *sp)
 	if (instr == FTS_FOLLOW &&
 	    (p->fts_info == FTS_SL || p->fts_info == FTS_SLNONE)) {
 		p->fts_info = fts_stat(sp, p, 1, -1);
-		if (p->fts_info == FTS_D && !ISSET(FTS_NOCHDIR)) {
-			if ((p->fts_symfd = _open(".", O_RDONLY | O_CLOEXEC,
-			    0)) < 0) {
-				p->fts_errno = errno;
-				p->fts_info = FTS_ERR;
-			} else
-				p->fts_flags |= FTS_SYMFOLLOW;
-		}
 		return (p);
 	}
 
@@ -470,29 +446,15 @@ fts_read(FTS *sp)
 			fts_lfree(sp->fts_child);
 			sp->fts_child = NULL;
 		}
-
+		
 		/*
-		 * Cd to the subdirectory.
-		 *
-		 * If have already read and now fail to chdir, whack the list
-		 * to make the names come out right, and set the parent errno
-		 * so the application will eventually get an error condition.
-		 * Set the FTS_DONTCHDIR flag so that when we logically change
-		 * directories back to the parent we don't do a chdir.
-		 *
-		 * If haven't read do so.  If the read fails, fts_build sets
-		 * FTS_STOP or the fts_info field of the node.
-		 */
-		if (sp->fts_child != NULL) {
-			if (fts_safe_changedir(sp, p, -1, p->fts_accpath)) {
-				p->fts_errno = errno;
-				p->fts_flags |= FTS_DONTCHDIR;
-				for (p = sp->fts_child; p != NULL;
-				    p = p->fts_link)
-					p->fts_accpath =
-					    p->fts_parent->fts_accpath;
-			}
-		} else if ((sp->fts_child = fts_build(sp, BREAD)) == NULL) {
+                 * Descend into the subdirectory.  If not yet read,
+                 * call fts_build.  If the read fails, fts_build sets
+                 * FTS_STOP or the fts_info field of the node.
+                 */
+		
+		if (sp->fts_child == NULL &&
+                    (sp->fts_child = fts_build(sp, BREAD)) == NULL) {
 			if (ISSET(FTS_STOP))
 				return (NULL);
 			return (p);
@@ -510,10 +472,6 @@ next:	tmp = p;
 		 * the root of the tree), and load the paths for the next root.
 		 */
 		if (p->fts_level == FTS_ROOTLEVEL) {
-			if (FCHDIR(sp, sp->fts_rfd)) {
-				SET(FTS_STOP);
-				return (NULL);
-			}
 			free(tmp);
 			fts_load(sp, p);
 			return (sp->fts_cur = p);
@@ -530,14 +488,6 @@ next:	tmp = p;
 		}
 		if (p->fts_instr == FTS_FOLLOW) {
 			p->fts_info = fts_stat(sp, p, 1, -1);
-			if (p->fts_info == FTS_D && !ISSET(FTS_NOCHDIR)) {
-				if ((p->fts_symfd =
-				    _open(".", O_RDONLY | O_CLOEXEC, 0)) < 0) {
-					p->fts_errno = errno;
-					p->fts_info = FTS_ERR;
-				} else
-					p->fts_flags |= FTS_SYMFOLLOW;
-			}
 			p->fts_instr = FTS_NOINSTR;
 		}
 
@@ -571,25 +521,6 @@ name:		t = sp->fts_path + NAPPEND(p->fts_parent);
 	 * a symlink, go back through the file descriptor.  Otherwise, cd up
 	 * one directory.
 	 */
-	if (p->fts_level == FTS_ROOTLEVEL) {
-		if (FCHDIR(sp, sp->fts_rfd)) {
-			SET(FTS_STOP);
-			return (NULL);
-		}
-	} else if (p->fts_flags & FTS_SYMFOLLOW) {
-		if (FCHDIR(sp, p->fts_symfd)) {
-			saved_errno = errno;
-			(void)_close(p->fts_symfd);
-			errno = saved_errno;
-			SET(FTS_STOP);
-			return (NULL);
-		}
-		(void)_close(p->fts_symfd);
-	} else if (!(p->fts_flags & FTS_DONTCHDIR) &&
-	    fts_safe_changedir(sp, p->fts_parent, -1, "..")) {
-		SET(FTS_STOP);
-		return (NULL);
-	}
 	free(tmp);
 	p->fts_info = p->fts_errno ? FTS_ERR : FTS_DP;
 	return (sp->fts_cur = p);

--- a/lib/libc/gen/fts.c
+++ b/lib/libc/gen/fts.c
@@ -747,7 +747,7 @@ fts_build(FTS *sp, int type)
 	DIR *dirp;
 	void *oldaddr;
 	char *cp;
-	int cderrno, descend, oflag, saved_errno, nostat, doadjust,
+	int oflag, saved_errno, nostat, doadjust,
 	    readdir_errno;
 	long level;
 	int64_t nlinks;	/* has to be signed because -1 is a magic value */
@@ -818,32 +818,14 @@ fts_build(FTS *sp, int type)
 	    ISSET(FTS_NOSTAT), ISSET(FTS_PHYSICAL), ISSET(FTS_SEEDOT));
 #endif
 	/*
-	 * If we're going to need to stat anything or we want to descend
-	 * and stay in the directory, chdir.  If this fails we keep going,
-	 * but set a flag so we don't chdir after the post-order visit.
-	 * We won't be able to stat anything, but we can still return the
-	 * names themselves.  Note, that since fts_read won't be able to
-	 * chdir into the directory, it will have to return different path
-	 * names than before, i.e. "a/b" instead of "b".  Since the node
-	 * has already been visited in pre-order, have to wait until the
-	 * post-order visit to return the error.  There is a special case
-	 * here, if there was nothing to stat then it's not an error to
-	 * not be able to stat.  This is all fairly nasty.  If a program
-	 * needed sorted entries or stat information, they had better be
-	 * checking FTS_NS on the returned nodes.
-	 */
-	cderrno = 0;
-	if (nlinks || type == BREAD) {
-		if (fts_safe_changedir(sp, cur, _dirfd(dirp), NULL)) {
-			if (nlinks && type == BREAD)
-				cur->fts_errno = errno;
-			cur->fts_flags |= FTS_DONTCHDIR;
-			descend = 0;
-			cderrno = errno;
-		} else
-			descend = 1;
-	} else
-		descend = 0;
+         * Save the directory fd for openat() calls during traversal.
+         * We use openat() instead of chdir() + open() to avoid changing
+         * the process CWD, which makes fts compatible with Capsicum
+         * capability mode.
+         */
+
+        if (nlinks || type == BREAD) 
+                sp->fts_rfd = _dirfd(dirp);
 
 	/*
 	 * Figure out the max file name length that can be stored in the
@@ -856,13 +838,8 @@ fts_build(FTS *sp, int type)
 	 * each new name into the path.
 	 */
 	len = NAPPEND(cur);
-	if (ISSET(FTS_NOCHDIR)) {
-		cp = sp->fts_path + len;
-		*cp++ = '/';
-	} else {
-		/* GCC, you're too verbose. */
-		cp = NULL;
-	}
+	cp = sp->fts_path + len;
+	*cp++ = '/';
 	len++;
 	maxlen = sp->fts_pathlen - len;
 
@@ -900,8 +877,7 @@ mem1:				saved_errno = errno;
 			/* Did realloc() change the pointer? */
 			if (oldaddr != sp->fts_path) {
 				doadjust = 1;
-				if (ISSET(FTS_NOCHDIR))
-					cp = sp->fts_path + len;
+				cp = sp->fts_path + len;
 			}
 			maxlen = sp->fts_pathlen - len;
 		}
@@ -913,28 +889,15 @@ mem1:				saved_errno = errno;
 		if (dp->d_type == DT_WHT)
 			p->fts_flags |= FTS_ISW;
 
-		if (cderrno) {
-			if (nlinks) {
-				p->fts_info = FTS_NS;
-				p->fts_errno = cderrno;
-			} else
-				p->fts_info = FTS_NSOK;
-			p->fts_accpath = cur->fts_accpath;
-		} else if (nlinks == 0 || (nostat &&
+		if (nlinks == 0 || (nostat &&
 		    dp->d_type != DT_DIR && dp->d_type != DT_UNKNOWN)) {
-			p->fts_accpath =
-			    ISSET(FTS_NOCHDIR) ? p->fts_path : p->fts_name;
+			p->fts_accpath = p->fts_path;
 			p->fts_info = FTS_NSOK;
 		} else {
 			/* Build a file name for fts_stat to stat. */
-			if (ISSET(FTS_NOCHDIR)) {
 				p->fts_accpath = p->fts_path;
 				memmove(cp, p->fts_name, p->fts_namelen + 1);
 				p->fts_info = fts_stat(sp, p, 0, _dirfd(dirp));
-			} else {
-				p->fts_accpath = p->fts_name;
-				p->fts_info = fts_stat(sp, p, 0, -1);
-			}
 
 			/* Decrement link count if applicable. */
 			if (nlinks > 0 && (p->fts_info == FTS_D ||
@@ -995,25 +958,8 @@ mem1:				saved_errno = errno;
 	 * If not changing directories, reset the path back to original
 	 * state.
 	 */
-	if (ISSET(FTS_NOCHDIR))
-		sp->fts_path[cur->fts_pathlen] = '\0';
 
-	/*
-	 * If descended after called from fts_children or after called from
-	 * fts_read and nothing found, get back.  At the root level we use
-	 * the saved fd; if one of fts_open()'s arguments is a relative path
-	 * to an empty directory, we wind up here with no other way back.  If
-	 * can't get back, we're done.
-	 */
-	if (descend && (type == BCHILD || !nitems) &&
-	    (cur->fts_level == FTS_ROOTLEVEL ?
-	    FCHDIR(sp, sp->fts_rfd) :
-	    fts_safe_changedir(sp, cur->fts_parent, -1, ".."))) {
-		fts_lfree(head);
-		cur->fts_info = FTS_ERR;
-		SET(FTS_STOP);
-		return (NULL);
-	}
+	sp->fts_path[cur->fts_pathlen] = '\0';
 
 	/* If didn't find anything, return NULL. */
 	if (!nitems) {
@@ -1121,6 +1067,7 @@ err:		memset(sbp, 0, sizeof(struct stat));
 		return (FTS_F);
 	return (FTS_DEFAULT);
 }
+
 
 static FTSENT *
 fts_sort(FTS *sp, FTSENT *head, size_t nitems)


### PR DESCRIPTION
fts(3) currently uses chdir(2) to descend into directories during traversal, relying on fts_safe_changedir() for safety and fts_rfd/fts_symfd to restore the original directory afterwards. This makes fts incompatible with Capsicum capability mode where chdir() is not permitted.

This patch series removes all chdir() usage from fts and replaces it with openat() using directory file descriptors:

Commit 1: fts_build() stores the directory fd in sp->fts_rfd and always uses the full path for fts_accpath (previously only done under FTS_NOCHDIR). The fts_safe_changedir() call is removed.

Commit 2: fts_read() removes all fchdir()/fts_safe_changedir() calls for descending and returning to parent. fts_close() no longer restores the original CWD since it is never changed.

The FTS_NOCHDIR flag and fts_safe_changedir() will be removed in follow-up commits.

Sponsored by: Google LLC (GSoC 2026)