### PR TITLE
CHERI: syscall implementation wrappers

### DIFF
--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -2163,81 +2163,21 @@ struct sf_hdtr32 {
 };
 
 static int
-freebsd32_do_sendfile(struct thread *td,
-    struct freebsd32_sendfile_args *uap, int compat)
+freebsd32_copyin_hdtr(const struct sf_hdtr32 *uhdtr,
+    struct sf_hdtr *hdtr)
 {
 	struct sf_hdtr32 hdtr32;
-	struct sf_hdtr hdtr;
-	struct uio *hdr_uio, *trl_uio;
-	struct file *fp;
-	cap_rights_t rights;
-	struct iovec32 *iov32;
-	off_t offset, sbytes;
 	int error;
 
-	offset = PAIR32TO64(off_t, uap->offset);
-	if (offset < 0)
-		return (EINVAL);
+	error = copyin(uhdtr, &hdtr32, sizeof(hdtr32));
+	if (error != 0)
+		return (error);
+	hdtr->headers = PTRIN(hdtr32.headers);
+	hdtr->hdr_cnt = hdtr32.hdr_cnt;
+	hdtr->trailers = PTRIN(hdtr32.trailers);
+	hdtr->hdr_cnt = hdtr32.trl_cnt;
 
-	hdr_uio = trl_uio = NULL;
-
-	if (uap->hdtr != NULL) {
-		error = copyin(uap->hdtr, &hdtr32, sizeof(hdtr32));
-		if (error)
-			goto out;
-		PTRIN_CP(hdtr32, hdtr, headers);
-		CP(hdtr32, hdtr, hdr_cnt);
-		PTRIN_CP(hdtr32, hdtr, trailers);
-		CP(hdtr32, hdtr, trl_cnt);
-
-		if (hdtr.headers != NULL) {
-			iov32 = PTRIN(hdtr32.headers);
-			error = freebsd32_copyinuio(iov32,
-			    hdtr32.hdr_cnt, &hdr_uio);
-			if (error)
-				goto out;
-#ifdef COMPAT_FREEBSD4
-			/*
-			 * In FreeBSD < 5.0 the nbytes to send also included
-			 * the header.  If compat is specified subtract the
-			 * header size from nbytes.
-			 */
-			if (compat) {
-				if (uap->nbytes > hdr_uio->uio_resid)
-					uap->nbytes -= hdr_uio->uio_resid;
-				else
-					uap->nbytes = 0;
-			}
-#endif
-		}
-		if (hdtr.trailers != NULL) {
-			iov32 = PTRIN(hdtr32.trailers);
-			error = freebsd32_copyinuio(iov32,
-			    hdtr32.trl_cnt, &trl_uio);
-			if (error)
-				goto out;
-		}
-	}
-
-	AUDIT_ARG_FD(uap->fd);
-
-	if ((error = fget_read(td, uap->fd,
-	    cap_rights_init_one(&rights, CAP_PREAD), &fp)) != 0)
-		goto out;
-
-	error = fo_sendfile(fp, uap->s, hdr_uio, trl_uio, offset,
-	    uap->nbytes, &sbytes, uap->flags, td);
-	fdrop(fp, td);
-
-	if (uap->sbytes != NULL)
-		(void)copyout(&sbytes, uap->sbytes, sizeof(off_t));
-
-out:
-	if (hdr_uio)
-		freeuio(hdr_uio);
-	if (trl_uio)
-		freeuio(trl_uio);
-	return (error);
+	return (0);
 }
 
 #ifdef COMPAT_FREEBSD4
@@ -2245,16 +2185,32 @@ int
 freebsd4_freebsd32_sendfile(struct thread *td,
     struct freebsd4_freebsd32_sendfile_args *uap)
 {
-	return (freebsd32_do_sendfile(td,
-	    (struct freebsd32_sendfile_args *)uap, 1));
+	return (kern_sendfile(td, &(struct sendfile_args){
+		.fd = uap->fd,
+		.s = uap->s,
+		.offset = PAIR32TO64(off_t, uap->offset),
+		.nbytes = uap->nbytes,
+		.hdtr = (struct sf_hdtr *)uap->hdtr,
+		.sbytes = uap->sbytes,
+		.flags = uap->flags,
+	    }, true, (copyin_hdtr_t *)freebsd32_copyin_hdtr,
+	    (copyinuio_t *)freebsd32_copyinuio));
 }
 #endif
 
 int
 freebsd32_sendfile(struct thread *td, struct freebsd32_sendfile_args *uap)
 {
-
-	return (freebsd32_do_sendfile(td, uap, 0));
+	return (kern_sendfile(td, &(struct sendfile_args){
+		.fd = uap->fd,
+		.s = uap->s,
+		.offset = PAIR32TO64(off_t, uap->offset),
+		.nbytes = uap->nbytes,
+		.hdtr = (struct sf_hdtr *)uap->hdtr,
+		.sbytes = uap->sbytes,
+		.flags = uap->flags,
+	    }, false, (copyin_hdtr_t *)freebsd32_copyin_hdtr,
+	    (copyinuio_t *)freebsd32_copyinuio));
 }
 
 static void

--- a/sys/kern/kern_cpuset.c
+++ b/sys/kern/kern_cpuset.c
@@ -1844,6 +1844,12 @@ struct cpuset_args {
 int
 sys_cpuset(struct thread *td, struct cpuset_args *uap)
 {
+	return (kern_cpuset(td, uap->setid));
+}
+
+int
+kern_cpuset(struct thread *td, cpusetid_t *setid)
+{
 	struct cpuset *root;
 	struct cpuset *set;
 	int error;
@@ -1856,7 +1862,7 @@ sys_cpuset(struct thread *td, struct cpuset_args *uap)
 	cpuset_rel(root);
 	if (error)
 		return (error);
-	error = copyout(&set->cs_id, uap->setid, sizeof(set->cs_id));
+	error = copyout(&set->cs_id, setid, sizeof(set->cs_id));
 	if (error == 0)
 		error = cpuset_setproc(-1, set, NULL, NULL, false);
 	cpuset_rel(set);
@@ -1873,7 +1879,6 @@ struct cpuset_setid_args {
 int
 sys_cpuset_setid(struct thread *td, struct cpuset_setid_args *uap)
 {
-
 	return (kern_cpuset_setid(td, uap->which, uap->id, uap->setid));
 }
 

--- a/sys/kern/kern_descrip.c
+++ b/sys/kern/kern_descrip.c
@@ -374,7 +374,6 @@ struct dup2_args {
 int
 sys_dup2(struct thread *td, struct dup2_args *uap)
 {
-
 	return (kern_dup(td, FDDUP_FIXED, 0, (int)uap->from, (int)uap->to));
 }
 
@@ -390,7 +389,6 @@ struct dup_args {
 int
 sys_dup(struct thread *td, struct dup_args *uap)
 {
-
 	return (kern_dup(td, FDDUP_NORMAL, 0, (int)uap->fd, 0));
 }
 
@@ -408,7 +406,6 @@ struct fcntl_args {
 int
 sys_fcntl(struct thread *td, struct fcntl_args *uap)
 {
-
 	return (kern_fcntl_freebsd(td, uap->fd, uap->cmd, uap->arg));
 }
 
@@ -1493,7 +1490,6 @@ struct close_args {
 int
 sys_close(struct thread *td, struct close_args *uap)
 {
-
 	return (kern_close(td, uap->fd));
 }
 
@@ -1610,7 +1606,6 @@ struct close_range_args {
 int
 sys_close_range(struct thread *td, struct close_range_args *uap)
 {
-
 	AUDIT_ARG_FD(uap->lowfd);
 	AUDIT_ARG_CMD(uap->highfd);
 	AUDIT_ARG_FFLAGS(uap->flags);
@@ -1704,12 +1699,18 @@ struct fstat_args {
 int
 sys_fstat(struct thread *td, struct fstat_args *uap)
 {
+	return (user_fstat(td, uap->fd, uap->sb));
+}
+
+int
+user_fstat(struct thread *td, int fd, struct stat *sb)
+{
 	struct stat ub;
 	int error;
 
-	error = kern_fstat(td, uap->fd, &ub);
+	error = kern_fstat(td, fd, &ub);
 	if (error == 0)
-		error = copyout(&ub, uap->sb, sizeof(ub));
+		error = copyout(&ub, sb, sizeof(ub));
 	return (error);
 }
 

--- a/sys/kern/kern_environment.c
+++ b/sys/kern/kern_environment.c
@@ -49,6 +49,7 @@
 #include <sys/priv.h>
 #include <sys/proc.h>
 #include <sys/queue.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysctl.h>
 #include <sys/sysent.h>
 #include <sys/sysproto.h>
@@ -191,6 +192,13 @@ kenv_read_allowed(struct thread *td, int which)
 int
 sys_kenv(struct thread *td, struct kenv_args *uap)
 {
+	return (kern_kenv(td, uap->what, uap->name, uap->value, uap->len));
+}
+
+int
+kern_kenv(struct thread *td, int what, const char *namep, char *u_val,
+    int u_len)
+{
 	char *name, *value;
 	size_t len;
 	int error;
@@ -199,21 +207,21 @@ sys_kenv(struct thread *td, struct kenv_args *uap)
 
 	error = 0;
 
-	switch (uap->what) {
+	switch (what) {
 	case KENV_DUMP:
-		error = kenv_read_allowed(td, uap->what);
+		error = kenv_read_allowed(td, what);
 		if (error)
 			return (error);
-		return (kenv_dump(td, kenvp, uap->what, uap->value, uap->len));
+		return (kenv_dump(td, kenvp, what, u_val, u_len));
 	case KENV_DUMP_LOADER:
 	case KENV_DUMP_STATIC:
-		error = kenv_read_allowed(td, uap->what);
+		error = kenv_read_allowed(td, what);
 		if (error)
 			return (error);
 #ifdef PRESERVE_EARLY_KENV
 		return (kenv_dump(td,
-		    uap->what == KENV_DUMP_LOADER ? (char **)md_envp :
-		    (char **)kern_envp, uap->what, uap->value, uap->len));
+		    what == KENV_DUMP_LOADER ? (char **)md_envp :
+		    (char **)kern_envp, what, u_val, u_len));
 #else
 		return (ENOENT);
 #endif
@@ -229,7 +237,7 @@ sys_kenv(struct thread *td, struct kenv_args *uap)
 			return (error);
 		break;
 	case KENV_GET:
-		error = kenv_read_allowed(td, uap->what);
+		error = kenv_read_allowed(td, what);
 		if (error)
 			return (error);
 		break;
@@ -237,11 +245,11 @@ sys_kenv(struct thread *td, struct kenv_args *uap)
 
 	name = malloc(KENV_MNAMELEN + 1, M_TEMP, M_WAITOK);
 
-	error = copyinstr(uap->name, name, KENV_MNAMELEN + 1, NULL);
+	error = copyinstr(namep, name, KENV_MNAMELEN + 1, NULL);
 	if (error)
 		goto done;
 
-	switch (uap->what) {
+	switch (what) {
 	case KENV_GET:
 #ifdef MAC
 		error = mac_kenv_check_get(td->td_ucred, name);
@@ -254,16 +262,16 @@ sys_kenv(struct thread *td, struct kenv_args *uap)
 			goto done;
 		}
 		len = strlen(value) + 1;
-		if (len > uap->len)
-			len = uap->len;
-		error = copyout(value, uap->value, len);
+		if (len > u_len)
+			len = u_len;
+		error = copyout(value, u_val, len);
 		freeenv(value);
 		if (error)
 			goto done;
 		td->td_retval[0] = len;
 		break;
 	case KENV_SET:
-		len = uap->len;
+		len = u_len;
 		if (len < 1) {
 			error = EINVAL;
 			goto done;
@@ -271,7 +279,7 @@ sys_kenv(struct thread *td, struct kenv_args *uap)
 		if (len > kenv_mvallen + 1)
 			len = kenv_mvallen + 1;
 		value = malloc(len, M_TEMP, M_WAITOK);
-		error = copyinstr(uap->value, value, len, NULL);
+		error = copyinstr(u_val, value, len, NULL);
 		if (error) {
 			free(value, M_TEMP);
 			goto done;

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -123,10 +123,6 @@ static int	kqueue_scan(struct kqueue *kq, int maxevents,
 static void 	kqueue_wakeup(struct kqueue *kq);
 static const struct filterops *kqueue_fo_find(int filt);
 static void	kqueue_fo_release(int filt);
-struct g_kevent_args;
-static int	kern_kevent_generic(struct thread *td,
-		    struct g_kevent_args *uap,
-		    struct kevent_copyops *k_ops, const char *struct_name);
 
 static fo_ioctl_t	kqueue_ioctl;
 static fo_poll_t	kqueue_poll;
@@ -1280,15 +1276,6 @@ kern_kqueue(struct thread *td, int flags, bool cponfork, struct filecaps *fcaps)
 	return (0);
 }
 
-struct g_kevent_args {
-	int	fd;
-	const void *changelist;
-	int	nchanges;
-	void	*eventlist;
-	int	nevents;
-	const struct timespec *timeout;
-};
-
 int
 sys_kevent(struct thread *td, struct kevent_args *uap)
 {
@@ -1310,7 +1297,7 @@ sys_kevent(struct thread *td, struct kevent_args *uap)
 	return (kern_kevent_generic(td, &gk_args, &k_ops, "kevent"));
 }
 
-static int
+int
 kern_kevent_generic(struct thread *td, struct g_kevent_args *uap,
     struct kevent_copyops *k_ops, const char *struct_name)
 {

--- a/sys/kern/kern_exit.c
+++ b/sys/kern/kern_exit.c
@@ -922,38 +922,43 @@ kern_wait4(struct thread *td, int pid, int *statusp, int options,
 int
 sys_wait6(struct thread *td, struct wait6_args *uap)
 {
-	struct __wrusage wru, *wrup;
 	siginfo_t si, *sip;
-	idtype_t idtype;
-	id_t id;
-	int error, status;
-
-	idtype = uap->idtype;
-	id = uap->id;
-
-	if (uap->wrusage != NULL)
-		wrup = &wru;
-	else
-		wrup = NULL;
+	int error;
 
 	if (uap->info != NULL) {
 		sip = &si;
 		bzero(sip, sizeof(*sip));
 	} else
 		sip = NULL;
+	error = user_wait6(td, uap->idtype, uap->id, uap->status, uap->options,
+	    uap->wrusage, sip);
+	if (uap->info != NULL && error == 0)
+		error = copyout(&si, uap->info, sizeof(si));
+	return (error);
+}
+
+int
+user_wait6(struct thread *td, idtype_t idtype, id_t id, int *statusp,
+    int options, struct __wrusage *wrusage, siginfo_t *sip)
+{
+	struct __wrusage wru, *wrup;
+	int error, status;
+
+	if (wrusage != NULL)
+		wrup = &wru;
+	else
+		wrup = NULL;
 
 	/*
 	 *  We expect all callers of wait6() to know about WEXITED and
 	 *  WTRAPPED.
 	 */
-	error = kern_wait6(td, idtype, id, &status, uap->options, wrup, sip);
+	error = kern_wait6(td, idtype, id, &status, options, wrup, sip);
 
-	if (uap->status != NULL && error == 0 && td->td_retval[0] != 0)
-		error = copyout(&status, uap->status, sizeof(status));
-	if (uap->wrusage != NULL && error == 0 && td->td_retval[0] != 0)
-		error = copyout(&wru, uap->wrusage, sizeof(wru));
-	if (uap->info != NULL && error == 0)
-		error = copyout(&si, uap->info, sizeof(si));
+	if (statusp != NULL && error == 0 && td->td_retval[0] != 0)
+		error = copyout(&status, statusp, sizeof(status));
+	if (wrusage != NULL && error == 0 && td->td_retval[0] != 0)
+		error = copyout(&wru, wrusage, sizeof(wru));
 	return (error);
 }
 

--- a/sys/kern/kern_exit.c
+++ b/sys/kern/kern_exit.c
@@ -965,11 +965,8 @@ user_wait6(struct thread *td, idtype_t idtype, id_t id, int *statusp,
 int
 sys_pdwait(struct thread *td, struct pdwait_args *uap)
 {
-	struct __wrusage wru, *wrup;
 	siginfo_t si, *sip;
-	int error, status;
-
-	wrup = uap->wrusage != NULL ? &wru : NULL;
+	int error;
 
 	if (uap->info != NULL) {
 		sip = &si;
@@ -977,15 +974,28 @@ sys_pdwait(struct thread *td, struct pdwait_args *uap)
 	} else {
 		sip = NULL;
 	}
-
-	error = kern_pdwait(td, uap->fd, &status, uap->options, wrup, sip);
-
-	if (uap->status != NULL && error == 0)
-		error = copyout(&status, uap->status, sizeof(status));
-	if (uap->wrusage != NULL && error == 0)
-		error = copyout(&wru, uap->wrusage, sizeof(wru));
+	error = user_pdwait(td, uap->fd, uap->status, uap->options,
+	    uap->wrusage, sip);
 	if (uap->info != NULL && error == 0)
 		error = copyout(&si, uap->info, sizeof(si));
+	return (error);
+}
+
+int
+user_pdwait(struct thread *td, int fd, int *statusp, int options,
+    struct __wrusage *wrusage, siginfo_t *sip)
+{
+	struct __wrusage wru, *wrup;
+	int error, status;
+
+	wrup = wrusage != NULL ? &wru : NULL;
+
+	error = kern_pdwait(td, fd, &status, options, wrup, sip);
+
+	if (statusp != NULL && error == 0)
+		error = copyout(&status, statusp, sizeof(status));
+	if (wrusage != NULL && error == 0)
+		error = copyout(&wru, wrusage, sizeof(wru));
 	return (error);
 }
 

--- a/sys/kern/kern_exit.c
+++ b/sys/kern/kern_exit.c
@@ -896,18 +896,26 @@ owait(struct thread *td, struct owait_args *uap __unused)
 int
 sys_wait4(struct thread *td, struct wait4_args *uap)
 {
+	return (kern_wait4(td, uap->pid, uap->status, uap->options,
+	    uap->rusage));
+}
+
+int
+kern_wait4(struct thread *td, int pid, int *statusp, int options,
+    struct rusage *rusage)
+{
 	struct rusage ru, *rup;
 	int error, status;
 
-	if (uap->rusage != NULL)
+	if (rusage != NULL)
 		rup = &ru;
 	else
 		rup = NULL;
-	error = kern_wait(td, uap->pid, &status, uap->options, rup);
-	if (uap->status != NULL && error == 0 && td->td_retval[0] != 0)
-		error = copyout(&status, uap->status, sizeof(status));
-	if (uap->rusage != NULL && error == 0 && td->td_retval[0] != 0)
-		error = copyout(&ru, uap->rusage, sizeof(struct rusage));
+	error = kern_wait(td, pid, &status, options, rup);
+	if (statusp != NULL && error == 0 && td->td_retval[0] != 0)
+		error = copyout(&status, statusp, sizeof(status));
+	if (rusage != NULL && error == 0 && td->td_retval[0] != 0)
+		error = copyout(&ru, rusage, sizeof(struct rusage));
 	return (error);
 }
 

--- a/sys/kern/kern_ffclock.c
+++ b/sys/kern/kern_ffclock.c
@@ -41,8 +41,9 @@
 #include <sys/priv.h>
 #include <sys/proc.h>
 #include <sys/sbuf.h>
-#include <sys/sysproto.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysctl.h>
+#include <sys/sysproto.h>
 #include <sys/systm.h>
 #include <sys/timeffc.h>
 
@@ -386,6 +387,12 @@ struct ffclock_getcounter_args {
 int
 sys_ffclock_getcounter(struct thread *td, struct ffclock_getcounter_args *uap)
 {
+	return (kern_ffclock_getcounter(td, uap->ffcount));
+}
+
+int
+kern_ffclock_getcounter(struct thread *td, ffcounter *uffcount)
+{
 	ffcounter ffcount;
 	int error;
 
@@ -393,7 +400,7 @@ sys_ffclock_getcounter(struct thread *td, struct ffclock_getcounter_args *uap)
 	ffclock_read_counter(&ffcount);
 	if (ffcount == 0)
 		return (EAGAIN);
-	error = copyout(&ffcount, uap->ffcount, sizeof(ffcounter));
+	error = copyout(&ffcount, uffcount, sizeof(ffcounter));
 
 	return (error);
 }
@@ -415,6 +422,13 @@ struct ffclock_setestimate_args {
 int
 sys_ffclock_setestimate(struct thread *td, struct ffclock_setestimate_args *uap)
 {
+	return (kern_ffclock_setestimate(td, uap->cest));
+}
+
+int
+kern_ffclock_setestimate(struct thread *td,
+    const struct ffclock_estimate *ucest)
+{
 	struct ffclock_estimate cest;
 	int error;
 
@@ -422,7 +436,7 @@ sys_ffclock_setestimate(struct thread *td, struct ffclock_setestimate_args *uap)
 	if ((error = priv_check(td, PRIV_CLOCK_SETTIME)) != 0)
 		return (error);
 
-	if ((error = copyin(uap->cest, &cest, sizeof(struct ffclock_estimate)))
+	if ((error = copyin(ucest, &cest, sizeof(struct ffclock_estimate)))
 	    != 0)
 		return (error);
 
@@ -447,13 +461,19 @@ struct ffclock_getestimate_args {
 int
 sys_ffclock_getestimate(struct thread *td, struct ffclock_getestimate_args *uap)
 {
+	return (kern_ffclock_getestimate(td, uap->cest));
+}
+
+int
+kern_ffclock_getestimate(struct thread *td, struct ffclock_estimate *ucest)
+{
 	struct ffclock_estimate cest;
 	int error;
 
 	mtx_lock(&ffclock_mtx);
 	memcpy(&cest, &ffclock_estimate, sizeof(struct ffclock_estimate));
 	mtx_unlock(&ffclock_mtx);
-	error = copyout(&cest, uap->cest, sizeof(struct ffclock_estimate));
+	error = copyout(&cest, ucest, sizeof(struct ffclock_estimate));
 	return (error);
 }
 

--- a/sys/kern/kern_fork.c
+++ b/sys/kern/kern_fork.c
@@ -69,9 +69,9 @@
 #include <sys/syscallsubr.h>
 #include <sys/sysent.h>
 #include <sys/sysproto.h>
+#include <sys/unistd.h>
 #include <sys/vmmeter.h>
 #include <sys/vnode.h>
-#include <sys/unistd.h>
 
 #include <security/audit/audit.h>
 #include <security/mac/mac_framework.h>
@@ -118,6 +118,12 @@ sys_fork(struct thread *td, struct fork_args *uap)
 int
 sys_pdfork(struct thread *td, struct pdfork_args *uap)
 {
+	return (kern_pdfork(td, uap->fdp, uap->flags));
+}
+
+int
+kern_pdfork(struct thread *td, int *fdp, int flags)
+{
 	struct fork_req fr;
 	int error, fd, pid;
 
@@ -125,8 +131,8 @@ sys_pdfork(struct thread *td, struct pdfork_args *uap)
 	fr.fr_flags = RFFDG | RFPROC | RFPROCDESC;
 	fr.fr_pidp = &pid;
 	fr.fr_pd_fd = &fd;
-	fr.fr_pd_flags = uap->flags;
-	AUDIT_ARG_FFLAGS(uap->flags);
+	fr.fr_pd_flags = flags;
+	AUDIT_ARG_FFLAGS(flags);
 	/*
 	 * It is necessary to return fd by reference because 0 is a valid file
 	 * descriptor number, and the child needs to be able to distinguish
@@ -136,7 +142,7 @@ sys_pdfork(struct thread *td, struct pdfork_args *uap)
 	if (error == 0) {
 		td->td_retval[0] = pid;
 		td->td_retval[1] = 0;
-		error = copyout(&fd, uap->fdp, sizeof(fd));
+		error = copyout(&fd, fdp, sizeof(fd));
 	}
 	return (error);
 }

--- a/sys/kern/kern_fork.c
+++ b/sys/kern/kern_fork.c
@@ -199,46 +199,51 @@ sys_rfork(struct thread *td, struct rfork_args *uap)
 int
 sys_pdrfork(struct thread *td, struct pdrfork_args *uap)
 {
+	return (kern_pdrfork(td, uap->fdp, uap->pdflags, uap->rfflags));
+}
+
+int
+kern_pdrfork(struct thread *td, int *fdp, int pdflags, int rfflags)
+{
 	struct fork_req fr;
 	int error, fd, pid;
 
 	bzero(&fr, sizeof(fr));
 	fd = -1;
 
-	AUDIT_ARG_FFLAGS(uap->pdflags);
-	AUDIT_ARG_CMD(uap->rfflags);
+	AUDIT_ARG_FFLAGS(pdflags);
+	AUDIT_ARG_CMD(rfflags);
 
-	if ((uap->rfflags & (RFSTOPPED | RFHIGHPID)) != 0)
+	if ((rfflags & (RFSTOPPED | RFHIGHPID)) != 0)
 		return (EXTERROR(EINVAL,
-		    "Kernel-only flags %#jx", uap->rfflags));
+		    "Kernel-only flags %#jx", rfflags));
 
 	/* RFSPAWN must not appear with others */
-	if ((uap->rfflags & RFSPAWN) != 0) {
-		if (uap->rfflags != RFSPAWN)
+	if ((rfflags & RFSPAWN) != 0) {
+		if (rfflags != RFSPAWN)
 			return (EXTERROR(EINVAL,
-			    "RFSPAWN must be the only flag %#jx",
-			    uap->rfflags));
+			    "RFSPAWN must be the only flag %#jx", rfflags));
 		fr.fr_flags = RFFDG | RFPROC | RFPPWAIT | RFMEM | RFPROCDESC;
 		fr.fr_flags2 = FR2_DROPSIG_CAUGHT;
 	} else {
-		if ((uap->rfflags & (RFPROC | RFPROCDESC)) !=
+		if ((rfflags & (RFPROC | RFPROCDESC)) !=
 		    (RFPROC | RFPROCDESC)) {
 			return (EXTERROR(EINVAL,
-			    "RFPROC|RFPROCDESC required %#jx", uap->rfflags));
+			    "RFPROC|RFPROCDESC required %#jx", rfflags));
 		}
-		fr.fr_flags = uap->rfflags;
+		fr.fr_flags = rfflags;
 	}
 
 	fr.fr_pidp = &pid;
 	fr.fr_pd_fd = &fd;
-	fr.fr_pd_flags = uap->pdflags;
+	fr.fr_pd_flags = pdflags;
 	error = fork1(td, &fr);
 	if (error == 0) {
 		td->td_retval[0] = pid;
 		td->td_retval[1] = 0;
 		if ((fr.fr_flags & (RFPROC | RFPROCDESC)) ==
-		    (RFPROC | RFPROCDESC) || uap->rfflags == RFSPAWN)
-			error = copyout(&fd, uap->fdp, sizeof(fd));
+		    (RFPROC | RFPROCDESC) || rfflags == RFSPAWN)
+			error = copyout(&fd, fdp, sizeof(fd));
 	}
 	return (error);
 }

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -565,17 +565,25 @@ kern_jail(struct thread *td, struct jail *j)
 int
 sys_jail_set(struct thread *td, struct jail_set_args *uap)
 {
+	return (user_jail_set(td, uap->iovp, uap->iovcnt, uap->flags,
+	    copyinuio));
+}
+
+int
+user_jail_set(struct thread *td, struct iovec *iovp,
+    unsigned int iovcnt, int flags, copyinuio_t *copyinuio_f)
+{
 	struct uio *auio;
 	int error;
 
 	/* Check that we have an even number of iovecs. */
-	if (uap->iovcnt & 1)
+	if (iovcnt & 1)
 		return (EINVAL);
 
-	error = copyinuio(uap->iovp, uap->iovcnt, &auio);
+	error = copyinuio_f(iovp, iovcnt, &auio);
 	if (error)
 		return (error);
-	error = kern_jail_set(td, auio, uap->flags);
+	error = kern_jail_set(td, auio, flags);
 	freeuio(auio);
 	return (error);
 }
@@ -2549,20 +2557,28 @@ get_next_deadid(struct prison **dinsprp)
 int
 sys_jail_get(struct thread *td, struct jail_get_args *uap)
 {
+	return (user_jail_get(td, uap->iovp, uap->iovcnt, uap->flags,
+	    copyinuio, updateiov));
+}
+
+int
+user_jail_get(struct thread *td, struct iovec *iovp,
+    unsigned int iovcnt, int flags, copyinuio_t *copyinuio_f,
+    updateiov_t *updateiov_f)
+{
 	struct uio *auio;
 	int error;
 
 	/* Check that we have an even number of iovecs. */
-	if (uap->iovcnt & 1)
+	if (iovcnt & 1)
 		return (EINVAL);
 
-	error = copyinuio(uap->iovp, uap->iovcnt, &auio);
+	error = copyinuio_f(iovp, iovcnt, &auio);
 	if (error)
 		return (error);
-	error = kern_jail_get(td, auio, uap->flags);
+	error = kern_jail_get(td, auio, flags);
 	if (error == 0)
-		error = copyout(auio->uio_iov, uap->iovp,
-		    uap->iovcnt * sizeof(struct iovec));
+		error = updateiov_f(auio, iovp);
 	freeuio(auio);
 	return (error);
 }

--- a/sys/kern/kern_ktrace.c
+++ b/sys/kern/kern_ktrace.c
@@ -50,6 +50,7 @@
 #include <sys/proc.h>
 #include <sys/resourcevar.h>
 #include <sys/socket.h>
+#include <sys/syscallsubr.h>
 #include <sys/stat.h>
 #include <sys/sx.h>
 #include <sys/sysctl.h>
@@ -1098,13 +1099,19 @@ struct ktrace_args {
 int
 sys_ktrace(struct thread *td, struct ktrace_args *uap)
 {
+	return (kern_ktrace(td, uap->fname, uap->ops, uap->facs, uap->pid));
+}
+
+int
+kern_ktrace(struct thread *td, const char *fname, int uops, int ufacs, int pid)
+{
 #ifdef KTRACE
 	struct vnode *vp = NULL;
 	struct proc *p;
 	struct pgrp *pg;
-	int facs = uap->facs & ~KTRFAC_ROOT;
-	int ops = KTROP(uap->ops);
-	int descend = uap->ops & KTRFLAG_DESCEND;
+	int facs = ufacs & ~KTRFAC_ROOT;
+	int ops = KTROP(uops);
+	int descend = uops & KTRFLAG_DESCEND;
 	int ret = 0;
 	int flags, error = 0;
 	struct nameidata nd;
@@ -1121,7 +1128,7 @@ sys_ktrace(struct thread *td, struct ktrace_args *uap)
 		/*
 		 * an operation which requires a file argument.
 		 */
-		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_USERSPACE, uap->fname);
+		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_USERSPACE, fname);
 		flags = FREAD | FWRITE | O_NOFOLLOW;
 		error = vn_open(&nd, &flags, 0, NULL);
 		if (error)
@@ -1169,11 +1176,11 @@ restart:
 	 * do it
 	 */
 	sx_slock(&proctree_lock);
-	if (uap->pid < 0) {
+	if (pid < 0) {
 		/*
 		 * by process group
 		 */
-		pg = pgfind(-uap->pid);
+		pg = pgfind(-pid);
 		if (pg == NULL) {
 			sx_sunlock(&proctree_lock);
 			error = ESRCH;
@@ -1201,7 +1208,7 @@ restart:
 		/*
 		 * by pid
 		 */
-		p = pfind(uap->pid);
+		p = pfind(pid);
 		if (p == NULL) {
 			error = ESRCH;
 			sx_sunlock(&proctree_lock);
@@ -1233,7 +1240,12 @@ done:
 int
 sys_utrace(struct thread *td, struct utrace_args *uap)
 {
+	return (kern_utrace(td, uap->addr, uap->len));
+}
 
+int
+kern_utrace(struct thread *td, const void *addr, size_t len)
+{
 #ifdef KTRACE
 	struct ktr_request *req;
 	void *cp;
@@ -1241,10 +1253,10 @@ sys_utrace(struct thread *td, struct utrace_args *uap)
 
 	if (!KTRPOINT(td, KTR_USER))
 		return (0);
-	if (uap->len > KTR_USER_MAXLEN)
+	if (len > KTR_USER_MAXLEN)
 		return (EINVAL);
-	cp = malloc(uap->len, M_KTRACE, M_WAITOK);
-	error = copyin(uap->addr, cp, uap->len);
+	cp = malloc(len, M_KTRACE, M_WAITOK);
+	error = copyin(addr, cp, len);
 	if (error) {
 		free(cp, M_KTRACE);
 		return (error);
@@ -1255,7 +1267,7 @@ sys_utrace(struct thread *td, struct utrace_args *uap)
 		return (ENOMEM);
 	}
 	req->ktr_buffer = cp;
-	req->ktr_header.ktr_len = uap->len;
+	req->ktr_header.ktr_len = len;
 	ktr_submitrequest(td, req);
 	return (0);
 #else /* !KTRACE */

--- a/sys/kern/kern_linker.c
+++ b/sys/kern/kern_linker.c
@@ -1250,7 +1250,7 @@ kern_kldload(struct thread *td, const char *file, int *fileid)
 }
 
 int
-sys_kldload(struct thread *td, struct kldload_args *uap)
+user_kldload(struct thread *td, const char *file)
 {
 	char *pathname = NULL;
 	int error, fileid;
@@ -1258,7 +1258,7 @@ sys_kldload(struct thread *td, struct kldload_args *uap)
 	td->td_retval[0] = -1;
 
 	pathname = malloc(MAXPATHLEN, M_TEMP, M_WAITOK);
-	error = copyinstr(uap->file, pathname, MAXPATHLEN, NULL);
+	error = copyinstr(file, pathname, MAXPATHLEN, NULL);
 	if (error == 0) {
 		error = kern_kldload(td, pathname, &fileid);
 		if (error == 0)
@@ -1266,6 +1266,12 @@ sys_kldload(struct thread *td, struct kldload_args *uap)
 	}
 	free(pathname, M_TEMP);
 	return (error);
+}
+
+int
+sys_kldload(struct thread *td, struct kldload_args *uap)
+{
+	return (user_kldload(td, uap->file));
 }
 
 int
@@ -1316,14 +1322,12 @@ kern_kldunload(struct thread *td, int fileid, int flags)
 int
 sys_kldunload(struct thread *td, struct kldunload_args *uap)
 {
-
 	return (kern_kldunload(td, uap->fileid, LINKER_UNLOAD_NORMAL));
 }
 
 int
 sys_kldunloadf(struct thread *td, struct kldunloadf_args *uap)
 {
-
 	if (uap->flags != LINKER_UNLOAD_NORMAL &&
 	    uap->flags != LINKER_UNLOAD_FORCE)
 		return (EINVAL);
@@ -1332,6 +1336,12 @@ sys_kldunloadf(struct thread *td, struct kldunloadf_args *uap)
 
 int
 sys_kldfind(struct thread *td, struct kldfind_args *uap)
+{
+	return (kern_kldfind(td, uap->file));
+}
+
+int
+kern_kldfind(struct thread *td, const char *file)
 {
 	char *pathname;
 	const char *filename;
@@ -1347,7 +1357,7 @@ sys_kldfind(struct thread *td, struct kldfind_args *uap)
 	td->td_retval[0] = -1;
 
 	pathname = malloc(MAXPATHLEN, M_TEMP, M_WAITOK);
-	if ((error = copyinstr(uap->file, pathname, MAXPATHLEN, NULL)) != 0)
+	if ((error = copyinstr(file, pathname, MAXPATHLEN, NULL)) != 0)
 		goto out;
 
 	filename = linker_basename(pathname);
@@ -1513,12 +1523,35 @@ sys_kldfirstmod(struct thread *td, struct kldfirstmod_args *uap)
 int
 sys_kldsym(struct thread *td, struct kldsym_args *uap)
 {
-	char *symstr = NULL;
+	struct kld_sym_lookup lookup;
+	struct kld_sym_lookup *user_lookup;
+	int error;
+
+	user_lookup = uap->data;
+	if ((error = copyin(user_lookup, &lookup, sizeof(lookup))) != 0)
+		return (error);
+	if (lookup.version != sizeof(lookup) || uap->cmd != KLDSYM_LOOKUP)
+		return (EINVAL);
+	error = kern_kldsym(td, uap->fileid, uap->cmd, lookup.symname,
+	    &lookup.symvalue, &lookup.symsize);
+	if (error != 0)
+		return (error);
+	error = suword(&user_lookup->symvalue, lookup.symvalue);
+	if (error == 0)
+		error = suword(&user_lookup->symsize, lookup.symsize);
+
+	return (error);
+}
+
+int
+kern_kldsym(struct thread *td, int fileid, int cmd, const char *symname,
+    u_long *symvalue, size_t *symsize)
+{
 	c_linker_sym_t sym;
 	linker_symval_t symval;
 	linker_file_t lf;
-	struct kld_sym_lookup lookup;
-	int error = 0;
+	char *symstr;
+	int error;
 
 #ifdef MAC
 	error = mac_kld_check_stat(td->td_ucred);
@@ -1526,34 +1559,28 @@ sys_kldsym(struct thread *td, struct kldsym_args *uap)
 		return (error);
 #endif
 
-	if ((error = copyin(uap->data, &lookup, sizeof(lookup))) != 0)
-		return (error);
-	if (lookup.version != sizeof(lookup) ||
-	    uap->cmd != KLDSYM_LOOKUP)
-		return (EINVAL);
 	symstr = malloc(MAXPATHLEN, M_TEMP, M_WAITOK);
-	if ((error = copyinstr(lookup.symname, symstr, MAXPATHLEN, NULL)) != 0)
+	if ((error = copyinstr(symname, symstr, MAXPATHLEN, NULL)) != 0)
 		goto out;
 	sx_xlock(&kld_sx);
-	if (uap->fileid != 0) {
-		lf = linker_find_file_by_id(uap->fileid);
+	if (fileid != 0) {
+		lf = linker_find_file_by_id(fileid);
 		if (lf == NULL)
 			error = ENOENT;
 		else if (LINKER_LOOKUP_SYMBOL(lf, symstr, &sym) == 0 &&
 		    LINKER_SYMBOL_VALUES(lf, sym, &symval) == 0) {
-			lookup.symvalue = (uintptr_t) symval.value;
-			lookup.symsize = symval.size;
-			error = copyout(&lookup, uap->data, sizeof(lookup));
+			*symvalue = (uintptr_t)symval.value;
+			*symsize = symval.size;
+			error = 0;
 		} else
 			error = ENOENT;
 	} else {
 		TAILQ_FOREACH(lf, &linker_files, link) {
 			if (LINKER_LOOKUP_SYMBOL(lf, symstr, &sym) == 0 &&
 			    LINKER_SYMBOL_VALUES(lf, sym, &symval) == 0) {
-				lookup.symvalue = (uintptr_t)symval.value;
-				lookup.symsize = symval.size;
-				error = copyout(&lookup, uap->data,
-				    sizeof(lookup));
+				*symvalue = (uintptr_t)symval.value;
+				*symsize = symval.size;
+				error = 0;
 				break;
 			}
 		}

--- a/sys/kern/kern_module.c
+++ b/sys/kern/kern_module.c
@@ -31,8 +31,9 @@
 #include <sys/systm.h>
 #include <sys/eventhandler.h>
 #include <sys/malloc.h>
-#include <sys/sysproto.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysent.h>
+#include <sys/sysproto.h>
 #include <sys/proc.h>
 #include <sys/lock.h>
 #include <sys/mutex.h>
@@ -374,17 +375,22 @@ struct module_stat_v2 {
 int
 sys_modstat(struct thread *td, struct modstat_args *uap)
 {
+	return (kern_modstat(td, uap->modid, uap->stat));
+}
+
+int
+kern_modstat(struct thread *td, int modid, struct module_stat *stat)
+{
 	module_t mod;
 	modspecific_t data;
 	int error = 0;
 	int id, namelen, refs, version;
-	struct module_stat *stat;
 	struct module_stat_v2 *stat_v2;
-	char *name;
+	char *name, *user_namep;
 	bool is_v1v2;
 
 	MOD_SLOCK;
-	mod = module_lookupbyid(uap->modid);
+	mod = module_lookupbyid(modid);
 	if (mod == NULL) {
 		MOD_SUNLOCK;
 		return (ENOENT);
@@ -394,7 +400,6 @@ sys_modstat(struct thread *td, struct modstat_args *uap)
 	name = mod->name;
 	data = mod->data;
 	MOD_SUNLOCK;
-	stat = uap->stat;
 
 	/*
 	 * Check the version of the user's structure.
@@ -405,12 +410,16 @@ sys_modstat(struct thread *td, struct modstat_args *uap)
 	    version == sizeof(struct module_stat_v2));
 	if (!is_v1v2 && version != sizeof(struct module_stat))
 		return (EINVAL);
+	if (is_v1v2)
+		user_namep = ((struct module_stat_v1 *)stat)->name;
+	else
+		user_namep = stat->name;
 	namelen = strlen(mod->name) + 1;
 	if (is_v1v2 && namelen > MAXMODNAMEV1V2)
 		namelen = MAXMODNAMEV1V2;
 	else if (namelen > MAXMODNAMEV3)
 		namelen = MAXMODNAMEV3;
-	if ((error = copyout(name, &stat->name[0], namelen)) != 0)
+	if ((error = copyout(name, user_namep, namelen)) != 0)
 		return (error);
 
 	/* Extending MAXMODNAME gives an offset change for v3. */
@@ -446,11 +455,17 @@ sys_modstat(struct thread *td, struct modstat_args *uap)
 int
 sys_modfind(struct thread *td, struct modfind_args *uap)
 {
+	return (kern_modfind(td, uap->name));
+}
+
+int
+kern_modfind(struct thread *td, const char *uname)
+{
 	int error = 0;
 	char name[MAXMODNAMEV3];
 	module_t mod;
 
-	if ((error = copyinstr(uap->name, name, sizeof name, 0)) != 0)
+	if ((error = copyinstr(uname, name, sizeof name, 0)) != 0)
 		return (error);
 
 	MOD_SLOCK;

--- a/sys/kern/kern_ntptime.c
+++ b/sys/kern/kern_ntptime.c
@@ -286,6 +286,12 @@ struct ntp_gettime_args {
 int
 sys_ntp_gettime(struct thread *td, struct ntp_gettime_args *uap)
 {	
+	return (kern_ntp_gettime(td, uap->ntvp));
+}
+
+int
+kern_ntp_gettime(struct thread *td, struct ntptimeval *ntvp)
+{
 	struct ntptimeval ntv;
 
 	memset(&ntv, 0, sizeof(ntv));
@@ -295,7 +301,7 @@ sys_ntp_gettime(struct thread *td, struct ntp_gettime_args *uap)
 	NTP_UNLOCK();
 
 	td->td_retval[0] = ntv.time_state;
-	return (copyout(&ntv, uap->ntvp, sizeof(ntv)));
+	return (copyout(&ntv, ntvp, sizeof(ntv)));
 }
 
 static int

--- a/sys/kern/kern_prot.c
+++ b/sys/kern/kern_prot.c
@@ -353,20 +353,26 @@ struct getgroups_args {
 int
 sys_getgroups(struct thread *td, struct getgroups_args *uap)
 {
+	return (kern_getgroups(td, uap->gidsetsize, uap->gidset));
+}
+
+int
+kern_getgroups(struct thread *td, int gidsetsize, gid_t *gidset)
+{
 	struct ucred *cred;
 	int ngrp, error;
 
 	cred = td->td_ucred;
 
 	ngrp = cred->cr_ngroups;
-	if (uap->gidsetsize == 0) {
+	if (gidsetsize == 0) {
 		error = 0;
 		goto out;
 	}
-	if (uap->gidsetsize < ngrp)
+	if (gidsetsize < ngrp)
 		return (EINVAL);
 
-	error = copyout(cred->cr_groups, uap->gidset, ngrp * sizeof(gid_t));
+	error = copyout(cred->cr_groups, gidset, ngrp * sizeof(gid_t));
 out:
 	td->td_retval[0] = ngrp;
 	return (error);
@@ -1254,9 +1260,15 @@ struct setgroups_args {
 int
 sys_setgroups(struct thread *td, struct setgroups_args *uap)
 {
+	return (user_setgroups(td, uap->gidsetsize, uap->gidset));
+}
+
+int
+user_setgroups(struct thread *td, int gidsetsize, const gid_t *gidset)
+{
 	gid_t smallgroups[CRED_SMALLGROUPS_NB];
 	gid_t *groups;
-	int gidsetsize, error;
+	int error;
 
 	/*
 	 * Sanity check size now to avoid passing too big a value to copyin(),
@@ -1267,7 +1279,6 @@ sys_setgroups(struct thread *td, struct setgroups_args *uap)
 	 * getgroups() to take an 'int' and it would be quite entrapping to have
 	 * setgroups() differ.
 	 */
-	gidsetsize = uap->gidsetsize;
 	if (gidsetsize > ngroups_max || gidsetsize < 0)
 		return (EINVAL);
 
@@ -1276,7 +1287,7 @@ sys_setgroups(struct thread *td, struct setgroups_args *uap)
 	else
 		groups = smallgroups;
 
-	error = copyin(uap->gidset, groups, gidsetsize * sizeof(gid_t));
+	error = copyin(gidset, groups, gidsetsize * sizeof(gid_t));
 	if (error == 0)
 		error = kern_setgroups(td, &gidsetsize, groups);
 
@@ -1664,19 +1675,22 @@ struct getresuid_args {
 int
 sys_getresuid(struct thread *td, struct getresuid_args *uap)
 {
+	return (kern_getresuid(td, uap->ruid, uap->euid, uap->suid));
+}
+
+int
+kern_getresuid(struct thread *td, uid_t *ruid, uid_t *euid, uid_t *suid)
+{
 	struct ucred *cred;
 	int error1 = 0, error2 = 0, error3 = 0;
 
 	cred = td->td_ucred;
-	if (uap->ruid)
-		error1 = copyout(&cred->cr_ruid,
-		    uap->ruid, sizeof(cred->cr_ruid));
-	if (uap->euid)
-		error2 = copyout(&cred->cr_uid,
-		    uap->euid, sizeof(cred->cr_uid));
-	if (uap->suid)
-		error3 = copyout(&cred->cr_svuid,
-		    uap->suid, sizeof(cred->cr_svuid));
+	if (ruid)
+		error1 = copyout(&cred->cr_ruid, ruid, sizeof(cred->cr_ruid));
+	if (euid)
+		error2 = copyout(&cred->cr_uid, euid, sizeof(cred->cr_uid));
+	if (suid)
+		error3 = copyout(&cred->cr_svuid, suid, sizeof(cred->cr_svuid));
 	return (error1 ? error1 : error2 ? error2 : error3);
 }
 
@@ -1691,19 +1705,22 @@ struct getresgid_args {
 int
 sys_getresgid(struct thread *td, struct getresgid_args *uap)
 {
+	return (kern_getresgid(td, uap->rgid, uap->egid, uap->sgid));
+}
+
+int
+kern_getresgid(struct thread *td, gid_t *rgid, gid_t *egid, gid_t *sgid)
+{
 	struct ucred *cred;
 	int error1 = 0, error2 = 0, error3 = 0;
 
 	cred = td->td_ucred;
-	if (uap->rgid)
-		error1 = copyout(&cred->cr_rgid,
-		    uap->rgid, sizeof(cred->cr_rgid));
-	if (uap->egid)
-		error2 = copyout(&cred->cr_gid,
-		    uap->egid, sizeof(cred->cr_gid));
-	if (uap->sgid)
-		error3 = copyout(&cred->cr_svgid,
-		    uap->sgid, sizeof(cred->cr_svgid));
+	if (rgid)
+		error1 = copyout(&cred->cr_rgid, rgid, sizeof(cred->cr_rgid));
+	if (egid)
+		error2 = copyout(&cred->cr_gid, egid, sizeof(cred->cr_gid));
+	if (sgid)
+		error3 = copyout(&cred->cr_svgid, sgid, sizeof(cred->cr_svgid));
 	return (error1 ? error1 : error2 ? error2 : error3);
 }
 
@@ -3066,20 +3083,26 @@ struct getlogin_args {
 int
 sys_getlogin(struct thread *td, struct getlogin_args *uap)
 {
+	return (kern_getlogin(td, uap->namebuf, uap->namelen));
+}
+
+int
+kern_getlogin(struct thread *td, char *namebuf, u_int namelen)
+{
 	char login[MAXLOGNAME];
 	struct proc *p = td->td_proc;
 	size_t len;
 
-	if (uap->namelen > MAXLOGNAME)
-		uap->namelen = MAXLOGNAME;
+	if (namelen > MAXLOGNAME)
+		namelen = MAXLOGNAME;
 	PROC_LOCK(p);
 	SESS_LOCK(p->p_session);
-	len = strlcpy(login, p->p_session->s_login, uap->namelen) + 1;
+	len = strlcpy(login, p->p_session->s_login, namelen) + 1;
 	SESS_UNLOCK(p->p_session);
 	PROC_UNLOCK(p);
-	if (len > uap->namelen)
+	if (len > namelen)
 		return (ERANGE);
-	return (copyout(login, uap->namebuf, len));
+	return (copyout(login, namebuf, len));
 }
 
 /*
@@ -3094,6 +3117,12 @@ struct setlogin_args {
 int
 sys_setlogin(struct thread *td, struct setlogin_args *uap)
 {
+	return (kern_setlogin(td, uap->namebuf));
+}
+
+int
+kern_setlogin(struct thread *td, const char *namebuf)
+{
 	struct proc *p = td->td_proc;
 	int error;
 	char logintmp[MAXLOGNAME];
@@ -3103,7 +3132,7 @@ sys_setlogin(struct thread *td, struct setlogin_args *uap)
 	error = priv_check(td, PRIV_PROC_SETLOGIN);
 	if (error)
 		return (error);
-	error = copyinstr(uap->namebuf, logintmp, sizeof(logintmp), NULL);
+	error = copyinstr(namebuf, logintmp, sizeof(logintmp), NULL);
 	if (error != 0) {
 		if (error == ENAMETOOLONG)
 			error = EINVAL;

--- a/sys/kern/kern_prot.c
+++ b/sys/kern/kern_prot.c
@@ -315,6 +315,12 @@ sys_getegid(struct thread *td, struct getegid_args *uap)
 int
 freebsd14_getgroups(struct thread *td, struct freebsd14_getgroups_args *uap)
 {
+	return (kern_freebsd14_getgroups(td, uap->gidsetsize, uap->gidset));
+}
+
+int
+kern_freebsd14_getgroups(struct thread *td, int gidsetsize, gid_t *gidset)
+{
 	struct ucred *cred;
 	int ngrp, error;
 
@@ -325,16 +331,16 @@ freebsd14_getgroups(struct thread *td, struct freebsd14_getgroups_args *uap)
 	 * beginning of the group list prior to all supplementary groups.
 	 */
 	ngrp = cred->cr_ngroups + 1;
-	if (uap->gidsetsize == 0) {
+	if (gidsetsize == 0) {
 		error = 0;
 		goto out;
-	} else if (uap->gidsetsize < ngrp) {
+	} else if (gidsetsize < ngrp) {
 		return (EINVAL);
 	}
 
-	error = copyout(&cred->cr_gid, uap->gidset, sizeof(gid_t));
+	error = copyout(&cred->cr_gid, gidset, sizeof(gid_t));
 	if (error == 0)
-		error = copyout(cred->cr_groups, uap->gidset + 1,
+		error = copyout(cred->cr_groups, gidset + 1,
 		    (ngrp - 1) * sizeof(gid_t));
 
 out:
@@ -1216,9 +1222,17 @@ fail:
 int
 freebsd14_setgroups(struct thread *td, struct freebsd14_setgroups_args *uap)
 {
+	return (user_freebsd14_setgroups(td, uap->gidsetsize,
+	    uap->gidset));
+}
+
+int
+user_freebsd14_setgroups(struct thread *td, int gidsetsize,
+    const gid_t *gidset)
+{
 	gid_t smallgroups[CRED_SMALLGROUPS_NB];
 	gid_t *groups;
-	int gidsetsize, error;
+	int error;
 
 	/*
 	 * Before FreeBSD 15.0, we allow one more group to be supplied to
@@ -1226,7 +1240,6 @@ freebsd14_setgroups(struct thread *td, struct freebsd14_setgroups_args *uap)
 	 * may technically allow one more supplementary group for systems that
 	 * did use the default NGROUPS_MAX if we round it back up to 1024.
 	 */
-	gidsetsize = uap->gidsetsize;
 	if (gidsetsize > ngroups_max + 1 || gidsetsize < 0)
 		return (EINVAL);
 
@@ -1235,7 +1248,7 @@ freebsd14_setgroups(struct thread *td, struct freebsd14_setgroups_args *uap)
 	else
 		groups = smallgroups;
 
-	error = copyin(uap->gidset, groups, gidsetsize * sizeof(gid_t));
+	error = copyin(gidset, groups, gidsetsize * sizeof(gid_t));
 	if (error == 0) {
 		int ngroups = gidsetsize > 0 ? gidsetsize - 1 /* egid */ : 0;
 

--- a/sys/kern/kern_rctl.c
+++ b/sys/kern/kern_rctl.c
@@ -46,6 +46,7 @@
 #include <sys/rctl.h>
 #include <sys/resourcevar.h>
 #include <sys/sx.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysproto.h>
 #include <sys/systm.h>
 #include <sys/types.h>
@@ -1608,6 +1609,14 @@ rctl_racct_to_sbuf(struct racct *racct, int sloppy)
 int
 sys_rctl_get_racct(struct thread *td, struct rctl_get_racct_args *uap)
 {
+	return (kern_rctl_get_racct(td, uap->inbufp, uap->inbuflen,
+	    uap->outbufp, uap->outbuflen));
+}
+
+int
+kern_rctl_get_racct(struct thread *td, const void *inbufp, size_t inbuflen,
+    void *outbufp, size_t outbuflen)
+{
 	struct rctl_rule *filter;
 	struct sbuf *outputsbuf = NULL;
 	struct proc *p;
@@ -1624,7 +1633,7 @@ sys_rctl_get_racct(struct thread *td, struct rctl_get_racct_args *uap)
 	if (error != 0)
 		return (error);
 
-	error = rctl_read_inbuf(&inputstr, uap->inbufp, uap->inbuflen);
+	error = rctl_read_inbuf(&inputstr, inbufp, inbuflen);
 	if (error != 0)
 		return (error);
 
@@ -1678,7 +1687,7 @@ out:
 	if (error != 0)
 		return (error);
 
-	error = rctl_write_outbuf(outputsbuf, uap->outbufp, uap->outbuflen);
+	error = rctl_write_outbuf(outputsbuf, outbufp, outbuflen);
 
 	return (error);
 }
@@ -1704,6 +1713,14 @@ rctl_get_rules_callback(struct racct *racct, void *arg2, void *arg3)
 int
 sys_rctl_get_rules(struct thread *td, struct rctl_get_rules_args *uap)
 {
+	return (kern_rctl_get_rules(td, uap->inbufp, uap->inbuflen,
+	    uap->outbufp, uap->outbuflen));
+}
+
+int
+kern_rctl_get_rules(struct thread *td, const void *inbufp, size_t inbuflen,
+    void *outbufp, size_t outbuflen)
+{
 	struct sbuf *sb;
 	struct rctl_rule *filter;
 	struct rctl_rule_link *link;
@@ -1719,7 +1736,7 @@ sys_rctl_get_rules(struct thread *td, struct rctl_get_rules_args *uap)
 	if (error != 0)
 		return (error);
 
-	error = rctl_read_inbuf(&inputstr, uap->inbufp, uap->inbuflen);
+	error = rctl_read_inbuf(&inputstr, inbufp, inbuflen);
 	if (error != 0)
 		return (error);
 
@@ -1731,7 +1748,7 @@ sys_rctl_get_rules(struct thread *td, struct rctl_get_rules_args *uap)
 		return (error);
 	}
 
-	bufsize = uap->outbuflen;
+	bufsize = outbuflen;
 	if (bufsize > rctl_maxbufsize) {
 		sx_sunlock(&allproc_lock);
 		return (E2BIG);
@@ -1779,7 +1796,7 @@ sys_rctl_get_rules(struct thread *td, struct rctl_get_rules_args *uap)
 	if (sbuf_len(sb) > 0)
 		sbuf_setpos(sb, sbuf_len(sb) - 1);
 
-	error = rctl_write_outbuf(sb, uap->outbufp, uap->outbuflen);
+	error = rctl_write_outbuf(sb, outbufp, outbuflen);
 out:
 	rctl_rule_release(filter);
 	sx_sunlock(&allproc_lock);
@@ -1789,6 +1806,14 @@ out:
 
 int
 sys_rctl_get_limits(struct thread *td, struct rctl_get_limits_args *uap)
+{
+	return (kern_rctl_get_limits(td, uap->inbufp, uap->inbuflen,
+	    uap->outbufp, uap->outbuflen));
+}
+
+int
+kern_rctl_get_limits(struct thread *td, const void *inbufp, size_t inbuflen,
+    void *outbufp, size_t outbuflen)
 {
 	struct sbuf *sb;
 	struct rctl_rule *filter;
@@ -1804,7 +1829,7 @@ sys_rctl_get_limits(struct thread *td, struct rctl_get_limits_args *uap)
 	if (error != 0)
 		return (error);
 
-	error = rctl_read_inbuf(&inputstr, uap->inbufp, uap->inbuflen);
+	error = rctl_read_inbuf(&inputstr, inbufp, inbuflen);
 	if (error != 0)
 		return (error);
 
@@ -1832,7 +1857,7 @@ sys_rctl_get_limits(struct thread *td, struct rctl_get_limits_args *uap)
 		return (EINVAL);
 	}
 
-	bufsize = uap->outbuflen;
+	bufsize = outbuflen;
 	if (bufsize > rctl_maxbufsize) {
 		rctl_rule_release(filter);
 		sx_sunlock(&allproc_lock);
@@ -1862,7 +1887,7 @@ sys_rctl_get_limits(struct thread *td, struct rctl_get_limits_args *uap)
 	if (sbuf_len(sb) > 0)
 		sbuf_setpos(sb, sbuf_len(sb) - 1);
 
-	error = rctl_write_outbuf(sb, uap->outbufp, uap->outbuflen);
+	error = rctl_write_outbuf(sb, outbufp, outbuflen);
 out:
 	rctl_rule_release(filter);
 	sx_sunlock(&allproc_lock);
@@ -1872,6 +1897,14 @@ out:
 
 int
 sys_rctl_add_rule(struct thread *td, struct rctl_add_rule_args *uap)
+{
+	return (kern_rctl_add_rule(td, uap->inbufp, uap->inbuflen,
+	    uap->outbufp, uap->outbuflen));
+}
+
+int
+kern_rctl_add_rule(struct thread *td, const void *inbufp, size_t inbuflen,
+    void *outbufp, size_t outbuflen)
 {
 	struct rctl_rule *rule;
 	char *inputstr;
@@ -1884,7 +1917,7 @@ sys_rctl_add_rule(struct thread *td, struct rctl_add_rule_args *uap)
 	if (error != 0)
 		return (error);
 
-	error = rctl_read_inbuf(&inputstr, uap->inbufp, uap->inbuflen);
+	error = rctl_read_inbuf(&inputstr, inbufp, inbuflen);
 	if (error != 0)
 		return (error);
 
@@ -1918,6 +1951,14 @@ out:
 int
 sys_rctl_remove_rule(struct thread *td, struct rctl_remove_rule_args *uap)
 {
+	return (kern_rctl_remove_rule(td, uap->inbufp, uap->inbuflen,
+	    uap->outbufp, uap->outbuflen));
+}
+
+int
+kern_rctl_remove_rule(struct thread *td, const void *inbufp, size_t inbuflen,
+    void *outbufp, size_t outbuflen)
+{
 	struct rctl_rule *filter;
 	char *inputstr;
 	int error;
@@ -1929,7 +1970,7 @@ sys_rctl_remove_rule(struct thread *td, struct rctl_remove_rule_args *uap)
 	if (error != 0)
 		return (error);
 
-	error = rctl_read_inbuf(&inputstr, uap->inbufp, uap->inbuflen);
+	error = rctl_read_inbuf(&inputstr, inbufp, inbuflen);
 	if (error != 0)
 		return (error);
 

--- a/sys/kern/kern_resource.c
+++ b/sys/kern/kern_resource.c
@@ -314,35 +314,42 @@ struct rtprio_thread_args {
 int
 sys_rtprio_thread(struct thread *td, struct rtprio_thread_args *uap)
 {
+	return (kern_rtprio_thread(td, uap->function, uap->lwpid, uap->rtp));
+}
+
+int
+kern_rtprio_thread(struct thread *td, int function, lwpid_t lwpid,
+    struct rtprio *urtp)
+{
 	struct proc *p;
 	struct rtprio rtp;
 	struct thread *td1;
 	int cierror, error;
 
 	/* Perform copyin before acquiring locks if needed. */
-	if (uap->function == RTP_SET)
-		cierror = copyin(uap->rtp, &rtp, sizeof(struct rtprio));
+	if (function == RTP_SET)
+		cierror = copyin(urtp, &rtp, sizeof(struct rtprio));
 	else
 		cierror = 0;
 
-	if (uap->lwpid == 0 || uap->lwpid == td->td_tid) {
+	if (lwpid == 0 || lwpid == td->td_tid) {
 		p = td->td_proc;
 		td1 = td;
 		PROC_LOCK(p);
 	} else {
-		td1 = tdfind(uap->lwpid, -1);
+		td1 = tdfind(lwpid, -1);
 		if (td1 == NULL)
 			return (ESRCH);
 		p = td1->td_proc;
 	}
 
-	switch (uap->function) {
+	switch (function) {
 	case RTP_LOOKUP:
 		if ((error = p_cansee(td, p)))
 			break;
 		pri_to_rtp(td1, &rtp);
 		PROC_UNLOCK(p);
-		return (copyout(&rtp, uap->rtp, sizeof(struct rtprio)));
+		return (copyout(&rtp, urtp, sizeof(struct rtprio)));
 	case RTP_SET:
 		if ((error = p_cansched(td, p)) || (error = cierror))
 			break;
@@ -395,27 +402,33 @@ struct rtprio_args {
 int
 sys_rtprio(struct thread *td, struct rtprio_args *uap)
 {
+	return (kern_rtprio(td, uap->function, uap->pid, uap->rtp));
+}
+
+int
+kern_rtprio(struct thread *td, int function, pid_t pid, struct rtprio *urtp)
+{
 	struct proc *p;
 	struct thread *tdp;
 	struct rtprio rtp;
 	int cierror, error;
 
 	/* Perform copyin before acquiring locks if needed. */
-	if (uap->function == RTP_SET)
-		cierror = copyin(uap->rtp, &rtp, sizeof(struct rtprio));
+	if (function == RTP_SET)
+		cierror = copyin(urtp, &rtp, sizeof(struct rtprio));
 	else
 		cierror = 0;
 
-	if (uap->pid == 0) {
+	if (pid == 0) {
 		p = td->td_proc;
 		PROC_LOCK(p);
 	} else {
-		p = pfind(uap->pid);
+		p = pfind(pid);
 		if (p == NULL)
 			return (ESRCH);
 	}
 
-	switch (uap->function) {
+	switch (function) {
 	case RTP_LOOKUP:
 		if ((error = p_cansee(td, p)))
 			break;
@@ -427,7 +440,7 @@ sys_rtprio(struct thread *td, struct rtprio_args *uap)
 		 * Note: specifying our own pid is not the same
 		 * as leaving it zero.
 		 */
-		if (uap->pid == 0) {
+		if (pid == 0) {
 			pri_to_rtp(td, &rtp);
 		} else {
 			struct rtprio rtp2;
@@ -445,7 +458,7 @@ sys_rtprio(struct thread *td, struct rtprio_args *uap)
 			}
 		}
 		PROC_UNLOCK(p);
-		return (copyout(&rtp, uap->rtp, sizeof(struct rtprio)));
+		return (copyout(&rtp, urtp, sizeof(struct rtprio)));
 	case RTP_SET:
 		if ((error = p_cansched(td, p)) || (error = cierror))
 			break;
@@ -469,7 +482,7 @@ sys_rtprio(struct thread *td, struct rtprio_args *uap)
 		 * do all the threads on that process. If we
 		 * specify our own pid we do the latter.
 		 */
-		if (uap->pid == 0) {
+		if (pid == 0) {
 			error = rtp_to_pri(&rtp, td);
 		} else {
 			FOREACH_THREAD_IN_PROC(p, td) {

--- a/sys/kern/kern_resource.c
+++ b/sys/kern/kern_resource.c
@@ -939,17 +939,22 @@ getrlimitusage_one(struct proc *p, struct vmspace *vm, u_int which, int flags,
 int
 sys_getrlimitusage(struct thread *td, struct getrlimitusage_args *uap)
 {
+	return (user_getrlimitusage(td, uap->which, uap->flags, uap->res));
+}
+
+int
+user_getrlimitusage(struct thread *td, u_int which, int flags, rlim_t *ures)
+{
 	struct proc *p;
 	rlim_t res;
 	int error;
 
-	if ((uap->flags & ~(GETRLIMITUSAGE_EUID)) != 0)
+	if ((flags & ~(GETRLIMITUSAGE_EUID)) != 0)
 		return (EINVAL);
 	p = curproc;
-	error = getrlimitusage_one(p, p->p_vmspace, uap->which, uap->flags,
-	    &res);
+	error = getrlimitusage_one(p, p->p_vmspace, which, flags, &res);
 	if (error == 0)
-		error = copyout(&res, uap->res, sizeof(res));
+		error = copyout(&res, ures, sizeof(res));
 	return (error);
 }
 

--- a/sys/kern/kern_sendfile.c
+++ b/sys/kern/kern_sendfile.c
@@ -1214,7 +1214,14 @@ out:
 }
 
 static int
-sendfile(struct thread *td, struct sendfile_args *uap, int compat)
+copyin_hdtr(const struct sf_hdtr *uhdtr, struct sf_hdtr *hdtr)
+{
+	return (copyin(uhdtr, hdtr, sizeof(*hdtr)));
+}
+
+int
+kern_sendfile(struct thread *td, struct sendfile_args *uap, bool compat,
+    copyin_hdtr_t *copyin_hdtr_f, copyinuio_t *copyinuio_f)
 {
 	struct sf_hdtr hdtr;
 	struct uio *hdr_uio, *trl_uio;
@@ -1233,11 +1240,11 @@ sendfile(struct thread *td, struct sendfile_args *uap, int compat)
 	hdr_uio = trl_uio = NULL;
 
 	if (uap->hdtr != NULL) {
-		error = copyin(uap->hdtr, &hdtr, sizeof(hdtr));
+		error = copyin_hdtr_f(uap->hdtr, &hdtr);
 		if (error != 0)
 			goto out;
 		if (hdtr.headers != NULL) {
-			error = copyinuio(hdtr.headers, hdtr.hdr_cnt,
+			error = copyinuio_f(hdtr.headers, hdtr.hdr_cnt,
 			    &hdr_uio);
 			if (error != 0)
 				goto out;
@@ -1256,7 +1263,7 @@ sendfile(struct thread *td, struct sendfile_args *uap, int compat)
 #endif
 		}
 		if (hdtr.trailers != NULL) {
-			error = copyinuio(hdtr.trailers, hdtr.trl_cnt,
+			error = copyinuio_f(hdtr.trailers, hdtr.trl_cnt,
 			    &trl_uio);
 			if (error != 0)
 				goto out;
@@ -1300,23 +1307,22 @@ int
 sys_sendfile(struct thread *td, struct sendfile_args *uap)
 {
 
-	return (sendfile(td, uap, 0));
+	return (kern_sendfile(td, uap, false, (copyin_hdtr_t *)copyin_hdtr,
+	    copyinuio));
 }
 
 #ifdef COMPAT_FREEBSD4
 int
 freebsd4_sendfile(struct thread *td, struct freebsd4_sendfile_args *uap)
 {
-	struct sendfile_args args;
-
-	args.fd = uap->fd;
-	args.s = uap->s;
-	args.offset = uap->offset;
-	args.nbytes = uap->nbytes;
-	args.hdtr = uap->hdtr;
-	args.sbytes = uap->sbytes;
-	args.flags = uap->flags;
-
-	return (sendfile(td, &args, 1));
+	return (kern_sendfile(td, &(struct sendfile_args){
+		.fd = uap->fd,
+		.s = uap->s,
+		.offset = uap->offset,
+		.nbytes = uap->nbytes,
+		.hdtr = uap->hdtr,
+		.sbytes = uap->sbytes,
+		.flags = uap->flags,
+	    }, true, (copyin_hdtr_t *)copyin_hdtr, copyinuio));
 }
 #endif /* COMPAT_FREEBSD4 */

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -1195,20 +1195,27 @@ struct sigprocmask_args {
 int
 sys_sigprocmask(struct thread *td, struct sigprocmask_args *uap)
 {
+	return (user_sigprocmask(td, uap->how, uap->set, uap->oset));
+}
+
+int
+user_sigprocmask(struct thread *td, int how, const sigset_t *uset,
+    sigset_t *uoset)
+{
 	sigset_t set, oset;
 	sigset_t *setp, *osetp;
 	int error;
 
-	setp = (uap->set != NULL) ? &set : NULL;
-	osetp = (uap->oset != NULL) ? &oset : NULL;
+	setp = (uset != NULL) ? &set : NULL;
+	osetp = (uoset != NULL) ? &oset : NULL;
 	if (setp) {
-		error = copyin(uap->set, setp, sizeof(set));
+		error = copyin(uset, setp, sizeof(set));
 		if (error)
 			return (error);
 	}
-	error = kern_sigprocmask(td, uap->how, setp, osetp, 0);
+	error = kern_sigprocmask(td, how, setp, osetp, 0);
 	if (osetp && !error) {
-		error = copyout(osetp, uap->oset, sizeof(oset));
+		error = copyout(osetp, uoset, sizeof(oset));
 	}
 	return (error);
 }
@@ -1236,11 +1243,17 @@ osigprocmask(struct thread *td, struct osigprocmask_args *uap)
 int
 sys_sigwait(struct thread *td, struct sigwait_args *uap)
 {
+	return (user_sigwait(td, uap->set, uap->sig));
+}
+
+int
+user_sigwait(struct thread *td, const sigset_t *uset, int *usig)
+{
 	ksiginfo_t ksi;
 	sigset_t set;
 	int error;
 
-	error = copyin(uap->set, &set, sizeof(set));
+	error = copyin(uset, &set, sizeof(set));
 	if (error) {
 		td->td_retval[0] = error;
 		return (0);
@@ -1261,13 +1274,27 @@ sys_sigwait(struct thread *td, struct sigwait_args *uap)
 		return (0);
 	}
 
-	error = copyout(&ksi.ksi_signo, uap->sig, sizeof(ksi.ksi_signo));
+	error = copyout(&ksi.ksi_signo, usig, sizeof(ksi.ksi_signo));
 	td->td_retval[0] = error;
 	return (0);
 }
 
+static int
+copyout_siginfo(const siginfo_t *si, void *info)
+{
+	return (copyout(si, info, sizeof(*si)));
+}
+
 int
 sys_sigtimedwait(struct thread *td, struct sigtimedwait_args *uap)
+{
+	return (user_sigtimedwait(td, uap->set, uap->info, uap->timeout,
+	    copyout_siginfo));
+}
+
+int
+user_sigtimedwait(struct thread *td, const sigset_t *uset, void *info,
+    const struct timespec *utimeout, copyout_siginfo_t *copyout_siginfop)
 {
 	struct timespec ts;
 	struct timespec *timeout;
@@ -1275,8 +1302,8 @@ sys_sigtimedwait(struct thread *td, struct sigtimedwait_args *uap)
 	ksiginfo_t ksi;
 	int error;
 
-	if (uap->timeout) {
-		error = copyin(uap->timeout, &ts, sizeof(ts));
+	if (utimeout) {
+		error = copyin(utimeout, &ts, sizeof(ts));
 		if (error)
 			return (error);
 
@@ -1284,7 +1311,7 @@ sys_sigtimedwait(struct thread *td, struct sigtimedwait_args *uap)
 	} else
 		timeout = NULL;
 
-	error = copyin(uap->set, &set, sizeof(set));
+	error = copyin(uset, &set, sizeof(set));
 	if (error)
 		return (error);
 
@@ -1292,8 +1319,8 @@ sys_sigtimedwait(struct thread *td, struct sigtimedwait_args *uap)
 	if (error)
 		return (error);
 
-	if (uap->info)
-		error = copyout(&ksi.ksi_info, uap->info, sizeof(siginfo_t));
+	if (info)
+		error = copyout_siginfop(&ksi.ksi_info, info);
 
 	if (error == 0)
 		td->td_retval[0] = ksi.ksi_signo;
@@ -1303,11 +1330,18 @@ sys_sigtimedwait(struct thread *td, struct sigtimedwait_args *uap)
 int
 sys_sigwaitinfo(struct thread *td, struct sigwaitinfo_args *uap)
 {
+	return (user_sigwaitinfo(td, uap->set, uap->info, copyout_siginfo));
+}
+
+int
+user_sigwaitinfo(struct thread *td, const sigset_t *uset, void *info,
+    copyout_siginfo_t *copyout_siginfop)
+{
 	ksiginfo_t ksi;
 	sigset_t set;
 	int error;
 
-	error = copyin(uap->set, &set, sizeof(set));
+	error = copyin(uset, &set, sizeof(set));
 	if (error)
 		return (error);
 
@@ -1315,8 +1349,8 @@ sys_sigwaitinfo(struct thread *td, struct sigwaitinfo_args *uap)
 	if (error)
 		return (error);
 
-	if (uap->info)
-		error = copyout(&ksi.ksi_info, uap->info, sizeof(siginfo_t));
+	if (info)
+		error = copyout_siginfop(&ksi.ksi_info, info);
 
 	if (error == 0)
 		td->td_retval[0] = ksi.ksi_signo;
@@ -1478,6 +1512,12 @@ struct sigpending_args {
 int
 sys_sigpending(struct thread *td, struct sigpending_args *uap)
 {
+	return (kern_sigpending(td, uap->set));
+}
+
+int
+kern_sigpending(struct thread *td, sigset_t *set)
+{
 	struct proc *p = td->td_proc;
 	sigset_t pending;
 
@@ -1485,7 +1525,7 @@ sys_sigpending(struct thread *td, struct sigpending_args *uap)
 	pending = p->p_sigqueue.sq_signals;
 	SIGSETOR(pending, td->td_sigqueue.sq_signals);
 	PROC_UNLOCK(p);
-	return (copyout(&pending, uap->set, sizeof(sigset_t)));
+	return (copyout(&pending, set, sizeof(sigset_t)));
 }
 
 #ifdef COMPAT_43	/* XXX - COMPAT_FBSD3 */
@@ -1600,10 +1640,16 @@ struct sigsuspend_args {
 int
 sys_sigsuspend(struct thread *td, struct sigsuspend_args *uap)
 {
+	return (user_sigsuspend(td, uap->sigmask));
+}
+
+int
+user_sigsuspend(struct thread *td, const sigset_t *sigmask)
+{
 	sigset_t mask;
 	int error;
 
-	error = copyin(uap->sigmask, &mask, sizeof(mask));
+	error = copyin(sigmask, &mask, sizeof(mask));
 	if (error)
 		return (error);
 	return (kern_sigsuspend(td, mask));
@@ -3965,24 +4011,30 @@ sigfastblock_resched(struct thread *td, bool resched)
 int
 sys_sigfastblock(struct thread *td, struct sigfastblock_args *uap)
 {
+	return (kern_sigfastblock(td, uap->cmd, uap->ptr));
+}
+
+int
+kern_sigfastblock(struct thread *td, int cmd, uint32_t *ptr)
+{
 	struct proc *p;
 	int error, res;
 	uint32_t oldval;
 
 	error = 0;
 	p = td->td_proc;
-	switch (uap->cmd) {
+	switch (cmd) {
 	case SIGFASTBLOCK_SETPTR:
 		if ((td->td_pflags & TDP_SIGFASTBLOCK) != 0) {
 			error = EBUSY;
 			break;
 		}
-		if (((uintptr_t)(uap->ptr) & (sizeof(uint32_t) - 1)) != 0) {
+		if (((uintptr_t)(ptr) & (sizeof(uint32_t) - 1)) != 0) {
 			error = EINVAL;
 			break;
 		}
 		td->td_pflags |= TDP_SIGFASTBLOCK;
-		td->td_sigblock_ptr = uap->ptr;
+		td->td_sigblock_ptr = ptr;
 		break;
 
 	case SIGFASTBLOCK_UNBLOCK:

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -2459,7 +2459,7 @@ kern_sysctl(struct thread *td, const int *uname, u_int namelen, void *old,
 	if (namelen > CTL_MAXNAME || namelen < 2)
 		return (EINVAL);
 
-	error = copyin(name, &name, namelen * sizeof(int));
+	error = copyin(uname, &name, namelen * sizeof(int));
 	if (error)
 		return (error);
 

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -58,6 +58,7 @@
 #include <sys/rmlock.h>
 #include <sys/sbuf.h>
 #include <sys/sx.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysproto.h>
 #include <sys/uio.h>
 #ifdef KTRACE
@@ -2444,23 +2445,30 @@ struct __sysctl_args {
 int
 sys___sysctl(struct thread *td, struct __sysctl_args *uap)
 {
+	return (kern_sysctl(td, uap->name, uap->namelen, uap->old,
+	    uap->oldlenp, uap->new, uap->newlen, 0));
+}
+
+int
+kern_sysctl(struct thread *td, const int *uname, u_int namelen, void *old,
+    size_t *oldlenp, const void *new, size_t newlen, int flags)
+{
 	int error, i, name[CTL_MAXNAME];
 	size_t j;
 
-	if (uap->namelen > CTL_MAXNAME || uap->namelen < 2)
+	if (namelen > CTL_MAXNAME || namelen < 2)
 		return (EINVAL);
 
- 	error = copyin(uap->name, &name, uap->namelen * sizeof(int));
- 	if (error)
+	error = copyin(name, &name, namelen * sizeof(int));
+	if (error)
 		return (error);
 
-	error = userland_sysctl(td, name, uap->namelen,
-		uap->old, uap->oldlenp, 0,
-		uap->new, uap->newlen, &j, 0);
+	error = userland_sysctl(td, name, namelen, old, oldlenp, 0,
+	    new, newlen, &j, flags);
 	if (error && error != ENOMEM)
 		return (error);
-	if (uap->oldlenp) {
-		i = copyout(&j, uap->oldlenp, sizeof(j));
+	if (oldlenp) {
+		i = copyout(&j, oldlenp, sizeof(j));
 		if (i)
 			return (i);
 	}

--- a/sys/kern/kern_thr.c
+++ b/sys/kern/kern_thr.c
@@ -606,6 +606,12 @@ sys_thr_wake(struct thread *td, struct thr_wake_args *uap)
 int
 sys_thr_set_name(struct thread *td, struct thr_set_name_args *uap)
 {
+	return (kern_thr_set_name(td, uap->id, uap->name));
+}
+
+int
+kern_thr_set_name(struct thread *td, lwpid_t id, const char *uname)
+{
 	struct proc *p;
 	char name[MAXCOMLEN + 1];
 	struct thread *ttd;
@@ -613,17 +619,17 @@ sys_thr_set_name(struct thread *td, struct thr_set_name_args *uap)
 
 	error = 0;
 	name[0] = '\0';
-	if (uap->name != NULL) {
-		error = copyinstr(uap->name, name, sizeof(name), NULL);
+	if (uname != NULL) {
+		error = copyinstr(uname, name, sizeof(name), NULL);
 		if (error == ENAMETOOLONG) {
-			error = copyin(uap->name, name, sizeof(name) - 1);
+			error = copyin(uname, name, sizeof(name) - 1);
 			name[sizeof(name) - 1] = '\0';
 		}
 		if (error)
 			return (error);
 	}
 	p = td->td_proc;
-	ttd = tdfind((lwpid_t)uap->id, p->p_pid);
+	ttd = tdfind(id, p->p_pid);
 	if (ttd == NULL)
 		return (ESRCH);
 	strcpy(ttd->td_name, name);

--- a/sys/kern/kern_time.c
+++ b/sys/kern/kern_time.c
@@ -86,9 +86,6 @@ static uma_zone_t	itimer_zone = NULL;
 
 static int	settime(struct thread *, struct timeval *);
 static void	timevalfix(struct timeval *);
-static int	user_clock_nanosleep(struct thread *td, clockid_t clock_id,
-		    int flags, const struct timespec *ua_rqtp,
-		    struct timespec *ua_rmtp);
 
 static void	itimer_start(void *);
 static int	itimer_init(void *, int, int);
@@ -631,7 +628,6 @@ struct nanosleep_args {
 int
 sys_nanosleep(struct thread *td, struct nanosleep_args *uap)
 {
-
 	return (user_clock_nanosleep(td, CLOCK_REALTIME, TIMER_RELTIME,
 	    uap->rqtp, uap->rmtp));
 }
@@ -655,7 +651,7 @@ sys_clock_nanosleep(struct thread *td, struct clock_nanosleep_args *uap)
 	return (kern_posix_error(td, error));
 }
 
-static int
+int
 user_clock_nanosleep(struct thread *td, clockid_t clock_id, int flags,
     const struct timespec *ua_rqtp, struct timespec *ua_rmtp)
 {
@@ -684,18 +680,24 @@ struct gettimeofday_args {
 int
 sys_gettimeofday(struct thread *td, struct gettimeofday_args *uap)
 {
+	return (kern_gettimeofday(td, uap->tp, uap->tzp));
+}
+
+int
+kern_gettimeofday(struct thread *td, struct timeval *tp, struct timezone *tzp)
+{
 	struct timeval atv;
 	struct timezone rtz;
 	int error = 0;
 
-	if (uap->tp) {
+	if (tp) {
 		microtime(&atv);
-		error = copyout(&atv, uap->tp, sizeof (atv));
+		error = copyout(&atv, tp, sizeof(atv));
 	}
-	if (error == 0 && uap->tzp != NULL) {
+	if (error == 0 && tzp != NULL) {
 		rtz.tz_minuteswest = 0;
 		rtz.tz_dsttime = 0;
-		error = copyout(&rtz, uap->tzp, sizeof (rtz));
+		error = copyout(&rtz, tzp, sizeof(rtz));
 	}
 	return (error);
 }
@@ -710,19 +712,26 @@ struct settimeofday_args {
 int
 sys_settimeofday(struct thread *td, struct settimeofday_args *uap)
 {
+	return (user_settimeofday(td, uap->tv, uap->tzp));
+}
+
+int
+user_settimeofday(struct thread *td, const struct timeval *tv,
+    const struct timezone *tz)
+{
 	struct timeval atv, *tvp;
 	struct timezone atz, *tzp;
 	int error;
 
-	if (uap->tv) {
-		error = copyin(uap->tv, &atv, sizeof(atv));
+	if (tv) {
+		error = copyin(tv, &atv, sizeof(atv));
 		if (error)
 			return (error);
 		tvp = &atv;
 	} else
 		tvp = NULL;
-	if (uap->tzp) {
-		error = copyin(uap->tzp, &atz, sizeof(atz));
+	if (tz) {
+		error = copyin(tz, &atz, sizeof(atz));
 		if (error)
 			return (error);
 		tzp = &atz;

--- a/sys/kern/kern_uuid.c
+++ b/sys/kern/kern_uuid.c
@@ -34,6 +34,7 @@
 #include <sys/mutex.h>
 #include <sys/sbuf.h>
 #include <sys/socket.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysproto.h>
 #include <sys/systm.h>
 #include <sys/jail.h>
@@ -176,8 +177,13 @@ struct uuidgen_args {
 int
 sys_uuidgen(struct thread *td, struct uuidgen_args *uap)
 {
+	return (user_uuidgen(td, uap->store, uap->count));
+}
+
+int
+user_uuidgen(struct thread *td, struct uuid *ustore, int count)
+{
 	struct uuid *store;
-	size_t count;
 	int error;
 
 	/*
@@ -186,13 +192,12 @@ sys_uuidgen(struct thread *td, struct uuidgen_args *uap)
 	 * like to have some sort of upper-bound that's less than 2G :-)
 	 * XXX probably needs to be tunable.
 	 */
-	if (uap->count < 1 || uap->count > UUIDGEN_BATCH_MAX)
+	if (count < 1 || count > UUIDGEN_BATCH_MAX)
 		return (EINVAL);
 
-	count = uap->count;
 	store = malloc(count * sizeof(struct uuid), M_TEMP, M_WAITOK);
 	kern_uuidgen(store, count);
-	error = copyout(store, uap->store, count * sizeof(struct uuid));
+	error = copyout(store, ustore, count * sizeof(struct uuid));
 	free(store, M_TEMP);
 	return (error);
 }

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -468,6 +468,23 @@ copyinuio(const struct iovec *iovp, u_int iovcnt, struct uio **uiop)
 	return (0);
 }
 
+/*
+ * Update the lengths of a userspace iovec to match those in a struct uio's
+ * iovec (previously created by copyinuio).
+ */
+int
+updateiov(const struct uio *uiop, struct iovec *iovp)
+{
+	int i, error;
+
+	for (i = 0; i < uiop->uio_iovcnt; i++) {
+		error = suword(&iovp[i].iov_len, uiop->uio_iov[i].iov_len);
+		if (error != 0)
+			return (EFAULT);
+	}
+	return (0);
+}
+
 struct uio *
 allocuio(u_int iovcnt)
 {

--- a/sys/kern/sys_generic.c
+++ b/sys/kern/sys_generic.c
@@ -191,19 +191,25 @@ struct read_args {
 int
 sys_read(struct thread *td, struct read_args *uap)
 {
+	return (user_read(td, uap->fd, uap->buf, uap->nbyte));
+}
+
+int
+user_read(struct thread *td, int fd, void *buf, size_t nbyte)
+{
 	struct uio auio;
 	struct iovec aiov;
 	int error;
 
-	if (uap->nbyte > IOSIZE_MAX)
+	if (nbyte > IOSIZE_MAX)
 		return (EXTERROR(EINVAL, "length > iosize_max"));
-	aiov.iov_base = uap->buf;
-	aiov.iov_len = uap->nbyte;
+	aiov.iov_base = buf;
+	aiov.iov_len = nbyte;
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	auio.uio_resid = uap->nbyte;
+	auio.uio_resid = nbyte;
 	auio.uio_segflg = UIO_USERSPACE;
-	error = kern_readv(td, uap->fd, &auio);
+	error = kern_readv(td, fd, &auio);
 	return (error);
 }
 
@@ -222,7 +228,6 @@ struct pread_args {
 int
 sys_pread(struct thread *td, struct pread_args *uap)
 {
-
 	return (kern_pread(td, uap->fd, uap->buf, uap->nbyte, uap->offset));
 }
 
@@ -267,13 +272,20 @@ struct readv_args {
 int
 sys_readv(struct thread *td, struct readv_args *uap)
 {
+	return (user_readv(td, uap->fd, uap->iovp, uap->iovcnt, copyinuio));
+}
+
+int
+user_readv(struct thread *td, int fd, const struct iovec *iovp, u_int iovcnt,
+    copyinuio_t *copyinuio_f)
+{
 	struct uio *auio;
 	int error;
 
-	error = copyinuio(uap->iovp, uap->iovcnt, &auio);
+	error = copyinuio_f(iovp, iovcnt, &auio);
 	if (error)
 		return (error);
-	error = kern_readv(td, uap->fd, auio);
+	error = kern_readv(td, fd, auio);
 	freeuio(auio);
 	return (error);
 }
@@ -306,13 +318,21 @@ struct preadv_args {
 int
 sys_preadv(struct thread *td, struct preadv_args *uap)
 {
+	return (user_preadv(td, uap->fd, uap->iovp, uap->iovcnt, uap->offset,
+	    copyinuio));
+}
+
+int
+user_preadv(struct thread *td, int fd, struct iovec *iovp, u_int iovcnt,
+    off_t offset, copyinuio_t *copyinuio_f)
+{
 	struct uio *auio;
 	int error;
 
-	error = copyinuio(uap->iovp, uap->iovcnt, &auio);
+	error = copyinuio_f(iovp, iovcnt, &auio);
 	if (error)
 		return (error);
-	error = kern_preadv(td, uap->fd, auio, uap->offset);
+	error = kern_preadv(td, fd, auio, offset);
 	freeuio(auio);
 	return (error);
 }
@@ -392,19 +412,25 @@ struct write_args {
 int
 sys_write(struct thread *td, struct write_args *uap)
 {
+	return (kern_write(td, uap->fd, uap->buf, uap->nbyte));
+}
+
+int
+kern_write(struct thread *td, int fd, const void *buf, size_t nbyte)
+{
 	struct uio auio;
 	struct iovec aiov;
 	int error;
 
-	if (uap->nbyte > IOSIZE_MAX)
+	if (nbyte > IOSIZE_MAX)
 		return (EXTERROR(EINVAL, "length > iosize_max"));
-	aiov.iov_base = (void *)(uintptr_t)uap->buf;
-	aiov.iov_len = uap->nbyte;
+	aiov.iov_base = (void *)(uintptr_t)buf;
+	aiov.iov_len = nbyte;
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	auio.uio_resid = uap->nbyte;
+	auio.uio_resid = nbyte;
 	auio.uio_segflg = UIO_USERSPACE;
-	error = kern_writev(td, uap->fd, &auio);
+	error = kern_writev(td, fd, &auio);
 	return (error);
 }
 
@@ -423,7 +449,6 @@ struct pwrite_args {
 int
 sys_pwrite(struct thread *td, struct pwrite_args *uap)
 {
-
 	return (kern_pwrite(td, uap->fd, uap->buf, uap->nbyte, uap->offset));
 }
 
@@ -469,13 +494,20 @@ struct writev_args {
 int
 sys_writev(struct thread *td, struct writev_args *uap)
 {
+	return (user_writev(td, uap->fd, uap->iovp, uap->iovcnt, copyinuio));
+}
+
+int
+user_writev(struct thread *td, int fd, const struct iovec *iovp, u_int iovcnt,
+    copyinuio_t *copyinuio_f)
+{
 	struct uio *auio;
 	int error;
 
-	error = copyinuio(uap->iovp, uap->iovcnt, &auio);
+	error = copyinuio_f(iovp, iovcnt, &auio);
 	if (error)
 		return (error);
-	error = kern_writev(td, uap->fd, auio);
+	error = kern_writev(td, fd, auio);
 	freeuio(auio);
 	return (error);
 }
@@ -508,13 +540,21 @@ struct pwritev_args {
 int
 sys_pwritev(struct thread *td, struct pwritev_args *uap)
 {
+	return (user_pwritev(td, uap->fd, uap->iovp, uap->iovcnt, uap->offset,
+	    copyinuio));
+}
+
+int
+user_pwritev(struct thread *td, int fd, struct iovec *iovp, u_int iovcnt,
+    off_t offset, copyinuio_t *copyinuio_f)
+{
 	struct uio *auio;
 	int error;
 
-	error = copyinuio(uap->iovp, uap->iovcnt, &auio);
+	error = copyinuio_f(iovp, iovcnt, &auio);
 	if (error)
 		return (error);
-	error = kern_pwritev(td, uap->fd, auio, uap->offset);
+	error = kern_pwritev(td, fd, auio, offset);
 	freeuio(auio);
 	return (error);
 }
@@ -627,7 +667,6 @@ struct ftruncate_args {
 int
 sys_ftruncate(struct thread *td, struct ftruncate_args *uap)
 {
-
 	return (kern_ftruncate(td, uap->fd, uap->length));
 }
 
@@ -657,6 +696,12 @@ struct ioctl_args {
 int
 sys_ioctl(struct thread *td, struct ioctl_args *uap)
 {
+	return (user_ioctl(td, uap->fd, uap->com, uap->data, &uap->data));
+}
+
+int
+user_ioctl(struct thread *td, int fd, u_long ucom, void *udata, void *datap)
+{
 	u_char smalldata[SYS_IOCTL_SMALL_SIZE] __aligned(SYS_IOCTL_SMALL_ALIGN);
 	uint32_t com;
 	int arg, error;
@@ -664,14 +709,14 @@ sys_ioctl(struct thread *td, struct ioctl_args *uap)
 	caddr_t data;
 
 #ifdef INVARIANTS
-	if (uap->com > 0xffffffff) {
+	if (ucom > 0xffffffff) {
 		printf(
 		    "WARNING pid %d (%s): ioctl sign-extension ioctl %lx\n",
-		    td->td_proc->p_pid, td->td_name, uap->com);
+		    td->td_proc->p_pid, td->td_name, ucom);
 	}
 #endif
-	com = (uint32_t)uap->com;
 
+	com = (uint32_t)ucom;
 	/*
 	 * Interpret high order word to find amount of data to be
 	 * copied to/from the user's address space.
@@ -690,7 +735,7 @@ sys_ioctl(struct thread *td, struct ioctl_args *uap)
 	if (size > 0) {
 		if (com & IOC_VOID) {
 			/* Integer argument. */
-			arg = (intptr_t)uap->data;
+			arg = (intptr_t)udata;
 			data = (void *)&arg;
 			size = 0;
 		} else {
@@ -700,9 +745,9 @@ sys_ioctl(struct thread *td, struct ioctl_args *uap)
 				data = smalldata;
 		}
 	} else
-		data = (void *)&uap->data;
+		data = datap;
 	if (com & IOC_IN) {
-		error = copyin(uap->data, data, (u_int)size);
+		error = copyin(udata, data, size);
 		if (error != 0)
 			goto out;
 	} else if (com & IOC_OUT) {
@@ -713,10 +758,10 @@ sys_ioctl(struct thread *td, struct ioctl_args *uap)
 		bzero(data, size);
 	}
 
-	error = kern_ioctl(td, uap->fd, com, data);
+	error = kern_ioctl(td, fd, com, data);
 
 	if (error == 0 && (com & IOC_OUT))
-		error = copyout(data, uap->data, (u_int)size);
+		error = copyout(data, udata, (u_int)size);
 
 out:
 	if (size > SYS_IOCTL_SMALL_SIZE)
@@ -877,17 +922,26 @@ kern_posix_fallocate(struct thread *td, int fd, off_t offset, off_t len)
 int
 sys_fspacectl(struct thread *td, struct fspacectl_args *uap)
 {
+	return (user_fspacectl(td, uap->fd, uap->cmd, uap->rqsr, uap->flags,
+	    uap->rmsr));
+}
+
+int
+user_fspacectl(struct thread *td, int fd, int cmd,
+    const struct spacectl_range *rqsrp, int flags,
+    struct spacectl_range *rmsrp)
+{
 	struct spacectl_range rqsr, rmsr;
 	int error, cerror;
 
-	error = copyin(uap->rqsr, &rqsr, sizeof(rqsr));
+	error = copyin(rqsrp, &rqsr, sizeof(rqsr));
 	if (error != 0)
 		return (error);
 
-	error = kern_fspacectl(td, uap->fd, uap->cmd, &rqsr, uap->flags,
+	error = kern_fspacectl(td, fd, cmd, &rqsr, flags,
 	    &rmsr);
-	if (uap->rmsr != NULL) {
-		cerror = copyout(&rmsr, uap->rmsr, sizeof(rmsr));
+	if (rmsrp != NULL) {
+		cerror = copyout(&rmsr, rmsrp, sizeof(rmsr));
 		if (error == 0)
 			error = cerror;
 	}
@@ -991,19 +1045,25 @@ kern_specialfd(struct thread *td, int type, void *arg)
 }
 
 int
-sys___specialfd(struct thread *td, struct __specialfd_args *args)
+sys___specialfd(struct thread *td, struct __specialfd_args *uap)
+{
+	return (user___specialfd(td, uap->type, uap->req, uap->len));
+}
+
+int
+user___specialfd(struct thread *td, int type, const void *req, size_t len)
 {
 	int error;
 
-	switch (args->type) {
+	switch (type) {
 	case SPECIALFD_EVENTFD: {
 		struct specialfd_eventfd ae;
 
-		if (args->len != sizeof(struct specialfd_eventfd)) {
+		if (len != sizeof(struct specialfd_eventfd)) {
 			error = EXTERROR(EINVAL, "eventfd params ABI");
 			break;
 		}
-		error = copyin(args->req, &ae, sizeof(ae));
+		error = copyin(req, &ae, sizeof(ae));
 		if (error != 0)
 			break;
 		if ((ae.flags & ~(EFD_CLOEXEC | EFD_NONBLOCK |
@@ -1011,24 +1071,24 @@ sys___specialfd(struct thread *td, struct __specialfd_args *args)
 			error = EXTERROR(EINVAL, "reserved flag");
 			break;
 		}
-		error = kern_specialfd(td, args->type, &ae);
+		error = kern_specialfd(td, type, &ae);
 		break;
 	}
 	case SPECIALFD_INOTIFY: {
 		struct specialfd_inotify si;
 
-		if (args->len != sizeof(si)) {
+		if (len != sizeof(si)) {
 			error = EINVAL;
 			break;
 		}
-		error = copyin(args->req, &si, sizeof(si));
+		error = copyin(req, &si, sizeof(si));
 		if (error != 0)
 			break;
-		error = kern_specialfd(td, args->type, &si);
+		error = kern_specialfd(td, type, &si);
 		break;
 	}
 	default:
-		error = EXTERROR(EINVAL, "unknown type", args->type);
+		error = EXTERROR(EINVAL, "unknown type", type);
 		break;
 	}
 	return (error);
@@ -1053,28 +1113,35 @@ poll_no_poll(int events)
 int
 sys_pselect(struct thread *td, struct pselect_args *uap)
 {
+	return (user_pselect(td, uap->nd, uap->in, uap->ou, uap->ex, uap->ts,
+	    uap->sm));
+}
+
+int
+user_pselect(struct thread *td, int nd, fd_set *in, fd_set *ou, fd_set *ex,
+    const struct timespec *uts, const sigset_t *sm)
+{
 	struct timespec ts;
 	struct timeval tv, *tvp;
 	sigset_t set, *uset;
 	int error;
 
-	if (uap->ts != NULL) {
-		error = copyin(uap->ts, &ts, sizeof(ts));
+	if (uts != NULL) {
+		error = copyin(uts, &ts, sizeof(ts));
 		if (error != 0)
 		    return (error);
 		TIMESPEC_TO_TIMEVAL(&tv, &ts);
 		tvp = &tv;
 	} else
 		tvp = NULL;
-	if (uap->sm != NULL) {
-		error = copyin(uap->sm, &set, sizeof(set));
+	if (sm != NULL) {
+		error = copyin(sm, &set, sizeof(set));
 		if (error != 0)
 			return (error);
 		uset = &set;
 	} else
 		uset = NULL;
-	return (kern_pselect(td, uap->nd, uap->in, uap->ou, uap->ex, tvp,
-	    uset, NFDBITS));
+	return (kern_pselect(td, nd, in, ou, ex, tvp, uset, NFDBITS));
 }
 
 int
@@ -1122,19 +1189,25 @@ struct select_args {
 int
 sys_select(struct thread *td, struct select_args *uap)
 {
+	return (user_select(td, uap->nd, uap->in, uap->ou, uap->ex, uap->tv));
+}
+
+int
+user_select(struct thread *td, int nd, fd_set *in, fd_set *ou, fd_set *ex,
+    struct timeval *utv)
+{
 	struct timeval tv, *tvp;
 	int error;
 
-	if (uap->tv != NULL) {
-		error = copyin(uap->tv, &tv, sizeof(tv));
+	if (utv != NULL) {
+		error = copyin(utv, &tv, sizeof(tv));
 		if (error)
 			return (error);
 		tvp = &tv;
 	} else
 		tvp = NULL;
 
-	return (kern_select(td, uap->nd, uap->in, uap->ou, uap->ex, tvp,
-	    NFDBITS));
+	return (kern_select(td, nd, in, ou, ex, tvp, NFDBITS));
 }
 
 /*
@@ -1525,18 +1598,24 @@ selscan(struct thread *td, fd_mask **ibits, fd_mask **obits, int nfd)
 int
 sys_poll(struct thread *td, struct poll_args *uap)
 {
+	return (user_poll(td, uap->fds, uap->nfds, uap->timeout));
+}
+
+int
+user_poll(struct thread *td, struct pollfd *fds, u_int nfds, int timeout)
+{
 	struct timespec ts, *tsp;
 
-	if (uap->timeout != INFTIM) {
-		if (uap->timeout < 0)
+	if (timeout != INFTIM) {
+		if (timeout < 0)
 			return (EXTERROR(EINVAL, "invalid timeout"));
-		ts.tv_sec = uap->timeout / 1000;
-		ts.tv_nsec = (uap->timeout % 1000) * 1000000;
+		ts.tv_sec = timeout / 1000;
+		ts.tv_nsec = (timeout % 1000) * 1000000;
 		tsp = &ts;
 	} else
 		tsp = NULL;
 
-	return (kern_poll(td, uap->fds, uap->nfds, tsp, NULL));
+	return (kern_poll(td, fds, nfds, tsp, NULL));
 }
 
 /*
@@ -1624,25 +1703,32 @@ kern_poll_kfds(struct thread *td, struct pollfd *kfds, u_int nfds,
 int
 sys_ppoll(struct thread *td, struct ppoll_args *uap)
 {
+	return (user_ppoll(td, uap->fds, uap->nfds, uap->ts, uap->set));
+}
+
+int
+user_ppoll(struct thread *td, struct pollfd *fds, u_int nfds,
+    const struct timespec *uts, const sigset_t *uset)
+{
 	struct timespec ts, *tsp;
 	sigset_t set, *ssp;
 	int error;
 
-	if (uap->ts != NULL) {
-		error = copyin(uap->ts, &ts, sizeof(ts));
+	if (uts != NULL) {
+		error = copyin(uts, &ts, sizeof(ts));
 		if (error)
 			return (error);
 		tsp = &ts;
 	} else
 		tsp = NULL;
-	if (uap->set != NULL) {
-		error = copyin(uap->set, &set, sizeof(set));
+	if (uset != NULL) {
+		error = copyin(uset, &set, sizeof(set));
 		if (error)
 			return (error);
 		ssp = &set;
 	} else
 		ssp = NULL;
-	return (kern_poll(td, uap->fds, uap->nfds, tsp, ssp));
+	return (kern_poll(td, fds, nfds, tsp, ssp));
 }
 
 /*

--- a/sys/kern/sys_getrandom.c
+++ b/sys/kern/sys_getrandom.c
@@ -31,6 +31,7 @@
 #include <sys/limits.h>
 #include <sys/proc.h>
 #include <sys/random.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysproto.h>
 #include <sys/systm.h>
 #include <sys/uio.h>
@@ -44,7 +45,7 @@
  */
 CTASSERT(EWOULDBLOCK == EAGAIN);
 
-static int
+int
 kern_getrandom(struct thread *td, void *user_buf, size_t buflen,
     unsigned int flags)
 {

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -541,14 +541,20 @@ freebsd10_pipe(struct thread *td, struct freebsd10_pipe_args *uap __unused)
 int
 sys_pipe2(struct thread *td, struct pipe2_args *uap)
 {
+	return (kern_pipe2(td, uap->fildes, uap->flags));
+}
+
+int
+kern_pipe2(struct thread *td, int *ufildes, int flags)
+{
 	int error, fildes[2];
 
-	if ((uap->flags & ~(O_CLOEXEC | O_CLOFORK | O_NONBLOCK)) != 0)
+	if ((flags & ~(O_CLOEXEC | O_CLOFORK | O_NONBLOCK)) != 0)
 		return (EINVAL);
-	error = kern_pipe(td, fildes, uap->flags, NULL, NULL);
+	error = kern_pipe(td, fildes, flags, NULL, NULL);
 	if (error)
 		return (error);
-	error = copyout(fildes, uap->fildes, 2 * sizeof(int));
+	error = copyout(fildes, ufildes, 2 * sizeof(int));
 	if (error) {
 		(void)kern_close(td, fildes[0]);
 		(void)kern_close(td, fildes[1]);

--- a/sys/kern/sys_procdesc.c
+++ b/sys/kern/sys_procdesc.c
@@ -191,13 +191,19 @@ out:
 int
 sys_pdgetpid(struct thread *td, struct pdgetpid_args *uap)
 {
+	return (user_pdgetpid(td, uap->fd, uap->pidp));
+}
+
+int
+user_pdgetpid(struct thread *td, int fd, pid_t *pidp)
+{
 	pid_t pid;
 	int error;
 
-	AUDIT_ARG_FD(uap->fd);
-	error = kern_pdgetpid(td, uap->fd, &cap_pdgetpid_rights, &pid);
+	AUDIT_ARG_FD(fd);
+	error = kern_pdgetpid(td, fd, &cap_pdgetpid_rights, &pid);
 	if (error == 0)
-		error = copyout(&pid, uap->pidp, sizeof(pid));
+		error = copyout(&pid, pidp, sizeof(pid));
 	return (error);
 }
 

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -464,7 +464,7 @@ kern_shmat_locked(struct thread *td, int shmid, const void *shmaddr,
 	return (error);
 }
 
-int
+static int
 kern_shmat(struct thread *td, int shmid, const void *shmaddr, int shmflg)
 {
 	int error;

--- a/sys/kern/uipc_shm.c
+++ b/sys/kern/uipc_shm.c
@@ -1406,11 +1406,17 @@ freebsd12_shm_open(struct thread *td, struct freebsd12_shm_open_args *uap)
 int
 sys_shm_unlink(struct thread *td, struct shm_unlink_args *uap)
 {
+	return (kern_shm_unlink(td, uap->path));
+}
+
+int
+kern_shm_unlink(struct thread *td, const char *userpath)
+{
 	char *path;
 	Fnv32_t fnv;
 	int error;
 
-	error = shm_copyin_path(td, uap->path, &path);
+	error = shm_copyin_path(td, userpath, &path);
 	if (error != 0)
 		return (error);
 
@@ -1427,14 +1433,19 @@ sys_shm_unlink(struct thread *td, struct shm_unlink_args *uap)
 int
 sys_shm_rename(struct thread *td, struct shm_rename_args *uap)
 {
+	return (kern_shm_rename(td, uap->path_from, uap->path_to, uap->flags));
+}
+
+int
+kern_shm_rename(struct thread *td, const char *path_from_p,
+    const char *path_to_p, int flags)
+{
 	char *path_from = NULL, *path_to = NULL;
 	Fnv32_t fnv_from, fnv_to;
 	struct shmfd *fd_from;
 	struct shmfd *fd_to;
 	int error;
-	int flags;
 
-	flags = uap->flags;
 	AUDIT_ARG_FFLAGS(flags);
 
 	/*
@@ -1460,16 +1471,16 @@ sys_shm_rename(struct thread *td, struct shm_rename_args *uap)
 	}
 
 	/* Renaming to or from anonymous makes no sense */
-	if (uap->path_from == SHM_ANON || uap->path_to == SHM_ANON) {
+	if (path_from_p == SHM_ANON || path_to_p == SHM_ANON) {
 		error = EINVAL;
 		goto out;
 	}
 
-	error = shm_copyin_path(td, uap->path_from, &path_from);
+	error = shm_copyin_path(td, path_from_p, &path_from);
 	if (error != 0)
 		goto out;
 
-	error = shm_copyin_path(td, uap->path_to, &path_to);
+	error = shm_copyin_path(td, path_to_p, &path_to);
 	if (error != 0)
 		goto out;
 

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -71,11 +71,8 @@
 #include <security/audit/audit.h>
 #include <security/mac/mac_framework.h>
 
-static int sendit(struct thread *td, int s, struct msghdr *mp, int flags);
 static int recvit(struct thread *td, int s, struct msghdr *mp, void *namelenp);
 
-static int accept1(struct thread *td, int s, struct sockaddr *uname,
-		   socklen_t *anamelen, int flags);
 static int sockargs(struct mbuf **, char *, socklen_t, int);
 
 /*
@@ -185,12 +182,19 @@ kern_socket(struct thread *td, int domain, int type, int protocol)
 int
 sys_bind(struct thread *td, struct bind_args *uap)
 {
+	return (user_bind(td, uap->s, uap->name, uap->namelen));
+}
+
+int
+user_bind(struct thread *td, int s, const struct sockaddr *name,
+    socklen_t namelen)
+{
 	struct sockaddr *sa;
 	int error;
 
-	error = getsockaddr(&sa, uap->name, uap->namelen);
+	error = getsockaddr(&sa, name, namelen);
 	if (error == 0) {
-		error = kern_bindat(td, AT_FDCWD, uap->s, sa);
+		error = kern_bindat(td, AT_FDCWD, s, sa);
 		free(sa, M_SONAME);
 	}
 	return (error);
@@ -240,12 +244,19 @@ kern_bindat(struct thread *td, int dirfd, int fd, struct sockaddr *sa)
 int
 sys_bindat(struct thread *td, struct bindat_args *uap)
 {
+	return (user_bindat(td, uap->fd, uap->s, uap->name, uap->namelen));
+}
+
+int
+user_bindat(struct thread *td, int fd, int s, const struct sockaddr *name,
+    socklen_t namelen)
+{
 	struct sockaddr *sa;
 	int error;
 
-	error = getsockaddr(&sa, uap->name, uap->namelen);
+	error = getsockaddr(&sa, name, namelen);
 	if (error == 0) {
-		error = kern_bindat(td, uap->fd, uap->s, sa);
+		error = kern_bindat(td, fd, s, sa);
 		free(sa, M_SONAME);
 	}
 	return (error);
@@ -254,7 +265,6 @@ sys_bindat(struct thread *td, struct bindat_args *uap)
 int
 sys_listen(struct thread *td, struct listen_args *uap)
 {
-
 	return (kern_listen(td, uap->s, uap->backlog));
 }
 
@@ -279,12 +289,9 @@ kern_listen(struct thread *td, int s, int backlog)
 	return (error);
 }
 
-/*
- * accept1()
- */
-static int
-accept1(struct thread *td, int s, struct sockaddr *uname, socklen_t *anamelen,
-    int flags)
+int
+user_accept(struct thread *td, int s, struct sockaddr *uname,
+    socklen_t *anamelen, int flags)
 {
 	struct sockaddr_storage ss = { .ss_len = sizeof(ss) };
 	socklen_t addrlen;
@@ -432,26 +439,24 @@ done:
 int
 sys_accept(struct thread *td, struct accept_args *uap)
 {
-
-	return (accept1(td, uap->s, uap->name, uap->anamelen, ACCEPT4_INHERIT));
+	return (user_accept(td, uap->s, uap->name, uap->anamelen,
+	    ACCEPT4_INHERIT));
 }
 
 int
 sys_accept4(struct thread *td, struct accept4_args *uap)
 {
-
 	if ((uap->flags & ~(SOCK_CLOEXEC | SOCK_CLOFORK | SOCK_NONBLOCK)) != 0)
 		return (EINVAL);
 
-	return (accept1(td, uap->s, uap->name, uap->anamelen, uap->flags));
+	return (user_accept(td, uap->s, uap->name, uap->anamelen, uap->flags));
 }
 
 #ifdef COMPAT_OLDSOCK
 int
 oaccept(struct thread *td, struct oaccept_args *uap)
 {
-
-	return (accept1(td, uap->s, uap->name, uap->anamelen,
+	return (user_accept(td, uap->s, uap->name, uap->anamelen,
 	    ACCEPT4_INHERIT | ACCEPT4_COMPAT));
 }
 #endif /* COMPAT_OLDSOCK */
@@ -459,12 +464,19 @@ oaccept(struct thread *td, struct oaccept_args *uap)
 int
 sys_connect(struct thread *td, struct connect_args *uap)
 {
+	return (user_connectat(td, AT_FDCWD, uap->s, uap->name, uap->namelen));
+}
+
+int
+user_connectat(struct thread *td, int fd, int s, const struct sockaddr *name,
+    socklen_t namelen)
+{
 	struct sockaddr *sa;
 	int error;
 
-	error = getsockaddr(&sa, uap->name, uap->namelen);
+	error = getsockaddr(&sa, name, namelen);
 	if (error == 0) {
-		error = kern_connectat(td, AT_FDCWD, uap->s, sa);
+		error = kern_connectat(td, AT_FDCWD, s, sa);
 		free(sa, M_SONAME);
 	}
 	return (error);
@@ -535,15 +547,7 @@ done1:
 int
 sys_connectat(struct thread *td, struct connectat_args *uap)
 {
-	struct sockaddr *sa;
-	int error;
-
-	error = getsockaddr(&sa, uap->name, uap->namelen);
-	if (error == 0) {
-		error = kern_connectat(td, uap->fd, uap->s, sa);
-		free(sa, M_SONAME);
-	}
-	return (error);
+	return (user_connectat(td, uap->fd, uap->s, uap->name, uap->namelen));
 }
 
 int
@@ -643,13 +647,20 @@ free1:
 int
 sys_socketpair(struct thread *td, struct socketpair_args *uap)
 {
+	return (user_socketpair(td, uap->domain, uap->type, uap->protocol,
+	    uap->rsv));
+}
+
+int
+user_socketpair(struct thread *td, int domain, int type, int protocol,
+    int *rsv)
+{
 	int error, sv[2];
 
-	error = kern_socketpair(td, uap->domain, uap->type,
-	    uap->protocol, sv);
+	error = kern_socketpair(td, domain, type, protocol, sv);
 	if (error != 0)
 		return (error);
-	error = copyout(sv, uap->rsv, 2 * sizeof(int));
+	error = copyout(sv, rsv, 2 * sizeof(int));
 	if (error != 0) {
 		(void)kern_close(td, sv[0]);
 		(void)kern_close(td, sv[1]);
@@ -657,8 +668,8 @@ sys_socketpair(struct thread *td, struct socketpair_args *uap)
 	return (error);
 }
 
-static int
-sendit(struct thread *td, int s, struct msghdr *mp, int flags)
+int
+user_sendit(struct thread *td, int s, struct msghdr *mp, int flags)
 {
 	struct mbuf *control;
 	struct sockaddr *to;
@@ -806,11 +817,19 @@ bad:
 int
 sys_sendto(struct thread *td, struct sendto_args *uap)
 {
+	return (user_sendto(td, uap->s, uap->buf, uap->len, uap->flags,
+	    uap->to, uap->tolen));
+}
+
+int
+user_sendto(struct thread *td, int s, const char *buf, size_t len, int flags,
+    const struct sockaddr *to, socklen_t tolen)
+{
 	struct msghdr msg;
 	struct iovec aiov;
 
-	msg.msg_name = __DECONST(void *, uap->to);
-	msg.msg_namelen = uap->tolen;
+	msg.msg_name = __DECONST(void *, to);
+	msg.msg_namelen = tolen;
 	msg.msg_iov = &aiov;
 	msg.msg_iovlen = 1;
 	msg.msg_control = 0;
@@ -818,9 +837,9 @@ sys_sendto(struct thread *td, struct sendto_args *uap)
 	if (SV_PROC_FLAG(td->td_proc, SV_AOUT))
 		msg.msg_flags = 0;
 #endif
-	aiov.iov_base = __DECONST(void *, uap->buf);
-	aiov.iov_len = uap->len;
-	return (sendit(td, uap->s, &msg, uap->flags));
+	aiov.iov_base = __DECONST(void *, buf);
+	aiov.iov_len = len;
+	return (user_sendit(td, s, &msg, flags));
 }
 
 #ifdef COMPAT_OLDSOCK
@@ -838,7 +857,7 @@ osend(struct thread *td, struct osend_args *uap)
 	aiov.iov_len = uap->len;
 	msg.msg_control = 0;
 	msg.msg_flags = 0;
-	return (sendit(td, uap->s, &msg, uap->flags));
+	return (user_sendit(td, uap->s, &msg, uap->flags));
 }
 
 int
@@ -856,7 +875,7 @@ osendmsg(struct thread *td, struct osendmsg_args *uap)
 		return (error);
 	msg.msg_iov = iov;
 	msg.msg_flags = MSG_COMPAT;
-	error = sendit(td, uap->s, &msg, uap->flags);
+	error = user_sendit(td, uap->s, &msg, uap->flags);
 	free(iov, M_IOV);
 	return (error);
 }
@@ -880,7 +899,7 @@ sys_sendmsg(struct thread *td, struct sendmsg_args *uap)
 	if (SV_PROC_FLAG(td->td_proc, SV_AOUT))
 		msg.msg_flags = 0;
 #endif
-	error = sendit(td, uap->s, &msg, uap->flags);
+	error = user_sendit(td, uap->s, &msg, uap->flags);
 	free(iov, M_IOV);
 	return (error);
 }
@@ -1059,7 +1078,7 @@ recvit(struct thread *td, int s, struct msghdr *mp, void *namelenp)
 	return (error);
 }
 
-static int
+int
 kern_recvfrom(struct thread *td, int s, void *buf, size_t len, int flags,
     struct sockaddr *from, socklen_t *fromlenaddr)
 {
@@ -1270,20 +1289,28 @@ kern_setsockopt(struct thread *td, int s, int level, int name, const void *val,
 int
 sys_getsockopt(struct thread *td, struct getsockopt_args *uap)
 {
+	return (user_getsockopt(td, uap->s, uap->level, uap->name,
+	    uap->val, uap->avalsize));
+}
+
+int
+user_getsockopt(struct thread *td, int s, int level, int name, void *val,
+    socklen_t *avalsize)
+{
 	socklen_t valsize;
 	int error;
 
-	if (uap->val) {
-		error = copyin(uap->avalsize, &valsize, sizeof (valsize));
+	if (val != NULL) {
+		error = copyin(avalsize, &valsize, sizeof(valsize));
 		if (error != 0)
 			return (error);
 	}
 
-	error = kern_getsockopt(td, uap->s, uap->level, uap->name,
-	    uap->val, UIO_USERSPACE, &valsize);
+	error = kern_getsockopt(td, s, level, name, val, UIO_USERSPACE,
+	    &valsize);
 
 	if (error == 0)
-		error = copyout(&valsize, uap->avalsize, sizeof (valsize));
+		error = copyout(&valsize, avalsize, sizeof(valsize));
 	return (error);
 }
 
@@ -1334,7 +1361,7 @@ kern_getsockopt(struct thread *td, int s, int level, int name, void *val,
 	return (error);
 }
 
-static int
+int
 user_getsockname(struct thread *td, int fdes, struct sockaddr *asa,
     socklen_t *alen, bool compat)
 {
@@ -1398,7 +1425,7 @@ ogetsockname(struct thread *td, struct ogetsockname_args *uap)
 }
 #endif /* COMPAT_OLDSOCK */
 
-static int
+int
 user_getpeername(struct thread *td, int fdes, struct sockaddr *asa,
     socklen_t *alen, bool compat)
 {

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -330,6 +330,8 @@ static int	filt_aio(struct knote *kn, long hint);
 static int	filt_lioattach(struct knote *kn);
 static void	filt_liodetach(struct knote *kn);
 static int	filt_lio(struct knote *kn, long hint);
+static int	kern_aio_cancel(struct thread *td, int fd, struct aiocb *ujob,
+		    struct aiocb_ops *ops);
 
 /*
  * Zones for:
@@ -2042,6 +2044,13 @@ sys_aio_suspend(struct thread *td, struct aio_suspend_args *uap)
 int
 sys_aio_cancel(struct thread *td, struct aio_cancel_args *uap)
 {
+	return (kern_aio_cancel(td, uap->fd, uap->aiocbp, &aiocb_ops));
+}
+
+static int
+kern_aio_cancel(struct thread *td, int fd, struct aiocb *ujob,
+    struct aiocb_ops *ops)
+{
 	struct proc *p = td->td_proc;
 	struct kaioinfo *ki;
 	struct kaiocb *job, *jobn, marker;
@@ -2052,7 +2061,7 @@ sys_aio_cancel(struct thread *td, struct aio_cancel_args *uap)
 	struct vnode *vp;
 
 	/* Lookup file object. */
-	error = fget(td, uap->fd, &cap_no_rights, &fp);
+	error = fget(td, fd, &cap_no_rights, &fp);
 	if (error)
 		return (error);
 
@@ -2081,8 +2090,8 @@ sys_aio_cancel(struct thread *td, struct aio_cancel_args *uap)
 
 	AIO_LOCK(ki);
 	TAILQ_FOREACH_SAFE(job, &ki->kaio_jobqueue, plist, jobn) {
-		if (uap->fd == job->uaiocb.aio_fildes &&
-		    (uap->aiocbp == NULL || uap->aiocbp == job->ujob) &&
+		if (fd == job->uaiocb.aio_fildes &&
+		    (ujob == NULL || ujob == job->ujob) &&
 		    (job->jobflags & KAIOCB_MARKER) == 0) {
 			TAILQ_INSERT_AFTER(&ki->kaio_jobqueue, job, &marker,
 			    plist);
@@ -2093,7 +2102,7 @@ sys_aio_cancel(struct thread *td, struct aio_cancel_args *uap)
 			}
 			jobn = TAILQ_NEXT(&marker, plist);
 			TAILQ_REMOVE(&ki->kaio_jobqueue, &marker, plist);
-			if (uap->aiocbp != NULL)
+			if (ujob != NULL)
 				break;
 		}
 	}
@@ -2102,7 +2111,7 @@ sys_aio_cancel(struct thread *td, struct aio_cancel_args *uap)
 done:
 	fdrop(fp, td);
 
-	if (uap->aiocbp != NULL) {
+	if (ujob != NULL) {
 		if (cancelled) {
 			td->td_retval[0] = AIO_CANCELED;
 			return (0);

--- a/sys/kern/vfs_cache.c
+++ b/sys/kern/vfs_cache.c
@@ -3223,11 +3223,15 @@ vfs_cache_lookup(struct vop_lookup_args *ap)
 int
 sys___getcwd(struct thread *td, struct __getcwd_args *uap)
 {
+	return (kern___getcwd(td, uap->buf, uap->buflen));
+}
+
+int
+kern___getcwd(struct thread *td, char *ubuf, size_t buflen)
+{
 	char *buf, *retbuf;
-	size_t buflen;
 	int error;
 
-	buflen = uap->buflen;
 	if (__predict_false(buflen < 2))
 		return (EINVAL);
 	if (buflen > MAXPATHLEN)
@@ -3236,7 +3240,7 @@ sys___getcwd(struct thread *td, struct __getcwd_args *uap)
 	buf = uma_zalloc(namei_zone, M_WAITOK);
 	error = vn_getcwd(buf, &retbuf, &buflen);
 	if (error == 0)
-		error = copyout(retbuf, uap->buf, buflen);
+		error = copyout(retbuf, ubuf, buflen);
 	uma_zfree(namei_zone, buf);
 	return (error);
 }
@@ -3277,7 +3281,7 @@ vn_getcwd(char *buf, char **retbuf, size_t *buflen)
  *   walk in userspace. Moreover, the path we return is inaccessible if the
  *   calling thread lacks permission to traverse "quux".
  */
-static int
+int
 kern___realpathat(struct thread *td, int fd, const char *path, char *buf,
     size_t size, int flags, enum uio_seg pathseg)
 {

--- a/sys/kern/vfs_extattr.c
+++ b/sys/kern/vfs_extattr.c
@@ -34,6 +34,7 @@
 #include <sys/lock.h>
 #include <sys/mount.h>
 #include <sys/mutex.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysproto.h>
 #include <sys/fcntl.h>
 #include <sys/namei.h>
@@ -46,17 +47,6 @@
 
 #include <security/audit/audit.h>
 #include <security/mac/mac_framework.h>
-
-static int	user_extattr_set_path(struct thread *td, const char *path,
-		    int attrnamespace, const char *attrname, void *data,
-		    size_t nbytes, int follow);
-static int	user_extattr_get_path(struct thread *td, const char *path,
-		    int attrnamespace, const char *attrname, void *data,
-		    size_t nbytes, int follow);
-static int	user_extattr_delete_path(struct thread *td, const char *path,
-		    int attrnamespace, const char *attrname, int follow);
-static int	user_extattr_list_path(struct thread *td, const char *path,
-		    int attrnamespace, void *data, size_t nbytes, int follow);
 
 /*
  * Syscall to push extended attribute configuration information into the VFS.
@@ -77,20 +67,28 @@ struct extattrctl_args {
 int
 sys_extattrctl(struct thread *td, struct extattrctl_args *uap)
 {
+	return (kern_extattrctl(td, uap->path, uap->cmd, uap->filename,
+	    uap->attrnamespace, uap->attrname));
+}
+
+int
+kern_extattrctl(struct thread *td, const char *path, int cmd,
+    const char *filename, int attrnamespace, const char *uattrname)
+{
 	struct vnode *filename_vp;
 	struct nameidata nd;
 	struct mount *mp, *mp_writable;
 	char attrname[EXTATTR_MAXNAMELEN + 1];
 	int error;
 
-	AUDIT_ARG_CMD(uap->cmd);
-	AUDIT_ARG_VALUE(uap->attrnamespace);
+	AUDIT_ARG_CMD(cmd);
+	AUDIT_ARG_VALUE(attrnamespace);
 	/*
-	 * uap->attrname is not always defined.  We check again later when we
+	 * attrname is not always defined.  We check again later when we
 	 * invoke the VFS call so as to pass in NULL there if needed.
 	 */
-	if (uap->attrname != NULL) {
-		error = copyinstr(uap->attrname, attrname, sizeof(attrname),
+	if (uattrname != NULL) {
+		error = copyinstr(uattrname, attrname, sizeof(attrname),
 		    NULL);
 		if (error)
 			return (error);
@@ -99,9 +97,9 @@ sys_extattrctl(struct thread *td, struct extattrctl_args *uap)
 
 	mp = NULL;
 	filename_vp = NULL;
-	if (uap->filename != NULL) {
+	if (filename != NULL) {
 		NDINIT(&nd, LOOKUP, FOLLOW | AUDITVNODE2, UIO_USERSPACE,
-		    uap->filename);
+		    filename);
 		error = namei(&nd);
 		if (error)
 			return (error);
@@ -109,9 +107,9 @@ sys_extattrctl(struct thread *td, struct extattrctl_args *uap)
 		NDFREE_PNBUF(&nd);
 	}
 
-	/* uap->path is always defined. */
+	/* path is always defined. */
 	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1, UIO_USERSPACE,
-	    uap->path);
+	    path);
 	error = namei(&nd);
 	if (error)
 		goto out;
@@ -131,7 +129,7 @@ sys_extattrctl(struct thread *td, struct extattrctl_args *uap)
 		goto out;
 	if (filename_vp != NULL) {
 		/*
-		 * uap->filename is not always defined.  If it is,
+		 * filename is not always defined.  If it is,
 		 * grab a vnode lock, which VFS_EXTATTRCTL() will
 		 * later release.
 		 */
@@ -142,8 +140,8 @@ sys_extattrctl(struct thread *td, struct extattrctl_args *uap)
 		}
 	}
 
-	error = VFS_EXTATTRCTL(mp, uap->cmd, filename_vp, uap->attrnamespace,
-	    uap->attrname != NULL ? attrname : NULL);
+	error = VFS_EXTATTRCTL(mp, cmd, filename_vp, attrnamespace,
+	    uattrname != NULL ? attrname : NULL);
 
 	vn_finished_write(mp_writable);
 out:
@@ -230,14 +228,22 @@ struct extattr_set_fd_args {
 int
 sys_extattr_set_fd(struct thread *td, struct extattr_set_fd_args *uap)
 {
+	return (user_extattr_set_fd(td, uap->fd, uap->attrnamespace,
+	    uap->attrname, uap->data, uap->nbytes));
+}
+
+int
+user_extattr_set_fd(struct thread *td, int fd, int attrnamespace,
+    const char *uattrname, void *data, size_t nbytes)
+{
 	char attrname[EXTATTR_MAXNAMELEN + 1];
 	int error;
 
-	error = copyinstr(uap->attrname, attrname, sizeof(attrname), NULL);
+	error = copyinstr(uattrname, attrname, sizeof(attrname), NULL);
 	if (error)
 		return (error);
-	return (kern_extattr_set_fd(td, uap->fd, uap->attrnamespace,
-	    attrname, uap->data, uap->nbytes));
+	return (kern_extattr_set_fd(td, fd, attrnamespace, attrname, data,
+	    nbytes));
 }
 
 int
@@ -285,7 +291,6 @@ struct extattr_set_file_args {
 int
 sys_extattr_set_file(struct thread *td, struct extattr_set_file_args *uap)
 {
-
 	return (user_extattr_set_path(td, uap->path, uap->attrnamespace,
 	    uap->attrname, uap->data, uap->nbytes, FOLLOW));
 }
@@ -302,12 +307,11 @@ struct extattr_set_link_args {
 int
 sys_extattr_set_link(struct thread *td, struct extattr_set_link_args *uap)
 {
-
 	return (user_extattr_set_path(td, uap->path, uap->attrnamespace,
 	    uap->attrname, uap->data, uap->nbytes, NOFOLLOW));
 }
 
-static int
+int
 user_extattr_set_path(struct thread *td, const char *path, int attrnamespace,
     const char *uattrname, void *data, size_t nbytes, int follow)
 {
@@ -427,14 +431,22 @@ struct extattr_get_fd_args {
 int
 sys_extattr_get_fd(struct thread *td, struct extattr_get_fd_args *uap)
 {
+	return (user_extattr_get_fd(td, uap->fd, uap->attrnamespace,
+	    uap->attrname, uap->data, uap->nbytes));
+}
+
+int
+user_extattr_get_fd(struct thread *td, int fd, int attrnamespace,
+    const char *uattrname, void *data, size_t nbytes)
+{
 	char attrname[EXTATTR_MAXNAMELEN + 1];
 	int error;
 
-	error = copyinstr(uap->attrname, attrname, sizeof(attrname), NULL);
+	error = copyinstr(uattrname, attrname, sizeof(attrname), NULL);
 	if (error)
 		return (error);
-	return (kern_extattr_get_fd(td, uap->fd, uap->attrnamespace,
-	    attrname, uap->data, uap->nbytes));
+	return (kern_extattr_get_fd(td, fd, attrnamespace, attrname, data,
+	    nbytes));
 }
 
 int
@@ -502,7 +514,7 @@ sys_extattr_get_link(struct thread *td, struct extattr_get_link_args *uap)
 	    uap->attrname, uap->data, uap->nbytes, NOFOLLOW));
 }
 
-static int
+int
 user_extattr_get_path(struct thread *td, const char *path, int attrnamespace,
     const char *uattrname, void *data, size_t nbytes, int follow)
 {
@@ -592,14 +604,21 @@ struct extattr_delete_fd_args {
 int
 sys_extattr_delete_fd(struct thread *td, struct extattr_delete_fd_args *uap)
 {
+	return (user_extattr_delete_fd(td, uap->fd, uap->attrnamespace,
+	    uap->attrname));
+}
+
+int
+user_extattr_delete_fd(struct thread *td, int fd, int attrnamespace,
+    const char *uattrname)
+{
 	char attrname[EXTATTR_MAXNAMELEN + 1];
 	int error;
 
-	error = copyinstr(uap->attrname, attrname, sizeof(attrname), NULL);
+	error = copyinstr(uattrname, attrname, sizeof(attrname), NULL);
 	if (error)
 		return (error);
-	return (kern_extattr_delete_fd(td, uap->fd, uap->attrnamespace,
-	    attrname));
+	return (kern_extattr_delete_fd(td, fd, attrnamespace, attrname));
 }
 
 int
@@ -757,16 +776,24 @@ struct extattr_list_fd_args {
 int
 sys_extattr_list_fd(struct thread *td, struct extattr_list_fd_args *uap)
 {
+	return (user_extattr_list_fd(td, uap->fd, uap->attrnamespace,
+	    uap->data, uap->nbytes));
+}
+
+int
+user_extattr_list_fd(struct thread *td, int fd, int attrnamespace, void *data,
+    size_t nbytes)
+{
 	struct uio auio, *auiop;
 	struct iovec aiov;
 
-	if (uap->data != NULL) {
-		aiov.iov_base = uap->data;
-		aiov.iov_len = uap->nbytes;
+	if (data != NULL) {
+		aiov.iov_base = data;
+		aiov.iov_len = nbytes;
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = 0;
-		auio.uio_resid = uap->nbytes;
+		auio.uio_resid = nbytes;
 		auio.uio_rw = UIO_READ;
 		auio.uio_segflg = UIO_USERSPACE;
 		auio.uio_td = td;
@@ -774,8 +801,7 @@ sys_extattr_list_fd(struct thread *td, struct extattr_list_fd_args *uap)
 	} else
 		auiop = NULL;
 
-	return (kern_extattr_list_fd(td, uap->fd, uap->attrnamespace,
-	    auiop));
+	return (kern_extattr_list_fd(td, fd, attrnamespace, auiop));
 }
 
 int
@@ -818,7 +844,6 @@ struct extattr_list_file_args {
 int
 sys_extattr_list_file(struct thread *td, struct extattr_list_file_args *uap)
 {
-
 	return (user_extattr_list_path(td, uap->path, uap->attrnamespace,
 	    uap->data, uap->nbytes, FOLLOW));
 }
@@ -834,12 +859,11 @@ struct extattr_list_link_args {
 int
 sys_extattr_list_link(struct thread *td, struct extattr_list_link_args *uap)
 {
-
 	return (user_extattr_list_path(td, uap->path, uap->attrnamespace,
 	    uap->data, uap->nbytes, NOFOLLOW));
 }
 
-static int
+int
 user_extattr_list_path(struct thread *td, const char *path, int attrnamespace,
     void *data, size_t nbytes, int follow)
 {

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -435,9 +435,16 @@ struct nmount_args {
 int
 sys_nmount(struct thread *td, struct nmount_args *uap)
 {
+	return (kern_nmount(td, uap->iovp, uap->iovcnt, uap->flags,
+	    copyinuio));
+}
+
+int
+kern_nmount(struct thread *td, struct iovec *iovp, u_int iovcnt, int flags32,
+    copyinuio_t *copyinuio_f)
+{
 	struct uio *auio;
 	int error;
-	u_int iovcnt;
 	uint64_t flags;
 
 	/*
@@ -445,11 +452,11 @@ sys_nmount(struct thread *td, struct nmount_args *uap)
 	 * 32-bits are passed in, but from here on everything handles
 	 * 64-bit flags correctly.
 	 */
-	flags = uap->flags;
+	flags = flags32;
 
 	AUDIT_ARG_FFLAGS(flags);
 	CTR4(KTR_VFS, "%s: iovp %p with iovcnt %d and flags %d", __func__,
-	    uap->iovp, uap->iovcnt, flags);
+	    (void *)iovp, iovcnt, flags);
 
 	/*
 	 * Filter out MNT_ROOTFS.  We do not want clients of nmount() in
@@ -460,18 +467,17 @@ sys_nmount(struct thread *td, struct nmount_args *uap)
 	 */
 	flags &= ~MNT_ROOTFS;
 
-	iovcnt = uap->iovcnt;
 	/*
 	 * Check that we have an even number of iovec's
 	 * and that we have at least two options.
 	 */
 	if ((iovcnt & 1) || (iovcnt < 4)) {
 		CTR2(KTR_VFS, "%s: failed for invalid iovcnt %d", __func__,
-		    uap->iovcnt);
+		    iovcnt);
 		return (EINVAL);
 	}
 
-	error = copyinuio(uap->iovp, iovcnt, &auio);
+	error = copyinuio_f(iovp, iovcnt, &auio);
 	if (error) {
 		CTR2(KTR_VFS, "%s: failed for invalid uio op with %d errno",
 		    __func__, error);

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -89,8 +89,6 @@
 
 MALLOC_DEFINE(M_FADVISE, "fadvise", "posix_fadvise(2) information");
 
-static int kern_chflagsat(struct thread *td, int fd, const char *path,
-    enum uio_seg pathseg, u_long flags, int atflag);
 static int setfflags(struct thread *td, struct vnode *, u_long);
 static int getutimes(const struct timeval *, enum uio_seg, struct timespec *);
 static int getutimens(const struct timespec *, enum uio_seg,
@@ -99,8 +97,6 @@ static int setutimes(struct thread *td, struct vnode *,
     const struct timespec *, int, int);
 static int vn_access(struct vnode *vp, int user_flags, struct ucred *cred,
     struct thread *td);
-static int kern_fhlinkat(struct thread *td, int fd, const char *path,
-    enum uio_seg pathseg, fhandle_t *fhp);
 static int kern_readlink_vp(struct vnode *vp, char *buf, enum uio_seg bufseg,
     size_t count, struct thread *td);
 static int kern_linkat_vp(struct thread *td, struct vnode *vp, int fd,
@@ -188,17 +184,23 @@ struct quotactl_args {
 int
 sys_quotactl(struct thread *td, struct quotactl_args *uap)
 {
+	return (kern_quotactl(td, uap->path, uap->cmd, uap->uid, uap->arg));
+}
+
+int
+kern_quotactl(struct thread *td, const char *path, int cmd, int uid, void *arg)
+{
 	struct mount *mp;
 	struct nameidata nd;
 	int error;
 	bool mp_busy;
 
-	AUDIT_ARG_CMD(uap->cmd);
-	AUDIT_ARG_UID(uap->uid);
+	AUDIT_ARG_CMD(cmd);
+	AUDIT_ARG_UID(uid);
 	if (!prison_allow(td->td_ucred, PR_ALLOW_QUOTAS))
 		return (EPERM);
 	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1, UIO_USERSPACE,
-	    uap->path);
+	    path);
 	if ((error = namei(&nd)) != 0)
 		return (error);
 	NDFREE_PNBUF(&nd);
@@ -211,7 +213,7 @@ sys_quotactl(struct thread *td, struct quotactl_args *uap)
 		return (error);
 	}
 	mp_busy = true;
-	error = VFS_QUOTACTL(mp, uap->cmd, uap->uid, uap->arg, &mp_busy);
+	error = VFS_QUOTACTL(mp, cmd, uid, arg, &mp_busy);
 
 	/*
 	 * Since quota on/off operations typically need to open quota
@@ -309,13 +311,19 @@ struct statfs_args {
 int
 sys_statfs(struct thread *td, struct statfs_args *uap)
 {
+	return (user_statfs(td, uap->path, uap->buf));
+}
+
+int
+user_statfs(struct thread *td, const char *path, struct statfs *buf)
+{
 	struct statfs *sfp;
 	int error;
 
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, uap->path, UIO_USERSPACE, sfp);
+	error = kern_statfs(td, path, UIO_USERSPACE, sfp);
 	if (error == 0)
-		error = copyout(sfp, uap->buf, sizeof(struct statfs));
+		error = copyout(sfp, buf, sizeof(struct statfs));
 	free(sfp, M_STATFS);
 	return (error);
 }
@@ -350,13 +358,19 @@ struct fstatfs_args {
 int
 sys_fstatfs(struct thread *td, struct fstatfs_args *uap)
 {
+	return (user_fstatfs(td, uap->fd, uap->buf));
+}
+
+int
+user_fstatfs(struct thread *td, int fd, struct statfs *buf)
+{
 	struct statfs *sfp;
 	int error;
 
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_fstatfs(td, uap->fd, sfp);
+	error = kern_fstatfs(td, fd, sfp);
 	if (error == 0)
-		error = copyout(sfp, uap->buf, sizeof(struct statfs));
+		error = copyout(sfp, buf, sizeof(struct statfs));
 	free(sfp, M_STATFS);
 	return (error);
 }
@@ -399,13 +413,18 @@ struct getfsstat_args {
 int
 sys_getfsstat(struct thread *td, struct getfsstat_args *uap)
 {
+	return (user_getfsstat(td, uap->buf, uap->bufsize, uap->mode));
+}
+
+int
+user_getfsstat(struct thread *td, struct statfs *buf, long bufsize, int mode)
+{
 	size_t count;
 	int error;
 
-	if (uap->bufsize < 0 || uap->bufsize > SIZE_MAX)
+	if (bufsize < 0 || bufsize > SIZE_MAX)
 		return (EINVAL);
-	error = kern_getfsstat(td, &uap->buf, uap->bufsize, &count,
-	    UIO_USERSPACE, uap->mode);
+	error = kern_getfsstat(td, &buf, bufsize, &count, UIO_USERSPACE, mode);
 	if (error == 0)
 		td->td_retval[0] = count;
 	return (error);
@@ -1021,11 +1040,17 @@ struct chroot_args {
 int
 sys_chroot(struct thread *td, struct chroot_args *uap)
 {
+	return (user_chroot(td, uap->path));
+}
+
+int
+user_chroot(struct thread *td, const char *path)
+{
 	struct nameidata nd;
 	int error;
 
 	NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF | AUDITVNODE1,
-	    UIO_USERSPACE, uap->path);
+	    UIO_USERSPACE, path);
 	error = namei(&nd);
 	if (error != 0)
 		return (error);
@@ -1919,6 +1944,12 @@ struct undelete_args {
 int
 sys_undelete(struct thread *td, struct undelete_args *uap)
 {
+	return (kern_undelete(td, uap->path, UIO_USERSPACE));
+}
+
+int
+kern_undelete(struct thread *td, const char *path, enum uio_seg pathseg)
+{
 	struct mount *mp;
 	struct nameidata nd;
 	int error;
@@ -1927,7 +1958,7 @@ sys_undelete(struct thread *td, struct undelete_args *uap)
 restart:
 	bwillwrite();
 	NDINIT(&nd, DELETE, LOCKPARENT | DOWHITEOUT | AUDITVNODE1,
-	    UIO_USERSPACE, uap->path);
+	    UIO_USERSPACE, path);
 	error = namei(&nd);
 	if (error != 0)
 		return (error);
@@ -1969,16 +2000,14 @@ struct unlink_args {
 int
 sys_unlink(struct thread *td, struct unlink_args *uap)
 {
-
 	return (kern_funlinkat(td, AT_FDCWD, uap->path, FD_NONE, UIO_USERSPACE,
 	    0, 0));
 }
 
-static int
+int
 kern_funlinkat_ex(struct thread *td, int dfd, const char *path, int fd,
     int flags, enum uio_seg pathseg, ino_t oldinum)
 {
-
 	if ((flags & ~(AT_REMOVEDIR | AT_RESOLVE_BENEATH)) != 0)
 		return (EINVAL);
 
@@ -2124,7 +2153,6 @@ struct lseek_args {
 int
 sys_lseek(struct thread *td, struct lseek_args *uap)
 {
-
 	return (kern_lseek(td, uap->fd, uap->offset, uap->whence));
 }
 
@@ -2158,7 +2186,6 @@ struct olseek_args {
 int
 olseek(struct thread *td, struct olseek_args *uap)
 {
-
 	return (kern_lseek(td, uap->fd, uap->offset, uap->whence));
 }
 #endif /* COMPAT_43 */
@@ -2168,7 +2195,6 @@ olseek(struct thread *td, struct olseek_args *uap)
 int
 freebsd6_lseek(struct thread *td, struct freebsd6_lseek_args *uap)
 {
-
 	return (kern_lseek(td, uap->fd, uap->offset, uap->whence));
 }
 #endif
@@ -2216,7 +2242,6 @@ struct access_args {
 int
 sys_access(struct thread *td, struct access_args *uap)
 {
-
 	return (kern_accessat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
 	    0, uap->amode));
 }
@@ -2232,7 +2257,6 @@ struct faccessat_args {
 int
 sys_faccessat(struct thread *td, struct faccessat_args *uap)
 {
-
 	return (kern_accessat(td, uap->fd, uap->path, UIO_USERSPACE, uap->flag,
 	    uap->amode));
 }
@@ -2539,13 +2563,19 @@ struct fstatat_args {
 int
 sys_fstatat(struct thread *td, struct fstatat_args *uap)
 {
+	return (user_fstatat(td, uap->fd, uap->path, uap->buf, uap->flag));
+}
+
+int
+user_fstatat(struct thread *td, int fd, const char *path, struct stat *buf,
+    int flag)
+{
 	struct stat sb;
 	int error;
 
-	error = kern_statat(td, uap->flag, uap->fd, uap->path,
-	    UIO_USERSPACE, &sb);
+	error = kern_statat(td, flag, fd, path, UIO_USERSPACE, &sb);
 	if (error == 0)
-		error = copyout(&sb, uap->buf, sizeof (sb));
+		error = copyout(&sb, buf, sizeof(sb));
 	return (error);
 }
 
@@ -2873,7 +2903,6 @@ struct chflags_args {
 int
 sys_chflags(struct thread *td, struct chflags_args *uap)
 {
-
 	return (kern_chflagsat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
 	    uap->flags, 0));
 }
@@ -2889,7 +2918,6 @@ struct chflagsat_args {
 int
 sys_chflagsat(struct thread *td, struct chflagsat_args *uap)
 {
-
 	return (kern_chflagsat(td, uap->fd, uap->path, UIO_USERSPACE,
 	    uap->flags, uap->atflag));
 }
@@ -2906,12 +2934,11 @@ struct lchflags_args {
 int
 sys_lchflags(struct thread *td, struct lchflags_args *uap)
 {
-
 	return (kern_chflagsat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
 	    uap->flags, AT_SYMLINK_NOFOLLOW));
 }
 
-static int
+int
 kern_chflagsat(struct thread *td, int fd, const char *path,
     enum uio_seg pathseg, u_long flags, int atflag)
 {
@@ -4323,15 +4350,23 @@ freebsd11_getdents(struct thread *td, struct freebsd11_getdents_args *uap)
 int
 sys_getdirentries(struct thread *td, struct getdirentries_args *uap)
 {
+	return (user_getdirentries(td, uap->fd, uap->buf, uap->count,
+	    uap->basep));
+}
+
+int
+user_getdirentries(struct thread *td, int fd, char *buf, size_t count,
+    off_t *basep)
+{
 	off_t base;
 	int error;
 
-	error = kern_getdirentries(td, uap->fd, uap->buf, uap->count, &base,
-	    NULL, UIO_USERSPACE);
+	error = kern_getdirentries(td, fd, buf, count, &base, NULL,
+	    UIO_USERSPACE);
 	if (error != 0)
 		return (error);
-	if (uap->basep != NULL)
-		error = copyout(&base, uap->basep, sizeof(off_t));
+	if (basep != NULL)
+		error = copyout(&base, basep, sizeof(off_t));
 	return (error);
 }
 
@@ -4455,13 +4490,19 @@ struct revoke_args {
 int
 sys_revoke(struct thread *td, struct revoke_args *uap)
 {
+	return (kern_revoke(td, uap->path, UIO_USERSPACE));
+}
+
+int
+kern_revoke(struct thread *td, const char *path, enum uio_seg pathseg)
+{
 	struct vnode *vp;
 	struct vattr vattr;
 	struct nameidata nd;
 	int error;
 
 	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1, UIO_USERSPACE,
-	    uap->path);
+	    path);
 	if ((error = namei(&nd)) != 0)
 		return (error);
 	vp = nd.ni_vp;
@@ -4654,7 +4695,6 @@ struct fhlink_args {
 int
 sys_fhlink(struct thread *td, struct fhlink_args *uap)
 {
-
 	return (kern_fhlinkat(td, AT_FDCWD, uap->to, UIO_USERSPACE, uap->fhp));
 }
 
@@ -4668,11 +4708,10 @@ struct fhlinkat_args {
 int
 sys_fhlinkat(struct thread *td, struct fhlinkat_args *uap)
 {
-
 	return (kern_fhlinkat(td, uap->tofd, uap->to, UIO_USERSPACE, uap->fhp));
 }
 
-static int
+int
 kern_fhlinkat(struct thread *td, int fd, const char *path,
     enum uio_seg pathseg, fhandle_t *fhp)
 {
@@ -4711,6 +4750,12 @@ struct fhreadlink_args {
 int
 sys_fhreadlink(struct thread *td, struct fhreadlink_args *uap)
 {
+	return (kern_fhreadlink(td, uap->fhp, uap->buf, uap->bufsize));
+}
+
+int
+kern_fhreadlink(struct thread *td, fhandle_t *fhp, char *buf, size_t bufsize)
+{
 	fhandle_t fh;
 	struct mount *mp;
 	struct vnode *vp;
@@ -4719,9 +4764,9 @@ sys_fhreadlink(struct thread *td, struct fhreadlink_args *uap)
 	error = priv_check(td, PRIV_VFS_GETFH);
 	if (error != 0)
 		return (error);
-	if (uap->bufsize > IOSIZE_MAX)
+	if (bufsize > IOSIZE_MAX)
 		return (EINVAL);
-	error = copyin(uap->fhp, &fh, sizeof(fh));
+	error = copyin(fhp, &fh, sizeof(fh));
 	if (error != 0)
 		return (error);
 	if ((mp = vfs_busyfs(&fh.fh_fsid)) == NULL)
@@ -4730,7 +4775,7 @@ sys_fhreadlink(struct thread *td, struct fhreadlink_args *uap)
 	vfs_unbusy(mp);
 	if (error != 0)
 		return (error);
-	error = kern_readlink_vp(vp, uap->buf, UIO_USERSPACE, uap->bufsize, td);
+	error = kern_readlink_vp(vp, buf, UIO_USERSPACE, bufsize, td);
 	vput(vp);
 	return (error);
 }
@@ -4851,16 +4896,22 @@ struct fhstat_args {
 int
 sys_fhstat(struct thread *td, struct fhstat_args *uap)
 {
+	return (user_fhstat(td, uap->u_fhp, uap->sb));
+}
+
+int
+user_fhstat(struct thread *td, const struct fhandle *u_fhp, struct stat *usb)
+{
 	struct stat sb;
 	struct fhandle fh;
 	int error;
 
-	error = copyin(uap->u_fhp, &fh, sizeof(fh));
+	error = copyin(u_fhp, &fh, sizeof(fh));
 	if (error != 0)
 		return (error);
 	error = kern_fhstat(td, fh, &sb);
 	if (error == 0)
-		error = copyout(&sb, uap->sb, sizeof(sb));
+		error = copyout(&sb, usb, sizeof(sb));
 	return (error);
 }
 
@@ -4897,17 +4948,24 @@ struct fhstatfs_args {
 int
 sys_fhstatfs(struct thread *td, struct fhstatfs_args *uap)
 {
+	return (user_fhstatfs(td, uap->u_fhp, uap->buf));
+}
+
+int
+user_fhstatfs(struct thread *td, const struct fhandle *u_fhp,
+    struct statfs *buf)
+{
 	struct statfs *sfp;
 	fhandle_t fh;
 	int error;
 
-	error = copyin(uap->u_fhp, &fh, sizeof(fhandle_t));
+	error = copyin(u_fhp, &fh, sizeof(fhandle_t));
 	if (error != 0)
 		return (error);
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
 	error = kern_fhstatfs(td, fh, sfp);
 	if (error == 0)
-		error = copyout(sfp, uap->buf, sizeof(*sfp));
+		error = copyout(sfp, buf, sizeof(*sfp));
 	free(sfp, M_STATFS);
 	return (error);
 }
@@ -5254,27 +5312,35 @@ out:
 int
 sys_copy_file_range(struct thread *td, struct copy_file_range_args *uap)
 {
+	return (user_copy_file_range(td, uap->infd, uap->inoffp, uap->outfd,
+	    uap->outoffp, uap->len, uap->flags));
+}
+
+int
+user_copy_file_range(struct thread *td, int infd, off_t *uinoffp, int outfd,
+    off_t *uoutoffp, size_t len, unsigned int flags)
+{
 	off_t inoff, outoff, *inoffp, *outoffp;
 	int error;
 
 	inoffp = outoffp = NULL;
-	if (uap->inoffp != NULL) {
-		error = copyin(uap->inoffp, &inoff, sizeof(off_t));
+	if (uinoffp != NULL) {
+		error = copyin(uinoffp, &inoff, sizeof(off_t));
 		if (error != 0)
 			return (error);
 		inoffp = &inoff;
 	}
-	if (uap->outoffp != NULL) {
-		error = copyin(uap->outoffp, &outoff, sizeof(off_t));
+	if (uoutoffp != NULL) {
+		error = copyin(uoutoffp, &outoff, sizeof(off_t));
 		if (error != 0)
 			return (error);
 		outoffp = &outoff;
 	}
-	error = kern_copy_file_range(td, uap->infd, inoffp, uap->outfd,
-	    outoffp, uap->len, uap->flags);
-	if (error == 0 && uap->inoffp != NULL)
-		error = copyout(inoffp, uap->inoffp, sizeof(off_t));
-	if (error == 0 && uap->outoffp != NULL)
-		error = copyout(outoffp, uap->outoffp, sizeof(off_t));
+	error = kern_copy_file_range(td, infd, inoffp, outfd, outoffp, len,
+	    flags);
+	if (error == 0 && uinoffp != NULL)
+		error = copyout(inoffp, uinoffp, sizeof(off_t));
+	if (error == 0 && uoutoffp != NULL)
+		error = copyout(outoffp, uoutoffp, sizeof(off_t));
 	return (error);
 }

--- a/sys/security/mac/mac_syscalls.c
+++ b/sys/security/mac/mac_syscalls.c
@@ -58,6 +58,7 @@
 #include <sys/mac.h>
 #include <sys/proc.h>
 #include <sys/systm.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysctl.h>
 #include <sys/sysent.h>
 #include <sys/sysproto.h>
@@ -77,11 +78,6 @@
 #ifdef MAC
 
 FEATURE(security_mac, "Mandatory Access Control Framework support");
-
-static int	kern___mac_get_path(struct thread *td, const char *path_p,
-		    struct mac *mac_p, int follow);
-static int	kern___mac_set_path(struct thread *td, const char *path_p,
-		    struct mac *mac_p, int follow);
 
 #ifdef COMPAT_FREEBSD32
 struct mac32 {
@@ -162,17 +158,23 @@ free_copied_label(const struct mac *const mac)
 int
 sys___mac_get_pid(struct thread *td, struct __mac_get_pid_args *uap)
 {
+	return (kern___mac_get_pid(td, uap->pid, uap->mac_p));
+}
+
+int
+kern___mac_get_pid(struct thread *td, pid_t pid, void *mac_p)
+{
 	char *buffer, *u_buffer;
 	struct mac mac;
 	struct proc *tproc;
 	struct ucred *tcred;
 	int error;
 
-	error = mac_label_copyin(uap->mac_p, &mac, &u_buffer);
+	error = mac_label_copyin(mac_p, &mac, &u_buffer);
 	if (error)
 		return (error);
 
-	tproc = pfind(uap->pid);
+	tproc = pfind(pid);
 	if (tproc == NULL) {
 		error = ESRCH;
 		goto free_mac_and_exit;
@@ -202,11 +204,17 @@ free_mac_and_exit:
 int
 sys___mac_get_proc(struct thread *td, struct __mac_get_proc_args *uap)
 {
+	return (kern___mac_get_proc(td, uap->mac_p));
+}
+
+int
+kern___mac_get_proc(struct thread *td, void *mac_p)
+{
 	char *buffer, *u_buffer;
 	struct mac mac;
 	int error;
 
-	error = mac_label_copyin(uap->mac_p, &mac, &u_buffer);
+	error = mac_label_copyin(mac_p, &mac, &u_buffer);
 	if (error)
 		return (error);
 
@@ -455,13 +463,19 @@ mac_set_prison_finish(struct thread *const td, bool prison_label_set __unused,
 int
 sys___mac_set_proc(struct thread *td, struct __mac_set_proc_args *uap)
 {
+	return (kern___mac_set_proc(td, uap->mac_p));
+}
+
+int
+kern___mac_set_proc(struct thread *td, void *mac_p)
+{
 	struct ucred *newcred, *oldcred;
 	void *intlabel;
 	struct proc *const p = td->td_proc;
 	struct mac mac;
 	int error;
 
-	error = mac_label_copyin(uap->mac_p, &mac, NULL);
+	error = mac_label_copyin(mac_p, &mac, NULL);
 	if (error)
 		return (error);
 
@@ -497,6 +511,12 @@ free_label:
 int
 sys___mac_get_fd(struct thread *td, struct __mac_get_fd_args *uap)
 {
+	return (kern___mac_get_fd(td, uap->fd, uap->mac_p));
+}
+
+int
+kern___mac_get_fd(struct thread *td, int fd, void *mac_p)
+{
 	char *u_buffer, *buffer;
 	struct label *intlabel;
 	struct file *fp;
@@ -508,13 +528,12 @@ sys___mac_get_fd(struct thread *td, struct __mac_get_fd_args *uap)
 	cap_rights_t rights;
 	int error;
 
-	error = mac_label_copyin(uap->mac_p, &mac, &u_buffer);
+	error = mac_label_copyin(mac_p, &mac, &u_buffer);
 	if (error)
 		return (error);
 
 	buffer = malloc(mac.m_buflen, M_MACTEMP, M_WAITOK | M_ZERO);
-	error = fget(td, uap->fd, cap_rights_init_one(&rights, CAP_MAC_GET),
-	    &fp);
+	error = fget(td, fd, cap_rights_init_one(&rights, CAP_MAC_GET), &fp);
 	if (error)
 		goto out;
 
@@ -600,19 +619,17 @@ out:
 int
 sys___mac_get_file(struct thread *td, struct __mac_get_file_args *uap)
 {
-
-	return (kern___mac_get_path(td, uap->path_p, uap->mac_p, FOLLOW));
+	return (kern_mac_get_path(td, uap->path_p, uap->mac_p, FOLLOW));
 }
 
 int
 sys___mac_get_link(struct thread *td, struct __mac_get_link_args *uap)
 {
-
-	return (kern___mac_get_path(td, uap->path_p, uap->mac_p, NOFOLLOW));
+	return (kern_mac_get_path(td, uap->path_p, uap->mac_p, NOFOLLOW));
 }
 
-static int
-kern___mac_get_path(struct thread *td, const char *path_p, struct mac *mac_p,
+int
+kern_mac_get_path(struct thread *td, const char *path_p, struct mac *mac_p,
    int follow)
 {
 	char *u_buffer, *buffer;
@@ -655,6 +672,12 @@ out:
 int
 sys___mac_set_fd(struct thread *td, struct __mac_set_fd_args *uap)
 {
+	return (kern___mac_set_fd(td, uap->fd, uap->mac_p));
+}
+
+int
+kern___mac_set_fd(struct thread *td, int fd, void *mac_p)
+{
 	struct label *intlabel;
 	struct pipe *pipe;
 	struct prison *pr;
@@ -666,11 +689,11 @@ sys___mac_set_fd(struct thread *td, struct __mac_set_fd_args *uap)
 	cap_rights_t rights;
 	int error;
 
-	error = mac_label_copyin(uap->mac_p, &mac, NULL);
+	error = mac_label_copyin(mac_p, &mac, NULL);
 	if (error)
 		return (error);
 
-	error = fget(td, uap->fd, cap_rights_init_one(&rights, CAP_MAC_SET),
+	error = fget(td, fd, cap_rights_init_one(&rights, CAP_MAC_SET),
 	    &fp);
 	if (error)
 		goto out;
@@ -767,19 +790,17 @@ out:
 int
 sys___mac_set_file(struct thread *td, struct __mac_set_file_args *uap)
 {
-
-	return (kern___mac_set_path(td, uap->path_p, uap->mac_p, FOLLOW));
+	return (kern_mac_set_path(td, uap->path_p, uap->mac_p, FOLLOW));
 }
 
 int
 sys___mac_set_link(struct thread *td, struct __mac_set_link_args *uap)
 {
-
-	return (kern___mac_set_path(td, uap->path_p, uap->mac_p, NOFOLLOW));
+	return (kern_mac_set_path(td, uap->path_p, uap->mac_p, NOFOLLOW));
 }
 
-static int
-kern___mac_set_path(struct thread *td, const char *path_p, struct mac *mac_p,
+int
+kern_mac_set_path(struct thread *td, const char *path_p, struct mac *mac_p,
     int follow)
 {
 	struct label *intlabel;
@@ -821,11 +842,17 @@ out:
 int
 sys_mac_syscall(struct thread *td, struct mac_syscall_args *uap)
 {
+	return (kern_mac_syscall(td, uap->policy, uap->call, uap->arg));
+}
+
+int
+kern_mac_syscall(struct thread *td, const char *policy, int call, void *arg)
+{
 	struct mac_policy_conf *mpc;
 	char target[MAC_MAX_POLICY_NAME];
 	int error;
 
-	error = copyinstr(uap->policy, target, sizeof(target), NULL);
+	error = copyinstr(policy, target, sizeof(target), NULL);
 	if (error)
 		return (error);
 
@@ -833,8 +860,7 @@ sys_mac_syscall(struct thread *td, struct mac_syscall_args *uap)
 	LIST_FOREACH(mpc, &mac_static_policy_list, mpc_list) {
 		if (strcmp(mpc->mpc_name, target) == 0 &&
 		    mpc->mpc_ops->mpo_syscall != NULL) {
-			error = mpc->mpc_ops->mpo_syscall(td,
-			    uap->call, uap->arg);
+			error = mpc->mpc_ops->mpo_syscall(td, call, arg);
 			goto out;
 		}
 	}
@@ -844,8 +870,8 @@ sys_mac_syscall(struct thread *td, struct mac_syscall_args *uap)
 		LIST_FOREACH(mpc, &mac_policy_list, mpc_list) {
 			if (strcmp(mpc->mpc_name, target) == 0 &&
 			    mpc->mpc_ops->mpo_syscall != NULL) {
-				error = mpc->mpc_ops->mpo_syscall(td,
-				    uap->call, uap->arg);
+				error = mpc->mpc_ops->mpo_syscall(td, call,
+				    arg);
 				break;
 			}
 		}

--- a/sys/sys/signal.h
+++ b/sys/sys/signal.h
@@ -246,6 +246,10 @@ typedef	struct __siginfo {
 	} _reason;
 } siginfo_t;
 
+#ifdef _KERNEL
+typedef int (copyout_siginfo_t)(const siginfo_t *si, void *info);
+#endif
+
 #define si_trapno	_reason._fault._trapno
 #define si_timerid	_reason._timer._timerid
 #define si_overrun	_reason._timer._overrun

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -114,7 +114,7 @@ typedef	__uintptr_t	uintptr_t;
 #define	SOCK_CLOFORK	0x40000000
 #ifdef _KERNEL
 /*
- * Flags for accept1(), kern_accept4() and solisten_dequeue, in addition
+ * Flags for user_accept(), kern_accept4() and solisten_dequeue, in addition
  * to SOCK_CLOEXEC, SOCK_CLOFORK and SOCK_NONBLOCK.
  */
 #define ACCEPT4_INHERIT 0x1

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -98,6 +98,7 @@ int	kern_accept4(struct thread *td, int s, struct sockaddr *sa,
 	    int flags, struct file **fp);
 int	kern_accessat(struct thread *td, int fd, const char *path,
 	    enum uio_seg pathseg, int flags, int mode);
+int	kern_acct(struct thread *td, const char *path);
 int	kern_adjtime(struct thread *td, struct timeval *delta,
 	    struct timeval *olddelta);
 int	kern_audit(struct thread *td, const void *record, u_int length);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -128,6 +128,7 @@ int	kern_connectat(struct thread *td, int dirfd, int fd,
 	    struct sockaddr *sa);
 int	kern_copy_file_range(struct thread *td, int infd, off_t *inoffp,
 	    int outfd, off_t *outoffp, size_t len, unsigned int flags);
+int	kern_cpuset(struct thread *td, cpusetid_t *setid);
 int	kern_cpuset_getaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize, cpuset_t *mask);
 int	kern_cpuset_setaffinity(struct thread *td, cpulevel_t level,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -96,6 +96,14 @@ struct mmap_req {
 	mmap_check_fp_fn	mr_check_fp_fn;
 };
 
+/*
+ * A copyinuio_t takes a pointer to an iovec in userspace along with a
+ * count and allocates a struct uio containing a copy of the iovec.
+ * The uio should be freed with freeuio().
+ */
+typedef int (copyinuio_t)(const struct iovec *iovp, unsigned int iovcnt,
+    struct uio **iov);
+
 uint64_t at2cnpflags(u_int at_flags, u_int mask);
 int	kern___cap_rights_get(struct thread *td, int version, int fd,
 	    cap_rights_t *rightsp);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -39,6 +39,7 @@
 #include <sys/socket.h>
 
 struct __wrusage;
+struct acl;
 struct cpuset_copy_cb;
 struct ffclock_estimate;
 struct file;
@@ -105,6 +106,20 @@ typedef int (copyinuio_t)(const struct iovec *iovp, unsigned int iovcnt,
     struct uio **iov);
 
 uint64_t at2cnpflags(u_int at_flags, u_int mask);
+int	kern___acl_aclcheck_fd(struct thread *td, int filedes,
+	    __acl_type_t type, const struct acl *aclp);
+int	kern___acl_aclcheck_path(struct thread *td, const char *path,
+	    __acl_type_t type, struct acl *aclp, int follow);
+int	kern___acl_delete_path(struct thread *td, const char *path,
+	    __acl_type_t type, int follow);
+int	kern___acl_get_fd(struct thread *td, int filedes, __acl_type_t type,
+	    struct acl *aclp);
+int	kern___acl_get_path(struct thread *td, const char *path,
+	    __acl_type_t type, struct acl *aclp, int follow);
+int	kern___acl_set_fd(struct thread *td, int filedes, __acl_type_t type,
+	    const struct acl *aclp);
+int	kern___acl_set_path(struct thread *td, const char *path,
+	    __acl_type_t type, const struct acl *aclp, int follow);
 int	kern___cap_rights_get(struct thread *td, int version, int fd,
 	    cap_rights_t *rightsp);
 int	kern___getcwd(struct thread *td, char *buf, enum uio_seg bufseg,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -122,13 +122,14 @@ int	kern___acl_set_path(struct thread *td, const char *path,
 	    __acl_type_t type, const struct acl *aclp, int follow);
 int	kern___cap_rights_get(struct thread *td, int version, int fd,
 	    cap_rights_t *rightsp);
-int	kern___getcwd(struct thread *td, char *buf, enum uio_seg bufseg,
-	    size_t buflen, size_t path_max);
+int	kern___getcwd(struct thread *td, char *buf, size_t buflen);
 int	kern___mac_get_fd(struct thread *td, int fd, void *mac_p);
 int	kern___mac_get_pid(struct thread *td, pid_t pid, void *mac_p);
 int	kern___mac_get_proc(struct thread *td, void *mac_p);
 int	kern___mac_set_fd(struct thread *td, int fd, void *mac_p);
 int	kern___mac_set_proc(struct thread *td, void *mac_p);
+int	kern___realpathat(struct thread *td, int fd, const char *path,
+	    char *buf, size_t size, int flags, enum uio_seg pathseg);
 int	kern_abort2(struct thread *td, const char *why, int nargs,
 	    void **uargs);
 int	kern_accept(struct thread *td, int s, struct sockaddr *sa,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -441,6 +441,8 @@ int	kern_utimensat(struct thread *td, int fd, const char *path,
 	    enum uio_seg tptrseg, int flag);
 int	kern_wait(struct thread *td, pid_t pid, int *status, int options,
 	    struct rusage *rup);
+int	kern_wait4(struct thread *td, int pid, int *statusp, int options,
+	    struct rusage *rusage);
 int	kern_wait6(struct thread *td, enum idtype idtype, id_t id, int *status,
 	    int options, struct __wrusage *wrup, siginfo_t *sip);
 int	kern_writev(struct thread *td, int fd, struct uio *auio);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -154,6 +154,8 @@ int	kern_cap_ioctls_limit(struct thread *td, int fd, u_long *cmds,
 	    size_t ncmds);
 int	kern_cap_rights_limit(struct thread *td, int fd, cap_rights_t *rights);
 int	kern_chdir(struct thread *td, const char *path, enum uio_seg pathseg);
+int	kern_chflagsat(struct thread *td, int fd, const char *path,
+	    enum uio_seg pathseg, u_long flags, int atflag);
 int	kern_clock_getcpuclockid2(struct thread *td, id_t id, int which,
 	    clockid_t *clk_id);
 int	kern_clock_getres(struct thread *td, clockid_t clock_id,
@@ -234,7 +236,11 @@ int	kern_ffclock_getestimate(struct thread *td,
 	    struct ffclock_estimate *ucest);
 int	kern_ffclock_setestimate(struct thread *td,
 	    const struct ffclock_estimate *ucest);
+int	kern_fhlinkat(struct thread *td, int fd, const char *path,
+	    enum uio_seg pathseg, fhandle_t *fhp);
 int	kern_fhopen(struct thread *td, const struct fhandle *u_fhp, int flags);
+int	kern_fhreadlink(struct thread *td, fhandle_t *fhp, char *buf,
+	    size_t bufsize);
 int	kern_fhstat(struct thread *td, fhandle_t fh, struct stat *buf);
 int	kern_fhstatfs(struct thread *td, fhandle_t fh, struct statfs *buf);
 int	kern_fpathconf(struct thread *td, int fd, int name, long *valuep);
@@ -248,6 +254,8 @@ int	kern_fsync(struct thread *td, int fd, bool fullsync);
 int	kern_ftruncate(struct thread *td, int fd, off_t length);
 int	kern_funlinkat(struct thread *td, int dfd, const char *path, int fd,
 	    enum uio_seg pathseg, int flag, ino_t oldinum);
+int	kern_funlinkat_ex(struct thread *td, int dfd, const char *path,
+	    int fd, int flag, enum uio_seg pathseg, ino_t oldinum);
 int	kern_futimes(struct thread *td, int fd, const struct timeval *tptr,
 	    enum uio_seg tptrseg);
 int	kern_futimens(struct thread *td, int fd, const struct timespec *tptr,
@@ -409,6 +417,8 @@ int	kern_ptrace(struct thread *td, int req, pid_t pid, void *addr,
 int	kern_pwrite(struct thread *td, int fd, const void *buf, size_t nbyte,
 	    off_t offset);
 int	kern_pwritev(struct thread *td, int fd, struct uio *auio, off_t offset);
+int	kern_quotactl(struct thread *td, const char *path, int cmd, int uid,
+	    void *arg);
 int	kern_rctl_add_rule(struct thread *td, const void *inbufp,
 	    size_t inbuflen, void *outbufp, size_t outbuflen);
 int	kern_rctl_get_limits(struct thread *td, const void *inbufp,
@@ -428,6 +438,7 @@ int	kern_recvit(struct thread *td, int s, struct msghdr *mp,
 	    enum uio_seg fromseg, struct mbuf **controlp);
 int	kern_renameat(struct thread *td, int oldfd, const char *old, int newfd,
 	    const char *new, enum uio_seg pathseg, u_int flags);
+int	kern_revoke(struct thread *td, const char *path, enum uio_seg pathseg);
 int	kern_rtprio(struct thread *td, int function, pid_t pid,
 	    struct rtprio *urtp);
 int	kern_rtprio_thread(struct thread *td, int function, lwpid_t lwpid,
@@ -526,6 +537,8 @@ int	kern_timerfd_settime(struct thread *td, int fd, int flags,
 	    const struct itimerspec *new_value, struct itimerspec *old_value);
 int	kern_truncate(struct thread *td, const char *path,
 	    enum uio_seg pathseg, off_t length);
+int	kern_undelete(struct thread *td, const char *path,
+	    enum uio_seg pathseg);
 int	kern_utimesat(struct thread *td, int fd, const char *path,
 	    enum uio_seg pathseg, const struct timeval *tptr,
 	    enum uio_seg tptrseg);
@@ -556,11 +569,13 @@ int	user_bindat(struct thread *td, int fd, int s,
 int	user_cap_ioctls_limit(struct thread *td, int fd, const u_long *ucmds,
 	    size_t ncmds);
 int	user_cap_rights_limit(struct thread *td, int fd, cap_rights_t *rightsp);
-int	user_clock_nanosleep(struct thread *td, clockid_t clock_id,
-	    int flags, const struct timespec *ua_rqtp,
-	    struct timespec *ua_rmtp);
+int	user_chroot(struct thread *td, const char *path);
+int	user_clock_nanosleep(struct thread *td, clockid_t clock_id, int flags,
+	    const struct timespec *ua_rqtp, struct timespec *ua_rmtp);
 int	user_connectat(struct thread *td, int fd, int s,
 	    const struct sockaddr *name, socklen_t namelen);
+int	user_copy_file_range(struct thread *td, int infd, off_t *uinoffp,
+	    int outfd, off_t *uoutoffp, size_t len, unsigned int flags);
 int	user_cpuset_getaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize, cpuset_t *maskp,
 	    const struct cpuset_copy_cb *cb);
@@ -585,10 +600,21 @@ int	user_extattr_set_fd(struct thread *td, int fd, int attrnamespace,
 int	user_extattr_set_path(struct thread *td, const char *path,
 	    int attrnamespace, const char *attrname, void *data,
 	    size_t nbytes, int follow);
+int	user_fhstat(struct thread *td, const struct fhandle *u_fhp,
+	    struct stat *usb);
+int	user_fhstatfs(struct thread *td, const struct fhandle *u_fhp,
+	    struct statfs *buf);
 int	user_fspacectl(struct thread *td, int fd, int cmd,
 	    const struct spacectl_range *rqsrp, int flags,
 	    struct spacectl_range *rmsrp);
 int	user_fstat(struct thread *td, int fd, struct stat *sb);
+int	user_fstatat(struct thread *td, int fd, const char *path,
+	    struct stat *buf, int flag);
+int	user_fstatfs(struct thread *td, int fd, struct statfs *buf);
+int	user_getdirentries(struct thread *td, int fd, char *buf, size_t count,
+	    off_t *basep);
+int	user_getfsstat(struct thread *td, struct statfs *buf, long bufsize,
+	    int mode);
 int	user_getpeername(struct thread *td, int fdes, struct sockaddr *asa,
 	    socklen_t *alen, bool compat);
 int	user_getrlimitusage(struct thread *td, u_int which, int flags,
@@ -641,6 +667,7 @@ int	user_sigwaitinfo(struct thread *td, const sigset_t *uset, void *info,
 	    copyout_siginfo_t *copyout_siginfop);
 int	user_socketpair(struct thread *td, int domain, int type, int protocol,
 	    int *rsv);
+int	user_statfs(struct thread *td, const char *path, struct statfs *buf);
 int	user_uuidgen(struct thread *td, struct uuid *ustore, int count);
 int	user_wait6(struct thread *td, enum idtype idtype, id_t id,
 	    int *statusp, int options, struct __wrusage *wrusage,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -511,6 +511,9 @@ int	kern_statat(struct thread *td, int flag, int fd, const char *path,
 int	kern_specialfd(struct thread *td, int type, void *arg);
 int	kern_statfs(struct thread *td, const char *path, enum uio_seg pathseg,
 	    struct statfs *buf);
+int	kern_swapoff(struct thread *td, const char *name,
+	    enum uio_seg name_seg, u_int flags);
+int	kern_swapon(struct thread *td, const char *name);
 int	kern_symlinkat(struct thread *td, const char *path1, int fd,
 	    const char *path2, enum uio_seg segflg);
 int	kern_sync(struct thread *td);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -441,6 +441,7 @@ int	user_cpuset_getaffinity(struct thread *td, cpulevel_t level,
 int	user_cpuset_setaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize,
 	    const cpuset_t *maskp, const struct cpuset_copy_cb *cb);
+int	user_fstat(struct thread *td, int fd, struct stat *sb);
 
 /* flags for kern_sigaction */
 #define	KSA_OSIGSET	0x0001	/* uses osigact_t */

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -395,6 +395,7 @@ int	kern_openatfp(struct thread *td, int dirfd, const char *path,
 int	kern_pathconf(struct thread *td, const char *path,
 	    enum uio_seg pathseg, int name, u_long flags, long *valuep);
 int	kern_pdfork(struct thread *td, int *fdp, int flags);
+int	kern_pdrfork(struct thread *td, int *fdp, int pdflags, int rfflags);
 int	kern_pipe(struct thread *td, int fildes[2], int flags,
 	    struct filecaps *fcaps1, struct filecaps *fcaps2);
 int	kern_pipe2(struct thread *td, int *ufildes, int flags);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -402,6 +402,8 @@ int	kern_rctl_remove_rule(struct thread *td, const void *inbufp,
 int	kern_readlinkat(struct thread *td, int fd, const char *path,
 	    enum uio_seg pathseg, char *buf, enum uio_seg bufseg, size_t count);
 int	kern_readv(struct thread *td, int fd, struct uio *auio);
+int	kern_recvfrom(struct thread *td, int s, void *buf, size_t len,
+	    int flags, struct sockaddr *from, socklen_t *fromlenaddr);
 int	kern_recvit(struct thread *td, int s, struct msghdr *mp,
 	    enum uio_seg fromseg, struct mbuf **controlp);
 int	kern_renameat(struct thread *td, int oldfd, const char *old, int newfd,
@@ -525,12 +527,20 @@ int	kern_unmount(struct thread *td, const char *path, uint64_t flags);
 
 int	user___specialfd(struct thread *td, int type, const void *req,
 	    size_t len);
+int	user_accept(struct thread *td, int s, struct sockaddr *uname,
+	    socklen_t *anamelen, int flags);
+int	user_bind(struct thread *td, int s, const struct sockaddr *name,
+	    socklen_t namelen);
+int	user_bindat(struct thread *td, int fd, int s,
+	    const struct sockaddr *name, socklen_t namelen);
 int	user_cap_ioctls_limit(struct thread *td, int fd, const u_long *ucmds,
 	    size_t ncmds);
 int	user_cap_rights_limit(struct thread *td, int fd, cap_rights_t *rightsp);
 int	user_clock_nanosleep(struct thread *td, clockid_t clock_id,
 	    int flags, const struct timespec *ua_rqtp,
 	    struct timespec *ua_rmtp);
+int	user_connectat(struct thread *td, int fd, int s,
+	    const struct sockaddr *name, socklen_t namelen);
 int	user_cpuset_getaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize, cpuset_t *maskp,
 	    const struct cpuset_copy_cb *cb);
@@ -541,8 +551,14 @@ int	user_fspacectl(struct thread *td, int fd, int cmd,
 	    const struct spacectl_range *rqsrp, int flags,
 	    struct spacectl_range *rmsrp);
 int	user_fstat(struct thread *td, int fd, struct stat *sb);
+int	user_getpeername(struct thread *td, int fdes, struct sockaddr *asa,
+	    socklen_t *alen, bool compat);
 int	user_getrlimitusage(struct thread *td, u_int which, int flags,
 	    rlim_t *ures);
+int	user_getsockname(struct thread *td, int fdes, struct sockaddr *asa,
+	    socklen_t *alen, bool compat);
+int	user_getsockopt(struct thread *td, int s, int level, int name,
+	    void *val, socklen_t *avalsize);
 int	user_ioctl(struct thread *td, int fd, u_long ucom, void *udata,
 	    void *datap);
 int	user_kldload(struct thread *td, const char *file);
@@ -570,6 +586,9 @@ int	user_sched_setscheduler(struct thread *td, pid_t pid, int policy,
 	    const struct sched_param *param);
 int	user_select(struct thread *td, int nd, fd_set *in, fd_set *ou,
 	    fd_set *ex, struct timeval *utv);
+int	user_sendit(struct thread *td, int s, struct msghdr *mp, int flags);
+int	user_sendto(struct thread *td, int s, const char *buf, size_t len,
+	    int flags, const struct sockaddr *to, socklen_t tolen);
 int	user_setgroups(struct thread *td, int gidsetsize, const gid_t *gidset);
 int	user_settimeofday(struct thread *td, const struct timeval *tv,
 	    const struct timezone *tz);
@@ -582,6 +601,8 @@ int	user_sigtimedwait(struct thread *td, const sigset_t *uset, void *info,
 int	user_sigwait(struct thread *td, const sigset_t *uset, int *usig);
 int	user_sigwaitinfo(struct thread *td, const sigset_t *uset, void *info,
 	    copyout_siginfo_t *copyout_siginfop);
+int	user_socketpair(struct thread *td, int domain, int type, int protocol,
+	    int *rsv);
 int	user_uuidgen(struct thread *td, struct uuid *ustore, int count);
 int	user_wait6(struct thread *td, enum idtype idtype, id_t id,
 	    int *statusp, int options, struct __wrusage *wrusage,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -513,6 +513,14 @@ int	user_fstat(struct thread *td, int fd, struct stat *sb);
 int	user_getrlimitusage(struct thread *td, u_int which, int flags,
 	    rlim_t *ures);
 int	user_kldload(struct thread *td, const char *file);
+int	user_sched_getparam(struct thread *td, pid_t pid,
+	    struct sched_param *param);
+int	user_sched_rr_get_interval(struct thread *td, pid_t pid,
+	    struct timespec *interval);
+int	user_sched_setparam(struct thread *td, pid_t pid,
+	    const struct sched_param *param);
+int	user_sched_setscheduler(struct thread *td, pid_t pid, int policy,
+	    const struct sched_param *param);
 int	user_setgroups(struct thread *td, int gidsetsize, const gid_t *gidset);
 int	user_settimeofday(struct thread *td, const struct timeval *tv,
 	    const struct timezone *tz);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -256,8 +256,11 @@ int	kern_kevent_fp(struct thread *td, struct file *fp, int nchanges,
 int	kern_kexec_load(struct thread *td, u_long entry,
 	    u_long nseg, struct kexec_segment *seg, u_long flags);
 int	kern_kill(struct thread *td, pid_t pid, int signum);
+int	kern_kldfind(struct thread *td, const char *file);
 int	kern_kldload(struct thread *td, const char *file, int *fileid);
 int	kern_kldstat(struct thread *td, int fileid, struct kld_file_stat *stat);
+int	kern_kldsym(struct thread *td, int fileid, int cmd,
+	    const char *symname, u_long *symvalue, size_t *symsize);
 int	kern_kldunload(struct thread *td, int fileid, int flags);
 int	kern_kmq_notify(struct thread *, int, struct sigevent *);
 int	kern_kmq_open(struct thread *, const char *, int, mode_t,
@@ -468,6 +471,7 @@ int	user_cpuset_setaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize,
 	    const cpuset_t *maskp, const struct cpuset_copy_cb *cb);
 int	user_fstat(struct thread *td, int fd, struct stat *sb);
+int	user_kldload(struct thread *td, const char *file);
 int	user_wait6(struct thread *td, enum idtype idtype, id_t id,
 	    int *statusp, int options, struct __wrusage *wrusage,
 	    siginfo_t *sip);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -97,6 +97,8 @@ struct mmap_req {
 };
 
 uint64_t at2cnpflags(u_int at_flags, u_int mask);
+int	kern___cap_rights_get(struct thread *td, int version, int fd,
+	    cap_rights_t *rightsp);
 int	kern___getcwd(struct thread *td, char *buf, enum uio_seg bufseg,
 	    size_t buflen, size_t path_max);
 int	kern___mac_get_fd(struct thread *td, int fd, void *mac_p);
@@ -120,6 +122,10 @@ int	kern_auditctl(struct thread *td, const char *path);
 int	kern_auditon(struct thread *td, int cmd, void *data, u_int length);
 int	kern_bindat(struct thread *td, int dirfd, int fd, struct sockaddr *sa);
 int	kern_break(struct thread *td, uintptr_t *addr);
+int	kern_cap_fcntls_get(struct thread *td, int fd, uint32_t *fcntlrightsp);
+int	kern_cap_getmode(struct thread *td, u_int *modep);
+int	kern_cap_ioctls_get(struct thread *td, int fd, u_long *dstcmds,
+	    size_t maxcmds);
 int	kern_cap_ioctls_limit(struct thread *td, int fd, u_long *cmds,
 	    size_t ncmds);
 int	kern_cap_rights_limit(struct thread *td, int fd, cap_rights_t *rights);
@@ -502,6 +508,9 @@ int	kern_socketpair(struct thread *td, int domain, int type, int protocol,
 	    int *rsv);
 int	kern_unmount(struct thread *td, const char *path, uint64_t flags);
 
+int	user_cap_ioctls_limit(struct thread *td, int fd, const u_long *ucmds,
+	    size_t ncmds);
+int	user_cap_rights_limit(struct thread *td, int fd, cap_rights_t *rightsp);
 int	user_clock_nanosleep(struct thread *td, clockid_t clock_id,
 	    int flags, const struct timespec *ua_rqtp,
 	    struct timespec *ua_rmtp);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -640,6 +640,8 @@ int	user_ioctl(struct thread *td, int fd, u_long ucom, void *udata,
 	    void *datap);
 int	user_kldload(struct thread *td, const char *file);
 int	user_pdgetpid(struct thread *td, int fd, pid_t *pidp);
+int	user_pdwait(struct thread *td, int fd, int *statusp, int options,
+	    struct __wrusage *wrusage, siginfo_t *sip);
 int	user_poll(struct thread *td, struct pollfd *fds, u_int nfds,
 	    int timeout);
 int	user_ppoll(struct thread *td, struct pollfd *fds, u_int nfds,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -228,11 +228,17 @@ int	kern_getfhat(struct thread *td, int flags, int fd, const char *path,
 	    enum uio_seg pathseg, fhandle_t *fhp, enum uio_seg fhseg);
 int	kern_getfsstat(struct thread *td, struct statfs **buf, size_t bufsize,
 	    size_t *countp, enum uio_seg bufseg, int mode);
+int	kern_getgroups(struct thread *td, int gidsetsize, gid_t *gidset);
 int	kern_getitimer(struct thread *, u_int, struct itimerval *);
+int	kern_getlogin(struct thread *td, char *namebuf, u_int namelen);
 int	kern_getloginclass(struct thread *td, char *namebuf, size_t namelen);
 int	kern_getppid(struct thread *);
 int	kern_getpeername(struct thread *td, int fd, struct sockaddr *sa);
 int	kern_getpriority(struct thread *td, int which, int who);
+int	kern_getresgid(struct thread *td, gid_t *rgid, gid_t *egid,
+	    gid_t *sgid);
+int	kern_getresuid(struct thread *td, uid_t *ruid, uid_t *euid,
+	    uid_t *suid);
 int	kern_getrusage(struct thread *td, int who, struct rusage *rup);
 int	kern_getsid(struct thread *td, pid_t pid);
 int	kern_getsockname(struct thread *td, int fd, struct sockaddr *sa);
@@ -394,6 +400,7 @@ int	kern_setcred(struct thread *const td, const u_int flags,
 int	kern_setgroups(struct thread *td, int *ngrpp, gid_t *groups);
 int	kern_setitimer(struct thread *, u_int, struct itimerval *,
 	    struct itimerval *);
+int	kern_setlogin(struct thread *td, const char *namebuf);
 int	kern_setloginclass(struct thread *td, const char *namebuf);
 int	kern_setpriority(struct thread *td, int which, int who, int prio);
 int	kern_setrlimit(struct thread *, u_int, struct rlimit *);
@@ -477,6 +484,7 @@ int	user_cpuset_setaffinity(struct thread *td, cpulevel_t level,
 	    const cpuset_t *maskp, const struct cpuset_copy_cb *cb);
 int	user_fstat(struct thread *td, int fd, struct stat *sb);
 int	user_kldload(struct thread *td, const char *file);
+int	user_setgroups(struct thread *td, int gidsetsize, const gid_t *gidset);
 int	user_wait6(struct thread *td, enum idtype idtype, id_t id,
 	    int *statusp, int options, struct __wrusage *wrusage,
 	    siginfo_t *sip);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -322,6 +322,7 @@ int	kern_openatfp(struct thread *td, int dirfd, const char *path,
 	    enum uio_seg pathseg, int flags, int mode, struct file **fpp);
 int	kern_pathconf(struct thread *td, const char *path,
 	    enum uio_seg pathseg, int name, u_long flags, long *valuep);
+int	kern_pdfork(struct thread *td, int *fdp, int flags);
 int	kern_pipe(struct thread *td, int fildes[2], int flags,
 	    struct filecaps *fcaps1, struct filecaps *fcaps2);
 int	kern_poll(struct thread *td, struct pollfd *fds, u_int nfds,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -191,6 +191,8 @@ int	kern_dup(struct thread *td, u_int mode, int flags, int old, int new);
 int	kern_execve(struct thread *td, struct image_args *args,
 	    struct mac *mac_p, struct vmspace *oldvmspace);
 void	kern_exit(struct thread *, int, int);
+int	kern_extattrctl(struct thread *td, const char *path, int cmd,
+	    const char *filename, int attrnamespace, const char *uattrname);
 int	kern_extattr_delete_fd(struct thread *td, int fd, int attrnamespace,
 	    const char *attrname);
 int	kern_extattr_delete_fp(struct thread *td, struct file *fp,
@@ -563,6 +565,24 @@ int	user_cpuset_getaffinity(struct thread *td, cpulevel_t level,
 int	user_cpuset_setaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize,
 	    const cpuset_t *maskp, const struct cpuset_copy_cb *cb);
+int	user_extattr_delete_fd(struct thread *td, int fd, int attrnamespace,
+	    const char *uattrname);
+int	user_extattr_delete_path(struct thread *td, const char *path,
+	    int attrnamespace, const char *attrname, int follow);
+int	user_extattr_get_fd(struct thread *td, int fd, int attrnamespace,
+	    const char *uattrname, void *data, size_t nbytes);
+int	user_extattr_get_path(struct thread *td, const char *path,
+	    int attrnamespace, const char *attrname, void *data,
+	    size_t nbytes, int follow);
+int	user_extattr_list_fd(struct thread *td, int fd, int attrnamespace,
+	    void *data, size_t nbytes);
+int	user_extattr_list_path(struct thread *td, const char *path,
+	    int attrnamespace, void *data, size_t nbytes, int follow);
+int	user_extattr_set_fd(struct thread *td, int fd, int attrnamespace,
+	    const char *uattrname, void *data, size_t nbytes);
+int	user_extattr_set_path(struct thread *td, const char *path,
+	    int attrnamespace, const char *attrname, void *data,
+	    size_t nbytes, int follow);
 int	user_fspacectl(struct thread *td, int fd, int cmd,
 	    const struct spacectl_range *rqsrp, int flags,
 	    struct spacectl_range *rmsrp);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -70,6 +70,15 @@ struct uio;
 struct vm_map;
 struct vmspace;
 
+struct g_kevent_args {
+	int	fd;
+	const void *changelist;
+	int	nchanges;
+	void	*eventlist;
+	int	nevents;
+	const struct timespec *timeout;
+};
+
 typedef int (*mmap_check_fp_fn)(struct file *, int, int, int);
 
 struct mmap_req {
@@ -230,6 +239,8 @@ int	kern_kenv(struct thread *td, int what, const char *namep, char *val,
 	    int vallen);
 int	kern_kevent(struct thread *td, int fd, int nchanges, int nevents,
 	    struct kevent_copyops *k_ops, const struct timespec *timeout);
+int	kern_kevent_generic(struct thread *td, struct g_kevent_args *uap,
+	    struct kevent_copyops *k_ops, const char *struct_name);
 int	kern_kevent_anonymous(struct thread *td, int nevents,
 	    struct kevent_copyops *k_ops);
 int	kern_kevent_fp(struct thread *td, struct file *fp, int nchanges,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -85,6 +85,11 @@ struct mmap_req {
 uint64_t at2cnpflags(u_int at_flags, u_int mask);
 int	kern___getcwd(struct thread *td, char *buf, enum uio_seg bufseg,
 	    size_t buflen, size_t path_max);
+int	kern___mac_get_fd(struct thread *td, int fd, void *mac_p);
+int	kern___mac_get_pid(struct thread *td, pid_t pid, void *mac_p);
+int	kern___mac_get_proc(struct thread *td, void *mac_p);
+int	kern___mac_set_fd(struct thread *td, int fd, void *mac_p);
+int	kern___mac_set_proc(struct thread *td, void *mac_p);
 int	kern_abort2(struct thread *td, const char *why, int nargs,
 	    void **uargs);
 int	kern_accept(struct thread *td, int s, struct sockaddr *sa,
@@ -249,6 +254,12 @@ int	kern_listen(struct thread *td, int s, int backlog);
 int	kern_lseek(struct thread *td, int fd, off_t offset, int whence);
 int	kern_lutimes(struct thread *td, const char *path, enum uio_seg pathseg,
 	    const struct timeval *tptr, enum uio_seg tptrseg);
+int	kern_mac_get_path(struct thread *td, const char *path_p,
+	    struct mac *mac_p, int follow);
+int	kern_mac_set_path(struct thread *td, const char *path_p,
+	    struct mac *mac_p, int follow);
+int	kern_mac_syscall(struct thread *td, const char *policy, int call,
+	    void *arg);
 int	kern_madvise(struct thread *td, uintptr_t addr, size_t len, int behav);
 int	kern_membarrier(struct thread *td, int cmd, unsigned flags,
 	    int cpu_id);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -60,6 +60,7 @@ struct pollfd;
 struct ogetdirentries_args;
 struct rlimit;
 struct rusage;
+struct rtprio;
 struct sched_param;
 struct sembuf;
 union semun;
@@ -383,6 +384,10 @@ int	kern_recvit(struct thread *td, int s, struct msghdr *mp,
 	    enum uio_seg fromseg, struct mbuf **controlp);
 int	kern_renameat(struct thread *td, int oldfd, const char *old, int newfd,
 	    const char *new, enum uio_seg pathseg, u_int flags);
+int	kern_rtprio(struct thread *td, int function, pid_t pid,
+	    struct rtprio *urtp);
+int	kern_rtprio_thread(struct thread *td, int function, lwpid_t lwpid,
+	    struct rtprio *urtp);
 int	kern_sched_getparam(struct thread *td, struct thread *targettd,
 	    struct sched_param *param);
 int	kern_sched_getscheduler(struct thread *td, struct thread *targettd,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -452,6 +452,9 @@ int	kern_shm_open2(struct thread *td, const char *path, int flags,
 	    const char *name, struct shmfd *shmfd);
 int	kern_shmat(struct thread *td, int shmid, const void *shmaddr,
 	    int shmflg);
+int	kern_shm_rename(struct thread *td, const char *path_from_p,
+	    const char *path_to_p, int flags);
+int	kern_shm_unlink(struct thread *td, const char *userpath);
 int	kern_shmctl(struct thread *td, int shmid, int cmd, void *buf,
 	    size_t *bufsz);
 int	kern_shutdown(struct thread *td, int s, int how);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -457,6 +457,9 @@ int	user_cpuset_setaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize,
 	    const cpuset_t *maskp, const struct cpuset_copy_cb *cb);
 int	user_fstat(struct thread *td, int fd, struct stat *sb);
+int	user_wait6(struct thread *td, enum idtype idtype, id_t id,
+	    int *statusp, int options, struct __wrusage *wrusage,
+	    siginfo_t *sip);
 
 /* flags for kern_sigaction */
 #define	KSA_OSIGSET	0x0001	/* uses osigact_t */

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -71,6 +71,7 @@ struct stat;
 struct thr_param;
 struct timex;
 struct uio;
+struct uuid;
 struct vm_map;
 struct vmspace;
 
@@ -524,6 +525,7 @@ int	user_sigtimedwait(struct thread *td, const sigset_t *uset, void *info,
 int	user_sigwait(struct thread *td, const sigset_t *uset, int *usig);
 int	user_sigwaitinfo(struct thread *td, const sigset_t *uset, void *info,
 	    copyout_siginfo_t *copyout_siginfop);
+int	user_uuidgen(struct thread *td, struct uuid *ustore, int count);
 int	user_wait6(struct thread *td, enum idtype idtype, id_t id,
 	    int *statusp, int options, struct __wrusage *wrusage,
 	    siginfo_t *sip);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -57,6 +57,7 @@ struct module_stat;
 struct mq_attr;
 struct msghdr;
 struct msqid_ds;
+struct ntptimeval;
 struct pollfd;
 struct ogetdirentries_args;
 struct rlimit;
@@ -375,6 +376,7 @@ int	kern_nmount(struct thread *td, struct iovec *iovp, u_int iovcnt,
 	    int flags32, copyinuio_t *copyinuio_f);
 int	kern_nosys(struct thread *td, int dummy);
 int	kern_ntp_adjtime(struct thread *td, struct timex *ntv, int *retvalp);
+int	kern_ntp_gettime(struct thread *td, struct ntptimeval *ntvp);
 int	kern_ogetdirentries(struct thread *td, struct ogetdirentries_args *uap,
 	    long *ploff);
 int	kern_ommap(struct thread *td, uintptr_t hint, int len, int oprot,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -251,6 +251,8 @@ int	kern_getloginclass(struct thread *td, char *namebuf, size_t namelen);
 int	kern_getppid(struct thread *);
 int	kern_getpeername(struct thread *td, int fd, struct sockaddr *sa);
 int	kern_getpriority(struct thread *td, int which, int who);
+int	kern_getrandom(struct thread *td, void *user_buf, size_t buflen,
+	    unsigned int flags);
 int	kern_getresgid(struct thread *td, gid_t *rgid, gid_t *egid,
 	    gid_t *sgid);
 int	kern_getresuid(struct thread *td, uid_t *ruid, uid_t *euid,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -498,6 +498,8 @@ int	user_cpuset_setaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize,
 	    const cpuset_t *maskp, const struct cpuset_copy_cb *cb);
 int	user_fstat(struct thread *td, int fd, struct stat *sb);
+int	user_getrlimitusage(struct thread *td, u_int which, int flags,
+	    rlim_t *ures);
 int	user_kldload(struct thread *td, const char *file);
 int	user_setgroups(struct thread *td, int gidsetsize, const gid_t *gidset);
 int	user_wait6(struct thread *td, enum idtype idtype, id_t id,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -360,6 +360,7 @@ int	kern_pathconf(struct thread *td, const char *path,
 int	kern_pdfork(struct thread *td, int *fdp, int flags);
 int	kern_pipe(struct thread *td, int fildes[2], int flags,
 	    struct filecaps *fcaps1, struct filecaps *fcaps2);
+int	kern_pipe2(struct thread *td, int *ufildes, int flags);
 int	kern_poll(struct thread *td, struct pollfd *fds, u_int nfds,
 	    struct timespec *tsp, sigset_t *uset);
 int	kern_poll_kfds(struct thread *td, struct pollfd *fds, u_int nfds,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -95,6 +95,9 @@ int	kern_accessat(struct thread *td, int fd, const char *path,
 	    enum uio_seg pathseg, int flags, int mode);
 int	kern_adjtime(struct thread *td, struct timeval *delta,
 	    struct timeval *olddelta);
+int	kern_audit(struct thread *td, const void *record, u_int length);
+int	kern_auditctl(struct thread *td, const char *path);
+int	kern_auditon(struct thread *td, int cmd, void *data, u_int length);
 int	kern_bindat(struct thread *td, int dirfd, int fd, struct sockaddr *sa);
 int	kern_break(struct thread *td, uintptr_t *addr);
 int	kern_cap_ioctls_limit(struct thread *td, int fd, u_long *cmds,
@@ -191,6 +194,10 @@ int	kern_futimes(struct thread *td, int fd, const struct timeval *tptr,
 	    enum uio_seg tptrseg);
 int	kern_futimens(struct thread *td, int fd, const struct timespec *tptr,
 	    enum uio_seg tptrseg);
+int	kern_getaudit(struct thread *td, struct auditinfo *auditinfo);
+int	kern_getaudit_addr(struct thread *td,
+	    struct auditinfo_addr *auditinfo_addr, u_int length);
+int	kern_getauid(struct thread *td, uid_t *auid);
 int	kern_getdirentries(struct thread *td, int fd, char *buf, size_t count,
 	    off_t *basep, ssize_t *residp, enum uio_seg bufseg);
 int	kern_getfhat(struct thread *td, int flags, int fd, const char *path,
@@ -335,6 +342,10 @@ int	kern_select(struct thread *td, int nd, fd_set *fd_in, fd_set *fd_ou,
 	    fd_set *fd_ex, struct timeval *tvp, int abi_nfdbits);
 int	kern_sendit(struct thread *td, int s, struct msghdr *mp, int flags,
 	    struct mbuf *control, enum uio_seg segflg);
+int	kern_setaudit(struct thread *td, struct auditinfo *auditinfo);
+int	kern_setaudit_addr(struct thread *td,
+	    struct auditinfo_addr *auditinfo_addr, u_int length);
+int	kern_setauid(struct thread *td, uid_t *auid);
 int	kern_setcred(struct thread *const td, const u_int flags,
 	    struct setcred *const wcred);
 int	kern_setgroups(struct thread *td, int *ngrpp, gid_t *groups);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -511,11 +511,14 @@ int	kern_wait4(struct thread *td, int pid, int *statusp, int options,
 	    struct rusage *rusage);
 int	kern_wait6(struct thread *td, enum idtype idtype, id_t id, int *status,
 	    int options, struct __wrusage *wrup, siginfo_t *sip);
+int	kern_write(struct thread *td, int fd, const void *buf, size_t nbyte);
 int	kern_writev(struct thread *td, int fd, struct uio *auio);
 int	kern_socketpair(struct thread *td, int domain, int type, int protocol,
 	    int *rsv);
 int	kern_unmount(struct thread *td, const char *path, uint64_t flags);
 
+int	user___specialfd(struct thread *td, int type, const void *req,
+	    size_t len);
 int	user_cap_ioctls_limit(struct thread *td, int fd, const u_long *ucmds,
 	    size_t ncmds);
 int	user_cap_rights_limit(struct thread *td, int fd, cap_rights_t *rightsp);
@@ -528,10 +531,28 @@ int	user_cpuset_getaffinity(struct thread *td, cpulevel_t level,
 int	user_cpuset_setaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize,
 	    const cpuset_t *maskp, const struct cpuset_copy_cb *cb);
+int	user_fspacectl(struct thread *td, int fd, int cmd,
+	    const struct spacectl_range *rqsrp, int flags,
+	    struct spacectl_range *rmsrp);
 int	user_fstat(struct thread *td, int fd, struct stat *sb);
 int	user_getrlimitusage(struct thread *td, u_int which, int flags,
 	    rlim_t *ures);
+int	user_ioctl(struct thread *td, int fd, u_long ucom, void *udata,
+	    void *datap);
 int	user_kldload(struct thread *td, const char *file);
+int	user_poll(struct thread *td, struct pollfd *fds, u_int nfds,
+	    int timeout);
+int	user_ppoll(struct thread *td, struct pollfd *fds, u_int nfds,
+	    const struct timespec *uts, const sigset_t *uset);
+int	user_preadv(struct thread *td, int fd, struct iovec *iovp,
+	    u_int iovcnt, off_t offset, copyinuio_t *copyinuio_f);
+int	user_pselect(struct thread *td, int nd, fd_set *in, fd_set *ou,
+	    fd_set *ex, const struct timespec *uts, const sigset_t *sm);
+int	user_pwritev(struct thread *td, int fd, struct iovec *iovp,
+	    u_int iovcnt, off_t offset, copyinuio_t *copyinuio_f);
+int	user_read(struct thread *td, int fd, void *buf, size_t nbyte);
+int	user_readv(struct thread *td, int fd, const struct iovec *iovp,
+	    u_int iovcnt, copyinuio_t *copyinuio_f);
 int	user_sched_getparam(struct thread *td, pid_t pid,
 	    struct sched_param *param);
 int	user_sched_rr_get_interval(struct thread *td, pid_t pid,
@@ -540,6 +561,8 @@ int	user_sched_setparam(struct thread *td, pid_t pid,
 	    const struct sched_param *param);
 int	user_sched_setscheduler(struct thread *td, pid_t pid, int policy,
 	    const struct sched_param *param);
+int	user_select(struct thread *td, int nd, fd_set *in, fd_set *ou,
+	    fd_set *ex, struct timeval *utv);
 int	user_setgroups(struct thread *td, int gidsetsize, const gid_t *gidset);
 int	user_settimeofday(struct thread *td, const struct timeval *tv,
 	    const struct timezone *tz);
@@ -556,6 +579,8 @@ int	user_uuidgen(struct thread *td, struct uuid *ustore, int count);
 int	user_wait6(struct thread *td, enum idtype idtype, id_t id,
 	    int *statusp, int options, struct __wrusage *wrusage,
 	    siginfo_t *sip);
+int	user_writev(struct thread *td, int fd, const struct iovec *iovp,
+	    u_int iovcnt, copyinuio_t *copyinuio_f);
 
 /* flags for kern_sigaction */
 #define	KSA_OSIGSET	0x0001	/* uses osigact_t */

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -226,6 +226,8 @@ int	kern_jail_get(struct thread *td, struct uio *options, int flags);
 int	kern_jail_set(struct thread *td, struct uio *options, int flags);
 int	kern_kcmp(struct thread *td, pid_t pid1, pid_t pid2, int type,
 	    uintptr_t idx1, uintptr_t idx2);
+int	kern_kenv(struct thread *td, int what, const char *namep, char *val,
+	    int vallen);
 int	kern_kevent(struct thread *td, int fd, int nchanges, int nevents,
 	    struct kevent_copyops *k_ops, const struct timespec *timeout);
 int	kern_kevent_anonymous(struct thread *td, int nevents,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -228,6 +228,7 @@ int	kern_getfhat(struct thread *td, int flags, int fd, const char *path,
 int	kern_getfsstat(struct thread *td, struct statfs **buf, size_t bufsize,
 	    size_t *countp, enum uio_seg bufseg, int mode);
 int	kern_getitimer(struct thread *, u_int, struct itimerval *);
+int	kern_getloginclass(struct thread *td, char *namebuf, size_t namelen);
 int	kern_getppid(struct thread *);
 int	kern_getpeername(struct thread *td, int fd, struct sockaddr *sa);
 int	kern_getpriority(struct thread *td, int which, int who);
@@ -390,6 +391,7 @@ int	kern_setcred(struct thread *const td, const u_int flags,
 int	kern_setgroups(struct thread *td, int *ngrpp, gid_t *groups);
 int	kern_setitimer(struct thread *, u_int, struct itimerval *,
 	    struct itimerval *);
+int	kern_setloginclass(struct thread *td, const char *namebuf);
 int	kern_setpriority(struct thread *td, int which, int who, int prio);
 int	kern_setrlimit(struct thread *, u_int, struct rlimit *);
 int	kern_setsockopt(struct thread *td, int s, int level, int name,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -254,6 +254,8 @@ int	kern_fhstatfs(struct thread *td, fhandle_t fh, struct statfs *buf);
 int	kern_fpathconf(struct thread *td, int fd, int name, long *valuep);
 int	kern_freebsd11_getfsstat(struct thread *td,
 	    struct freebsd11_statfs *ubuf, long bufsize, int mode);
+int	kern_freebsd14_getgroups(struct thread *td, int gidsetsize,
+	    gid_t *gidset);
 int	kern_frmdirat(struct thread *td, int dfd, const char *path, int fd,
 	    enum uio_seg pathseg, int flag);
 int	kern_fstat(struct thread *td, int fd, struct stat *sbp);
@@ -617,6 +619,8 @@ int	user_fhstat(struct thread *td, const struct fhandle *u_fhp,
 	    struct stat *usb);
 int	user_fhstatfs(struct thread *td, const struct fhandle *u_fhp,
 	    struct statfs *buf);
+int	user_freebsd14_setgroups(struct thread *td, int gidsetsize,
+	    const gid_t *gidset);
 int	user_fspacectl(struct thread *td, int fd, int cmd,
 	    const struct spacectl_range *rqsrp, int flags,
 	    struct spacectl_range *rmsrp);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -65,6 +65,7 @@ struct rusage;
 struct rtprio;
 struct sched_param;
 struct sembuf;
+struct sendfile_args;
 union semun;
 struct shmfd;
 struct sockaddr;
@@ -97,6 +98,12 @@ struct mmap_req {
 	off_t			mr_pos;
 	mmap_check_fp_fn	mr_check_fp_fn;
 };
+
+/*
+ * A copyin_hdtr_t takes a pointer to a sendfile header/trailer in
+ * userspace and storage for on in the kernel and copies it in.
+ */
+typedef        int (copyin_hdtr_t)(const void *hdtrp, struct sf_hdtr *hdtr);
 
 /*
  * A copyinuio_t takes a pointer to an iovec in userspace along with a
@@ -459,6 +466,8 @@ int	kern_sched_rr_get_interval_td(struct thread *td, struct thread *targettd,
 	    struct timespec *ts);
 int	kern_semctl(struct thread *td, int semid, int semnum, int cmd,
 	    union semun *arg, register_t *rval);
+int	kern_sendfile(struct thread *td, struct sendfile_args *uap, bool compat,
+	    copyin_hdtr_t *copyin_hdtr_f, copyinuio_t *copyinuio_f);
 int	kern_select(struct thread *td, int nd, fd_set *fd_in, fd_set *fd_ou,
 	    fd_set *fd_ex, struct timeval *tvp, int abi_nfdbits);
 int	kern_sendit(struct thread *td, int s, struct msghdr *mp, int flags,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -270,6 +270,8 @@ int	kern_kmq_timedsend(struct thread *td, int, const char *,
 	    size_t, unsigned int, const struct timespec *);
 int	kern_kqueue(struct thread *td, int flags, bool cponfork,
 	    struct filecaps *fcaps);
+int	kern_ktrace(struct thread *td, const char *fname, int uops, int ufacs,
+	    int pid);
 int	kern_linkat(struct thread *td, int fd1, int fd2, const char *path1,
 	    const char *path2, enum uio_seg segflg, int flag);
 int	kern_listen(struct thread *td, int s, int backlog);
@@ -447,6 +449,7 @@ int	kern_utimesat(struct thread *td, int fd, const char *path,
 int	kern_utimensat(struct thread *td, int fd, const char *path,
 	    enum uio_seg pathseg, const struct timespec *tptr,
 	    enum uio_seg tptrseg, int flag);
+int	kern_utrace(struct thread *td, const void *addr, size_t len);
 int	kern_wait(struct thread *td, pid_t pid, int *status, int options,
 	    struct rusage *rup);
 int	kern_wait4(struct thread *td, int pid, int *statusp, int options,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -366,6 +366,16 @@ int	kern_ptrace(struct thread *td, int req, pid_t pid, void *addr,
 int	kern_pwrite(struct thread *td, int fd, const void *buf, size_t nbyte,
 	    off_t offset);
 int	kern_pwritev(struct thread *td, int fd, struct uio *auio, off_t offset);
+int	kern_rctl_add_rule(struct thread *td, const void *inbufp,
+	    size_t inbuflen, void *outbufp, size_t outbuflen);
+int	kern_rctl_get_limits(struct thread *td, const void *inbufp,
+	    size_t inbuflen, void *outbufp, size_t outbuflen);
+int	kern_rctl_get_racct(struct thread *td, const void *inbufp,
+	    size_t inbuflen, void *outbufp, size_t outbuflen);
+int	kern_rctl_get_rules(struct thread *td, const void *inbufp,
+	    size_t inbuflen, void *outbufp, size_t outbuflen);
+int	kern_rctl_remove_rule(struct thread *td, const void *inbufp,
+	    size_t inbuflen, void *outbufp, size_t outbuflen);
 int	kern_readlinkat(struct thread *td, int fd, const char *path,
 	    enum uio_seg pathseg, char *buf, enum uio_seg bufseg, size_t count);
 int	kern_readv(struct thread *td, int fd, struct uio *auio);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -543,6 +543,7 @@ int	user_getrlimitusage(struct thread *td, u_int which, int flags,
 int	user_ioctl(struct thread *td, int fd, u_long ucom, void *udata,
 	    void *datap);
 int	user_kldload(struct thread *td, const char *file);
+int	user_pdgetpid(struct thread *td, int fd, pid_t *pidp);
 int	user_poll(struct thread *td, struct pollfd *fds, u_int nfds,
 	    int timeout);
 int	user_ppoll(struct thread *td, struct pollfd *fds, u_int nfds,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -436,6 +436,8 @@ int	kern_shutdown(struct thread *td, int s, int how);
 int	kern_sigaction(struct thread *td, int sig, const struct sigaction *act,
 	    struct sigaction *oact, int flags);
 int	kern_sigaltstack(struct thread *td, stack_t *ss, stack_t *oss);
+int	kern_sigfastblock(struct thread *td, int cmd, uint32_t *ptr);
+int	kern_sigpending(struct thread *td, sigset_t *set);
 int	kern_sigprocmask(struct thread *td, int how,
 	    sigset_t *set, sigset_t *oset, int flags);
 int	kern_sigsuspend(struct thread *td, sigset_t mask);
@@ -502,6 +504,15 @@ int	user_getrlimitusage(struct thread *td, u_int which, int flags,
 	    rlim_t *ures);
 int	user_kldload(struct thread *td, const char *file);
 int	user_setgroups(struct thread *td, int gidsetsize, const gid_t *gidset);
+int	user_sigprocmask(struct thread *td, int how, const sigset_t *uset,
+	    sigset_t *uoset);
+int	user_sigsuspend(struct thread *td, const sigset_t *sigmask);
+int	user_sigtimedwait(struct thread *td, const sigset_t *uset, void *info,
+	    const struct timespec *utimeout,
+	    copyout_siginfo_t *copyout_siginfop);
+int	user_sigwait(struct thread *td, const sigset_t *uset, int *usig);
+int	user_sigwaitinfo(struct thread *td, const sigset_t *uset, void *info,
+	    copyout_siginfo_t *copyout_siginfop);
 int	user_wait6(struct thread *td, enum idtype idtype, id_t id,
 	    int *statusp, int options, struct __wrusage *wrusage,
 	    siginfo_t *sip);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -470,6 +470,7 @@ int	kern_semop(struct thread *td, int usemid, struct sembuf *usops,
 int	kern_thr_alloc(struct proc *, int pages, struct thread **);
 int	kern_thr_exit(struct thread *td);
 int	kern_thr_new(struct thread *td, struct thr_param *param);
+int	kern_thr_set_name(struct thread *td, lwpid_t id, const char *uname);
 int	kern_thr_suspend(struct thread *td, struct timespec *tsp);
 int	kern_timerfd_create(struct thread *td, int clockid, int flags);
 int	kern_timerfd_gettime(struct thread *td, int fd,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <sys/_cpuset.h>
 #include <sys/_domainset.h>
+#include <sys/_ffcounter.h>
 #include <sys/_uio.h>
 #include <sys/mac.h>
 #include <sys/mount.h>
@@ -39,6 +40,7 @@
 
 struct __wrusage;
 struct cpuset_copy_cb;
+struct ffclock_estimate;
 struct file;
 struct filecaps;
 enum idtype;
@@ -192,6 +194,11 @@ int	kern_fchownat(struct thread *td, int fd, const char *path,
 	    enum uio_seg pathseg, int uid, int gid, int flag);
 int	kern_fcntl(struct thread *td, int fd, int cmd, intptr_t arg);
 int	kern_fcntl_freebsd(struct thread *td, int fd, int cmd, intptr_t arg);
+int	kern_ffclock_getcounter(struct thread *td, ffcounter *ffcountp);
+int	kern_ffclock_getestimate(struct thread *td,
+	    struct ffclock_estimate *ucest);
+int	kern_ffclock_setestimate(struct thread *td,
+	    const struct ffclock_estimate *ucest);
 int	kern_fhopen(struct thread *td, const struct fhandle *u_fhp, int flags);
 int	kern_fhstat(struct thread *td, fhandle_t fh, struct stat *buf);
 int	kern_fhstatfs(struct thread *td, fhandle_t fh, struct statfs *buf);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -112,6 +112,12 @@ typedef        int (copyin_hdtr_t)(const void *hdtrp, struct sf_hdtr *hdtr);
  */
 typedef int (copyinuio_t)(const struct iovec *iovp, unsigned int iovcnt,
     struct uio **iov);
+/*
+ * A updateiov_t takes a pointer to a struct uio previously created with
+ * copyinuio_t and a pointer to the corresponding iovec in userspace.
+ * It updates all lengths in userspace to match those in the uio.
+ */
+typedef int(updateiov_t)(const struct uio *uiop, struct iovec *iovp);
 
 uint64_t at2cnpflags(u_int at_flags, u_int mask);
 int	kern___acl_aclcheck_fd(struct thread *td, int filedes,
@@ -642,6 +648,11 @@ int	user_getsockopt(struct thread *td, int s, int level, int name,
 	    void *val, socklen_t *avalsize);
 int	user_ioctl(struct thread *td, int fd, u_long ucom, void *udata,
 	    void *datap);
+int	user_jail_get(struct thread *td, struct iovec *iovp,
+	    unsigned int iovcnt, int flags, copyinuio_t *copyinuio_f,
+	    updateiov_t *updateiov_f);
+int	user_jail_set(struct thread *td, struct iovec *iovp,
+	    unsigned int iovcnt, int flags, copyinuio_t *copyinuio_f);
 int	user_kldload(struct thread *td, const char *file);
 int	user_pdgetpid(struct thread *td, int fd, pid_t *pidp);
 int	user_pdwait(struct thread *td, int fd, int *statusp, int options,

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -52,6 +52,7 @@ struct kexec_segment;
 struct kld_file_stat;
 struct ksiginfo;
 struct mbuf;
+struct module_stat;
 struct mq_attr;
 struct msghdr;
 struct msqid_ds;
@@ -306,6 +307,8 @@ int	kern_mmap(struct thread *td, const struct mmap_req *mrp);
 int	kern_mmap_racct_check(struct thread *td, struct vm_map *map,
 	    vm_size_t size);
 int	kern_mmap_maxprot(struct proc *p, int prot);
+int	kern_modfind(struct thread *td, const char *uname);
+int	kern_modstat(struct thread *td, int modid, struct module_stat *stat);
 int	kern_mprotect(struct thread *td, uintptr_t addr, size_t size,
 	    int prot, int flags);
 int	kern_msgctl(struct thread *, int, int, struct msqid_ds *);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -360,6 +360,8 @@ int	kern_pdwait(struct thread *td, int fd, int *status,
 	    int options, struct __wrusage *wrusage, siginfo_t *sip);
 int	kern_procctl(struct thread *td, enum idtype idtype, id_t id, int com,
 	    void *data);
+int	kern_profil(struct thread *td, char *samples, size_t size,
+	    size_t offset, u_int scale);
 int	kern_pread(struct thread *td, int fd, void *buf, size_t nbyte,
 	    off_t offset);
 int	kern_preadv(struct thread *td, int fd, struct uio *auio, off_t offset);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -485,8 +485,6 @@ int	kern_shm_open(struct thread *td, const char *userpath, int flags,
 int	kern_shm_open2(struct thread *td, const char *path, int flags,
 	    mode_t mode, int shmflags, struct filecaps *fcaps,
 	    const char *name, struct shmfd *shmfd);
-int	kern_shmat(struct thread *td, int shmid, const void *shmaddr,
-	    int shmflg);
 int	kern_shm_rename(struct thread *td, const char *path_from_p,
 	    const char *path_to_p, int flags);
 int	kern_shm_unlink(struct thread *td, const char *userpath);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -245,6 +245,8 @@ int	kern_getsid(struct thread *td, pid_t pid);
 int	kern_getsockname(struct thread *td, int fd, struct sockaddr *sa);
 int	kern_getsockopt(struct thread *td, int s, int level, int name,
 	    void *optval, enum uio_seg valseg, socklen_t *valsize);
+int	kern_gettimeofday(struct thread *td, struct timeval *tp,
+	    struct timezone *tzp);
 int	kern_ioctl(struct thread *td, int fd, u_long com, caddr_t data);
 int	kern_jail(struct thread *td, struct jail *j);
 int	kern_jail_get(struct thread *td, struct uio *options, int flags);
@@ -497,6 +499,9 @@ int	kern_socketpair(struct thread *td, int domain, int type, int protocol,
 	    int *rsv);
 int	kern_unmount(struct thread *td, const char *path, uint64_t flags);
 
+int	user_clock_nanosleep(struct thread *td, clockid_t clock_id,
+	    int flags, const struct timespec *ua_rqtp,
+	    struct timespec *ua_rmtp);
 int	user_cpuset_getaffinity(struct thread *td, cpulevel_t level,
 	    cpuwhich_t which, id_t id, size_t cpusetsize, cpuset_t *maskp,
 	    const struct cpuset_copy_cb *cb);
@@ -508,6 +513,8 @@ int	user_getrlimitusage(struct thread *td, u_int which, int flags,
 	    rlim_t *ures);
 int	user_kldload(struct thread *td, const char *file);
 int	user_setgroups(struct thread *td, int gidsetsize, const gid_t *gidset);
+int	user_settimeofday(struct thread *td, const struct timeval *tv,
+	    const struct timezone *tz);
 int	user_sigprocmask(struct thread *td, int how, const sigset_t *uset,
 	    sigset_t *uoset);
 int	user_sigsuspend(struct thread *td, const sigset_t *sigmask);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -454,6 +454,9 @@ int	kern_statfs(struct thread *td, const char *path, enum uio_seg pathseg,
 int	kern_symlinkat(struct thread *td, const char *path1, int fd,
 	    const char *path2, enum uio_seg segflg);
 int	kern_sync(struct thread *td);
+int	kern_sysctl(struct thread *td, const int *uname, u_int namelen,
+	    void *old, size_t *oldlenp, const void *new, size_t newlen,
+	    int flags);
 int	kern_ktimer_create(struct thread *td, clockid_t clock_id,
 	    struct sigevent *evp, int *timerid, int preset_id);
 int	kern_ktimer_delete(struct thread *, int);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -363,6 +363,8 @@ int	kern_munlock(struct thread *td, uintptr_t addr, size_t size);
 int	kern_munmap(struct thread *td, uintptr_t addr, size_t size);
 int     kern_nanosleep(struct thread *td, struct timespec *rqt,
 	    struct timespec *rmt);
+int	kern_nmount(struct thread *td, struct iovec *iovp, u_int iovcnt,
+	    int flags32, copyinuio_t *copyinuio_f);
 int	kern_nosys(struct thread *td, int dummy);
 int	kern_ntp_adjtime(struct thread *td, struct timex *ntv, int *retvalp);
 int	kern_ogetdirentries(struct thread *td, struct ogetdirentries_args *uap,

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -99,6 +99,7 @@ int	uiomove_fromphys(struct vm_page *ma[], vm_offset_t offset, int n,
 int	uiomove_nofault(void *cp, int n, struct uio *uio);
 int	uiomove_object(struct vm_object *obj, off_t obj_size, struct uio *uio);
 int	uiomove_step(void *cp, void *base, size_t cnt, struct uio *uio);
+int	updateiov(const struct uio *uiop, struct iovec *iovp);
 
 #else /* !_KERNEL */
 

--- a/sys/vm/swap_pager.c
+++ b/sys/vm/swap_pager.c
@@ -92,6 +92,7 @@
 #include <sys/resourcevar.h>
 #include <sys/rwlock.h>
 #include <sys/sbuf.h>
+#include <sys/syscallsubr.h>
 #include <sys/sysctl.h>
 #include <sys/sysproto.h>
 #include <sys/systm.h>
@@ -2645,6 +2646,12 @@ struct swapon_args {
 int
 sys_swapon(struct thread *td, struct swapon_args *uap)
 {
+	return (kern_swapon(td, uap->name));
+}
+
+int
+kern_swapon(struct thread *td, const char *name)
+{
 	struct vattr attr;
 	struct vnode *vp;
 	struct nameidata nd;
@@ -2666,7 +2673,7 @@ sys_swapon(struct thread *td, struct swapon_args *uap)
 	}
 
 	NDINIT(&nd, LOOKUP, ISOPEN | FOLLOW | LOCKLEAF | AUDITVNODE1,
-	    UIO_USERSPACE, uap->name);
+	    UIO_USERSPACE, name);
 	error = namei(&nd);
 	if (error)
 		goto done;
@@ -2785,7 +2792,7 @@ swaponsomething(struct vnode *vp, void *id, u_long nblks,
  * rather than filename as specification.  We keep sw_vp around
  * only to make this work.
  */
-static int
+int
 kern_swapoff(struct thread *td, const char *name, enum uio_seg name_seg,
     u_int flags)
 {


### PR DESCRIPTION
With CHERI the set of system calls that need to be translated in compatibility layers changes. Instead of systems calls that point to objects whose underlying type changes (e.g., pointers in freebsd32 are 32-bit integers), all systems calls that take a pointer need to be changed.  This is because all access to userspace in a CHERI kernel is via a capability and we need to make one from the integer pointer arguments. This series of commits adds kern_ or, where a kern_ that isn't suitable already exists, user_ wrapper functions. These new functions will take capability arguments either directly from sys_ system call implementations or from freebsd64_ (and perhaps eventually freebsd32_) implementations that create capabilities to pass in.

Most of these functions are trivial (often to the point that they could theoretically be generated), but in a few cases, such as sendfile(2), I've done a more significant refactoring of existing code.

In the creation of user_ functions I've strongly biased toward reduction of duplicate code based on my experiences writing first compat/cheriabi (the initial CHERI syscall interface) and compat/freebsd64. The goal is to make freebsd64_ implementations as thin as possible.

Changes are generally split by file to allow bisection and easy reverts should they become necessary.