### PR TITLE
tcp.fastopen.client_enable: fix documented default value.

### DIFF
--- a/share/man/man4/tcp.4
+++ b/share/man/man4/tcp.4
@@ -31,7 +31,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd May 17, 2026
+.Dd June 17, 2026
 .Dt TCP 4
 .Os
 .Sh NAME
@@ -589,7 +589,7 @@ On the transition from enabled to disabled, the client cookie cache is cleared
 and disabled.
 The transition from enabled to disabled does not affect any active TFO
 connections in progress; it only prevents new ones from being established.
-The default is 0.
+The default is 1.
 .It Va fastopen.keylen
 The key length in bytes.
 Read-only.

--- a/sys/netinet/tcp_fastopen.c
+++ b/sys/netinet/tcp_fastopen.c
@@ -84,7 +84,7 @@
  * net.inet.tcp.fastopen.ccache_list (RO)
  *     Print the client cookie cache.
  *
- * net.inet.tcp.fastopen.client_enable (RW, default 0)
+ * net.inet.tcp.fastopen.client_enable (RW, default 1)
  *     When zero, no new active (i.e., client) TFO connections can be
  *     created.  On the transition from enabled to disabled, the client
  *     cookie cache is cleared and disabled.  The transition from enabled to


### PR DESCRIPTION
The default value has been 1 since June 2018, but the docs were not updated to reflect the change.