### PR TITLE
libc: Implement qualifier-preserving standard library functions

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -414,4 +414,16 @@ errno_t	 qsort_s(void *, rsize_t, rsize_t,
 __END_DECLS
 __NULLABILITY_PRAGMA_POP
 
+#if defined(__qualsel) && !defined(__cplusplus) && \
+    defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define	bsearch(key, base, nmemb, size, compar)		__qualsel((base),    \
+	(const void *)(bsearch)((key), (base), (nmemb), (size), (compar)),   \
+	(bsearch)((key), (base), (nmemb), (size), (compar)))
+#ifdef __BLOCKS__
+#define	bsearch_b(key, base, nmemb, size, compar)	__qualsel((base),    \
+	(const void *)(bsearch_b)((key), (base), (nmemb), (size), (compar)), \
+	(bsearch_b)((key), (base), (nmemb), (size), (compar)))
+#endif
+#endif
+
 #endif /* !_STDLIB_H_ */

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -418,4 +418,16 @@ errno_t	 qsort_s(void *, rsize_t, rsize_t,
 __END_DECLS
 __NULLABILITY_PRAGMA_POP
 
+#if defined(__qualsel) && !defined(__cplusplus) && \
+    defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define	bsearch(key, base, nmemb, size, compar)		__qualsel((base),    \
+	(const void *)(bsearch)((key), (base), (nmemb), (size), (compar)),   \
+	(bsearch)((key), (base), (nmemb), (size), (compar)))
+#ifdef __BLOCKS__
+#define	bsearch_b(key, base, nmemb, size, compar)	__qualsel((base),    \
+	(const void *)(bsearch_b)((key), (base), (nmemb), (size), (compar)), \
+	(bsearch_b)((key), (base), (nmemb), (size), (compar)))
+#endif
+#endif
+
 #endif /* !_STDLIB_H_ */

--- a/include/string.h
+++ b/include/string.h
@@ -205,4 +205,32 @@ errno_t memset_s(void *, rsize_t, int, rsize_t);
 #endif /* __EXT1_VISIBLE */
 __END_DECLS
 
+#if defined(__qualsel) && !defined(__cplusplus) && \
+    defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define	memchr(b, c, n)		__qualsel((b),				\
+	(const void *)(memchr)((b), (c), (n)), (memchr)((b), (c), (n)))
+#define	strchr(s, c)		__qualsel((s),				\
+	(const char *)(strchr)((s), (c)), (strchr)((s), (c)))
+#define	strpbrk(s, charset)	__qualsel((s),				\
+	(const char *)(strpbrk)((s), (charset)), (strpbrk)((s), (charset)))
+#define	strrchr(s, c)		__qualsel((s),				\
+	(const char *)(strrchr)((s), (c)), (strrchr)((s), (c)))
+#define	strstr(s, find)		__qualsel((s),				\
+	(const char *)(strstr)((s), (find)), (strstr)((s), (find)))
+#if __BSD_VISIBLE
+#define	memmem(b, blen, pat, plen)	__qualsel((b),			\
+	(const void *)(memmem)((b), (blen), (pat), (plen)),		\
+	(memmem)((b), (blen), (pat), (plen)))
+#define	memrchr(b, c, n)	__qualsel((b),				\
+	(const void *)(memrchr)((b), (c), (n)), (memrchr)((b), (c), (n)))
+#define	strcasestr(s, find)	__qualsel((s),				\
+	(const char *)(strcasestr)((s), (find)), (strcasestr)((s), (find)))
+#define	strchrnul(s, c)		__qualsel((s),				\
+	(const char *)(strchrnul)((s), (c)), (strchrnul)((s), (c)))
+#define	strnstr(s, find, slen)	__qualsel((s),				\
+	(const char *)(strnstr)((s), (find), (slen)),			\
+	(strnstr)((s), (find), (slen)))
+#endif /* __BSD_VISIBLE */
+#endif
+
 #endif /* _STRING_H_ */

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -246,4 +246,18 @@ size_t	wcslcpy(wchar_t *, const wchar_t *, size_t);
 #endif
 __END_DECLS
 
+#if defined(__qualsel) && !defined(__cplusplus) && \
+    defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define	wcschr(s, c)		__qualsel((s),				\
+	(const wchar_t *)(wcschr)((s), (c)), (wcschr)((s), (c)))
+#define	wcspbrk(s, set)		__qualsel((s),				\
+	(const wchar_t *)(wcspbrk)((s), (set)), (wcspbrk)((s), (set)))
+#define	wcsrchr(s, c)		__qualsel((s),				\
+	(const wchar_t *)(wcsrchr)((s), (c)), (wcsrchr)((s), (c)))
+#define	wcsstr(s, find)		__qualsel((s),				\
+	(const wchar_t *)(wcsstr)((s), (find)), (wcsstr)((s), (find)))
+#define	wmemchr(s, c, n)	__qualsel((s),				\
+	(const wchar_t *)(wmemchr)((s), (c), (n)), (wmemchr)((s), (c), (n)))
+#endif
+
 #endif /* !_WCHAR_H_ */

--- a/lib/libc/stdlib/bsearch.3
+++ b/lib/libc/stdlib/bsearch.3
@@ -39,8 +39,8 @@
 .Lb libc
 .Sh SYNOPSIS
 .In stdlib.h
-.Ft void *
-.Fn bsearch "const void *key" "const void *base" "size_t nmemb" "size_t size" "int (*compar) (const void *, const void *)"
+.Ft "QVoid *"
+.Fn bsearch "const void *key" "QVoid *base" "size_t nmemb" "size_t size" "int (*compar) (const void *, const void *)"
 .Sh DESCRIPTION
 The
 .Fn bsearch

--- a/lib/libc/stdlib/bsearch.3
+++ b/lib/libc/stdlib/bsearch.3
@@ -29,7 +29,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd July 17, 2019
+.Dd June 21, 2026
 .Dt BSEARCH 3
 .Os
 .Sh NAME
@@ -153,4 +153,5 @@ main(void)
 The
 .Fn bsearch
 function conforms to
-.St -isoC .
+.St -isoC-2023 ,
+where it is specified as a qualifier-preserving function.

--- a/lib/libc/string/bstring.3
+++ b/lib/libc/string/bstring.3
@@ -27,7 +27,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 5, 2023
+.Dd June 21, 2026
 .Dt BSTRING 3
 .Os
 .Sh NAME
@@ -88,7 +88,6 @@ See the specific manual pages for more information.
 .Xr memset 3
 .Sh STANDARDS
 The functions
-.Fn memchr ,
 .Fn memcmp ,
 .Fn memcpy ,
 .Fn memmove ,
@@ -96,6 +95,12 @@ and
 .Fn memset
 conform to
 .St -isoC .
+.Pp
+The
+.Fn memchr
+function conforms to
+.St -isoC-2023 ,
+where it is specified as a qualifier-preserving function.
 .Sh HISTORY
 The functions
 .Fn bzero

--- a/lib/libc/string/bstring.3
+++ b/lib/libc/string/bstring.3
@@ -51,8 +51,8 @@
 .Fn bcopy "const void *src" "void *dst" "size_t len"
 .Ft void
 .Fn bzero "void *b" "size_t len"
-.Ft void *
-.Fn memchr "const void *b" "int c" "size_t len"
+.Ft "QVoid *"
+.Fn memchr "QVoid *b" "int c" "size_t len"
 .Ft int
 .Fn memcmp "const void *b1" "const void *b2" "size_t len"
 .Ft void *

--- a/lib/libc/string/memchr.3
+++ b/lib/libc/string/memchr.3
@@ -39,10 +39,10 @@
 .Lb libc
 .Sh SYNOPSIS
 .In string.h
-.Ft void *
-.Fn memchr "const void *b" "int c" "size_t len"
-.Ft void *
-.Fn memrchr "const void *b" "int c" "size_t len"
+.Ft "QVoid *"
+.Fn memchr "QVoid *b" "int c" "size_t len"
+.Ft "QVoid *"
+.Fn memrchr "QVoid *b" "int c" "size_t len"
 .Sh DESCRIPTION
 The
 .Fn memchr

--- a/lib/libc/string/memchr.3
+++ b/lib/libc/string/memchr.3
@@ -29,7 +29,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 9, 2008
+.Dd June 21, 2026
 .Dt MEMCHR 3
 .Os
 .Sh NAME
@@ -92,13 +92,18 @@ bytes.
 .Sh STANDARDS
 The
 .Fn memchr
-function
-conforms to
-.St -isoC .
+function conforms to
+.St -isoC-2023 ,
+where it is specified as a qualifier-preserving function.
 .Pp
 The
 .Fn memrchr
 function is a GNU extension and conforms to no standard.
+Like the qualifier-preserving functions in
+.St -isoC-2023 ,
+.Fx implements
+.Fn memrchr
+as qualifier-preserving as well.
 .Sh HISTORY
 The
 .Fn memrchr

--- a/lib/libc/string/memmem.3
+++ b/lib/libc/string/memmem.3
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 29, 2023
+.Dd June 21, 2026
 .Dt MEMMEM 3
 .Os
 .Sh NAME
@@ -71,6 +71,11 @@ is returned.
 .Fn memmem
 conforms to
 .St -p1003.1-2024 .
+Like the qualifier-preserving functions in
+.St -isoC-2023 ,
+.Fx implements
+.Fn memmem
+as qualifier-preserving as well.
 .Sh HISTORY
 The
 .Fn memmem

--- a/lib/libc/string/memmem.3
+++ b/lib/libc/string/memmem.3
@@ -34,9 +34,9 @@
 .Lb libc
 .Sh SYNOPSIS
 .In string.h
-.Ft "void *"
+.Ft "QVoid *"
 .Fo memmem
-.Fa "const void *big" "size_t big_len"
+.Fa "QVoid *big" "size_t big_len"
 .Fa "const void *little" "size_t little_len"
 .Fc
 .Sh DESCRIPTION

--- a/lib/libc/string/memmem.3
+++ b/lib/libc/string/memmem.3
@@ -71,6 +71,11 @@ is returned.
 .Fn memmem
 conforms to
 .St -p1003.1-2024 .
+Like the qualifier-preserving functions in
+.St -isoC-2023 ,
+.Fx implements
+.Fn memmem
+as qualifier-preserving as well.
 .Sh HISTORY
 The
 .Fn memmem

--- a/lib/libc/string/strchr.3
+++ b/lib/libc/string/strchr.3
@@ -29,7 +29,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd February 13, 2013
+.Dd June 21, 2026
 .Dt STRCHR 3
 .Os
 .Sh NAME
@@ -109,12 +109,20 @@ The functions
 and
 .Fn strrchr
 conform to
-.St -isoC .
+.St -isoC-2023 ,
+where they are specified as qualifier-preserving functions.
+.Pp
 The function
 .Fn strchrnul
 is a
 .Tn GNU
 extension.
+Like the qualifier-preserving functions in
+.St -isoC-2023 ,
+.Fx
+implements
+.Fn strchrnul
+as qualifier-preserving as well.
 .Sh HISTORY
 The
 .Fn strchrnul

--- a/lib/libc/string/strchr.3
+++ b/lib/libc/string/strchr.3
@@ -39,12 +39,12 @@
 .Lb libc
 .Sh SYNOPSIS
 .In string.h
-.Ft "char *"
-.Fn strchr "const char *s" "int c"
-.Ft "char *"
-.Fn strrchr "const char *s" "int c"
-.Ft "char *"
-.Fn strchrnul "const char *s" "int c"
+.Ft "QChar *"
+.Fn strchr "QChar *s" "int c"
+.Ft "QChar *"
+.Fn strrchr "QChar *s" "int c"
+.Ft "QChar *"
+.Fn strchrnul "QChar *s" "int c"
 .Sh DESCRIPTION
 The
 .Fn strchr

--- a/lib/libc/string/string.3
+++ b/lib/libc/string/string.3
@@ -27,7 +27,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd September 2, 2023
+.Dd June 21, 2026
 .Dt STRING 3
 .Os
 .Sh NAME
@@ -136,20 +136,26 @@ for size limitations.
 The
 .Fn strcat ,
 .Fn strncat ,
-.Fn strchr ,
-.Fn strrchr ,
 .Fn strcmp ,
 .Fn strncmp ,
 .Fn strcpy ,
 .Fn strncpy ,
 .Fn strerror ,
 .Fn strlen ,
-.Fn strpbrk ,
 .Fn strspn ,
 .Fn strcspn ,
-.Fn strstr ,
 and
 .Fn strtok
 functions
 conform to
 .St -isoC .
+.Pp
+The
+.Fn strchr ,
+.Fn strrchr ,
+.Fn strpbrk ,
+and
+.Fn strstr
+functions conform to
+.St -isoC-2023 ,
+where they are specified as qualifier-preserving functions.

--- a/lib/libc/string/string.3
+++ b/lib/libc/string/string.3
@@ -63,10 +63,10 @@
 .Fn strcat "char *s" "const char * append"
 .Ft char *
 .Fn strncat "char *s" "const char *append" "size_t count"
-.Ft char *
-.Fn strchr "const char *s" "int c"
-.Ft char *
-.Fn strrchr "const char *s" "int c"
+.Ft "QChar *"
+.Fn strchr "QChar *s" "int c"
+.Ft "QChar *"
+.Fn strrchr "QChar *s" "int c"
 .Ft int
 .Fn strcmp "const char *s1" "const char *s2"
 .Ft int
@@ -83,16 +83,16 @@
 .Fn strerror "int errno"
 .Ft size_t
 .Fn strlen "const char *s"
-.Ft char *
-.Fn strpbrk "const char *s" "const char *charset"
+.Ft "QChar *"
+.Fn strpbrk "QChar *s" "const char *charset"
 .Ft char *
 .Fn strsep "char **stringp" "const char *delim"
 .Ft size_t
 .Fn strspn "const char *s" "const char *charset"
 .Ft size_t
 .Fn strcspn "const char *s" "const char *charset"
-.Ft char *
-.Fn strstr "const char *big" "const char *little"
+.Ft "QChar *"
+.Fn strstr "QChar *big" "const char *little"
 .Ft char *
 .Fn strtok "char *s" "const char *delim"
 .Ft char *

--- a/lib/libc/string/strpbrk.3
+++ b/lib/libc/string/strpbrk.3
@@ -39,8 +39,8 @@
 .Lb libc
 .Sh SYNOPSIS
 .In string.h
-.Ft char *
-.Fn strpbrk "const char *s" "const char *charset"
+.Ft "QChar *"
+.Fn strpbrk "QChar *s" "const char *charset"
 .Sh DESCRIPTION
 The
 .Fn strpbrk

--- a/lib/libc/string/strpbrk.3
+++ b/lib/libc/string/strpbrk.3
@@ -29,7 +29,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 4, 1993
+.Dd June 21, 2026
 .Dt STRPBRK 3
 .Os
 .Sh NAME
@@ -69,6 +69,6 @@ returns NULL.
 .Sh STANDARDS
 The
 .Fn strpbrk
-function
-conforms to
-.St -isoC .
+function conforms to
+.St -isoC-2023 ,
+where it is specified as a qualifier-preserving function.

--- a/lib/libc/string/strstr.3
+++ b/lib/libc/string/strstr.3
@@ -30,7 +30,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd October 11, 2001
+.Dd June 21, 2026
 .Dt STRSTR 3
 .Os
 .Sh NAME
@@ -147,9 +147,22 @@ ptr = strnstr(largestring, smallstring, 4);
 .Sh STANDARDS
 The
 .Fn strstr
-function
-conforms to
-.St -isoC .
+function conforms to
+.St -isoC-2023 ,
+where it is specified as a qualifier-preserving function.
+.Pp
+The
+.Fn strcasestr
+function is a
+.Tn GNU
+extension, and the
+.Fn strnstr
+function is a
+.Bx
+extension.
+Like the qualifier-preserving functions in
+.St -isoC-2023 ,
+.Fx implements them as qualifier-preserving as well.
 .Sh HISTORY
 The
 .Fn strnstr

--- a/lib/libc/string/strstr.3
+++ b/lib/libc/string/strstr.3
@@ -40,16 +40,16 @@
 .Lb libc
 .Sh SYNOPSIS
 .In string.h
-.Ft char *
-.Fn strstr "const char *big" "const char *little"
-.Ft char *
-.Fn strcasestr "const char *big" "const char *little"
-.Ft char *
-.Fn strnstr "const char *big" "const char *little" "size_t len"
+.Ft "QChar *"
+.Fn strstr "QChar *big" "const char *little"
+.Ft "QChar *"
+.Fn strcasestr "QChar *big" "const char *little"
+.Ft "QChar *"
+.Fn strnstr "QChar *big" "const char *little" "size_t len"
 .In string.h
 .In xlocale.h
-.Ft char *
-.Fn strcasestr_l "const char *big" "const char *little" "locale_t loc"
+.Ft "QChar *"
+.Fn strcasestr_l "QChar *big" "const char *little" "locale_t loc"
 .Sh DESCRIPTION
 The
 .Fn strstr

--- a/lib/libc/string/wmemchr.3
+++ b/lib/libc/string/wmemchr.3
@@ -67,8 +67,8 @@
 .Lb libc
 .Sh SYNOPSIS
 .In wchar.h
-.Ft wchar_t *
-.Fn wmemchr "const wchar_t *s" "wchar_t c" "size_t n"
+.Ft "QWchar_t *"
+.Fn wmemchr "QWchar_t *s" "wchar_t c" "size_t n"
 .Ft int
 .Fn wmemcmp "const wchar_t *s1" "const wchar_t *s2" "size_t n"
 .Ft wchar_t *
@@ -87,8 +87,8 @@
 .Fn wcscasecmp "const wchar_t *s1" "const wchar_t *s2"
 .Ft wchar_t *
 .Fn wcscat "wchar_t * restrict s1" "const wchar_t * restrict s2"
-.Ft wchar_t *
-.Fn wcschr "const wchar_t *s" "wchar_t c"
+.Ft "QWchar_t *"
+.Fn wcschr "QWchar_t *s" "wchar_t c"
 .Ft int
 .Fn wcscmp "const wchar_t *s1" "const wchar_t *s2"
 .Ft wchar_t *
@@ -113,14 +113,14 @@
 .Fn wcsncpy "wchar_t * restrict s1" "const wchar_t * restrict s2" "size_t n"
 .Ft size_t
 .Fn wcsnlen "const wchar_t *s" "size_t maxlen"
-.Ft wchar_t *
-.Fn wcspbrk "const wchar_t *s1" "const wchar_t *s2"
-.Ft wchar_t *
-.Fn wcsrchr "const wchar_t *s" "wchar_t c"
+.Ft "QWchar_t *"
+.Fn wcspbrk "QWchar_t *s1" "const wchar_t *s2"
+.Ft "QWchar_t *"
+.Fn wcsrchr "QWchar_t *s" "wchar_t c"
 .Ft size_t
 .Fn wcsspn "const wchar_t *s1" "const wchar_t *s2"
-.Ft wchar_t *
-.Fn wcsstr "const wchar_t * restrict s1" "const wchar_t * restrict s2"
+.Ft "QWchar_t *"
+.Fn wcsstr "QWchar_t *s1" "const wchar_t *s2"
 .Sh DESCRIPTION
 The functions implement string manipulation operations over wide character
 strings.

--- a/lib/libc/string/wmemchr.3
+++ b/lib/libc/string/wmemchr.3
@@ -154,21 +154,57 @@ counterpart, such as
 .Xr strspn 3 ,
 .Xr strstr 3
 .Sh STANDARDS
-These functions conform to
-.St -isoC-99 ,
-with the exception of
+Functions
+.Fn wmemcmp ,
+.Fn wmemcpy ,
+.Fn wmemmove ,
+.Fn wmemset ,
+.Fn wcscat ,
+.Fn wcscmp ,
+.Fn wcscpy ,
+.Fn wcscspn ,
+.Fn wcslen ,
+.Fn wcsncat ,
+.Fn wcsncmp ,
+.Fn wcsncpy ,
+and
+.Fn wcsspn
+conform to
+.St -isoC-99 .
+.Pp
+Functions
+.Fn wmemchr ,
+.Fn wcschr ,
+.Fn wcspbrk ,
+.Fn wcsrchr ,
+and
+.Fn wcsstr
+conform to
+.St -isoC-2023 ,
+where they are specified as qualifier-preserving functions.
+.Pp
+Functions
 .Fn wcpcpy ,
 .Fn wcpncpy ,
 .Fn wcscasecmp ,
 .Fn wcsdup ,
 .Fn wcsncasecmp ,
 and
-.Fn wcsnlen ,
-which conform to
-.St -p1003.1-2008 ;
+.Fn wcsnlen
+conform to
+.St -p1003.1-2008 ,
+and functions
+.Fn wcslcat
 and
-.Fn wcslcat ,
 .Fn wcslcpy ,
-and
-.Fn wmempcpy ,
-which are extensions.
+first introduced by
+.Ox ,
+conform to
+.St -p1003.1-2024 .
+.Pp
+Function
+.Fn wmempcpy
+is a
+.Tn GNU
+extensions.
+

--- a/sys/sys/cdefs.h
+++ b/sys/sys/cdefs.h
@@ -228,6 +228,27 @@
 #endif
 
 /*
+ * __qualsel() is the building block for C23 qualifier-preserving macros
+ * as proposed in N3020: it selects cexpr when the pointer expression p
+ * references a const-qualified object, and expr otherwise.
+ *
+ * The conditional operator's composite-type rule collapses every
+ * pointer-to-const-object type onto the single "const void *"" association,
+ * so callers passing any such pointer are matched even though _Generic()
+ * otherwise compares types exactly.
+ *
+ * The (__uintptr_t) round-trip only suppresses -Wcast-qual on the throwaway
+ * second operand.
+ */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) || \
+    __has_extension(c_generic_selections)
+#define	__qualsel(p, cexpr, expr)					\
+	_Generic(1 ? (p) : (void *)(__uintptr_t)(p),			\
+	    const void *: (cexpr),					\
+	    default: (expr))
+#endif
+
+/*
  * C99 Static array indices in function parameter declarations.  Syntax such as:
  * void bar(int myArray[static 10]);
  * is allowed in C99 but not in C++.  Define __min_size appropriately so


### PR DESCRIPTION
This PR implements the qualifier-preserving standard library functions as proposed in [N3020](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3020.pdf). I've all the cases I could think of. Both world and kernel builds complete successfully as well.

The one thing on my radar is the upcoming C23 migration of the base. There are still a bunch of inconsistencies in the tree that need sorting out before we get there, so I've already started chipping away at the cleanup. Should have it wrapped up within a week or two.

Cc: @clausecker