### PR TITLE
netinet6: Remove unused rip6_usrreqs declaration

### DIFF
--- a/sys/netinet6/ip6_var.h
+++ b/sys/netinet6/ip6_var.h
@@ -373,8 +373,6 @@ VNET_DECLARE(int, ip6stealth);
 VNET_DECLARE(bool, ip6_log_cannot_forward);
 #define	V_ip6_log_cannot_forward	VNET(ip6_log_cannot_forward)
 
-extern struct	pr_usrreqs rip6_usrreqs;
-
 struct inpcb;
 struct socket;
 struct sockopt;


### PR DESCRIPTION
The rip6_usrreqs extern declaration has been stale since https://github.com/freebsd/freebsd-src/commit/e7d02be19d40063783d6b8f1ff2bc4c7170fd434. pr_usrreqs is not declared anywhere, and rip6_usrreqs is no longer referenced either.

This PR will remove the stale extern declaration. 