### PR TITLE
if_bridge: Remove unused disable parameter in bridge_stop

### DIFF
--- a/sys/net/if_bridge.c
+++ b/sys/net/if_bridge.c
@@ -327,7 +327,7 @@ static void	bridge_init(void *);
 static void	bridge_dummynet(struct mbuf *, struct ifnet *);
 static bool	bridge_same(const void *, const void *);
 static void	*bridge_get_softc(struct ifnet *);
-static void	bridge_stop(struct ifnet *, int);
+static void	bridge_stop(struct ifnet *);
 static int	bridge_transmit(struct ifnet *, struct mbuf *);
 #ifdef ALTQ
 static void	bridge_altq_start(if_t);
@@ -937,7 +937,7 @@ bridge_clone_destroy(struct if_clone *ifc, struct ifnet *ifp, uint32_t flags)
 
 	BRIDGE_LOCK(sc);
 
-	bridge_stop(ifp, 1);
+	bridge_stop(ifp);
 	ifp->if_flags &= ~IFF_UP;
 
 	while ((bif = CK_LIST_FIRST(&sc->sc_iflist)) != NULL)
@@ -1068,9 +1068,9 @@ bridge_ioctl(struct ifnet *ifp, u_long cmd, caddr_t data)
 		    (ifp->if_drv_flags & IFF_DRV_RUNNING)) {
 			/*
 			 * If interface is marked down and it is running,
-			 * then stop and disable it.
+			 * then stop it.
 			 */
-			bridge_stop(ifp, 1);
+			bridge_stop(ifp);
 		} else if ((ifp->if_flags & IFF_UP) &&
 		    !(ifp->if_drv_flags & IFF_DRV_RUNNING)) {
 			/*
@@ -2346,7 +2346,7 @@ bridge_init(void *xsc)
  *	Stop the bridge interface.
  */
 static void
-bridge_stop(struct ifnet *ifp, int disable)
+bridge_stop(struct ifnet *ifp)
 {
 	struct bridge_softc *sc = ifp->if_softc;
 


### PR DESCRIPTION
The ```int disable``` parameter is included in the bridge_stop function signature but is not used in the function body.

This parameter originally appeared when importing the driver from NetBSD. However, the FreeBSD ifnet library no longer requires an if_stop function. Meaning that the function signature can be changed to only contain needed parameters for our bridge driver.

Discussed with: freebsd-net@ mailing list