### PR TITLE
implemented flag decoding in sysdecode_netlink() using print_mask_int()

### DIFF
--- a/lib/libsysdecode/flags.c
+++ b/lib/libsysdecode/flags.c
@@ -70,7 +70,6 @@
 #include <netgraph/bluetooth/include/ng_l2cap.h>
 #include <netgraph/bluetooth/include/ng_btsocket.h>
 #include <netpfil/pf/pf_nl.h>
-#include <netlink/netlink.h>
 
 #include "support.h"
 
@@ -1218,8 +1217,3 @@ sysdecode_pfnl_cmd(int cmd)
 }
 
 const char *
-sysdecode_nlm_flag(int flag)
-{
-
-	return (lookup_value(nlm_flag, flag));
-}

--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -190,7 +190,6 @@ fi
 gen_table "shmflags"  "SHM_[A-Z_]+[[:space:]]+0x[0-9]+"                    "sys/mman.h"         "SHM_ANON"
 gen_table "itimerwhich"     "ITIMER_[A-Z]+[[:space:]]+[0-9]+"              "sys/time.h"
 gen_table_enum "pfnl_cmd"   "PFNL_CMD_[A-Z_]+"                             "netpfil/pf/pf_nl.h"
-gen_table "nlm_flag"        "NLM_F_[A-Z]+[[:space:]]+0x[0-9]+"             "netlink/netlink.h"
 
 # Generate a .depend file for our output file
 if [ -n "$output_file" ]; then

--- a/lib/libsysdecode/netlink.c
+++ b/lib/libsysdecode/netlink.c
@@ -26,6 +26,32 @@
  * to fallback to a standard hex/string dump.
  */
 
+/*
+ * These nlmsg_flags bits have a unique meaning regardless of the
+ * message direction or operation type.  Bits in the 0x100-0x800 range
+ * are operation-specific and are left as raw hex to avoid ambiguity.
+ */
+static struct name_table netlink_base_flags[] = {
+	{ NLM_F_REQUEST,	"NLM_F_REQUEST" },
+	{ NLM_F_MULTI,		"NLM_F_MULTI" },
+	{ NLM_F_ACK,		"NLM_F_ACK" },
+	{ NLM_F_ECHO,		"NLM_F_ECHO" },
+	{ NLM_F_DUMP_INTR,	"NLM_F_DUMP_INTR" },
+	{ NLM_F_DUMP_FILTERED,	"NLM_F_DUMP_FILTERED" },
+	{ 0,			NULL },
+};
+
+static void
+print_netlink_flags(FILE *fp, uint16_t flags)
+{
+	int rem;
+
+	if (!print_mask_int(fp, netlink_base_flags, flags, &rem))
+		fprintf(fp, "0x%x", rem);
+	else if (rem != 0)
+		fprintf(fp, "|0x%x", rem);
+}
+
 static struct name_table *family_table = NULL;
 static size_t num_family = 0;
 
@@ -79,11 +105,7 @@ sysdecode_netlink(FILE *fp, const void *buf, size_t len, int protocol)
 		}
 
 		fprintf(fp, "flags=");
-		const char *nlm_f = sysdecode_nlm_flag(nl->nlmsg_flags);
-		if (nlm_f != NULL)
-			fprintf(fp, "%s", nlm_f);
-		else
-			fprintf(fp, "0x%x", nl->nlmsg_flags);
+		print_netlink_flags(fp, nl->nlmsg_flags);
 
 		fprintf(fp, ",seq=%u,pid=%u", nl->nlmsg_seq, nl->nlmsg_pid);
 

--- a/lib/libsysdecode/sysdecode.h
+++ b/lib/libsysdecode/sysdecode.h
@@ -67,7 +67,6 @@ void	sysdecode_kevent_fflags(FILE *_fp, short _filter, int _fflags,
 	    int _base);
 const char *sysdecode_itimer(int _which);
 const char *sysdecode_pfnl_cmd(int _cmd);
-const char *sysdecode_nlm_flag(int _flag);
 const char *sysdecode_kevent_filter(int _filter);
 bool	sysdecode_kevent_flags(FILE *_fp, int _flags, int *_rem);
 const char *sysdecode_kldsym_cmd(int _cmd);

--- a/lib/libsysdecode/tests/sysdecode_test.c
+++ b/lib/libsysdecode/tests/sysdecode_test.c
@@ -29,6 +29,8 @@
  */
 
 #include <sys/capsicum.h>
+#include <netlink/netlink.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -144,9 +146,55 @@ ATF_TC_BODY(cap_rights, tc)
 	free(buf);
 }
 
+static void
+check_sysdecode_netlink(const struct nlmsghdr *msg, const char *expected)
+{
+	char *buf;
+	FILE *fp;
+	size_t sz;
+
+	fp = open_memstream(&buf, &sz);
+	ATF_REQUIRE(fp != NULL);
+
+	ATF_REQUIRE(sysdecode_netlink(fp, msg, sizeof(*msg), NETLINK_ROUTE));
+	ATF_REQUIRE(fflush(fp) == 0);
+	buf[sz] = '\0';
+	ATF_REQUIRE_STREQ(buf, expected);
+
+	ATF_REQUIRE(fclose(fp) == 0);
+	free(buf);
+}
+
+ATF_TC_WITHOUT_HEAD(netlink);
+ATF_TC_BODY(netlink, tc)
+{
+	const struct nlmsghdr msg_known = {
+		.nlmsg_len = sizeof(struct nlmsghdr),
+		.nlmsg_type = NLMSG_NOOP,
+		.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK,
+		.nlmsg_seq = 42,
+		.nlmsg_pid = 1000,
+	};
+	const struct nlmsghdr msg_mixed = {
+		.nlmsg_len = sizeof(struct nlmsghdr),
+		.nlmsg_type = NLMSG_DONE,
+		.nlmsg_flags = NLM_F_REQUEST | NLM_F_ROOT,
+		.nlmsg_seq = 43,
+		.nlmsg_pid = 1000,
+	};
+
+	check_sysdecode_netlink(&msg_known,
+	    "netlink{flags=NLM_F_REQUEST|NLM_F_ACK,seq=42,pid=1000,"
+	    "len=16,type=NLMSG_NOOP}");
+	check_sysdecode_netlink(&msg_mixed,
+	    "netlink{flags=NLM_F_REQUEST|0x100,seq=43,pid=1000,"
+	    "len=16,type=NLMSG_DONE}");
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, cap_rights);
+	ATF_TP_ADD_TC(tp, netlink);
 
 	return (atf_no_error());
 }


### PR DESCRIPTION
Decode common nlmsg_flags in sysdecode_netlink() instead of always printing hex. Unknown/overloaded bits stay as hex since they depend on message type.

CHANGES:
1.Decode known Netlink base flags in lib/libsysdecode/netlink.c

2.Add a regression test for fully-decoded and mixed flag cases in sysdecode_test.c 