### PR TITLE
bhyveload: Introduce -s option to set console device speed.

### DIFF
--- a/usr.sbin/bhyveload/bhyveload.8
+++ b/usr.sbin/bhyveload/bhyveload.8
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 12, 2024
+.Dd June 24, 2026
 .Dt BHYVELOAD 8
 .Os
 .Sh NAME
@@ -36,6 +36,7 @@ guest inside a bhyve virtual machine
 .Op Fl C
 .Op Fl S
 .Op Fl c Ar cons-dev
+.Op Fl s Ar speed
 .Op Fl d Ar disk-path
 .Op Fl e Ar name=value
 .Op Fl h Ar host-path
@@ -74,6 +75,14 @@ terminal I/O.
 .Pp
 The text string "stdio" is also accepted and selects the use of
 unbuffered standard I/O. This is the default value.
+.It Fl s Ar speed
+Set the speed of
+.Ar cons-dev .
+The default speed is 9600. If
+.Ar cons-dev
+is "stdio", the
+.Ar speed
+will be ignored.
 .It Fl d Ar disk-path
 The
 .Ar disk-path

--- a/usr.sbin/bhyveload/bhyveload.c
+++ b/usr.sbin/bhyveload/bhyveload.c
@@ -681,7 +681,18 @@ static struct loader_callbacks cb = {
 };
 
 static int
-altcons_open(char *path)
+setup_tty(int fd, int speed)
+{
+        struct termios cntrl;
+
+        if (tcgetattr(fd, &cntrl))
+                return (-1);
+        cfsetspeed(&cntrl, speed);
+        return (tcsetattr(fd, TCSANOW, &cntrl));
+}
+
+static int
+altcons_open(char *path, int speed)
 {
 	struct stat sb;
 	int err;
@@ -703,8 +714,13 @@ altcons_open(char *path)
 			fd = open(path, O_RDWR | O_NONBLOCK);
 			if (fd < 0)
 				err = errno;
-			else
+			else {
 				consin_fd = consout_fd = fd;
+				if (isatty(fd) && setup_tty(fd, speed) < 0) {
+					err = errno;
+					close(fd);
+				}
+			}
 		}
 	}
 
@@ -790,7 +806,9 @@ main(int argc, char** argv)
 {
 	void (*func)(struct loader_callbacks *, void *, int, int);
 	uint64_t mem_size;
-	int bootfd, opt, error, memflags, need_reinit;
+	int bootfd, opt, error, memflags, need_reinit, speed = B9600;
+	long l;
+	char *cp, *cons = NULL;
 
 	bootfd = -1;
 	progname = basename(argv[0]);
@@ -801,14 +819,17 @@ main(int argc, char** argv)
 	consin_fd = STDIN_FILENO;
 	consout_fd = STDOUT_FILENO;
 
-	while ((opt = getopt(argc, argv, "CSc:d:e:h:l:m:")) != -1) {
+	while ((opt = getopt(argc, argv, "CSc:s:d:e:h:l:m:")) != -1) {
 		switch (opt) {
 		case 'c':
-			error = altcons_open(optarg);
-			if (error != 0)
-				errx(EX_USAGE, "Could not open '%s'", optarg);
+			cons = optarg;
 			break;
-
+		case 's':
+			l = strtol(optarg, &cp, 10);
+			if (*cp != '\0' || l < 0 || l >= INT_MAX)
+				errx(EX_USAGE, "Unsupported speed '%s'", optarg);
+			speed = (int)l;
+			break;
 		case 'd':
 			error = disk_open(optarg);
 			if (error != 0)
@@ -849,6 +870,9 @@ main(int argc, char** argv)
 			usage();
 		}
 	}
+
+	if (cons != NULL && altcons_open(cons, speed) != 0)
+		errx(EX_USAGE, "Could not open '%s'", optarg);
 
 	argc -= optind;
 	argv += optind;


### PR DESCRIPTION
The boot loader improves its performance and now prints the loader menu at a rate faster than 9600 bps. It's time to introduce the -s option to let users increase the console device's speed. If the console device is an nmdm(4), the speeds at both ends need to be configured. This option sets bhyveload's end.

I almost always see the following console menu on my bhyveload via nmdm(4). The "Options: " menu is missing in detail. I'm developing the [bhyve management daemon](https://github.com/yuichiro-naito/bmd), which connects to the console nmdm as soon as bhyveload starts. I can see all the boot loader messages via nmdm(4).

```
   ______               ____   _____ _____  
  |  ____|             |  _ \ / ____|  __ \ 
  | |___ _ __ ___  ___ | |_) | (___ | |  | |
  |  ___| '__/ _ \/ _ \|  _ < \___ \| |  | |
  | |   | | |  __/  __/| |_) |____) | |__| |
  | |   | | |    |    ||     |      |      |
  |_|   |_|  \___|\___||____/|_____/|_____/ 

 +-------- Welcome to FreeBSD ----------+     ```                        `
 |                                      |    s` `.....---.......--.```   -/
 |  1. Boot Multi user [Enter]          |    +o   .--`         /y:`      +.
 |  2. Boot Single user                 |     yo`:.            :o      `+-
 |  3. Escape to loader prompt          |      y/               -/`   -o/
 |  4. Reboot                           |     .-                  ::/sy+:.
 |  5. Cons: Serial                     |     /                     `--  /
 |                                      |    `:                          :`
 |  Options:                            |    `:                          :`
 |  6.                                  |     /                          /
 |                                      |     .-                        -.
 |                                      |      --                      -.
 |                                      |       `:`                  `:`
 |                                      |         .--             `--.
 +--------------------------------------+            .---.....----.
   Autoboot in 9 seconds. [Space] to pause 
```

I'm running FreeBSD-current. I think the bhyveload and the userboot improve their performance, and now print the loader menu at a rate faster than 9600 bps. I wrote a simple dtrace script as follows to check whether ttyoutq is full.

```
#!/usr/sbin/dtrace -s

:kernel:ttyoutq_write:return /execname == "bhyveload"/ {
    @io = lquantize(arg1, 0, 9, 1);
}
```

I got the following result, which shows ttyoutq was full 149 times when printing a character.

```
           value  ------------- Distribution ------------- count    
             < 0 |                                         0        
               0 |@@                                       149      
               1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@   2299     
               2 |                                         0        
```

After speeding up to 115200, I don't see that the ttyoutq is full.