### PR TITLE
netlink: decode netlink message flags symbolically

### DIFF
--- a/lib/libsysdecode/flags.c
+++ b/lib/libsysdecode/flags.c
@@ -70,6 +70,7 @@
 #include <netgraph/bluetooth/include/ng_l2cap.h>
 #include <netgraph/bluetooth/include/ng_btsocket.h>
 #include <netpfil/pf/pf_nl.h>
+#include <netlink/netlink.h>
 
 #include "support.h"
 
@@ -1214,4 +1215,11 @@ sysdecode_pfnl_cmd(int cmd)
 {
 
 	return (lookup_value(pfnl_cmd, cmd));
+}
+
+const char *
+sysdecode_nlm_flag(int flag)
+{
+
+	return (lookup_value(nlm_flag, flag));
 }

--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -171,6 +171,7 @@ fi
 gen_table "shmflags"  "SHM_[A-Z_]+[[:space:]]+0x[0-9]+"                    "sys/mman.h"         "SHM_ANON"
 gen_table "itimerwhich"     "ITIMER_[A-Z]+[[:space:]]+[0-9]+"              "sys/time.h"
 gen_table "pfnl_cmd"        "PFNL_CMD_[A-Z_]+[[:space:]]+[0-9]+"           "netpfil/pf/pf_nl.h"
+gen_table "nlm_flag"        "NLM_F_[A-Z]+[[:space:]]+0x[0-9]+"             "netlink/netlink.h"
 
 # Generate a .depend file for our output file
 if [ -n "$output_file" ]; then

--- a/lib/libsysdecode/netlink.c
+++ b/lib/libsysdecode/netlink.c
@@ -73,8 +73,11 @@ sysdecode_netlink(FILE *fp, const void *buf, size_t len)
 		}
 
 		fprintf(fp, ",flags=");
-		/* TODO: decode flags symbolically using sysdecode_mask. */
-		fprintf(fp, "0x%x", nl->nlmsg_flags);
+		const char *nlm_f = sysdecode_nlm_flag(nl->nlmsg_flags);
+		if (nlm_f != NULL)
+			fprintf(fp, "%s", nlm_f);
+		else
+			fprintf(fp, "0x%x", nl->nlmsg_flags);
 
 		fprintf(fp, ",seq=%u,pid=%u", nl->nlmsg_seq, nl->nlmsg_pid);
 

--- a/lib/libsysdecode/sysdecode.h
+++ b/lib/libsysdecode/sysdecode.h
@@ -66,7 +66,8 @@ const char *sysdecode_ipproto(int _protocol);
 void	sysdecode_kevent_fflags(FILE *_fp, short _filter, int _fflags,
 	    int _base);
 const char *sysdecode_itimer(int _which);
-const char *sysdecode_pfnl_cmd(int cmd);
+const char *sysdecode_pfnl_cmd(int _cmd);
+const char *sysdecode_nlm_flag(int _flag);
 const char *sysdecode_kevent_filter(int _filter);
 bool	sysdecode_kevent_flags(FILE *_fp, int _flags, int *_rem);
 const char *sysdecode_kldsym_cmd(int _cmd);


### PR DESCRIPTION
Generate an nlm_flag table definition for mktable from netlink/netlink.h, add a sysdecode_nlm_flag() helper to libsysdecode, and use it when decoding netlink message headers.

This enables mktable to generate netlink message flag lookup tables and replaces raw hexadecimal output for recognized NLM_F_* flag values with their symbolic names.


Sponsored by: Google LLC (GSoC 2026)