### PR TITLE
(linuxkpi) USB endpoint accessor and predicate functions

### DIFF
--- a/sys/compat/linuxkpi/common/include/linux/usb.h
+++ b/sys/compat/linuxkpi/common/include/linux/usb.h
@@ -288,6 +288,14 @@ int	usb_set_interface(struct usb_device *dev, uint8_t ifnum,
 int	usb_setup_endpoint(struct usb_device *dev,
 	    struct usb_host_endpoint *uhe, usb_frlength_t bufsize);
 
+int	usb_endpoint_num(struct usb_endpoint_descriptor *endpoint);
+int	usb_endpoint_dir_in(struct usb_endpoint_descriptor *endpoint);
+int	usb_endpoint_dir_out(struct usb_endpoint_descriptor *endpoint);
+int	usb_endpoint_xfer_bulk(struct usb_endpoint_descriptor *endpoint);
+int	usb_endpoint_xfer_control(struct usb_endpoint_descriptor *endpoint);
+int	usb_endpoint_xfer_int(struct usb_endpoint_descriptor *endpoint);
+int	usb_endpoint_xfer_isoc(struct usb_endpoint_descriptor *endpoint);
+
 struct usb_host_endpoint *usb_find_host_endpoint(struct usb_device *dev,
 	    uint8_t type, uint8_t ep);
 struct urb *usb_alloc_urb(uint16_t iso_packets, uint16_t mem_flags);

--- a/sys/compat/linuxkpi/common/src/linux_usb.c
+++ b/sys/compat/linuxkpi/common/src/linux_usb.c
@@ -1708,6 +1708,50 @@ usb_bulk_msg(struct usb_device *udev, struct usb_host_endpoint *uhe,
 
 	return (err);
 }
+
+/* Endpoint accessors */
+int
+usb_endpoint_num(struct usb_endpoint_descriptor *endpoint)
+{
+	return UE_GET_ADDR(endpoint->bEndpointAddress);
+}
+
+int
+usb_endpoint_dir_in(struct usb_endpoint_descriptor *endpoint)
+{
+	return (endpoint->bEndpointAddress & UE_DIR_IN) != 0;
+}
+
+int
+usb_endpoint_dir_out(struct usb_endpoint_descriptor *endpoint)
+{
+	return (endpoint->bEndpointAddress & UE_DIR_IN) == 0;
+}
+
+int
+usb_endpoint_xfer_bulk(struct usb_endpoint_descriptor *endpoint)
+{
+	return (endpoint->bmAttributes & UE_XFERTYPE) == UE_BULK;
+}
+
+int
+usb_endpoint_xfer_control(struct usb_endpoint_descriptor *endpoint)
+{
+	return (endpoint->bmAttributes & UE_XFERTYPE) == UE_CONTROL;
+}
+
+int
+usb_endpoint_xfer_int(struct usb_endpoint_descriptor *endpoint)
+{
+	return (endpoint->bmAttributes & UE_XFERTYPE) == UE_INTERRUPT;
+}
+
+int
+usb_endpoint_xfer_isoc(struct usb_endpoint_descriptor *endpoint)
+{
+	return (endpoint->bmAttributes & UE_XFERTYPE) == UE_ISOCHRONOUS;
+}
+
 MODULE_DEPEND(linuxkpi, usb, 1, 1, 1);
 
 static void


### PR DESCRIPTION
These functions were added to Linux decades ago.  The rtw88 and rtw89 drivers I am working on need some of them.  The other KPI changes for these drivers are not ready for integration.