### PR TITLE
makefs: Fix build on systems without st_birthtime such as Linux

### DIFF
--- a/usr.sbin/makefs/cd9660/iso9660_rrip.c
+++ b/usr.sbin/makefs/cd9660/iso9660_rrip.c
@@ -750,8 +750,13 @@ cd9660node_rrip_tf(struct ISO_SUSP_ATTRIBUTES *p, fsnode *_node)
 	 * expiration time, and effective time.
 	 */
 
+#if HAVE_STRUCT_STAT_BIRTHTIME
 	cd9660_time_915(p->attr.rr_entry.TF.timestamp,
 		_node->inode->st.st_birthtime);
+#else
+	cd9660_time_915(p->attr.rr_entry.TF.timestamp,
+		_node->inode->st.st_ctime);
+#endif
 	p->attr.rr_entry.TF.h.length[0] += 7;
 
 	cd9660_time_915(p->attr.rr_entry.TF.timestamp + 7,


### PR DESCRIPTION
Fixes:		0a301f33306c ("makefs cd9660: Populate creation time stamps in RockRidge extensions")