### PR TITLE
fts: add fts_get_dirfd() accessor for parent directory fd

### DIFF
--- a/lib/libc/gen/Symbol.map
+++ b/lib/libc/gen/Symbol.map
@@ -476,6 +476,7 @@ FBSD_1.8 {
 
 FBSD_1.9 {
 	freadlink;
+	fts_get_dirfd;
 	posix_spawn_file_actions_addchdir;
 	posix_spawn_file_actions_addfchdir;
 	posix_spawnattr_getexecfd_np;

--- a/lib/libc/gen/fts.c
+++ b/lib/libc/gen/fts.c
@@ -81,6 +81,7 @@ static int	 fts_ufslinks(FTS *, const FTSENT *);
 #define	SET(opt)	(sp->fts_options |= (opt))
 
 #define	FCHDIR(sp, fd)	(!ISSET(FTS_NOCHDIR) && fchdir(fd))
+#define FTSP(sp)        ((struct _fts_private *)(sp))
 
 /* fts_build flags */
 #define	BCHILD		1		/* fts_children */
@@ -97,6 +98,7 @@ struct _fts_private {
 	struct statfs	ftsp_statfs;
 	dev_t		ftsp_dev;
 	int		ftsp_linksreliable;
+	int             ftsp_dirfd;
 };
 
 /*
@@ -249,6 +251,7 @@ fts_open(char * const *argv, int options,
 	sp = &priv->ftsp_fts;
 	sp->fts_compar = compar;
 	sp->fts_options = options;
+	priv->ftsp_dirfd = -1;
 
 	return (__fts_open(sp, argv));
 }
@@ -711,6 +714,12 @@ fts_set_clientptr(FTS *sp, void *clientptr)
 	sp->fts_clientptr = clientptr;
 }
 
+int
+fts_get_dirfd(const FTS *sp)
+{
+        return (FTSP(sp)->ftsp_dirfd);
+}
+
 static struct dirent *
 fts_safe_readdir(DIR *dirp, int *readdir_errno)
 {
@@ -867,6 +876,7 @@ fts_build(FTS *sp, int type)
 	maxlen = sp->fts_pathlen - len;
 
 	level = cur->fts_level + 1;
+	FTSP(sp)->ftsp_dirfd = _dirfd(dirp);
 
 	/* Read the directory, attaching each entry to the `link' pointer. */
 	doadjust = 0;
@@ -1322,7 +1332,7 @@ fts_ufslinks(FTS *sp, const FTSENT *ent)
 	 * avoidance.
 	 */
 	if (priv->ftsp_dev != ent->fts_dev) {
-		if (statfs(ent->fts_path, &priv->ftsp_statfs) != -1) {
+		if ((priv->ftsp_dirfd >= 0 ? _fstatfs(priv->ftsp_dirfd, &priv->ftsp_statfs) : statfs(ent->fts_path, &priv->ftsp_statfs)) != -1) {
 			priv->ftsp_dev = ent->fts_dev;
 			priv->ftsp_linksreliable = 0;
 			for (cpp = ufslike_filesystems; *cpp; cpp++) {


### PR DESCRIPTION
Add ftsp_dirfd to struct `_fts_private `to store the `fd `of the current directory being traversed. This `fd `is set in `fts_build()` to `_dirfd(dirp)` and provides safe access to the parent directory without exposing an `fd `in the public struct `_ftsent`.

Add `fts_get_dirfd(const FTS *)` as the public accessor. Callers can use `openat(fts_get_dirfd(fts), ent->fts_name, ...)` to access files safely, which works in Capsicum capability mode where path-based operations are not permitted.

Replace statfs(ent->fts_path) with `fstatfs(ftsp_dirfd)` in `fts_ufslinks()` when the `fd ` is available, avoiding a path-based syscall.

Export `fts_get_dirfd ` in `FBSD_1.9 `version map.

Sponsored by:Google LLC (GSoC 2026)