### PR TITLE
dpaa2: runtime DPNI create/destroy + dpaa2ctl control device

### DIFF
--- a/sys/dev/dpaa2/dpaa2_channel.c
+++ b/sys/dev/dpaa2/dpaa2_channel.c
@@ -285,6 +285,59 @@ fail_rc_open:
 }
 
 /**
+ * @brief Tear down a QBMan channel and free the resources allocated by
+ *        dpaa2_chan_setup().
+ *
+ * The caller must guarantee that the channel can no longer generate CDANs
+ * (i.e. the owning DPNI has been disabled) before calling this routine, so
+ * that no notification can reference the channel while it is being freed.
+ *
+ * NOTE: The Rx buffers seeded into the DPBP and the per-Tx-ring buffers are
+ *	 not reclaimed here; they are released together with the buffer pool
+ *	 when the DPBP resource is returned to the container.
+ */
+void
+dpaa2_chan_free(struct dpaa2_channel *ch)
+{
+	if (ch == NULL)
+		return;
+
+	/*
+	 * Stop and drain the per-channel cleanup taskqueue first so that no
+	 * cleanup task runs (and re-arms the CDAN) while we free the channel.
+	 */
+	if (ch->cleanup_tq != NULL) {
+		while (taskqueue_cancel(ch->cleanup_tq, &ch->cleanup_task,
+		    NULL) != 0)
+			taskqueue_drain(ch->cleanup_tq, &ch->cleanup_task);
+		taskqueue_free(ch->cleanup_tq);
+		ch->cleanup_tq = NULL;
+	}
+
+	/* Free the DMA-mapped channel storage used for VDQ responses. */
+	if (ch->store.vaddr != NULL)
+		bus_dmamem_free(ch->store.dmat, ch->store.vaddr, ch->store.dmap);
+	if (ch->store.dmat != NULL)
+		bus_dma_tag_destroy(ch->store.dmat);
+
+	/* Free the software Tx ring. */
+	if (ch->xmit_br != NULL)
+		buf_ring_free(ch->xmit_br, M_DEVBUF);
+	mtx_destroy(&ch->xmit_mtx);
+
+	/* Destroy the per-channel DMA tags. */
+	if (ch->rx_dmat != NULL)
+		bus_dma_tag_destroy(ch->rx_dmat);
+	if (ch->tx_dmat != NULL)
+		bus_dma_tag_destroy(ch->tx_dmat);
+	if (ch->sgt_dmat != NULL)
+		bus_dma_tag_destroy(ch->sgt_dmat);
+	mtx_destroy(&ch->dma_mtx);
+
+	free(ch, M_DPAA2_CH);
+}
+
+/**
  * @brief Performs an initial configuration of the frame queue.
  */
 int

--- a/sys/dev/dpaa2/dpaa2_channel.h
+++ b/sys/dev/dpaa2/dpaa2_channel.h
@@ -88,6 +88,7 @@ struct dpaa2_channel {
 
 int dpaa2_chan_setup(device_t, device_t, device_t, device_t,
     struct dpaa2_channel **, uint32_t, task_fn_t);
+void dpaa2_chan_free(struct dpaa2_channel *);
 int dpaa2_chan_setup_fq(device_t, struct dpaa2_channel *,
     enum dpaa2_ni_queue_type);
 int dpaa2_chan_next_frame(struct dpaa2_channel *, struct dpaa2_dq **);

--- a/sys/dev/dpaa2/dpaa2_ioctl.h
+++ b/sys/dev/dpaa2/dpaa2_ioctl.h
@@ -1,0 +1,42 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Userland control interface for the DPAA2 driver.
+ *
+ * Lets a userland tool (dpaa2ctl) create/destroy/list DPAA2 network
+ * interfaces at run-time -- the FreeBSD equivalent of NXP's
+ * "restool ls-addni / ls-listni". Each control device (/dev/dpaa2rcN)
+ * corresponds to one DPAA2 resource container (dpaa2_rcN).
+ */
+#ifndef _DEV_DPAA2_DPAA2_IOCTL_H_
+#define _DEV_DPAA2_DPAA2_IOCTL_H_
+
+#include <sys/ioccom.h>
+
+#define DPAA2_NI_NAME_LEN	16
+#define DPAA2_NI_LIST_MAX	32
+
+/* Description of a single DPAA2 network interface. */
+struct dpaa2_ni_desc {
+	uint32_t	ni_id;		/* DPNI object id */
+	uint32_t	dpmac_id;	/* connected DPMAC id, or ~0u if none */
+	char		name[DPAA2_NI_NAME_LEN]; /* e.g. "dpni1" */
+};
+
+/* DPAA2IOC_ADDNI argument. */
+struct dpaa2_addni_args {
+	uint32_t	dpmac_id;	/* in:  DPMAC to wire the new DPNI to */
+	uint32_t	ni_id;		/* out: id of the created DPNI */
+};
+
+/* DPAA2IOC_LISTNI argument. */
+struct dpaa2_listni_args {
+	uint32_t		count;	/* out: number of valid entries */
+	struct dpaa2_ni_desc	ni[DPAA2_NI_LIST_MAX];
+};
+
+#define DPAA2IOC_ADDNI	_IOWR('D', 1, struct dpaa2_addni_args)
+#define DPAA2IOC_DELNI	_IOW('D', 2, uint32_t)			/* DPNI id */
+#define DPAA2IOC_LISTNI	_IOR('D', 3, struct dpaa2_listni_args)
+
+#endif /* _DEV_DPAA2_DPAA2_IOCTL_H_ */

--- a/sys/dev/dpaa2/dpaa2_mc.h
+++ b/sys/dev/dpaa2/dpaa2_mc.h
@@ -120,6 +120,7 @@ struct dpaa2_rc_softc {
 	device_t		 dev;
 	int			 unit;
 	uint32_t		 cont_id;
+	struct cdev		*cdev;	/* /dev/dpaa2rcN control device */
 };
 
 /**
@@ -181,7 +182,7 @@ int dpaa2_mc_detach(device_t dev);
 
 struct rman *dpaa2_mc_rman(device_t mcdev, int type, u_int flags);
 struct resource * dpaa2_mc_alloc_resource(device_t mcdev, device_t child,
-    int type, int rid, rman_res_t start, rman_res_t end, rman_res_t count,
+    int type, int *rid, rman_res_t start, rman_res_t end, rman_res_t count,
     u_int flags);
 int dpaa2_mc_adjust_resource(device_t mcdev, device_t child,
     struct resource *r, rman_res_t start, rman_res_t end);

--- a/sys/dev/dpaa2/dpaa2_mc_fdt.c
+++ b/sys/dev/dpaa2/dpaa2_mc_fdt.c
@@ -193,6 +193,31 @@ dpaa2_mac_fdt_get_phy_dev(device_t dev)
 	return (OF_device_from_xref(OF_xref_from_node(sc->phy_handle)));
 }
 
+/*
+ * Resolve the i2c bus that this DPMAC's SFP+ module EEPROM sits on, from the
+ * "sfp" phandle parsed at attach: the referenced "sff,sfp" node carries an
+ * "i2c-bus" phandle pointing at the (possibly muxed) i2c bus.  Returns NULL if
+ * the DPMAC has no SFP association.
+ */
+static device_t
+dpaa2_mac_fdt_get_sfp_i2c_dev(device_t dev)
+{
+	struct dpaa2_mac_fdt_softc *sc;
+	phandle_t i2c_xref;
+
+	if (dev == NULL)
+		return (NULL);
+
+	sc = device_get_softc(dev);
+	if (sc->sfp == 0)
+		return (NULL);
+
+	if (OF_getencprop(sc->sfp, "i2c-bus", &i2c_xref, sizeof(i2c_xref)) <= 0)
+		return (NULL);
+
+	return (OF_device_from_xref(i2c_xref));
+}
+
 static device_method_t dpaa2_mac_fdt_methods[] = {
 	/* Device interface */
 	DEVMETHOD(device_probe,		dpaa2_mac_dev_probe),
@@ -342,6 +367,30 @@ dpaa2_mc_fdt_get_phy_dev(device_t dev, device_t *phy_dev, uint32_t id)
 	return (0);
 }
 
+static int
+dpaa2_mc_fdt_get_sfp_dev(device_t dev, device_t *sfp_dev, uint32_t id)
+{
+	device_t mdev, i2cdev;
+
+	mdev = dpaa2_mc_fdt_find_dpaa2_mac_dev(dev, id);
+	if (mdev == NULL)
+		return (ENXIO);
+
+	i2cdev = dpaa2_mac_fdt_get_sfp_i2c_dev(mdev);
+	if (i2cdev == NULL)
+		return (ENXIO);
+
+	if (sfp_dev != NULL)
+		*sfp_dev = i2cdev;
+
+	if (bootverbose)
+		device_printf(dev, "dpmac_id %u mdev %s sfp i2c bus %s\n",
+		    id, device_get_nameunit(mdev),
+		    device_get_nameunit(i2cdev));
+
+	return (0);
+}
+
 static const struct ofw_bus_devinfo *
 dpaa2_mc_simplebus_get_devinfo(device_t bus, device_t child)
 {
@@ -379,6 +428,7 @@ static device_method_t dpaa2_mc_fdt_methods[] = {
 	DEVMETHOD(dpaa2_mc_reserve_dev,	dpaa2_mc_reserve_dev),
 	DEVMETHOD(dpaa2_mc_release_dev, dpaa2_mc_release_dev),
 	DEVMETHOD(dpaa2_mc_get_phy_dev,	dpaa2_mc_fdt_get_phy_dev),
+	DEVMETHOD(dpaa2_mc_get_sfp_dev,	dpaa2_mc_fdt_get_sfp_dev),
 
 	/* OFW/simplebus */
 	DEVMETHOD(ofw_bus_get_devinfo,	dpaa2_mc_simplebus_get_devinfo),

--- a/sys/dev/dpaa2/dpaa2_mc_if.m
+++ b/sys/dev/dpaa2/dpaa2_mc_if.m
@@ -106,6 +106,15 @@ CODE {
 			    phy_dev, id));
 		return (ENXIO);
 	}
+
+	static int
+	bypass_get_sfp_dev(device_t dev, device_t *sfp_dev, uint32_t id)
+	{
+		if (device_get_parent(dev) != NULL)
+			return (DPAA2_MC_GET_SFP_DEV(device_get_parent(dev),
+			    sfp_dev, id));
+		return (ENXIO);
+	}
 }
 
 METHOD int manage_dev {
@@ -150,3 +159,20 @@ METHOD int get_phy_dev {
 	device_t	 *phy_dev;
 	uint32_t	 id;
 } DEFAULT bypass_get_phy_dev;
+
+/**
+ * @brief Look up the i2c bus device that a DPMAC's SFP+ cage sits on.
+ *
+ * Resolved from the "sfp" phandle in the DPMAC's device-tree node (its
+ * "i2c-bus" property). Only implemented on the FDT compat layer; returns
+ * ENXIO under ACPI, where the association comes from loader tunables instead.
+ *
+ *   dev     - requesting device (walked up to the MC bus)
+ *   sfp_dev - the i2c bus (iicbus) device the SFP EEPROM answers on
+ *   id      - DPMAC object id
+ */
+METHOD int get_sfp_dev {
+	device_t	 dev;
+	device_t	 *sfp_dev;
+	uint32_t	 id;
+} DEFAULT bypass_get_sfp_dev;

--- a/sys/dev/dpaa2/dpaa2_mcp.h
+++ b/sys/dev/dpaa2/dpaa2_mcp.h
@@ -124,6 +124,8 @@
 #define CMDID_RC_GET_OBJ_REG_V3			CMD_RC_V3(0x15E)
 #define CMDID_RC_SET_OBJ_IRQ			CMD_RC(0x15F)
 #define CMDID_RC_GET_CONN			CMD_RC(0x16C)
+#define CMDID_RC_CONNECT			CMD_RC(0x167)
+#define CMDID_RC_DISCONNECT			CMD_RC(0x168)
 
 /* ------------------------- DPIO command IDs ------------------------------- */
 #define CMD_IO_BASE_VERSION	1
@@ -152,6 +154,8 @@
 #define CMD_NI_V2(id)	(((id) << CMD_NI_ID_OFFSET) | CMD_NI_2ND_VERSION)
 #define CMD_NI_V4(id)	(((id) << CMD_NI_ID_OFFSET) | CMD_NI_4TH_VERSION)
 
+#define CMDID_NI_CREATE				CMD_NI(0x901)
+#define CMDID_NI_DESTROY			CMD_NI(0x981)
 #define CMDID_NI_OPEN				CMD_NI(0x801)
 #define CMDID_NI_CLOSE				CMD_NI(0x800)
 #define CMDID_NI_ENABLE				CMD_NI(0x002)
@@ -193,6 +197,8 @@
 
 #define CMD_BP(id)	(((id) << CMD_BP_ID_OFFSET) | CMD_BP_BASE_VERSION)
 
+#define CMDID_BP_CREATE				CMD_BP(0x904)
+#define CMDID_BP_DESTROY			CMD_BP(0x984)
 #define CMDID_BP_OPEN				CMD_BP(0x804)
 #define CMDID_BP_CLOSE				CMD_BP(0x800)
 #define CMDID_BP_ENABLE				CMD_BP(0x002)
@@ -226,6 +232,8 @@
 
 #define CMD_CON(id)	(((id) << CMD_CON_ID_OFFSET) | CMD_CON_BASE_VERSION)
 
+#define CMDID_CON_CREATE			CMD_CON(0x908)
+#define CMDID_CON_DESTROY			CMD_CON(0x988)
 #define CMDID_CON_OPEN				CMD_CON(0x808)
 #define CMDID_CON_CLOSE				CMD_CON(0x800)
 #define CMDID_CON_ENABLE			CMD_CON(0x002)

--- a/sys/dev/dpaa2/dpaa2_ni.c
+++ b/sys/dev/dpaa2/dpaa2_ni.c
@@ -693,24 +693,134 @@ dpaa2_ni_fixed_media_status(if_t ifp, struct ifmediareq* ifmr)
 }
 
 static void
-dpaa2_ni_setup_fixed_link(struct dpaa2_ni_softc *sc)
+dpaa2_ni_setup_fixed_link(struct dpaa2_ni_softc *sc, uint32_t max_rate)
 {
-	/*
-	 * FIXME: When the DPNI is connected to a DPMAC, we can get the
-	 * 'apparent' speed from it.
-	 */
+	int subtype;
+
 	sc->fixed_link = true;
+
+	/*
+	 * The link is managed by the MC firmware; derive the reported media
+	 * from the connected DPMAC's maximum rate (in Mbit/s) so that
+	 * ifconfig shows e.g. 10Gbase-LR for an SFP+ port instead of a
+	 * hardcoded 1000baseT. The actual link is brought up by the MC.
+	 */
+	switch (max_rate) {
+	case 100000:
+		subtype = IFM_100G_LR4;
+		break;
+	case 40000:
+		subtype = IFM_40G_LR4;
+		break;
+	case 25000:
+		subtype = IFM_25G_LR;
+		break;
+	case 10000:
+		subtype = IFM_10G_LR;
+		break;
+	case 2500:
+		subtype = IFM_2500_KX;
+		break;
+	case 1000:
+		subtype = IFM_1000_KX;
+		break;
+	default:
+		subtype = IFM_1000_T;	/* historical fallback */
+		break;
+	}
 
 	ifmedia_init(&sc->fixed_ifmedia, 0, dpaa2_ni_media_change,
 		     dpaa2_ni_fixed_media_status);
-	ifmedia_add(&sc->fixed_ifmedia, IFM_ETHER | IFM_1000_T, 0, NULL);
-	ifmedia_set(&sc->fixed_ifmedia, IFM_ETHER | IFM_1000_T);
+	ifmedia_add(&sc->fixed_ifmedia, IFM_ETHER | subtype, 0, NULL);
+	ifmedia_set(&sc->fixed_ifmedia, IFM_ETHER | subtype);
 }
 
 static int
 dpaa2_ni_detach(device_t dev)
 {
-	/* TBD */
+	device_t pdev = device_get_parent(dev);
+	device_t child = dev;
+	struct dpaa2_ni_softc *sc = device_get_softc(dev);
+	struct dpaa2_devinfo *rcinfo = device_get_ivars(pdev);
+	struct dpaa2_devinfo *dinfo = device_get_ivars(dev);
+	struct dpaa2_cmd cmd;
+	uint16_t rc_token, ni_token;
+	uint32_t i;
+
+	/*
+	 * Detach the network interface from the stack first. After
+	 * ether_ifdetach() returns no ioctl, transmit or interface-dump path
+	 * (e.g. a netlink GETLINK walk) can reach this interface, so it is
+	 * safe to tear the rest of the device down.
+	 */
+	if (sc->ifp != NULL) {
+		DPNI_LOCK(sc);
+		if_setdrvflagbits(sc->ifp, 0, IFF_DRV_RUNNING | IFF_DRV_OACTIVE);
+		DPNI_UNLOCK(sc);
+		ether_ifdetach(sc->ifp);
+	}
+
+	/* Stop the periodic link-status callout. */
+	callout_drain(&sc->mii_callout);
+
+	/*
+	 * Disable the DPNI and its link-change interrupt in the MC. Once the
+	 * DPNI is disabled the MC stops dequeuing frames to our channels, so
+	 * no further CDANs can be generated.
+	 */
+	DPAA2_CMD_INIT(&cmd);
+	if (DPAA2_CMD_RC_OPEN(dev, child, &cmd, rcinfo->id, &rc_token) == 0) {
+		if (DPAA2_CMD_NI_OPEN(dev, child, &cmd, dinfo->id,
+		    &ni_token) == 0) {
+			(void)DPAA2_CMD_NI_SET_IRQ_ENABLE(dev, child, &cmd,
+			    DPNI_IRQ_INDEX, false);
+			(void)DPAA2_CMD_NI_DISABLE(dev, child, &cmd);
+			(void)DPAA2_CMD_NI_CLOSE(dev, child,
+			    DPAA2_CMD_TK(&cmd, ni_token));
+		}
+		(void)DPAA2_CMD_RC_CLOSE(dev, child,
+		    DPAA2_CMD_TK(&cmd, rc_token));
+	}
+
+	/* Tear down the link-change interrupt handler. */
+	if (sc->intr != NULL)
+		bus_teardown_intr(dev, sc->irq_res, sc->intr);
+	if (sc->irq_res != NULL)
+		bus_release_resource(dev, SYS_RES_IRQ, sc->irq_rid[0],
+		    sc->irq_res);
+	pci_release_msi(dev);
+
+	/*
+	 * Free the buffer-pool replenish taskqueue before the channels: it
+	 * runs ch->bp_task which references the channels, and taskqueue_free()
+	 * drains any pending task.
+	 */
+	if (sc->bp_taskq != NULL) {
+		taskqueue_free(sc->bp_taskq);
+		sc->bp_taskq = NULL;
+	}
+
+	/* Free the per-CPU QBMan channels. */
+	for (i = 0; i < sc->chan_n; i++) {
+		dpaa2_chan_free(sc->channels[i]);
+		sc->channels[i] = NULL;
+	}
+	sc->chan_n = 0;
+
+	/* Detach any child (e.g. miibus) and return DPAA2 objects to the RC. */
+	bus_generic_detach(dev);
+	bus_release_resources(dev, dpaa2_ni_spec, sc->res);
+
+	/* Release the fixed-link media and the interface itself. */
+	if (sc->fixed_link)
+		ifmedia_removeall(&sc->fixed_ifmedia);
+	if (sc->ifp != NULL) {
+		if_free(sc->ifp);
+		sc->ifp = NULL;
+	}
+
+	mtx_destroy(&sc->lock);
+
 	return (0);
 }
 
@@ -729,7 +839,7 @@ dpaa2_ni_setup(device_t dev)
 	struct dpaa2_cmd cmd;
 	uint8_t eth_bca[ETHER_ADDR_LEN]; /* broadcast physical address */
 	uint16_t rc_token, ni_token, mac_token;
-	struct dpaa2_mac_attr attr;
+	struct dpaa2_mac_attr attr = { 0 };
 	enum dpaa2_mac_link_type link_type;
 	uint32_t link;
 	int error;
@@ -874,7 +984,7 @@ dpaa2_ni_setup(device_t dev)
 			if (link_type == DPAA2_MAC_LINK_TYPE_FIXED) {
 				device_printf(dev, "connected DPMAC is in FIXED "
 				    "mode\n");
-				dpaa2_ni_setup_fixed_link(sc);
+				dpaa2_ni_setup_fixed_link(sc, attr.max_rate);
 			} else if (link_type == DPAA2_MAC_LINK_TYPE_PHY) {
 				device_printf(dev, "connected DPMAC is in PHY "
 				    "mode\n");
@@ -930,7 +1040,7 @@ dpaa2_ni_setup(device_t dev)
 		} else if (ep2_desc.type == DPAA2_DEV_NI ||
 			   ep2_desc.type == DPAA2_DEV_MUX ||
 			   ep2_desc.type == DPAA2_DEV_SW) {
-			dpaa2_ni_setup_fixed_link(sc);
+			dpaa2_ni_setup_fixed_link(sc, 0);
 		}
 	}
 

--- a/sys/dev/dpaa2/dpaa2_ni.c
+++ b/sys/dev/dpaa2/dpaa2_ni.c
@@ -79,6 +79,8 @@
 #include <dev/mii/mii.h>
 #include <dev/mii/miivar.h>
 #include <dev/mdio/mdio.h>
+#include <dev/iicbus/iic.h>
+#include <dev/iicbus/iiconf.h>
 
 #include "opt_acpi.h"
 #include "opt_platform.h"
@@ -2675,6 +2677,147 @@ dpaa2_ni_qflush(if_t ifp)
 	if_qflush(ifp);
 }
 
+/*
+ * SFP+ EEPROM access for SIOCGI2C, so "ifconfig -v <dpni>" can show the
+ * module's SFF-8472 identity and diagnostics.  The module EEPROM lives on an
+ * i2c bus reached in one of two ways:
+ *
+ *  - FDT: the DPMAC's device-tree node has an "sfp" phandle to an "sff,sfp"
+ *    node whose "i2c-bus" points at the (possibly muxed) i2c bus.  The MC bus
+ *    resolves this via DPAA2_MC_GET_SFP_DEV(); any i2c mux is switched
+ *    transparently by the i2c framework when the bus is requested.
+ *
+ *  - ACPI: firmware exposes no such association, so it is supplied per
+ *    interface by loader tunables and any i2c mux is switched explicitly here:
+ *      hw.dpaa2.dpni<unit>.sfp_bus    iicbus unit (e.g. 0 for iic0); <0 disabled
+ *      hw.dpaa2.dpni<unit>.sfp_mux    7-bit i2c mux address (e.g. 0x77); 0 none
+ *      hw.dpaa2.dpni<unit>.sfp_chan   mux channel the cage sits on
+ *      hw.dpaa2.dpni<unit>.sfp_type   0 = PCA9547 (sel 0x08|ch), 1 = PCA9548
+ */
+#define	DPAA2_SFP_MUX_9547	0
+#define	DPAA2_SFP_MUX_9548	1
+
+/*
+ * Read len bytes at offset from an SFP EEPROM (dev_addr 0xA0/0xA2) on the i2c
+ * bus that `requester` (a device on that bus) hangs off; the bus is held for
+ * the whole exchange.  When muxaddr != 0 an i2c mux channel is selected first
+ * (chsel) and restored afterwards (chrestore) -- the ACPI path, where the mux
+ * has no driver.  The FDT path passes muxaddr 0 and lets the i2c mux driver
+ * switch transparently on the bus request.
+ */
+static int
+dpaa2_ni_sfp_i2c_read(device_t requester, int muxaddr, uint8_t chsel,
+    uint8_t chrestore, uint8_t dev_addr, uint8_t offset, uint8_t *buf, int len)
+{
+	device_t bus = device_get_parent(requester);
+	struct iic_msg sel, rd[2];
+	uint8_t off = offset;
+	int error;
+
+	error = iicbus_request_bus(bus, requester, IIC_INTRWAIT);
+	if (error != 0)
+		return (iic2errno(error));
+
+	if (muxaddr != 0) {
+		sel.slave = (uint16_t)muxaddr << 1;
+		sel.flags = IIC_M_WR;
+		sel.len = 1;
+		sel.buf = &chsel;
+		error = iicbus_transfer(requester, &sel, 1);
+	}
+
+	if (error == 0) {
+		/* Write the byte offset (repeat-start), then read the data. */
+		rd[0].slave = dev_addr;		/* already 8-bit (0xA0/0xA2) */
+		rd[0].flags = IIC_M_WR | IIC_M_NOSTOP;
+		rd[0].len = 1;
+		rd[0].buf = &off;
+		rd[1].slave = dev_addr;
+		rd[1].flags = IIC_M_RD;
+		rd[1].len = len;
+		rd[1].buf = buf;
+		error = iicbus_transfer(requester, rd, 2);
+	}
+
+	if (muxaddr != 0) {
+		sel.slave = (uint16_t)muxaddr << 1;
+		sel.flags = IIC_M_WR;
+		sel.len = 1;
+		sel.buf = &chrestore;
+		(void)iicbus_transfer(requester, &sel, 1);
+	}
+
+	iicbus_release_bus(bus, requester);
+	return (error != 0 ? iic2errno(error) : 0);
+}
+
+static int
+dpaa2_ni_sfp_ioctl(struct dpaa2_ni_softc *sc, struct ifreq *ifr)
+{
+	struct ifi2creq req;
+	device_t requester = NULL, sfpbus = NULL;
+	char tname[64];
+	int unit, muxaddr = 0, error;
+	uint8_t chsel = 0, chrestore = 0;
+
+	error = copyin(ifr_data_get_ptr(ifr), &req, sizeof(req));
+	if (error != 0)
+		return (error);
+	if (req.dev_addr != 0xa0 && req.dev_addr != 0xa2)
+		return (EINVAL);
+	if (req.len == 0 || req.len > (int)sizeof(req.data))
+		return (EINVAL);
+	if ((u_int)req.offset + req.len > 256)
+		return (EINVAL);
+
+	/*
+	 * Primary path: the DPMAC's device tree names the SFP i2c bus.  Any mux
+	 * is switched transparently by the i2c framework (muxaddr stays 0).
+	 */
+	if (DPAA2_MC_GET_SFP_DEV(sc->dev, &sfpbus, sc->mac.dpmac_id) == 0 &&
+	    sfpbus != NULL)
+		requester = device_find_child(sfpbus, "iic", -1);
+
+	/*
+	 * Fallback: no device-tree association (e.g. ACPI boot).  Use the
+	 * per-interface loader tunables and drive the mux explicitly.
+	 */
+	if (requester == NULL) {
+		int busunit = -1, mux = 0, chan = 0, type = DPAA2_SFP_MUX_9547;
+
+		unit = device_get_unit(sc->dev);
+		snprintf(tname, sizeof(tname), "hw.dpaa2.dpni%d.sfp_bus", unit);
+		TUNABLE_INT_FETCH(tname, &busunit);
+		if (busunit < 0)
+			return (ENXIO);
+		snprintf(tname, sizeof(tname), "hw.dpaa2.dpni%d.sfp_mux", unit);
+		TUNABLE_INT_FETCH(tname, &mux);
+		snprintf(tname, sizeof(tname), "hw.dpaa2.dpni%d.sfp_chan", unit);
+		TUNABLE_INT_FETCH(tname, &chan);
+		snprintf(tname, sizeof(tname), "hw.dpaa2.dpni%d.sfp_type", unit);
+		TUNABLE_INT_FETCH(tname, &type);
+
+		requester = devclass_get_device(devclass_find("iic"), busunit);
+		if (requester == NULL)
+			return (ENXIO);
+		muxaddr = mux;
+		if (type == DPAA2_SFP_MUX_9548) {
+			chsel = (uint8_t)(1u << (chan & 0x07));
+			chrestore = 0x00;		/* all channels off */
+		} else {
+			chsel = (uint8_t)(0x08 | (chan & 0x07));  /* 9547 enable|ch */
+			chrestore = 0x08;		/* power-on value (ch0) */
+		}
+	}
+
+	error = dpaa2_ni_sfp_i2c_read(requester, muxaddr, chsel, chrestore,
+	    req.dev_addr, req.offset, req.data, req.len);
+	if (error != 0)
+		return (error);
+
+	return (copyout(&req, ifr_data_get_ptr(ifr), sizeof(req)));
+}
+
 static int
 dpaa2_ni_ioctl(if_t ifp, u_long c, caddr_t data)
 {
@@ -2689,6 +2832,13 @@ dpaa2_ni_ioctl(if_t ifp, u_long c, caddr_t data)
 	uint32_t changed = 0;
 	uint16_t rc_token, ni_token;
 	int mtu, error, rc = 0;
+
+	/*
+	 * SFP+ EEPROM access (SIOCGI2C) talks to an i2c bus, not the MC; handle
+	 * it before opening the resource container / NI object below.
+	 */
+	if (c == SIOCGI2C)
+		return (dpaa2_ni_sfp_ioctl(sc, ifr));
 
 	DPAA2_CMD_INIT(&cmd);
 
@@ -3939,6 +4089,7 @@ DRIVER_MODULE(miibus, dpaa2_ni, miibus_driver, 0, 0);
 DRIVER_MODULE(dpaa2_ni, dpaa2_rc, dpaa2_ni_driver, 0, 0);
 
 MODULE_DEPEND(dpaa2_ni, miibus, 1, 1, 1);
+MODULE_DEPEND(dpaa2_ni, iicbus, 1, 1, 1);
 #ifdef DEV_ACPI
 MODULE_DEPEND(dpaa2_ni, memac_mdio_acpi, 1, 1, 1);
 #endif

--- a/sys/dev/dpaa2/dpaa2_rc.c
+++ b/sys/dev/dpaa2/dpaa2_rc.c
@@ -46,6 +46,7 @@
 #include <sys/types.h>
 #include <sys/systm.h>
 #include <sys/smp.h>
+#include <sys/conf.h>
 
 #include <machine/bus.h>
 #include <machine/resource.h>
@@ -56,6 +57,7 @@
 #include "dpaa2_mcp.h"
 #include "dpaa2_mc.h"
 #include "dpaa2_ni.h"
+#include "dpaa2_ioctl.h"
 #include "dpaa2_mc_if.h"
 #include "dpaa2_cmd_if.h"
 
@@ -79,9 +81,13 @@ static int dpaa2_rc_add_managed_child(struct dpaa2_rc_softc *,
 static int dpaa2_rc_enable_irq(struct dpaa2_mcp *, struct dpaa2_cmd *, uint8_t,
     bool, uint16_t);
 static int dpaa2_rc_configure_irq(device_t, device_t, int, uint64_t, uint32_t);
-static int dpaa2_rc_add_res(device_t, device_t, enum dpaa2_dev_type, int, int);
+static int dpaa2_rc_add_res(device_t, device_t, enum dpaa2_dev_type, int *, int);
 static int dpaa2_rc_print_type(struct resource_list *, enum dpaa2_dev_type);
 static struct dpaa2_mcp *dpaa2_rc_select_portal(device_t, device_t);
+
+/* Userland control device (/dev/dpaa2rcN) for dpaa2ctl(8). */
+static d_ioctl_t dpaa2_rc_ioctl;
+static struct cdevsw dpaa2_rc_cdevsw;
 
 /* Routines to send commands to MC. */
 static int dpaa2_rc_exec_cmd(struct dpaa2_mcp *, struct dpaa2_cmd *, uint16_t);
@@ -100,8 +106,12 @@ dpaa2_rc_probe(device_t dev)
 static int
 dpaa2_rc_detach(device_t dev)
 {
+	struct dpaa2_rc_softc *sc = device_get_softc(dev);
 	struct dpaa2_devinfo *dinfo;
 	int error;
+
+	if (sc != NULL && sc->cdev != NULL)
+		destroy_dev(sc->cdev);
 
 	error = bus_generic_detach(dev);
 	if (error)
@@ -180,6 +190,12 @@ dpaa2_rc_attach(device_t dev)
 		return (error);
 	}
 
+	/* Control device (/dev/dpaa2rcN) for the dpaa2ctl(8) userland tool. */
+	sc->cdev = make_dev(&dpaa2_rc_cdevsw, device_get_unit(dev), UID_ROOT,
+	    GID_WHEEL, 0600, "dpaa2rc%d", device_get_unit(dev));
+	if (sc->cdev != NULL)
+		sc->cdev->si_drv1 = sc;
+
 	return (0);
 }
 
@@ -225,7 +241,7 @@ dpaa2_rc_delete_resource(device_t rcdev, device_t child, int type, int rid)
 }
 
 static struct resource *
-dpaa2_rc_alloc_multi_resource(device_t rcdev, device_t child, int type, int rid,
+dpaa2_rc_alloc_multi_resource(device_t rcdev, device_t child, int type, int *rid,
     rman_res_t start, rman_res_t end, rman_res_t count, u_int flags)
 {
 	struct resource_list *rl;
@@ -243,7 +259,7 @@ dpaa2_rc_alloc_multi_resource(device_t rcdev, device_t child, int type, int rid,
 	 *	 dedicated software portal interrupt wire.
 	 *	 See registers SWP_INTW0_CFG to SWP_INTW3_CFG for details.
 	 */
-	if (type == SYS_RES_IRQ && rid == 0)
+	if (type == SYS_RES_IRQ && *rid == 0)
 		return (NULL);
 
 	return (resource_list_alloc(rl, rcdev, child, type, rid,
@@ -251,7 +267,7 @@ dpaa2_rc_alloc_multi_resource(device_t rcdev, device_t child, int type, int rid,
 }
 
 static struct resource *
-dpaa2_rc_alloc_resource(device_t rcdev, device_t child, int type, int rid,
+dpaa2_rc_alloc_resource(device_t rcdev, device_t child, int type, int *rid,
     rman_res_t start, rman_res_t end, rman_res_t count, u_int flags)
 {
 	if (device_get_parent(child) != rcdev)
@@ -2736,6 +2752,476 @@ dpaa2_rc_mcp_reset(device_t dev, device_t child, struct dpaa2_cmd *cmd)
 }
 
 /**
+ * @brief Create a new DPNI object in this resource container.
+ *
+ * A minimal configuration is requested (the MC fills in defaults for the
+ * zeroed fields); this mirrors what Linux'es "restool ls-addni" does in order
+ * to wire a DPNI to a DPMAC (e.g. an SFP port) at run-time. On success the id
+ * of the freshly created DPNI is returned in *ni_id.
+ *
+ * NOTE: 'cmd' must already carry an open DPRC token (the parent container).
+ */
+static int
+dpaa2_rc_ni_create(device_t dev, device_t child, struct dpaa2_cmd *cmd,
+    uint8_t num_queues, uint32_t *ni_id)
+{
+	struct __packed ni_create_args {
+		uint32_t options;
+		uint8_t  num_queues;
+		uint8_t  num_tcs;
+		uint8_t  mac_filter_entries;
+		uint8_t  num_rx_tcs;
+		uint8_t  vlan_filter_entries;
+		uint8_t  qos_entries;
+		uint16_t fs_entries;
+		uint8_t  num_cgs;
+		uint8_t  num_opr;
+		uint8_t  dist_key_size;
+		uint8_t  num_channels;
+	} *args;
+	struct dpaa2_mcp *portal = dpaa2_rc_select_portal(dev, child);
+	int error;
+
+	if (portal == NULL || cmd == NULL || ni_id == NULL)
+		return (DPAA2_CMD_STAT_ERR);
+
+	args = (struct ni_create_args *) &cmd->params[0];
+	args->options = 0;
+	args->num_queues = num_queues;	/* Rx/Tx queues == channels */
+	args->num_tcs = 1;
+	args->mac_filter_entries = 16;
+	args->num_rx_tcs = 1;
+	args->vlan_filter_entries = 0;
+	args->qos_entries = 0;
+	args->fs_entries = 0;
+	args->num_cgs = 0;
+	args->num_opr = 0;
+	args->dist_key_size = 0;
+	args->num_channels = 0;
+
+	error = dpaa2_rc_exec_cmd(portal, cmd, CMDID_NI_CREATE);
+	if (error == 0) {
+		/*
+		 * The MC returns the new object id in the low 32 bits of the
+		 * first response parameter (mc_cmd_read_object_id()).
+		 */
+		*ni_id = (uint32_t) cmd->params[0];
+		if (bootverbose)
+			device_printf(dev, "%s: dpni created, raw resp "
+			    "params[0]=%#jx -> id=%u\n", __func__,
+			    (uintmax_t) cmd->params[0], *ni_id);
+	}
+	return (error);
+}
+
+/**
+ * @brief Connect two endpoints (e.g. a DPNI and a DPMAC) inside the container.
+ *
+ * 'cmd' must already carry an open DPRC token.
+ */
+static int
+dpaa2_rc_connect(device_t dev, device_t child, struct dpaa2_cmd *cmd,
+    const struct dpaa2_ep_desc *ep1, const struct dpaa2_ep_desc *ep2)
+{
+	struct __packed connect_args {
+		uint32_t ep1_id;
+		uint32_t ep1_ifid;
+		uint32_t ep2_id;
+		uint32_t ep2_ifid;
+		uint8_t  ep1_type[16];
+		uint32_t max_rate;
+		uint32_t committed_rate;
+		uint8_t  ep2_type[16];
+	} *args;
+	struct dpaa2_mcp *portal = dpaa2_rc_select_portal(dev, child);
+
+	if (portal == NULL || cmd == NULL || ep1 == NULL || ep2 == NULL)
+		return (DPAA2_CMD_STAT_ERR);
+
+	args = (struct connect_args *) &cmd->params[0];
+	args->ep1_id = ep1->obj_id;
+	args->ep1_ifid = ep1->if_id;
+	args->ep2_id = ep2->obj_id;
+	args->ep2_ifid = ep2->if_id;
+	args->max_rate = 0;		/* let the MC use the link's default rate */
+	args->committed_rate = 0;
+	strncpy(args->ep1_type, dpaa2_ttos(ep1->type), sizeof(args->ep1_type));
+	strncpy(args->ep2_type, dpaa2_ttos(ep2->type), sizeof(args->ep2_type));
+
+	return (dpaa2_rc_exec_cmd(portal, cmd, CMDID_RC_CONNECT));
+}
+
+/**
+ * @brief Break the connection between an endpoint (e.g. a DPNI) and its peer.
+ *
+ * dprc_disconnect() takes a single endpoint; the MC tears down the link to
+ * whatever it is connected to. A DPNI must be disconnected from its DPMAC
+ * before it can be destroyed. 'cmd' must carry an open DPRC token.
+ */
+static int
+dpaa2_rc_disconnect(device_t dev, device_t child, struct dpaa2_cmd *cmd,
+    const struct dpaa2_ep_desc *ep)
+{
+	struct __packed disconnect_args {
+		uint32_t id;
+		uint32_t if_id;
+		uint8_t  type[16];
+	} *args;
+	struct dpaa2_mcp *portal = dpaa2_rc_select_portal(dev, child);
+	int i;
+
+	if (portal == NULL || cmd == NULL || ep == NULL)
+		return (DPAA2_CMD_STAT_ERR);
+
+	for (i = 0; i < DPAA2_CMD_PARAMS_N; i++)
+		cmd->params[i] = 0;
+	args = (struct disconnect_args *) &cmd->params[0];
+	args->id = ep->obj_id;
+	args->if_id = ep->if_id;
+	strncpy(args->type, dpaa2_ttos(ep->type), sizeof(args->type));
+
+	return (dpaa2_rc_exec_cmd(portal, cmd, CMDID_RC_DISCONNECT));
+}
+
+/**
+ * @brief Create a managed DPAA2 object (DPBP or DPCON) and add it to the
+ *        container's pool of allocatable resources.
+ *
+ * Minimal firmware DPLs hand all of their DPBPs/DPCONs to the DPL-defined
+ * DPNI(s), leaving no spares for a run-time created DPNI. Create a fresh one
+ * here so the new network interface has the buffer pool / concentrator it
+ * needs. 'cmd' must carry an open DPRC token.
+ */
+static int
+dpaa2_rc_create_managed(struct dpaa2_rc_softc *sc, struct dpaa2_cmd *cmd,
+    enum dpaa2_dev_type type, uint8_t num_prio)
+{
+	device_t rcdev = sc->dev;
+	device_t child = sc->dev;
+	struct dpaa2_mcp *portal = dpaa2_rc_select_portal(rcdev, child);
+	struct dpaa2_obj obj;
+	uint32_t id;
+	uint16_t cmdid;
+	int i, error;
+
+	if (portal == NULL)
+		return (DPAA2_CMD_STAT_ERR);
+
+	/* Clear the parameter area but keep the open DPRC token. */
+	for (i = 0; i < DPAA2_CMD_PARAMS_N; i++)
+		cmd->params[i] = 0;
+
+	switch (type) {
+	case DPAA2_DEV_BP:
+		cmdid = CMDID_BP_CREATE;	/* dpbp_create: no meaningful cfg */
+		break;
+	case DPAA2_DEV_CON:
+		cmdid = CMDID_CON_CREATE;	/* dpcon_create: 1-byte cfg */
+		((uint8_t *) &cmd->params[0])[0] = num_prio;
+		break;
+	default:
+		return (EINVAL);
+	}
+
+	error = dpaa2_rc_exec_cmd(portal, cmd, cmdid);
+	if (error) {
+		device_printf(rcdev, "%s: failed to create %s: error=%d\n",
+		    __func__, dpaa2_ttos(type), error);
+		return (error);
+	}
+	id = (uint32_t) cmd->params[0];	/* mc_cmd_read_object_id() */
+
+	/* Fetch the full descriptor (region/IRQ counts) of the new object. */
+	memset(&obj, 0, sizeof(obj));
+	error = dpaa2_rc_get_obj_descriptor(rcdev, child, cmd, id, type, &obj);
+	if (error) {
+		device_printf(rcdev, "%s: failed to get descriptor of %s "
+		    "(id=%u): error=%d\n", __func__, dpaa2_ttos(type), id,
+		    error);
+		return (error);
+	}
+	obj.id = id;
+	obj.type = type;
+	device_printf(rcdev, "created %s (id=%u) for run-time dpni\n",
+	    dpaa2_ttos(type), id);
+
+	return (dpaa2_rc_add_managed_child(sc, cmd, &obj));
+}
+
+/**
+ * @brief Create a DPNI, wire it to a DPMAC and add it as a child interface.
+ *
+ * Creates a DPBP and a full set (one per CPU) of DPCONs for the new interface
+ * -- the minimal DPL leaves no spares, and a single channel does not steer Rx
+ * frames correctly -- then creates the DPNI, connects it to the DPMAC and adds
+ * the network-interface child. 'cmd' must carry an open DPRC token. The id of
+ * the created DPNI is returned in *ni_id_out.
+ *
+ * This is FreeBSD's equivalent of Linux'es "restool ls-addni dpmac.N".
+ */
+static int
+dpaa2_rc_create_ni_locked(struct dpaa2_rc_softc *sc, struct dpaa2_cmd *cmd,
+    int dpmac_id, uint32_t *ni_id_out)
+{
+	device_t rcdev = sc->dev;
+	device_t child = sc->dev;
+	struct dpaa2_ep_desc ep_ni, ep_mac;
+	struct dpaa2_obj obj;
+	uint32_t ni_id;
+	int ncon = 0;
+	int i, error;
+
+	error = dpaa2_rc_create_managed(sc, cmd, DPAA2_DEV_BP, 0);
+	if (error) {
+		device_printf(rcdev, "%s: failed to create a dpbp: error=%d\n",
+		    __func__, error);
+		return (error);
+	}
+	for (i = 0; i < mp_ncpus; i++) {
+		if (dpaa2_rc_create_managed(sc, cmd, DPAA2_DEV_CON, 2) != 0)
+			break;	/* ran out of MC resources; use what we have */
+		ncon++;
+	}
+	if (ncon == 0) {
+		device_printf(rcdev, "%s: failed to create any dpcon\n",
+		    __func__);
+		return (ENXIO);
+	}
+	/* Probe/attach the new DPBP/DPCONs so they register as free resources. */
+	bus_identify_children(rcdev);
+	bus_attach_children(rcdev);
+
+	error = dpaa2_rc_ni_create(rcdev, child, cmd, (uint8_t) ncon, &ni_id);
+	if (error) {
+		device_printf(rcdev, "%s: dpni_create failed: error=%d\n",
+		    __func__, error);
+		return (error);
+	}
+	device_printf(rcdev, "created dpni (id=%u) to attach to dpmac (id=%d)\n",
+	    ni_id, dpmac_id);
+
+	ep_ni.obj_id = ni_id;
+	ep_ni.if_id = 0;
+	ep_ni.type = DPAA2_DEV_NI;
+	ep_mac.obj_id = (uint32_t) dpmac_id;
+	ep_mac.if_id = 0;
+	ep_mac.type = DPAA2_DEV_MAC;
+
+	error = dpaa2_rc_connect(rcdev, child, cmd, &ep_ni, &ep_mac);
+	if (error) {
+		device_printf(rcdev, "%s: failed to connect dpni (id=%u) to "
+		    "dpmac (id=%d): error=%d\n", __func__, ni_id, dpmac_id,
+		    error);
+		return (error);
+	}
+	device_printf(rcdev, "connected dpni (id=%u) to dpmac (id=%d)\n", ni_id,
+	    dpmac_id);
+
+	/* Add the freshly created DPNI as a child network interface. */
+	memset(&obj, 0, sizeof(obj));
+	obj.id = ni_id;
+	obj.type = DPAA2_DEV_NI;
+	obj.irq_count = 1;	/* DPNI exposes a single (link-change) IRQ */
+	error = dpaa2_rc_add_child(sc, cmd, &obj);
+	if (error)
+		return (error);
+
+	if (ni_id_out != NULL)
+		*ni_id_out = ni_id;
+	return (0);
+}
+
+/**
+ * @brief Boot-time hook: create a DPNI on the DPMAC named by the
+ *        "hw.dpaa2.add_dpmac" loader tunable (if set).
+ *
+ * Called from dpaa2_rc_discover() with an open DPRC token, before RC_CLOSE.
+ */
+static void
+dpaa2_rc_add_dpni_to_dpmac(struct dpaa2_rc_softc *sc, struct dpaa2_cmd *cmd)
+{
+	uint32_t ni_id;
+	int dpmac_id = -1;
+
+	TUNABLE_INT_FETCH("hw.dpaa2.add_dpmac", &dpmac_id);
+	if (dpmac_id < 0)
+		return;	/* feature disabled */
+
+	(void) dpaa2_rc_create_ni_locked(sc, cmd, dpmac_id, &ni_id);
+}
+
+/**
+ * @brief Run-time create: open the container, create + wire a DPNI to a DPMAC
+ *        and attach it. Used by the dpaa2ctl(8) control interface.
+ */
+static int
+dpaa2_rc_create_ni(struct dpaa2_rc_softc *sc, int dpmac_id, uint32_t *ni_id_out)
+{
+	device_t rcdev = sc->dev;
+	struct dpaa2_cmd cmd;
+	uint16_t rc_token;
+	int error;
+
+	DPAA2_CMD_INIT(&cmd);
+	error = DPAA2_CMD_RC_OPEN(rcdev, rcdev, &cmd, sc->cont_id, &rc_token);
+	if (error)
+		return (error);
+	error = dpaa2_rc_create_ni_locked(sc, &cmd, dpmac_id, ni_id_out);
+	(void) DPAA2_CMD_RC_CLOSE(rcdev, rcdev, &cmd);
+
+	/* Probe and attach the new network interface. */
+	bus_identify_children(rcdev);
+	bus_attach_children(rcdev);
+	return (error);
+}
+
+/**
+ * @brief Destroy a DPNI object in the MC (issued to the parent DPRC token).
+ */
+static int
+dpaa2_rc_ni_destroy(device_t dev, device_t child, struct dpaa2_cmd *cmd,
+    uint32_t ni_id)
+{
+	struct dpaa2_mcp *portal = dpaa2_rc_select_portal(dev, child);
+	int i;
+
+	if (portal == NULL || cmd == NULL)
+		return (DPAA2_CMD_STAT_ERR);
+	for (i = 0; i < DPAA2_CMD_PARAMS_N; i++)
+		cmd->params[i] = 0;
+	cmd->params[0] = (uint64_t) ni_id;	/* dpni_destroy: object id */
+	return (dpaa2_rc_exec_cmd(portal, cmd, CMDID_NI_DESTROY));
+}
+
+/**
+ * @brief Run-time destroy: detach the network-interface child and destroy the
+ *        DPNI object. Used by the dpaa2ctl(8) control interface.
+ */
+static int
+dpaa2_rc_destroy_ni(struct dpaa2_rc_softc *sc, uint32_t ni_id)
+{
+	device_t rcdev = sc->dev;
+	device_t *children, target = NULL;
+	struct dpaa2_devinfo *dinfo;
+	struct dpaa2_cmd cmd;
+	uint16_t rc_token;
+	int nchild, i, error;
+
+	error = device_get_children(rcdev, &children, &nchild);
+	if (error)
+		return (error);
+	for (i = 0; i < nchild; i++) {
+		dinfo = device_get_ivars(children[i]);
+		if (dinfo != NULL && dinfo->dtype == DPAA2_DEV_NI &&
+		    dinfo->id == ni_id) {
+			target = children[i];
+			break;
+		}
+	}
+	free(children, M_TEMP);
+	if (target == NULL)
+		return (ENOENT);
+
+	/* Detach the ifnet and release its resources back to the container. */
+	device_delete_child(rcdev, target);
+
+	/* Disconnect from the DPMAC, then destroy the DPNI object itself. */
+	DPAA2_CMD_INIT(&cmd);
+	error = DPAA2_CMD_RC_OPEN(rcdev, rcdev, &cmd, sc->cont_id, &rc_token);
+	if (error == 0) {
+		struct dpaa2_ep_desc ep_ni;
+
+		ep_ni.obj_id = ni_id;
+		ep_ni.if_id = 0;
+		ep_ni.type = DPAA2_DEV_NI;
+		/* A connected DPNI cannot be destroyed; ignore "not connected". */
+		(void) dpaa2_rc_disconnect(rcdev, rcdev, &cmd, &ep_ni);
+
+		error = dpaa2_rc_ni_destroy(rcdev, rcdev, &cmd, ni_id);
+		(void) DPAA2_CMD_RC_CLOSE(rcdev, rcdev, &cmd);
+	}
+	if (error)
+		device_printf(rcdev, "%s: dpni_destroy (id=%u) returned "
+		    "error=%d\n", __func__, ni_id, error);
+	else
+		device_printf(rcdev, "destroyed dpni (id=%u)\n", ni_id);
+	return (error);
+}
+
+/**
+ * @brief List the DPNI network interfaces present in this container.
+ */
+static int
+dpaa2_rc_list_ni(struct dpaa2_rc_softc *sc, struct dpaa2_listni_args *list)
+{
+	device_t rcdev = sc->dev;
+	device_t *children;
+	struct dpaa2_devinfo *dinfo;
+	struct dpaa2_ni_softc *nisc;
+	int nchild, i, error;
+	uint32_t n = 0;
+
+	bzero(list, sizeof(*list));
+	error = device_get_children(rcdev, &children, &nchild);
+	if (error)
+		return (error);
+	for (i = 0; i < nchild && n < DPAA2_NI_LIST_MAX; i++) {
+		dinfo = device_get_ivars(children[i]);
+		if (dinfo == NULL || dinfo->dtype != DPAA2_DEV_NI)
+			continue;
+		list->ni[n].ni_id = dinfo->id;
+		nisc = device_get_softc(children[i]);
+		list->ni[n].dpmac_id = (nisc != NULL) ? nisc->mac.dpmac_id : ~0u;
+		strlcpy(list->ni[n].name, device_get_nameunit(children[i]),
+		    DPAA2_NI_NAME_LEN);
+		n++;
+	}
+	free(children, M_TEMP);
+	list->count = n;
+	return (0);
+}
+
+/* ------------------------- /dev/dpaa2rcN control device ------------------- */
+
+static int
+dpaa2_rc_ioctl(struct cdev *cdev, u_long ucmd, caddr_t data, int fflag,
+    struct thread *td)
+{
+	struct dpaa2_rc_softc *sc = cdev->si_drv1;
+	int error;
+
+	if (sc == NULL)
+		return (ENXIO);
+
+	switch (ucmd) {
+	case DPAA2IOC_ADDNI: {
+		struct dpaa2_addni_args *a = (struct dpaa2_addni_args *) data;
+		uint32_t ni_id = 0;
+
+		error = dpaa2_rc_create_ni(sc, (int) a->dpmac_id, &ni_id);
+		a->ni_id = ni_id;
+		break;
+	}
+	case DPAA2IOC_DELNI:
+		error = dpaa2_rc_destroy_ni(sc, *(uint32_t *) data);
+		break;
+	case DPAA2IOC_LISTNI:
+		error = dpaa2_rc_list_ni(sc, (struct dpaa2_listni_args *) data);
+		break;
+	default:
+		error = ENOTTY;
+		break;
+	}
+	return (error);
+}
+
+static struct cdevsw dpaa2_rc_cdevsw = {
+	.d_version =	D_VERSION,
+	.d_ioctl =	dpaa2_rc_ioctl,
+	.d_name =	"dpaa2",
+};
+
+/**
  * @brief Create and add devices for DPAA2 objects in this resource container.
  */
 static int
@@ -2869,6 +3355,12 @@ dpaa2_rc_discover(struct dpaa2_rc_softc *sc)
 		dpaa2_rc_add_child(sc, &cmd, &obj);
 	}
 
+	/*
+	 * Optionally create a DPNI and wire it to a DPMAC (e.g. an SFP port)
+	 * when requested via the "hw.dpaa2.add_dpmac" tunable.
+	 */
+	dpaa2_rc_add_dpni_to_dpmac(sc, &cmd);
+
 	DPAA2_CMD_RC_CLOSE(rcdev, child, &cmd);
 
 	/* Probe and attach the rest of devices. */
@@ -2891,7 +3383,7 @@ dpaa2_rc_add_child(struct dpaa2_rc_softc *sc, struct dpaa2_cmd *cmd,
 	const char *devclass;
 	int dpio_n = 0; /* to limit DPIOs by # of CPUs */
 	int dpcon_n = 0; /* to limit DPCONs by # of CPUs */
-	int error;
+	int rid, error;
 
 	rcdev = sc->dev;
 	rcinfo = device_get_ivars(rcdev);
@@ -2945,6 +3437,7 @@ dpaa2_rc_add_child(struct dpaa2_rc_softc *sc, struct dpaa2_cmd *cmd,
 	for (; res_spec && res_spec->type != -1; res_spec++) {
 		if (res_spec->type < DPAA2_DEV_MC)
 			continue; /* Skip non-DPAA2 resource. */
+		rid = res_spec->rid;
 
 		/* Limit DPIOs and DPCONs by number of CPUs. */
 		if (res_spec->type == DPAA2_DEV_IO && dpio_n >= mp_ncpus) {
@@ -2956,8 +3449,8 @@ dpaa2_rc_add_child(struct dpaa2_rc_softc *sc, struct dpaa2_cmd *cmd,
 			continue;
 		}
 
-		error = dpaa2_rc_add_res(rcdev, dev, res_spec->type,
-		    res_spec->rid, res_spec->flags);
+		error = dpaa2_rc_add_res(rcdev, dev, res_spec->type, &rid,
+		    res_spec->flags);
 		if (error)
 			device_printf(rcdev, "%s: dpaa2_rc_add_res() failed: "
 			    "error=%d\n", __func__, error);
@@ -2993,7 +3486,7 @@ dpaa2_rc_add_managed_child(struct dpaa2_rc_softc *sc, struct dpaa2_cmd *cmd,
 	const char *devclass;
 	uint64_t start, end, count;
 	uint32_t flags = 0;
-	int error;
+	int rid, error;
 
 	rcdev = sc->dev;
 	child = sc->dev;
@@ -3088,9 +3581,10 @@ dpaa2_rc_add_managed_child(struct dpaa2_rc_softc *sc, struct dpaa2_cmd *cmd,
 	for (; res_spec && res_spec->type != -1; res_spec++) {
 		if (res_spec->type < DPAA2_DEV_MC)
 			continue; /* Skip non-DPAA2 resource. */
+		rid = res_spec->rid;
 
-		error = dpaa2_rc_add_res(rcdev, dev, res_spec->type,
-		    res_spec->rid, res_spec->flags);
+		error = dpaa2_rc_add_res(rcdev, dev, res_spec->type, &rid,
+		    res_spec->flags);
 		if (error)
 			device_printf(rcdev, "%s: dpaa2_rc_add_res() failed: "
 			    "error=%d\n", __func__, error);
@@ -3284,7 +3778,7 @@ dpaa2_rc_wait_for_cmd(struct dpaa2_mcp *mcp, struct dpaa2_cmd *cmd)
  */
 static int
 dpaa2_rc_add_res(device_t rcdev, device_t child, enum dpaa2_dev_type devtype,
-    int rid, int flags)
+    int *rid, int flags)
 {
 	device_t dpaa2_dev;
 	struct dpaa2_devinfo *dinfo = device_get_ivars(child);
@@ -3296,7 +3790,7 @@ dpaa2_rc_add_res(device_t rcdev, device_t child, enum dpaa2_dev_type devtype,
 	error = DPAA2_MC_GET_FREE_DEV(rcdev, &dpaa2_dev, devtype);
 	if (error && !(flags & RF_SHAREABLE)) {
 		device_printf(rcdev, "%s: failed to obtain a free %s (rid=%d) "
-		    "for: %s (id=%u)\n", __func__, dpaa2_ttos(devtype), rid,
+		    "for: %s (id=%u)\n", __func__, dpaa2_ttos(devtype), *rid,
 		    dpaa2_ttos(dinfo->dtype), dinfo->id);
 		return (error);
 	}
@@ -3307,7 +3801,7 @@ dpaa2_rc_add_res(device_t rcdev, device_t child, enum dpaa2_dev_type devtype,
 		if (error) {
 			device_printf(rcdev, "%s: failed to obtain a shared "
 			    "%s (rid=%d) for: %s (id=%u)\n", __func__,
-			    dpaa2_ttos(devtype), rid, dpaa2_ttos(dinfo->dtype),
+			    dpaa2_ttos(devtype), *rid, dpaa2_ttos(dinfo->dtype),
 			    dinfo->id);
 			return (error);
 		}
@@ -3315,7 +3809,7 @@ dpaa2_rc_add_res(device_t rcdev, device_t child, enum dpaa2_dev_type devtype,
 	}
 
 	/* Add DPAA2 device to the resource list of the child device. */
-	resource_list_add(&dinfo->resources, devtype, rid,
+	resource_list_add(&dinfo->resources, devtype, *rid,
 	    (rman_res_t) dpaa2_dev, (rman_res_t) dpaa2_dev, 1);
 
 	/* Reserve a newly added DPAA2 resource. */
@@ -3324,7 +3818,7 @@ dpaa2_rc_add_res(device_t rcdev, device_t child, enum dpaa2_dev_type devtype,
 	    flags & ~RF_ACTIVE);
 	if (!res) {
 		device_printf(rcdev, "%s: failed to reserve %s (rid=%d) for: %s "
-		    "(id=%u)\n", __func__, dpaa2_ttos(devtype), rid,
+		    "(id=%u)\n", __func__, dpaa2_ttos(devtype), *rid,
 		    dpaa2_ttos(dinfo->dtype), dinfo->id);
 		return (EBUSY);
 	}
@@ -3335,7 +3829,7 @@ dpaa2_rc_add_res(device_t rcdev, device_t child, enum dpaa2_dev_type devtype,
 		if (error) {
 			device_printf(rcdev, "%s: failed to reserve a shared "
 			    "%s (rid=%d) for: %s (id=%u)\n", __func__,
-			    dpaa2_ttos(devtype), rid, dpaa2_ttos(dinfo->dtype),
+			    dpaa2_ttos(devtype), *rid, dpaa2_ttos(dinfo->dtype),
 			    dinfo->id);
 			return (error);
 		}


### PR DESCRIPTION
Add a /dev/dpaa2rcN control device and ioctls so a userland tool (dpaa2ctl) can create, destroy and list DPNI network interfaces at run time, wiring a DPNI to a DPMAC (e.g. an SFP+ port) without a firmware DPL change or reboot -- the FreeBSD equivalent of NXP's "restool ls-addni".

- dpaa2_rc.c: /dev/dpaa2rcN cdev + DPAA2IOC_ADDNI/DELNI/LISTNI; runtime DPNI create (DPBP + per-CPU DPCONs, connect to DPMAC), dprc_disconnect + dpni_destroy on delete; hw.dpaa2.add_dpmac boot tunable.
- dpaa2_ni.c: implement dpaa2_ni_detach() (was a TBD stub) for a clean teardown that ether_ifdetach()es first; fixed-link media derived from the DPMAC max_rate.
- dpaa2_channel.c/.h: dpaa2_chan_free() helper.
- dpaa2_mcp.h: NI/BP/CON create + correct destroy opcodes (0x981/0x984/0x988) and DPRC connect/disconnect command IDs.
- dpaa2_ioctl.h: shared userland ioctl ABI.