### PR TITLE
syslogd: match all elements of a comma-separated host/program filter

### DIFF
--- a/usr.sbin/syslogd/syslogd.c
+++ b/usr.sbin/syslogd/syslogd.c
@@ -1424,6 +1424,8 @@ skip_message(const char *name, const char *spec, int checkcase)
 	const char *s;
 	char prev, next;
 	int exclude = 0;
+	size_t namelen;
+	char *(*find)(const char *, const char *);
 	/* Behaviour on explicit match */
 
 	if (spec == NULL || *spec == '\0')
@@ -1438,15 +1440,17 @@ skip_message(const char *name, const char *spec, int checkcase)
 	default:
 		break;
 	}
-	if (checkcase)
-		s = strstr (spec, name);
-	else
-		s = strcasestr (spec, name);
+	find = checkcase ? strstr : strcasestr;
+	namelen = strlen(name);
+	for (s = find(spec, name); s != NULL; s = find(s + 1, name)) {
+		prev = (s == spec) ? ',' : *(s - 1);
+		next = *(s + namelen);
 
-	if (s != NULL) {
-		prev = (s == spec ? ',' : *(s - 1));
-		next = *(s + strlen (name));
-
+		/*
+		 * Only a whole comma-delimited element is a match; on a
+		 * substring hit keep scanning so a later element can
+		 * still match.
+		 */
 		if (prev == ',' && (next == '\0' || next == ','))
 			/* Explicit match: skip iff the spec is an
 			   exclusive one. */

--- a/usr.sbin/syslogd/tests/syslogd_test.sh
+++ b/usr.sbin/syslogd/tests/syslogd_test.sh
@@ -194,6 +194,82 @@ host_filter_cleanup()
     syslogd_stop
 }
 
+atf_test_case "host_filter_overlap" "cleanup"
+host_filter_overlap_head()
+{
+    atf_set descr "Comma-separated host filters match every element when one name is a substring of another"
+}
+host_filter_overlap_body()
+{
+    logfile="${PWD}/host_filter_overlap.log"
+    printf "+webhost,host\nuser.debug\t${logfile}\n" > "${SYSLOGD_CONFIG}"
+    syslogd_start
+
+    for h in webhost host; do
+        syslogd_log -p user.debug -t "${h}" -H "${h}" \
+            -h "${SYSLOGD_LOCAL_SOCKET}" "hello this is ${h}"
+    done
+    atf_check -s exit:0 -o match:"webhost: hello this is webhost" \
+        cat "${logfile}"
+    atf_check -s exit:0 -o match:"host: hello this is host" cat "${logfile}"
+
+    # Exclusion must drop every element too.
+    truncate -s 0 ${logfile}
+    printf "\-webhost,host\nuser.debug\t${logfile}\n" > "${SYSLOGD_CONFIG}"
+    syslogd_reload
+
+    for h in webhost host; do
+        syslogd_log -p user.debug -t "${h}" -H "${h}" \
+            -h "${SYSLOGD_LOCAL_SOCKET}" "hello this is ${h}"
+    done
+    atf_check -s exit:0 -o not-match:"webhost: hello this is webhost" \
+        cat "${logfile}"
+    atf_check -s exit:0 -o not-match:"host: hello this is host" \
+        cat "${logfile}"
+}
+host_filter_overlap_cleanup()
+{
+    syslogd_stop
+}
+
+atf_test_case "prog_filter_overlap" "cleanup"
+prog_filter_overlap_head()
+{
+    atf_set descr "Comma-separated program filters match every element when one name is a substring of another"
+}
+prog_filter_overlap_body()
+{
+    logfile="${PWD}/prog_filter_overlap.log"
+    printf "!myprog,prog\nuser.debug\t${logfile}\n" > "${SYSLOGD_CONFIG}"
+    syslogd_start
+
+    for p in myprog prog; do
+        syslogd_log -p user.debug -t "${p}" -h "${SYSLOGD_LOCAL_SOCKET}" \
+            "hello this is ${p}"
+    done
+    atf_check -s exit:0 -o match:"myprog: hello this is myprog" \
+        cat "${logfile}"
+    atf_check -s exit:0 -o match:"prog: hello this is prog" cat "${logfile}"
+
+    # Exclusion must drop every element too.
+    truncate -s 0 ${logfile}
+    printf "!-myprog,prog\nuser.debug\t${logfile}\n" > "${SYSLOGD_CONFIG}"
+    syslogd_reload
+
+    for p in myprog prog; do
+        syslogd_log -p user.debug -t "${p}" -h "${SYSLOGD_LOCAL_SOCKET}" \
+            "hello this is ${p}"
+    done
+    atf_check -s exit:0 -o not-match:"myprog: hello this is myprog" \
+        cat "${logfile}"
+    atf_check -s exit:0 -o not-match:"prog: hello this is prog" \
+        cat "${logfile}"
+}
+prog_filter_overlap_cleanup()
+{
+    syslogd_stop
+}
+
 atf_test_case "prop_filter" "cleanup"
 prop_filter_head()
 {
@@ -596,6 +672,8 @@ atf_init_test_cases()
     atf_add_test_case "reload"
     atf_add_test_case "prog_filter"
     atf_add_test_case "host_filter"
+    atf_add_test_case "host_filter_overlap"
+    atf_add_test_case "prog_filter_overlap"
     atf_add_test_case "prop_filter"
     atf_add_test_case "host_action"
     atf_add_test_case "pipe_action"


### PR DESCRIPTION
## Problem

syslog.conf(5) documents that a host or program filter may list multiple
comma-separated values (e.g. `+host1,host2` or `!prog1,prog2`), matching any
listed name. `skip_message()` only inspected the *first* substring occurrence
of the message's name within the specification. When a name appears as a
substring of an earlier list element, the genuine comma-delimited element is
never reached, so it is silently ignored.

Observed on 15.0-RELEASE:

- `+webhost,host` drops messages from `host`.
- `-webhost,host` fails to exclude `host`.

The program filter (e.g. `!myprog,prog`) shares the routine and is affected
identically. Distinct, non-overlapping names already worked and are unchanged.

## Fix

Iterate over every occurrence until a whole comma-delimited element matches,
instead of giving up after the first substring hit.

## Test

Adds ATF cases `host_filter_overlap` and `prog_filter_overlap` to
`usr.sbin/syslogd/tests/syslogd_test.sh`, covering the substring-overlap case
for both inclusive and exclusive comma lists. They pass with the fix and fail
without it. The pre-existing `host_filter`/`prog_filter` cases use
non-overlapping names (host1/host2/host3) and so never exercised this path.

Verified by building `syslogd` from source on 15.0-RELEASE and exercising both
the inclusive and exclusive forms before and after the change.
