### PR TITLE
linuxulator: Fix operator precedence for LINUX_XATTR_FLAGS in setxattr()

### DIFF
--- a/sys/compat/linux/linux_xattr.c
+++ b/sys/compat/linux/linux_xattr.c
@@ -53,7 +53,7 @@
 
 #define	LINUX_XATTR_CREATE	0x1
 #define	LINUX_XATTR_REPLACE	0x2
-#define	LINUX_XATTR_FLAGS	LINUX_XATTR_CREATE|LINUX_XATTR_REPLACE
+#define	LINUX_XATTR_FLAGS	(LINUX_XATTR_CREATE | LINUX_XATTR_REPLACE)
 
 struct listxattr_args {
 	int		fd;
@@ -511,8 +511,8 @@ setxattr(struct thread *td, struct setxattr_args *args)
 			return (error);
 	}
 
-	if ((args->flags & ~(LINUX_XATTR_FLAGS)) != 0 ||
-	    args->flags == (LINUX_XATTR_FLAGS)) {
+	if ((args->flags & ~LINUX_XATTR_FLAGS) != 0 ||
+	    args->flags == LINUX_XATTR_FLAGS) {
 		error = EINVAL;
 		goto out_err;
 	}
@@ -520,7 +520,7 @@ setxattr(struct thread *td, struct setxattr_args *args)
 	if (error != 0)
 		goto out_err;
 
-	if ((args->flags & (LINUX_XATTR_FLAGS)) != 0 ) {
+	if ((args->flags & LINUX_XATTR_FLAGS) != 0) {
 		if (args->path != NULL)
 			error = kern_extattr_get_path(td, args->path,
 			    attrnamespace, attrname, NULL, args->size,


### PR DESCRIPTION
The LINUX_XATTR_FLAGS macro expands to (LINUX_XATTR_CREATE|LINUX_XATTR_REPLACE). Without parentheses around the macro expansion, the bitwise & operator has higher precedence than |, causing incorrect flag evaluation and a compiler warning.

Add the missing parentheses around LINUX_XATTR_FLAGS to ensure correct operator grouping, matching the existing usage in getxattr().

Fixes:          2c905456312b ("linuxulator: Fix O_PATH file descriptors errno for f*xattr(2)")