### PR TITLE
arm64: fill NULL stream bus_space slots on memmap_bus

### DIFF
--- a/sys/arm64/arm64/bus_machdep.c
+++ b/sys/arm64/arm64/bus_machdep.c
@@ -242,11 +242,11 @@ struct bus_space memmap_bus = {
 	.bs_c_4 = NULL,
 	.bs_c_8 = NULL,
 
-	/* read single stream */
-	.bs_r_1_s = NULL,
-	.bs_r_2_s = NULL,
-	.bs_r_4_s = NULL,
-	.bs_r_8_s = NULL,
+	/* read single stream (LE CPU + LE bus: no swap, same as non-stream) */
+	.bs_r_1_s = generic_bs_r_1,
+	.bs_r_2_s = generic_bs_r_2,
+	.bs_r_4_s = generic_bs_r_4,
+	.bs_r_8_s = generic_bs_r_8,
 
 	/* read multiple stream */
 	.bs_rm_1_s = generic_bs_rm_1,
@@ -254,17 +254,17 @@ struct bus_space memmap_bus = {
 	.bs_rm_4_s = generic_bs_rm_4,
 	.bs_rm_8_s = generic_bs_rm_8,
 
-	/* read region stream */
-	.bs_rr_1_s = NULL,
-	.bs_rr_2_s = NULL,
-	.bs_rr_4_s = NULL,
-	.bs_rr_8_s = NULL,
+	/* read region stream (LE CPU + LE bus: no swap, same as non-stream) */
+	.bs_rr_1_s = generic_bs_rr_1,
+	.bs_rr_2_s = generic_bs_rr_2,
+	.bs_rr_4_s = generic_bs_rr_4,
+	.bs_rr_8_s = generic_bs_rr_8,
 
-	/* write single stream */
-	.bs_w_1_s = NULL,
-	.bs_w_2_s = NULL,
-	.bs_w_4_s = NULL,
-	.bs_w_8_s = NULL,
+	/* write single stream (LE CPU + LE bus: no swap, same as non-stream) */
+	.bs_w_1_s = generic_bs_w_1,
+	.bs_w_2_s = generic_bs_w_2,
+	.bs_w_4_s = generic_bs_w_4,
+	.bs_w_8_s = generic_bs_w_8,
 
 	/* write multiple stream */
 	.bs_wm_1_s = generic_bs_wm_1,
@@ -272,11 +272,11 @@ struct bus_space memmap_bus = {
 	.bs_wm_4_s = generic_bs_wm_4,
 	.bs_wm_8_s = generic_bs_wm_8,
 
-	/* write region stream */
-	.bs_wr_1_s = NULL,
-	.bs_wr_2_s = NULL,
-	.bs_wr_4_s = NULL,
-	.bs_wr_8_s = NULL,
+	/* write region stream (LE CPU + LE bus: no swap, same as non-stream) */
+	.bs_wr_1_s = generic_bs_wr_1,
+	.bs_wr_2_s = generic_bs_wr_2,
+	.bs_wr_4_s = generic_bs_wr_4,
+	.bs_wr_8_s = generic_bs_wr_8,
 
 	/* peek */
 	.bs_peek_1 = generic_bs_peek_1,


### PR DESCRIPTION
## Summary

`memmap_bus` in `sys/arm64/arm64/bus_machdep.c` leaves every "stream" access slot NULL except the multi variants. Any caller that reaches for e.g. `bus_read_region_stream_2()` on arm64 jumps through a NULL function pointer.

`bhnd(4)` exercises this path. On RockPro64 (RK3399) with a BCM4312 attached under `bwn(4)`, `bhndb_pci_attach()` succeeds and `bhnd_nvram0 <SPROM/OTP>` is announced; the first SPROM read inside `bhnd_nvram_sprom_ident()` then panics:

```
Fatal data abort:
 x9:  memmap_bus
 x16: bhnd_nvram_iores_read+0x0
 lr:  bhnd_nvram_iores_read+0x12c
 elr: 0x0000000000000000
 far: 0x0000000000000000
 esr: 0x86000004         (instruction abort, address 0)
```

Callchain: `bwn_pci_attach → bhndb_attach_bridge → bhndb_pci_attach → bhnd_sprom_attach → bhnd_nvram_store_parse_new → bhnd_nvram_data_new → bhnd_nvram_sprom_new → bhnd_nvram_sprom_ident → bhnd_nvram_iores_read` (dispatching `bus_read_region_stream_2`) → `memmap_bus.bs_rr_2_s == NULL`.

Fill in the NULL slots by aliasing them to their non-stream twins. On aarch64 (little-endian CPU) accessing little-endian PCIe/MMIO, "stream" (no host↔bus swap) and "non-stream" access are byte-identical, so no functional change for existing callers — the multi-stream slots are already handled the same way.

## Test plan

- [x] arm64 kernel build (RockPro64, RP64KERN_KMS)
- [x] `bwn(4)` BCM4312 attach through full bhnd/SIBA enumeration; no NULL-fn panic
- [x] `wpa_supplicant(8)` WPA2/CCMP 4-way handshake completes
- [x] ICMP round-trip over the air to the AP