### PR TITLE
vt: reprogram display controller on KDSETMODE KD_TEXT for active window

### DIFF
--- a/sys/dev/vt/vt_core.c
+++ b/sys/dev/vt/vt_core.c
@@ -2924,6 +2924,23 @@ skip_thunk:
 		case KD_TEXT:
 		case KD_TEXT1:
 		case KD_PIXEL:
+			if ((vw->vw_flags & VWF_GRAPHICS) &&
+			    vw == vd->vd_curwindow) {
+				/*
+				 * When leaving graphics mode on the currently
+				 * active window, reprogram the display
+				 * controller back to text mode immediately.
+				 * Without this, the CRTC retains the graphical
+				 * state and the console stays invisible until
+				 * the next VT switch.
+				 */
+				VT_LOCK(vd);
+				vd->vd_flags |= VDF_INVALID;
+				VT_UNLOCK(vd);
+				if (vd->vd_driver->vd_postswitch)
+					vd->vd_driver->vd_postswitch(vd);
+				vt_resume_flush_timer(vw, 0);
+			}
 			vw->vw_flags &= ~VWF_GRAPHICS;
 			break;
 		case KD_GRAPHICS:

--- a/sys/dev/vt/vt_core.c
+++ b/sys/dev/vt/vt_core.c
@@ -2923,9 +2923,31 @@ skip_thunk:
 		switch (*(int *)data) {
 		case KD_TEXT:
 		case KD_TEXT1:
-		case KD_PIXEL:
+		case KD_PIXEL: {
+			bool restore = false;
+			VT_LOCK(vd);
+			if ((vw->vw_flags & VWF_GRAPHICS) &&
+			    vw == vd->vd_curwindow) {
+				/*
+				 * When leaving graphics mode on the currently
+				 * active window, reprogram the display
+				 * controller back to text mode immediately.
+				 * Without this, the CRTC retains the graphical
+				 * state and the console stays invisible until
+				 * the next VT switch.
+				 */
+				restore = true;
+				vd->vd_flags |= VDF_INVALID;
+			}
+			VT_UNLOCK(vd);
+			if (restore) {
+				if (vd->vd_driver->vd_postswitch)
+					vd->vd_driver->vd_postswitch(vd);
+				vt_resume_flush_timer(vw, 0);
+			}
 			vw->vw_flags &= ~VWF_GRAPHICS;
 			break;
+		}
 		case KD_GRAPHICS:
 			vw->vw_flags |= VWF_GRAPHICS;
 			break;


### PR DESCRIPTION
When a graphical application (X.Org display server, Wayland compositor) calls KDSETMODE to set the active VT back to KD_TEXT, vt(4) does not reset the CRTC to point to its framebuffer, leaving the last image of the graphical application visible instead of the text console until the next VT switch.

Add a call to vd_postswitch to reset the CRTC, set VDF_INVALID to force a redraw and schedule the flush timer, like vt(4) does in vt_window_switch().