### PR TITLE
libc: Fix stack buffer overflow in cgetnext()

### DIFF
--- a/lib/libc/gen/getcap.3
+++ b/lib/libc/gen/getcap.3
@@ -28,7 +28,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd March 22, 2002
+.Dd July 23, 2026
 .Dt GETCAP 3
 .Os
 .Sh NAME
@@ -549,6 +549,19 @@ as follows:
 .Bl -tag -width Er
 .It Bq Er ENOMEM
 No memory to allocate.
+.El
+.Pp
+The
+.Fn cgetfirst
+and
+.Fn cgetnext
+functions
+may fail and set
+.Va errno
+as follows:
+.Bl -tag -width Er
+.It Bq Er ENAMETOOLONG
+The name field of a capability record is too long.
 .El
 .Sh SEE ALSO
 .Xr cap_mkdb 1 ,

--- a/lib/libc/gen/getcap.c
+++ b/lib/libc/gen/getcap.c
@@ -709,6 +709,11 @@ cgetnext(char **bp, char **db_array)
 		np = nbuf;
 		for (;;) {
 			for (cp = line; *cp != '\0'; cp++) {
+				if (np >= nbuf + sizeof(nbuf) - 1) {
+					(void)cgetclose();
+					errno = ENAMETOOLONG;
+					return (-1);
+				}
 				if (*cp == ':') {
 					*np++ = ':';
 					done = 1;


### PR DESCRIPTION
`cgetnext()` copies a capability record's name field into a fixed 1024 byte on-stack buffer (`nbuf[BSIZE]`) one character at a time, but never checks that the write pointer stays within the buffer. Therefore, a record name that is longer than `BSIZE` (either on a single line, or accumulated across several `\`-continued lines as the pointer is not reset amidst continuation) writes past the end of `nbuf` and smashes the stack.

The name field is read directly from the capability file, so any consumer of `cgetnext()`/`cgetfirst()` that processes an untrusted `termcap(5)`- or `printcap(5)`-style database (e.g. `cap_mkdb(1)`, `lpr(1)`, or any third-party caller) can be exposed and hence made to corrupt the stack.