### PR TITLE
procstat: report ntsync file descriptors in procstat -f

### DIFF
--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -629,6 +629,10 @@ procstat_getfiles_kvm(struct procstat *procstat, struct kinfo_proc *kp, int mmap
 			type = PS_FST_TYPE_INOTIFY;
 			data = file.f_data;
 			break;
+		case DTYPE_NTSYNC:
+			type = PS_FST_TYPE_NTSYNC;
+			data = file.f_data;
+			break;
 		default:
 			continue;
 		}
@@ -722,6 +726,7 @@ kinfo_type2fst(int kftype)
 		{ KF_TYPE_VNODE, PS_FST_TYPE_VNODE },
 		{ KF_TYPE_EVENTFD, PS_FST_TYPE_EVENTFD },
 		{ KF_TYPE_INOTIFY, PS_FST_TYPE_INOTIFY },
+		{ KF_TYPE_NTSYNC, PS_FST_TYPE_NTSYNC },
 		{ KF_TYPE_UNKNOWN, PS_FST_TYPE_UNKNOWN }
 	};
 #define NKFTYPES	(sizeof(kftypes2fst) / sizeof(*kftypes2fst))

--- a/lib/libprocstat/libprocstat.h
+++ b/lib/libprocstat/libprocstat.h
@@ -72,6 +72,7 @@
 #define	PS_FST_TYPE_DEV		14
 #define	PS_FST_TYPE_EVENTFD	15
 #define	PS_FST_TYPE_INOTIFY	16
+#define	PS_FST_TYPE_NTSYNC	17
 
 /*
  * Special descriptor numbers.

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -381,6 +381,8 @@ shared memory
 inotify descriptor
 .It k
 kqueue
+.It N
+ntsync semaphore, mutex, event, or domain descriptor
 .It m
 message queue
 .It P

--- a/usr.bin/procstat/procstat_files.c
+++ b/usr.bin/procstat/procstat_files.c
@@ -291,6 +291,37 @@ print_capability(cap_rights_t *rightsp, u_int capwidth)
 	xo_close_list("capabilities");
 }
 
+static void
+ntsync_kinfo_path(const struct kinfo_file *kif, char *buf, size_t buflen)
+{
+
+	if (kif == NULL || kif->kf_type != KF_TYPE_NTSYNC) {
+		strlcpy(buf, "-", buflen);
+		return;
+	}
+
+	switch (kif->kf_un.kf_ntsync.kf_ntsync_type) {
+	case KF_NTSYNC_TYPE_SEM:
+		snprintf(buf, buflen, "sem %u/%u",
+		    kif->kf_un.kf_ntsync.kf_ntsync_un.kf_ntsync_sem.count,
+		    kif->kf_un.kf_ntsync.kf_ntsync_un.kf_ntsync_sem.max);
+		break;
+	case KF_NTSYNC_TYPE_MUTEX:
+		snprintf(buf, buflen, "mutex owner=%u count=%u",
+		    kif->kf_un.kf_ntsync.kf_ntsync_un.kf_ntsync_mutex.owner,
+		    kif->kf_un.kf_ntsync.kf_ntsync_un.kf_ntsync_mutex.count);
+		break;
+	case KF_NTSYNC_TYPE_EVENT:
+		snprintf(buf, buflen, "event manual=%u signaled=%u",
+		    kif->kf_un.kf_ntsync.kf_ntsync_un.kf_ntsync_event.manual,
+		    kif->kf_un.kf_ntsync.kf_ntsync_un.kf_ntsync_event.signaled);
+		break;
+	default:
+		strlcpy(buf, "ntsync", buflen);
+		break;
+	}
+}
+
 void
 procstat_files(struct procstat *procstat, struct kinfo_proc *kipp)
 {
@@ -423,6 +454,11 @@ procstat_files(struct procstat *procstat, struct kinfo_proc *kipp)
 		case PS_FST_TYPE_INOTIFY:
 			str = "i";
 			xo_emit("{eq:fd_type/inotify}");
+			break;
+
+		case PS_FST_TYPE_NTSYNC:
+			str = "N";
+			xo_emit("{eq:fd_type/ntsync}");
 			break;
 
 		case PS_FST_TYPE_NONE:
@@ -589,6 +625,17 @@ procstat_files(struct procstat *procstat, struct kinfo_proc *kipp)
 				addr_to_string(&sock.sa_peer, dst_addr,
 				    sizeof(dst_addr));
 				xo_emit("{:path/%s %s}", src_addr, dst_addr);
+			}
+			break;
+
+		case PS_FST_TYPE_NTSYNC:
+			if (fst->fs_typedep != NULL) {
+				ntsync_kinfo_path(fst->fs_typedep, src_addr,
+				    sizeof(src_addr));
+				xo_emit("{:path/%s}", src_addr);
+			} else {
+				xo_emit("{:path/%-18s/%s}", fst->fs_path !=
+				    NULL ? fst->fs_path : "-");
 			}
 			break;
 


### PR DESCRIPTION
## Summary

- Map `KF_TYPE_NTSYNC` / `DTYPE_NTSYNC` in libprocstat so kinfo data from the ntsync(4) driver is not reported as unknown.
- Teach `procstat -f` to print file type `N` and sem/mutex/event details in the NAME column when kinfo fields are present.
- Document the new type in procstat(1).

## Test plan

Validated on **FreeBSD 16.0-CURRENT** (QEMU guest matching `main`):

- [x] `tools/build/checkstyle9.pl` on touched C files (0 errors)
- [x] `make -C lib/libprocstat && make -C lib/libprocstat install && make -C usr.bin/procstat` — **PROCSTAT_BUILD_OK**

Depends on ntsync(4) already in tree; no kernel changes in this PR.