### PR TITLE
netmap: fix VALE offset handling in nm_vale_flush()

### DIFF
--- a/sys/dev/netmap/netmap_vale.c
+++ b/sys/dev/netmap/netmap_vale.c
@@ -974,7 +974,7 @@ retry:
 					char *dst, *src = ft_p->ft_buf;
 					size_t copy_len = ft_p->ft_len, dst_len = copy_len;
 					uintptr_t src_cb;
-					uint64_t dstoff, dstoff_cb;
+					uint64_t dstoff = 0, dstoff_cb = 0;
 					int src_co, dst_co;
 					const uintptr_t mask = NM_BUF_ALIGN - 1;
 
@@ -985,7 +985,7 @@ retry:
 					src_cb = ((uintptr_t)src) & ~mask;
 					src_co = ((uintptr_t)src) & mask;
 					dst_co = ((uintptr_t)(dst + dstoff)) & mask;
-					if (dst_co < src_co) {
+					if (src_co < dst_co) {
 						dstoff_cb += NM_BUF_ALIGN;
 					}
 					dstoff = dstoff_cb + src_co;
@@ -1008,13 +1008,14 @@ retry:
 							// invalid user pointer, pretend len is 0
 							dst_len = 0;
 						}
-					} else {
-						//memcpy(dst, src, copy_len);
+					} else if (!src_co || kring->offset_mask) {
 						pkt_copy((char *)src_cb, dst + dstoff_cb, (int)copy_len);
+						nm_write_offset(kring, slot, dstoff);
+					} else {
+						memcpy(dst, src, copy_len);
 					}
 					slot->len = dst_len;
 					slot->flags = (cnt << 8)| NS_MOREFRAG;
-					nm_write_offset(kring, slot, dstoff);
 					j = nm_next(j, lim);
 					needed--;
 					ft_p++;


### PR DESCRIPTION
Backport of upstream netmap commits ef8fa11e3 and e0de5b529 by Giuseppe Lettieri, fixing multiple offset handling bugs in nm_vale_flush():

- Inverted cache-line alignment comparison (`dst_co < src_co` → `src_co < dst_co`) could place data before the requested offset in the destination buffer.
- nm_write_offset() called unconditionally, silently failing on rings with offset_mask == 0 while pkt_copy already placed data at a non-zero offset the consumer can't read.
- No fallback for destinations without offset support — now uses plain memcpy when offset_mask == 0 and source is unaligned.

Tested on FreeBSD 16.0-CURRENT (DEBUG kernel) with VALE vp-to-vp and VALE-to-iflib forwarding using various buffer offsets (0–63). Confirmed the bug reproduces on the unpatched kernel and is fixed by this patch.

PR: [294491](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=294491)