### PR TITLE
virtio: Add feature bits up to VirtIO v1.3 and accept VIRTIO_F_RING_RESET in the modern PCI transport

### DIFF
--- a/sys/dev/virtio/pci/virtio_pci_modern.c
+++ b/sys/dev/virtio/pci/virtio_pci_modern.c
@@ -464,7 +464,10 @@ vtpci_modern_finalize_features(device_t dev)
 
 	status = vtpci_modern_get_status(sc);
 	if ((status & VIRTIO_CONFIG_S_FEATURES_OK) == 0) {
-		device_printf(dev, "desired features were not accepted\n");
+		device_printf(dev, "desired features were not accepted "
+		    "(host %#jx, written %#jx)\n",
+		    (uintmax_t)sc->vtpci_common.vtpci_host_features,
+		    (uintmax_t)sc->vtpci_common.vtpci_features);
 		return (ENOTSUP);
 	}
 

--- a/sys/dev/virtio/pci/virtio_pci_modern.c
+++ b/sys/dev/virtio/pci/virtio_pci_modern.c
@@ -441,6 +441,14 @@ vtpci_modern_negotiate_features(device_t dev, uint64_t child_features)
 	 */
 	child_features |= VIRTIO_F_VERSION_1;
 
+	/*
+	 * Accept per-virtqueue reset if the device offers it: negotiating
+	 * the feature carries no obligation for a driver that never uses
+	 * it, while declining capability-only transport features can make
+	 * strict devices refuse the entire feature set.
+	 */
+	child_features |= host_features & VIRTIO_F_RING_RESET;
+
 	features = vtpci_negotiate_features(&sc->vtpci_common,
 	    child_features, host_features);
 	vtpci_modern_write_features(sc, features);

--- a/sys/dev/virtio/virtio.c
+++ b/sys/dev/virtio/virtio.c
@@ -87,6 +87,14 @@ static struct virtio_feature_desc virtio_common_feature_desc[] = {
 	{ VIRTIO_F_BAD_FEATURE,		"BadFeature"		}, /* Legacy */
 	{ VIRTIO_F_VERSION_1,		"Version1"		},
 	{ VIRTIO_F_IOMMU_PLATFORM,	"IOMMUPlatform"		},
+	{ VIRTIO_F_RING_PACKED,		"RingPacked"		},
+	{ VIRTIO_F_IN_ORDER,		"InOrder"		},
+	{ VIRTIO_F_ORDER_PLATFORM,	"OrderPlatform"		},
+	{ VIRTIO_F_SR_IOV,		"SRIOV"			},
+	{ VIRTIO_F_NOTIFICATION_DATA,	"NotificationData"	},
+	{ VIRTIO_F_NOTIF_CONFIG_DATA,	"NotifConfigData"	},
+	{ VIRTIO_F_RING_RESET,		"RingReset"		},
+	{ VIRTIO_F_ADMIN_VQ,		"AdminVq"		},
 
 	{ 0, NULL }
 };

--- a/sys/dev/virtio/virtio_config.h
+++ b/sys/dev/virtio/virtio_config.h
@@ -63,10 +63,10 @@
  * The guest should never negotiate this feature; it
  * is used to detect faulty drivers.
  */
-#define VIRTIO_F_BAD_FEATURE	(1UL << 30)
+#define VIRTIO_F_BAD_FEATURE		(1UL << 30)
 
 /* v1.0 compliant. */
-#define VIRTIO_F_VERSION_1	(1ULL << 32)
+#define VIRTIO_F_VERSION_1		(1ULL << 32)
 
 /*
  * If clear - device has the IOMMU bypass quirk feature.
@@ -76,6 +76,30 @@
  * this is for compatibility with legacy systems.
  */
 #define VIRTIO_F_IOMMU_PLATFORM		(1ULL << 33)
+
+/* Support for packed virtqueues. */
+#define VIRTIO_F_RING_PACKED		(1ULL << 34)
+
+/* Device may behave as if IN_ORDER was negotiated. */
+#define VIRTIO_F_IN_ORDER		(1ULL << 35)
+
+/* Memory accesses are ordered by the platform. */
+#define VIRTIO_F_ORDER_PLATFORM		(1ULL << 36)
+
+/* Device supports Single Root I/O Virtualization. */
+#define VIRTIO_F_SR_IOV			(1ULL << 37)
+
+/* Driver passes extra data in device notifications. */
+#define VIRTIO_F_NOTIFICATION_DATA	(1ULL << 38)
+
+/* Driver uses the data provided by the device as a virtqueue identifier. */
+#define VIRTIO_F_NOTIF_CONFIG_DATA	(1ULL << 39)
+
+/* Driver can reset a queue individually. */
+#define VIRTIO_F_RING_RESET		(1ULL << 40)
+
+/* Device supports an administration virtqueue. */
+#define VIRTIO_F_ADMIN_VQ		(1ULL << 41)
 
 /*
  * Some VirtIO feature bits (currently bits 28 through 34) are


### PR DESCRIPTION
FreeBSD/arm64 guests under macOS `Virtualization.framework` boot to multiuser but have no network: Apple's `virtio-net` rejects `FEATURES_OK` when `VIRTIO_F_RING_RESET` (bit 40) is not acknowledged, and we do not define bits above 33.

This PR adds the VirtIO 1.1+ transport feature bit definitions, acknowledges `RING_RESET` in the modern PCI transport when offered (safe: it only permits per-`virtqueue` reset), and prints the host/written masks on negotiation failure so such mismatches are diagnosable.

I have tested arm64 GENERIC under `QEMU`/`HVF` (no regressions; all `virtio` devices attach and networking works) and under `Virtualization.framework` on macOS/arm64 (negotiation proceeds past the `RING_RESET` rejection).

For Apple, note that this is a prerequisite rather than a complete fix. I'm currently working on the remaining issues and will address them in a separate PR once they're resolved.