### PR TITLE
lib/libc/tests/stdlib/libatexit: add static to resolve -Wmissing-prot…

### DIFF
--- a/lib/libc/tests/stdlib/libatexit/libatexit.cc
+++ b/lib/libc/tests/stdlib/libatexit/libatexit.cc
@@ -44,7 +44,7 @@ struct other_object {
 	}
 };
 
-void
+static void
 create_staticobj()
 {
 	static other_object obj;


### PR DESCRIPTION
This fixes compile warning introduced in PR-285870.
When building buildworld with WITH_TESTS=yes, create_staticobj() lacks static and triggers -Wmissing-prototypes error.
Adding static modifier fixes the compile failure, only modifies test code.