### PR TITLE
cuse: Fix server reference leak in cuse_client_open()

### DIFF
--- a/sys/fs/cuse/cuse.c
+++ b/sys/fs/cuse/cuse.c
@@ -1546,11 +1546,19 @@ cuse_client_open(struct cdev *dev, int fflags, int devtype, struct thread *td)
 	}
 	cuse_server_unlock(pcs);
 
-	if (error != 0)
+	/*
+	 * On error, free the client and unref the server, so that the
+	 * exiting server process does not become unkillable.
+	 */
+	if (error != 0) {
+		cuse_client_free(pcc);
 		return (error);
+	}
 
-	if ((error = devfs_set_cdevpriv(pcc, &cuse_client_free)) != 0)
+	if ((error = devfs_set_cdevpriv(pcc, &cuse_client_free)) != 0) {
+		cuse_client_free(pcc);
 		return (error);
+	}
 
 	pccmd = &pcc->cmds[CUSE_CMD_OPEN];
 


### PR DESCRIPTION
If the server is closing (or the device node is going away), or if `devfs_set_cdevpriv()` fails, `cuse_client_open()` returns with the server reference taken at the top of the function still held and the newly allocated client still linked on `pcs->hcli`. Since `cuse_client_free()` has not been registered as the cdevpriv destructor at that point, nothing ever undoes this work: every `open()` that races the `is_closing` window permanently leaks one server reference and one `cuse_client`.

A leaked reference is fatal on server exit: `cuse_server_free()` busy-waits in an uninterruptible `pause("W", hz)` loop until `pcs->refs` drops to 1, which now never happens, so the exiting server process (e.g. virtual_oss(8)) is left wedged in state "D", immune to SIGKILL, cuse.ko is pinned (kldunload hangs too), and only a reboot recovers.

Before 634e578ac7b0 the `is_closing` error path dropped the reference by calling `devfs_clear_cdevpriv()`, which ran the `cuse_client_free()` destructor. That commit moved `devfs_set_cdevpriv()` after the `is_closing` check to fix the panic paths, but left both error returns without any cleanup.

Fix by calling `cuse_client_free()` directly on both error paths. The client is fully constructed and linked on `pcs->hcli` at these points, which is exactly the state `cuse_client_free()` expects.

Reported and analyzed in [bug 296291](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=296291): the leak was captured live on 15.1-RELEASE with an instrumented cuse.ko, dtrace on the client/server teardown path, and a kgdb walk of the wedged `cuse_server` (refs=4 with three leaked `cuse_client`s on `hcli`, all with the destructor never registered). The reliable reproducer is a virtual_oss loopback (`-L dsp.loop`) with a busy client polling the device while the server is killed.

Compile-tested on amd64 (`-Werror`-clean module build). Runtime testing against the reproducer is in progress on the affected machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)