### PR TITLE
ntpdate temporal consistency check

### DIFF
--- a/contrib/ntp/ntpdate/ntpdate.c
+++ b/contrib/ntp/ntpdate/ntpdate.c
@@ -161,6 +161,7 @@ int sys_numservers = 0; 	/* number of servers to poll */
 int sys_authenticate = 0;	/* true when authenticating */
 u_int32 sys_authkey = 0;	/* set to authentication key in use */
 u_long sys_authdelay = 0;	/* authentication delay */
+l_fp sys_maxoffset;      	/* maximum offset (zero is disabled) */
 int sys_version = NTP_VERSION;	/* version to poll with */
 
 /*
@@ -350,7 +351,7 @@ ntpdatemain (
 	/*
 	 * Decode argument list
 	 */
-	while ((c = ntp_getopt(argc, argv, "46a:bBde:k:o:p:qst:uv")) != EOF)
+	while ((c = ntp_getopt(argc, argv, "46a:bBde:k:o:p:qst:m:uv")) != EOF)
 		switch (c)
 		{
 		case '4':
@@ -419,6 +420,16 @@ ntpdatemain (
 				sys_timeout = ((LFPTOFP(&tmp) * TIMER_HZ)
 					   + 0x8000) >> 16;
 				sys_timeout = max(sys_timeout, MINTIMEOUT);
+			}
+			break;
+		case 'm':
+			if (!atolfp(ntp_optarg, &tmp)) {
+				(void) fprintf(stderr,
+					   "%s: maxoffset %s is undecodeable\n",
+					   progname, ntp_optarg);
+				errflg++;
+			} else {
+				sys_maxoffset = tmp;
 			}
 			break;
 		case 'v':
@@ -1262,6 +1273,7 @@ clock_adjust(void)
 {
 	register struct server *sp, *server;
 	int dostep;
+	l_fp offset;
 
 	for (sp = sys_servers; sp != NULL; sp = sp->next_server)
 		clock_filter(sp);
@@ -1294,6 +1306,22 @@ clock_adjust(void)
 		else
 			absoffset = (u_fp)server->soffset;
 		dostep = (absoffset >= NTPDATE_THRESHOLD);
+	}
+
+	offset = server->offset;
+	if (L_ISNEG(&offset)) {
+		L_NEG(&offset);
+	}
+	if (L_ISNEG(&sys_maxoffset)) {
+		L_NEG(&sys_maxoffset);
+	}
+	if (!L_ISZERO(&sys_maxoffset) && L_ISGT(&offset, &sys_maxoffset)) {
+		char offsetbuf[24], maxoffsetbuf[24];
+		strlcpy(offsetbuf, lfptoa(&server->offset, 6), sizeof(offsetbuf));
+		strlcpy(maxoffsetbuf, lfptoa(&sys_maxoffset, 6), sizeof(maxoffsetbuf));
+		msyslog(LOG_ERR, "absolute offset %s exceeded: offset %s sec",
+				maxoffsetbuf, offsetbuf);
+		exit(1);
 	}
 
 	if (dostep) {

--- a/libexec/rc/rc.d/ntpdate
+++ b/libexec/rc/rc.d/ntpdate
@@ -14,6 +14,36 @@ rcvar="ntpdate_enable"
 stop_cmd=":"
 start_cmd="ntpdate_start"
 
+ntpdate_maxoffset()
+{
+	last -x -n2 reboot | \
+	    awk -v t_err=$ntpdate_reboot_error_dev \
+		-v t_max=$ntpdate_reboot_offset_max \
+		-v t_min=$ntpdate_reboot_offset_min '
+		BEGIN {
+			t_boot = 0
+			t_shutdown = 0
+		}
+		/boot time/     { t_boot = $3 }
+		/shutdown time/ { t_shutdown = $3 }
+		END {
+			if (t_boot > 0 && t_shutdown > 0 && t_boot > t_shutdown) {
+			       t_offset = t_err * (t_boot - t_shutdown)
+			       if (t_offset == 0) {
+				       print 0
+			       } else if (t_offset > t_max) {
+				       print t_max
+			       } else if (t_offset > t_min) {
+				       print t_offset
+			       } else {
+				       print t_min
+			       }
+			} else {
+				print 0
+			}
+		}'
+}
+
 ntpdate_start()
 {
 	if [ -z "$ntpdate_hosts" -a -f "$ntpdate_config" ]; then
@@ -26,11 +56,27 @@ ntpdate_start()
 	fi
 	if [ -n "$ntpdate_hosts" -o -n "$rc_flags" ]; then
 		echo "Setting date via ntp."
+		if checkyesno ntpdate_reboot_error_check; then
+			maxoffset=$(ntpdate_maxoffset)
+			if [ "$(echo "$maxoffset > 0" | bc -l)" -eq 1 ]; then
+				rc_flags="$rc_flags -m $maxoffset"
+				echo "maximum absolute offset: $maxoffset secs"
+			fi
+		fi
 		${ntpdate_program:-ntpdate} $rc_flags $ntpdate_hosts
 	fi
 }
 
 load_rc_config $name
+
+# enable temporal consistency check
+: ${ntpdate_reboot_error_check:=NO}
+# 0.01% deviation or ~8.64 seconds per day
+: ${ntpdate_reboot_error_dev:=0.0001}
+# 10 mins maximum absolute time offset
+: ${ntpdate_reboot_offset_max:=600}
+# 10 msec minimum absolute time offset
+: ${ntpdate_reboot_offset_min:=0.01}
 
 # doesn't make sense to run in a svcj: privileged operations
 ntpdate_svcj="NO"

--- a/usr.bin/last/last.1
+++ b/usr.bin/last/last.1
@@ -34,7 +34,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl -libxo
-.Op Fl swy
+.Op Fl swxy
 .Oo
 .Fl d
 .Sm off
@@ -164,6 +164,8 @@ equivalent to
 .It Fl w
 Widen the duration field to show seconds, as well as the
 default days, hours and minutes.
+.It Fl x
+Report the time in seconds instead of as a date.
 .It Fl y
 Report the year in the session start time.
 .El

--- a/usr.bin/last/last.c
+++ b/usr.bin/last/last.c
@@ -81,6 +81,7 @@ static long	maxrec;				/* records to display */
 static const	char *file = NULL;		/* utx.log file */
 static int	sflag = 0;			/* show delta in seconds */
 static int	width = 5;			/* show seconds in delta */
+static int	xflag;				/* show date in seconds */
 static int	yflag;				/* show year */
 static int      d_first;
 static int	snapfound = 0;			/* found snapshot entry? */
@@ -123,7 +124,7 @@ main(int argc, char *argv[])
 
 	maxrec = -1;
 	snaptime = 0;
-	while ((ch = getopt(argc, argv, "0123456789d:f:h:n:st:wy")) != -1)
+	while ((ch = getopt(argc, argv, "0123456789d:f:h:n:st:wxy")) != -1)
 		switch (ch) {
 		case '0': case '1': case '2': case '3': case '4':
 		case '5': case '6': case '7': case '8': case '9':
@@ -168,6 +169,9 @@ main(int argc, char *argv[])
 			break;
 		case 'w':
 			width = 8;
+			break;
+		case 'x':
+			xflag++;	/* Show date as seconds */
 			break;
 		case 'y':
 			yflag++;
@@ -354,7 +358,7 @@ printentry(struct utmpx *bp, struct idtab *tt)
 	xo_open_instance("last");
 	t = bp->ut_tv.tv_sec;
 	tm = localtime(&t);
-	(void) strftime(ct, sizeof(ct), d_first ?
+	(void) strftime(ct, sizeof(ct), xflag ? "%s" :  d_first ?
 	    (yflag ? "%a %e %b %Y %R" : "%a %e %b %R") :
 	    (yflag ? "%a %b %e %Y %R" : "%a %b %e %R"), tm);
 	switch (bp->ut_type) {

--- a/usr.sbin/ntp/doc/ntpdate.8
+++ b/usr.sbin/ntp/doc/ntpdate.8
@@ -14,6 +14,7 @@
 .Op Fl o Ar version
 .Op Fl p Ar samples
 .Op Fl t Ar timeout
+.Op Fl m Ar maxoffset
 .Ar server ...
 .Sh DESCRIPTION
 .Em Note :
@@ -151,6 +152,13 @@ The value is
 rounded to a multiple of 0.2 seconds.
 The default is 1 second, a
 value suitable for polling across a LAN.
+.It Fl m Ar maxoffset
+Specify the maximum acceptable offset as the value
+.Ar maxoffset ,
+in seconds and fraction.
+The clock will not be adjusted if the absolute time offset
+reported by the server exceeds
+.Ar maxoffset .
 .It Fl u
 Direct
 .Nm


### PR DESCRIPTION
discussions about time system attacks causing time corruption resulted in the idea of a temporal consistency check that treats
large time steps by ntpdate as a potential vulnerability. the check uses time powered down to calculate a maximum clock drift.

this series adds an `-x` flag to `last` that reports time in seconds.
this series adds an `-m` flag to `ntpdate` for a maximum absolute offset.
this series adds a few rc.conf parameter defaults to rc.d/ntpdate:

- ntpdate_reboot_error_check=NO
  - temporal consistency check disabled
- ntpdate_reboot_error_dev=0.0001
  - 0.01% deviation or ~8.64 seconds per day
- ntpdate_reboot_offset_max=600
  - 10 mins maximum absolute time offset
- ntpdate_reboot_offset_min=0.01
  - 10 millisecond minimum absolute time offset

the -m maxoffset value is caculated as follows:

    min(max(t_error * abs(t_boot - t_shutdown), t_min), t_max)

shut down time unavailable, e.g. first boot, sets date as usual.
shut down for 60 seconds, maximum allowed offset is ~ +/-0.01 sec.
shut down for one week, maximum allowed offset is ~ +/-1 min.

example normal operation:

```
$ sudo /etc/rc.d/ntpdate start
Setting date via ntp.
maximum absolute offset: 0.0175 secs
16 Jul 17:30:14 ntpdate[3357]: step time server 2001:4428:0:dc::20 offset -0.005959 sec
```

example error operation:

```
$ sudo /etc/rc.d/ntpdate start
Setting date via ntp.
maximum absolute offset: 0.0175 secs
16 Jul 17:33:27 ntpdate[3446]: absolute offset +0.017500 exceeded: offset +1.054452 sec
```

this patch is a proof of concept for review purposes and is not expected to be merged.
