### PR TITLE
man: Fix RFC 1918 network prefix lengths

### DIFF
--- a/sbin/ipf/ippool/ippool.5
+++ b/sbin/ipf/ippool/ippool.5
@@ -131,7 +131,7 @@ The contents of the file might look something like this:
 10.0.0.0/8
 !127.0.0.0/8
 172.16.0.0/12
-192.168.0.0/24
+192.168.0.0/16
 .fi
 .PP
 In this example, the inclusion of the line "!127.0.0.0/8" is, strictly

--- a/sys/netinet/libalias/libalias.3
+++ b/sys/netinet/libalias/libalias.3
@@ -203,8 +203,8 @@ originate from unregistered address spaces will be ignored.
 The standard private IP address ranges are:
 .Pp
 10.0.0.0           ->        10.255.255.255   (/8)
-172.16.0.0         ->        172.31.255.255   (/16)
-192.168.0.0        ->        192.168.255.255  (/24)
+172.16.0.0         ->        172.31.255.255   (/12)
+192.168.0.0        ->        192.168.255.255  (/16)
 .Pp
 This option is useful in the case that the packet aliasing host has both
 registered and unregistered subnets on different interfaces.


### PR DESCRIPTION
According to [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918), the following IP prefixes are reserved for private internets:

- 10.0.0.0/8
- 172.16.0.0/12
- 192.168.0.0/16

This PR fixes the prefix lengths in references to private networks ("RFC 1918 networks", "the standard private IP address ranges").
The changes are limited to man pages.