### PR TITLE
nvmf: Report when no transport is registered for a host association

### DIFF
--- a/sys/dev/nvmf/nvmf_transport.c
+++ b/sys/dev/nvmf/nvmf_transport.c
@@ -66,8 +66,11 @@ nvmf_allocate_qpair(enum nvmf_trtype trtype, bool controller,
 		}
 	}
 	sx_sunlock(&nvmf_transports_lock);
-	if (qp == NULL)
-		return (NULL);
+  if (qp == NULL) {
+    printf("NVMF: No transport registered for trtype %u\n",
+           trtype);
+    return (NULL);
+  }
 
 	qp->nq_transport = nt;
 	qp->nq_ops = nt->nt_ops;


### PR DESCRIPTION
While testing NVMe over Fabrics (nvmf) in a lab, connecting from a host
that had `nvmf` loaded but not `nvmf_tcp` produced a confusing error:

    nvme0: Failed to setup admin queue
    device_attach: nvme0 attach returned 6

The real cause — no transport registered for the requested trtype — was
not surfaced anywhere. `nvmf_allocate_qpair()` returned NULL silently in
that case.

This adds a diagnostic identifying the missing trtype, matching the style
of the existing message in `nvmf_register_transport()`. With the change,
the log now shows:

    NVMF: No transport registered for trtype 1
    nvme0: Failed to setup admin queue

Reproduction:
1. Set up an NVMe/TCP target (e.g. ctld with an nvmft controller).
2. On the host: `kldload nvmf` (but NOT nvmf_tcp).
3. `nvmecontrol connect <ip>:4420 <nqn>` -> observe the new message.

Tested on 16.0-CURRENT.
