### PR TITLE
unix: allow `connectat(2)` to name the peer socket by descriptor

### DIFF
--- a/sys/kern/uipc_usrreq.c
+++ b/sys/kern/uipc_usrreq.c
@@ -294,6 +294,8 @@ static int	unp_connect(struct socket *, struct sockaddr *,
 		    struct thread *);
 static int	unp_connectat(int, struct socket *, struct sockaddr *,
 		    struct thread *, bool);
+static int	unp_connect_peer(struct socket *, struct unpcb *,
+		    struct sockaddr **, struct thread *, bool);
 static void	unp_connect2(struct socket *, struct socket *, bool);
 static void	unp_disconnect(struct unpcb *unp, struct unpcb *unp2);
 static void	unp_dispose(struct socket *so);
@@ -2878,8 +2880,7 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 	struct mtx *vplock;
 	struct sockaddr_un *soun;
 	struct vnode *vp;
-	struct socket *so2;
-	struct unpcb *unp, *unp2, *unp3;
+	struct unpcb *unp, *unp2;
 	struct nameidata nd;
 	char buf[SOCK_MAXADDRLEN];
 	struct sockaddr *sa;
@@ -2968,9 +2969,6 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 	if (error)
 		goto bad;
 
-	unp = sotounpcb(so);
-	KASSERT(unp != NULL, ("unp_connect: unp == NULL"));
-
 	vplock = mtx_pool_find(unp_vp_mtxpool, vp);
 	mtx_lock(vplock);
 	VOP_UNP_CONNECT(vp, &unp2);
@@ -2978,30 +2976,75 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 		error = ECONNREFUSED;
 		goto bad2;
 	}
-	so2 = unp2->unp_socket;
-	if (so->so_type != so2->so_type) {
-		error = EPROTOTYPE;
-		goto bad2;
+	error = unp_connect_peer(so, unp2, &sa, td, return_locked);
+bad2:
+	mtx_unlock(vplock);
+bad:
+	if (vp != NULL) {
+		/*
+		 * If we are returning locked (called via uipc_sosend_dgram()),
+		 * we need to be sure that vput() won't sleep.  This is
+		 * guaranteed by VOP_UNP_CONNECT() call above and unp2 lock.
+		 * SOCK_STREAM/SEQPACKET can't request return_locked (yet).
+		 */
+		MPASS(!(return_locked && connreq));
+		vput(vp);
 	}
+	free(sa, M_SONAME);
+	if (__predict_false(error)) {
+		UNP_PCB_LOCK(unp);
+		KASSERT((unp->unp_flags & UNP_CONNECTING) != 0,
+		    ("%s: unp %p has UNP_CONNECTING clear", __func__, unp));
+		unp->unp_flags &= ~UNP_CONNECTING;
+		UNP_PCB_UNLOCK(unp);
+	}
+	return (error);
+}
+
+/*
+ * Second half of connecting a unix socket: 'so' is our connecting socket,
+ * with UNP_CONNECTING set, and 'unp2' is the PCB of the peer named by the
+ * caller, which must guarantee its stability (by holding a reference on the
+ * peer socket, or the vnode lock plus unp_vp_mtxpool lock for a peer found
+ * via VOP_UNP_CONNECT()).
+ *
+ * For connection-oriented sockets '*sap' points to a buffer to hold the
+ * listener's address; it is consumed (set to NULL) if used.  On success
+ * UNP_CONNECTING is cleared; on error the caller must clear it.
+ */
+static int
+unp_connect_peer(struct socket *so, struct unpcb *unp2, struct sockaddr **sap,
+    struct thread *td, bool return_locked)
+{
+	struct socket *so2;
+	struct unpcb *unp, *unp3;
+	int error;
+	bool connreq;
+
+	unp = sotounpcb(so);
+	KASSERT(unp != NULL, ("%s: unp == NULL", __func__));
+	connreq = (so->so_proto->pr_flags & PR_CONNREQUIRED) != 0;
+
+	so2 = unp2->unp_socket;
+	if (so->so_type != so2->so_type)
+		return (EPROTOTYPE);
 	if (connreq) {
 		if (SOLISTENING(so2))
 			so2 = solisten_clone(so2);
 		else
 			so2 = NULL;
-		if (so2 == NULL) {
-			error = ECONNREFUSED;
-			goto bad2;
-		}
+		if (so2 == NULL)
+			return (ECONNREFUSED);
 		if ((error = uipc_attach(so2, 0, NULL)) != 0) {
 			sodealloc(so2);
-			goto bad2;
+			return (error);
 		}
 		unp3 = sotounpcb(so2);
 		unp_pcb_lock_pair(unp2, unp3);
 		if (unp2->unp_addr != NULL) {
-			bcopy(unp2->unp_addr, sa, unp2->unp_addr->sun_len);
-			unp3->unp_addr = (struct sockaddr_un *) sa;
-			sa = NULL;
+			bcopy(unp2->unp_addr, *sap, unp2->unp_addr->sun_len);
+			unp3->unp_addr = (struct sockaddr_un *)*sap;
+			*sap = NULL;
 		}
 
 		unp_copy_peercred(td, unp3, unp, unp2);
@@ -3032,28 +3075,7 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 	unp->unp_flags &= ~UNP_CONNECTING;
 	if (!return_locked)
 		unp_pcb_unlock_pair(unp, unp2);
-bad2:
-	mtx_unlock(vplock);
-bad:
-	if (vp != NULL) {
-		/*
-		 * If we are returning locked (called via uipc_sosend_dgram()),
-		 * we need to be sure that vput() won't sleep.  This is
-		 * guaranteed by VOP_UNP_CONNECT() call above and unp2 lock.
-		 * SOCK_STREAM/SEQPACKET can't request return_locked (yet).
-		 */
-		MPASS(!(return_locked && connreq));
-		vput(vp);
-	}
-	free(sa, M_SONAME);
-	if (__predict_false(error)) {
-		UNP_PCB_LOCK(unp);
-		KASSERT((unp->unp_flags & UNP_CONNECTING) != 0,
-		    ("%s: unp %p has UNP_CONNECTING clear", __func__, unp));
-		unp->unp_flags &= ~UNP_CONNECTING;
-		UNP_PCB_UNLOCK(unp);
-	}
-	return (error);
+	return (0);
 }
 
 /*

--- a/sys/kern/uipc_usrreq.c
+++ b/sys/kern/uipc_usrreq.c
@@ -2880,6 +2880,7 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 	struct mtx *vplock;
 	struct sockaddr_un *soun;
 	struct vnode *vp;
+	struct socket *so2;
 	struct unpcb *unp, *unp2;
 	struct nameidata nd;
 	char buf[SOCK_MAXADDRLEN];
@@ -2895,7 +2896,7 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 	if (nam->sa_len > sizeof(struct sockaddr_un))
 		return (EINVAL);
 	len = nam->sa_len - offsetof(struct sockaddr_un, sun_path);
-	if (len <= 0)
+	if (len < 0 || (len == 0 && fd == AT_FDCWD))
 		return (EINVAL);
 	soun = (struct sockaddr_un *)nam;
 	bcopy(soun->sun_path, buf, len);
@@ -2943,6 +2944,30 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 		sa = malloc(sizeof(struct sockaddr_un), M_SONAME, M_WAITOK);
 	else
 		sa = NULL;
+
+	vp = NULL;
+	if (len == 0) {
+		struct file *fp;
+
+		/*
+		 * An empty path means that the descriptor itself is the peer
+		 * socket, rather than the starting directory for a pathname
+		 * lookup.
+		 */
+		error = getsock(td, fd,
+		    cap_rights_init_one(&rights, CAP_CONNECTAT), &fp);
+		if (error != 0)
+			goto bad;
+		so2 = fp->f_data;
+		if (so2->so_proto->pr_domain->dom_family != AF_UNIX)
+			error = EPROTOTYPE;
+		else
+			error = unp_connect_peer(so, sotounpcb(so2), &sa, td,
+			    return_locked);
+		fdrop(fp, td);
+		goto bad;
+	}
+
 	NDINIT_ATRIGHTS(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF |
 	    (fd == AT_FDCWD ? 0 : EMPTYPATH), UIO_SYSSPACE, buf, fd,
 	    cap_rights_init_one(&rights, CAP_CONNECTAT));

--- a/tests/sys/kern/Makefile
+++ b/tests/sys/kern/Makefile
@@ -63,6 +63,7 @@ LIBADD.timerfd+=	pthread
 # One test modifies the system time.
 TEST_METADATA.timerfd+=	is_exclusive="true"
 ATF_TESTS_C+=	tty_pts
+ATF_TESTS_C+=	unix_connectat
 ATF_TESTS_C+=	unix_dgram
 ATF_TESTS_C+=	unix_passfd_dgram
 TEST_METADATA.unix_passfd_dgram+=	is_exclusive="true"

--- a/tests/sys/kern/unix_connectat.c
+++ b/tests/sys/kern/unix_connectat.c
@@ -1,0 +1,247 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 John Ericson
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Tests for connectat(2) where the descriptor argument names the peer
+ * unix socket directly, signalled by an empty sun_path.
+ */
+
+#include <sys/socket.h>
+#include <sys/capsicum.h>
+#include <sys/un.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <atf-c.h>
+
+/* An AF_UNIX address with an empty path: "the fd is the peer". */
+static const struct sockaddr_un empty_sun = {
+	.sun_family = AF_UNIX,
+	.sun_len = offsetof(struct sockaddr_un, sun_path),
+};
+
+/*
+ * Make a bound, listening stream socket.  Binding is not optional:
+ * uipc_listen() refuses unbound sockets with EDESTADDRREQ.
+ */
+static int
+mklistener(const char *path)
+{
+	struct sockaddr_un sun = { .sun_family = AF_UNIX };
+	int l;
+
+	strlcpy(sun.sun_path, path, sizeof(sun.sun_path));
+	sun.sun_len = SUN_LEN(&sun);
+	ATF_REQUIRE((l = socket(PF_UNIX, SOCK_STREAM, 0)) >= 0);
+	ATF_REQUIRE_MSG(bind(l, (struct sockaddr *)&sun, sun.sun_len) == 0,
+	    "bind(%s): %s", path, strerror(errno));
+	ATF_REQUIRE_MSG(listen(l, 1) == 0, "listen: %s", strerror(errno));
+	return (l);
+}
+
+static int
+fdconnect(int fd, int s)
+{
+	return (connectat(fd, s, (const struct sockaddr *)&empty_sun,
+	    empty_sun.sun_len));
+}
+
+/* Connect to a listening stream socket by its fd; pass data. */
+ATF_TC_WITHOUT_HEAD(stream);
+ATF_TC_BODY(stream, tc)
+{
+	char buf[8];
+	int l, s, a;
+
+	l = mklistener("stream.sock");
+	ATF_REQUIRE((s = socket(PF_UNIX, SOCK_STREAM, 0)) >= 0);
+	ATF_REQUIRE_EQ(0, fdconnect(l, s));
+	ATF_REQUIRE((a = accept(l, NULL, NULL)) >= 0);
+
+	ATF_REQUIRE_EQ(5, write(s, "hello", 5));
+	ATF_REQUIRE_EQ(5, read(a, buf, sizeof(buf)));
+	ATF_REQUIRE_EQ(0, memcmp(buf, "hello", 5));
+	ATF_REQUIRE_EQ(5, write(a, "world", 5));
+	ATF_REQUIRE_EQ(5, read(s, buf, sizeof(buf)));
+	ATF_REQUIRE_EQ(0, memcmp(buf, "world", 5));
+
+	close(a);
+	close(s);
+	close(l);
+}
+
+/* A bound listener's path is still reported to the connecting side. */
+ATF_TC_WITHOUT_HEAD(stream_bound);
+ATF_TC_BODY(stream_bound, tc)
+{
+	struct sockaddr_un sun;
+	socklen_t len;
+	int l, s;
+
+	l = mklistener("bound.sock");
+	ATF_REQUIRE((s = socket(PF_UNIX, SOCK_STREAM, 0)) >= 0);
+	ATF_REQUIRE_EQ(0, fdconnect(l, s));
+
+	memset(&sun, 0, sizeof(sun));
+	len = sizeof(sun);
+	ATF_REQUIRE_EQ(0, getpeername(s, (struct sockaddr *)&sun, &len));
+	ATF_REQUIRE_EQ(0, strcmp(sun.sun_path, "bound.sock"));
+
+	close(s);
+	close(l);
+}
+
+/* Connect a datagram socket to an unbound peer by its fd. */
+ATF_TC_WITHOUT_HEAD(dgram);
+ATF_TC_BODY(dgram, tc)
+{
+	char buf[8];
+	int p, s;
+
+	ATF_REQUIRE((p = socket(PF_UNIX, SOCK_DGRAM, 0)) >= 0);
+	ATF_REQUIRE((s = socket(PF_UNIX, SOCK_DGRAM, 0)) >= 0);
+	ATF_REQUIRE_EQ(0, fdconnect(p, s));
+	ATF_REQUIRE_EQ(5, send(s, "hello", 5, 0));
+	ATF_REQUIRE_EQ(5, recv(p, buf, sizeof(buf), 0));
+	ATF_REQUIRE_EQ(0, memcmp(buf, "hello", 5));
+
+	close(s);
+	close(p);
+}
+
+/* An empty path is only meaningful with a real descriptor. */
+ATF_TC_WITHOUT_HEAD(empty_path_at_fdcwd);
+ATF_TC_BODY(empty_path_at_fdcwd, tc)
+{
+	int s;
+
+	ATF_REQUIRE((s = socket(PF_UNIX, SOCK_STREAM, 0)) >= 0);
+	ATF_REQUIRE_ERRNO(EINVAL, connect(s,
+	    (const struct sockaddr *)&empty_sun, empty_sun.sun_len) == -1);
+	ATF_REQUIRE_ERRNO(EINVAL, fdconnect(AT_FDCWD, s) == -1);
+	close(s);
+}
+
+/* Error matrix for unsuitable descriptors and peers. */
+ATF_TC_WITHOUT_HEAD(bad_peers);
+ATF_TC_BODY(bad_peers, tc)
+{
+	int s, d, fd;
+
+	ATF_REQUIRE((s = socket(PF_UNIX, SOCK_STREAM, 0)) >= 0);
+	ATF_REQUIRE((d = socket(PF_UNIX, SOCK_DGRAM, 0)) >= 0);
+
+	/* Non-socket descriptor. */
+	ATF_REQUIRE((fd = open(".", O_RDONLY)) >= 0);
+	ATF_REQUIRE_ERRNO(ENOTSOCK, fdconnect(fd, s) == -1);
+	close(fd);
+
+	/* Socket from another domain. */
+	ATF_REQUIRE((fd = socket(PF_INET, SOCK_STREAM, 0)) >= 0);
+	ATF_REQUIRE_ERRNO(EPROTOTYPE, fdconnect(fd, s) == -1);
+	close(fd);
+
+	/* Type mismatch between the two unix sockets. */
+	fd = mklistener("mismatch.sock");
+	ATF_REQUIRE_ERRNO(EPROTOTYPE, fdconnect(fd, d) == -1);
+
+	close(fd);
+
+	/* Stream peer that is not listening: 's' never called listen(2). */
+	ATF_REQUIRE((fd = socket(PF_UNIX, SOCK_STREAM, 0)) >= 0);
+	ATF_REQUIRE_ERRNO(ECONNREFUSED, fdconnect(s, fd) == -1);
+
+	close(fd);
+	close(d);
+	close(s);
+}
+
+/*
+ * A descriptor limited to CAP_CONNECTAT is a pure connect-to-me token:
+ * it can be connected to, but not listened on, accepted from, or read.
+ */
+ATF_TC_WITHOUT_HEAD(cap_connectat);
+ATF_TC_BODY(cap_connectat, tc)
+{
+	cap_rights_t rights;
+	char buf[8];
+	int l, s, token, a;
+
+	l = mklistener("cap.sock");
+	ATF_REQUIRE((token = dup(l)) >= 0);
+	ATF_REQUIRE_EQ(0, cap_rights_limit(token,
+	    cap_rights_init(&rights, CAP_CONNECTAT)));
+
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE, listen(token, 1) == -1);
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE, accept(token, NULL, NULL) == -1);
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE, read(token, buf, sizeof(buf)) == -1);
+
+	ATF_REQUIRE((s = socket(PF_UNIX, SOCK_STREAM, 0)) >= 0);
+	ATF_REQUIRE_EQ(0, fdconnect(token, s));
+	ATF_REQUIRE((a = accept(l, NULL, NULL)) >= 0);
+
+	close(a);
+	close(s);
+	close(token);
+	close(l);
+}
+
+/* Without CAP_CONNECTAT, the descriptor cannot be a connect target. */
+ATF_TC_WITHOUT_HEAD(cap_connectat_denied);
+ATF_TC_BODY(cap_connectat_denied, tc)
+{
+	cap_rights_t rights;
+	int l, s, token;
+
+	l = mklistener("capdeny.sock");
+	ATF_REQUIRE((token = dup(l)) >= 0);
+	ATF_REQUIRE_EQ(0, cap_rights_limit(token,
+	    cap_rights_init(&rights, CAP_READ, CAP_WRITE)));
+
+	ATF_REQUIRE((s = socket(PF_UNIX, SOCK_STREAM, 0)) >= 0);
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE, fdconnect(token, s) == -1);
+
+	close(s);
+	close(token);
+	close(l);
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+	ATF_TP_ADD_TC(tp, stream);
+	ATF_TP_ADD_TC(tp, stream_bound);
+	ATF_TP_ADD_TC(tp, dgram);
+	ATF_TP_ADD_TC(tp, empty_path_at_fdcwd);
+	ATF_TP_ADD_TC(tp, bad_peers);
+	ATF_TP_ADD_TC(tp, cap_connectat);
+	ATF_TP_ADD_TC(tp, cap_connectat_denied);
+
+	return (atf_no_error());
+}


### PR DESCRIPTION
The second commit is the heart of the change (and from whence I am getting the PR title).

The first commit is a preparatory refactor without any behavior change, and the third and final commit is a test.

The idea is that, if we have the listening socket already open, there is no reason to have to go consult the file system again to find it, we can just connect to it directly.

If this change is accepted, the natural follow-up would be also allow listening on unbound sockets, and then the file system can be avoided entirely!

The existing capsicum system of fine-grained permissions on file descriptors works very well for this, I am happy to report. :)

*Draft because I am currently figuring out how to test this. I have run my tests on an stock FreeBSD machine and seen them fail as expected, but I am still getting cross-compiling the kernel working*