### PR TITLE
e1000: Fix link state stuck DOWN at 10/100 after TSO automask

### DIFF
--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -2301,10 +2301,16 @@ em_if_update_admin_status(if_ctx_t ctx)
 		if (hw->mac.type < igb_mac_min)
 			automasked = em_automask_tso(ctx);
 
-		/* Automasking resets the interface so don't mark it up yet */
+		/*
+		 * Automasking resets the interface, so don't mark it up;
+		 * clear link_active instead so the post-reset pass redelivers
+		 * the deferred UP.
+		 */
 		if (!automasked)
 			iflib_link_state_change(ctx, LINK_STATE_UP,
 			    IF_Mbps(sc->link_speed));
+		else
+			sc->link_active = 0;
 	} else if (!link_check && (sc->link_active == 1)) {
 		sc->link_speed = 0;
 		sc->link_duplex = 0;


### PR DESCRIPTION
This patch fixes a link-state regression from 2ddf24f8f525.

On [lem(4)](https://man.freebsd.org/cgi/man.cgi?lem(4))/[em(4)](https://man.freebsd.org/cgi/man.cgi?em(4)) sub-gigabit media, `em_automask_tso()` disables TSO and forces a reset, so `LINK_STATE_UP` is deferred; but `sc->link_active` is left set, and hence the post-reset pass never re-enters the up-transition branch and the UP is never delivered.

`if_link_state` then stays DOWN while the link is actually up, breaking consumers that key off link state.
Clearing `sc->link_active` when the UP is deferred is desired, so the post-reset pass redelivers it.

Cc: @spmzt 