### PR TITLE
libsysdecode: use local sysdecode.h

### DIFF
--- a/lib/libsysdecode/flags.c
+++ b/lib/libsysdecode/flags.c
@@ -63,7 +63,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
-#include <sysdecode.h>
 #include <unistd.h>
 #include <sys/bitstring.h>
 #include <netgraph/bluetooth/include/ng_hci.h>
@@ -73,6 +72,7 @@
 #include <netlink/netlink.h>
 
 #include "support.h"
+#include "sysdecode.h"
 
 #define	X(a)	{ a, #a },
 #define	XEND	{ 0, NULL }


### PR DESCRIPTION
Replace <sysdecode.h> with "sysdecode.h" so local builds use the in-tree header in lib/libsysdecode instead of a stale installed copy in /usr/include, avoiding build failures after updating sysdecode.h.


Sponsored-by : Google LLC (GSoC 2026)