### PR TITLE
rpcinfo(8): Fix two stack buffer overflow bugs

### DIFF
--- a/usr.bin/rpcinfo/rpcinfo.c
+++ b/usr.bin/rpcinfo/rpcinfo.c
@@ -837,22 +837,31 @@ failed:
 "   program version(s) netid(s)                         service     owner\n");
 		for (rs = rs_head; rs; rs = rs->next) {
 			char *p = buf;
+			char *end = p + sizeof(buf);
+			int n;
 
 			printf("%10ld  ", rs->prog);
+
 			for (vl = rs->vlist; vl; vl = vl->next) {
-				sprintf(p, "%d", vl->vers);
-				p = p + strlen(p);
-				if (vl->next)
-					sprintf(p++, ",");
+				n = snprintf(p, end - p, "%d%s", vl->vers,
+					     vl->next ? "," : "");
+				if (n < 0 || n + p >= end)
+					break;
+				p += n;
 			}
 			printf("%-10s", buf);
+
 			buf[0] = '\0';
+			p = buf;
 			for (nl = rs->nlist; nl; nl = nl->next) {
-				strlcat(buf, nl->netid, sizeof(buf));
-				if (nl->next)
-					strlcat(buf, ",", sizeof(buf));
+				n = snprintf(p, end - p, "%s%s", nl->netid,
+					     nl->next ? "," : "");
+				if (n < 0 || n + p >= end)
+					break;
+				p += n;
 			}
 			printf("%-32s", buf);
+
 			rpc = getrpcbynumber(rs->prog);
 			if (rpc)
 				printf(" %-11s", rpc->r_name);

--- a/usr.bin/rpcinfo/rpcinfo.c
+++ b/usr.bin/rpcinfo/rpcinfo.c
@@ -949,7 +949,7 @@ rpcbaddrlist(char *netid, int argc, char **argv)
 			re = &head->rpcb_entry_map;
 			printf("%10u%3u    ",
 				parms.r_prog, parms.r_vers);
-			sprintf(buf, "%s/%s/%s ",
+			snprintf(buf, sizeof(buf), "%s/%s/%s ",
 				re->r_nc_protofmly, re->r_nc_proto,
 				re->r_nc_semantics == NC_TPI_CLTS ? "clts" :
 				re->r_nc_semantics == NC_TPI_COTS ? "cots" :


### PR DESCRIPTION
The Openwall list [1] recently notified CVE-2026-16277 and CVE-2026-16461 in rpcbind(8), which are two stack buffer overflow bugs.

I've just fixed them in DragonFly BSD [2][3].

[1] CVE-2026-16277 & CVE-2026-16461: buffer overflows in rpcinfo:
    https://www.openwall.com/lists/oss-security/2026/07/23/8
[2] DragonFly: rpcinfo(8): Fix stack buffer overflow in rpcbaddrlist()
    https://github.com/DragonFlyBSD/DragonFlyBSD/commit/41a496c2f4cdc254824e6c3d6c05bf50d195a59d
[3] DragonFly: rpcinfo(8): Fix stack buffer overflow in rpcbdump()
    https://github.com/DragonFlyBSD/DragonFlyBSD/commit/a5e541a40dbcd2ca45f56ba11b87cd8a666a5cb8