### PR TITLE
libsysdecode: fix nlm_flag regex in mktables

### DIFF
--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -190,7 +190,7 @@ fi
 gen_table "shmflags"  "SHM_[A-Z_]+[[:space:]]+0x[0-9]+"                    "sys/mman.h"         "SHM_ANON"
 gen_table "itimerwhich"     "ITIMER_[A-Z]+[[:space:]]+[0-9]+"              "sys/time.h"
 gen_table_enum "pfnl_cmd"   "PFNL_CMD_[A-Z_]+"                             "netpfil/pf/pf_nl.h"
-gen_table "nlm_flag"        "NLM_F_[A-Z]+[[:space:]]+0x[0-9]+"             "netlink/netlink.h"
+gen_table "nlm_flag"        "NLM_F_[A-Z_]+[[:space:]]+0x[0-9]+"            "netlink/netlink.h"
 
 # Generate a .depend file for our output file
 if [ -n "$output_file" ]; then


### PR DESCRIPTION
Some NLM_F_ definitions contain multiple underscores in their name; this should pick them up.

Fixes:  4c932a4d45fb ("netlink: decode netlink message flags symbolically")