### PR TITLE
zonectl: Consistently report ZAC conv. zones WP LBA

### DIFF
--- a/usr.sbin/zonectl/zonectl.c
+++ b/usr.sbin/zonectl/zonectl.c
@@ -292,7 +292,8 @@ zonectl_print_rz(struct disk_zone_report *report, zone_output_flags out_flags,
 		    (uintmax_t)entry->zone_start_lba,
 		    field_widths[ZONE_FW_LEN],
 		    (uintmax_t)entry->zone_length);
-		if (entry->write_pointer_lba == 0xffffffffffffffff) {
+		if (entry->write_pointer_lba == 0xffffffffffff ||
+		    entry->write_pointer_lba == 0xffffffffffffffff) {
 			/*
 			 * This value is reported by HDDs for conventional
 			 * zones.  It really means "N/A".  Reported it as -1,


### PR DESCRIPTION
zonectl: Consistently report ZAC conv. zones WP LBA

On ZAC drives, conventional zones conventionally report a write pointer
LBA of 0xffffffffffff. This field is 48 bits wide, unlike ZBC's 64 bits.

Recognize both ZAC and ZBC all-ones behaviour in the WRITE POINTER LBA
field to indicate non-valid information.

Tested by:      fuz
Discussed with: fuz, asomers, ken
Fixes:          4735ef6196bc ("zonectl: display conventional zones better during RZ")
Sponsored by:   Google Summer Of Code 2026

(sorry for manually having to fill in PR bodies/titles... gh CLI is not collaborating...)