### PR TITLE
libpmc: Fix AMD L3 counters

### DIFF
--- a/lib/libpmc/libpmc_pmu_util.c
+++ b/lib/libpmc/libpmc_pmu_util.c
@@ -371,13 +371,13 @@ pmu_parse_event(struct pmu_event_desc *ped, const char *eventin)
 		else if (strcmp(key, "l3_slice_mask") == 0)
 			ped->ped_l3_slice = strtol(value, NULL, 16);
 		else if (strcmp(key, "sourceid") == 0)
-			ped->ped_sourceid = strtol(value, NULL, 16);
+			ped->ped_sourceid = strtol(value, NULL, 0);
 		else if (strcmp(key, "coreid") == 0)
-			ped->ped_coreid = strtol(value, NULL, 16);
+			ped->ped_coreid = strtol(value, NULL, 0);
 		else if (strcmp(key, "allcores") == 0)
-			ped->ped_allcores = strtol(value, NULL, 10);
+			ped->ped_allcores = strtol(value, NULL, 0);
 		else if (strcmp(key, "allsources") == 0)
-			ped->ped_allsources = strtol(value, NULL, 10);
+			ped->ped_allsources = strtol(value, NULL, 0);
 		else if (strcmp(key, "pebs") == 0)
 			ped->ped_pebs = strtol(value, NULL, 10);
 		else {

--- a/lib/libpmc/pmu-events/jevents.c
+++ b/lib/libpmc/pmu-events/jevents.c
@@ -623,7 +623,14 @@ static int json_events(const char *fn,
 			} else if (json_streq(map, field, "EnAllCores")) {
 				addfield(map, &allcores, "", "allcores=", val);
 			} else if (json_streq(map, field, "EnAllSlices")) {
-				addfield(map, &allslices, "", "allslices=", val);
+				/*
+				 * We use the AMD PPR Family 1Ah Model 70h
+				 * naming scheme of allsources rather than
+				 * slices.  The symbol EnAllSlices is not used
+				 * anywhere except in Zen 4+ for the L3
+				 * counters.
+				 */
+				addfield(map, &allslices, "", "allsources=", val);
 			} else if (json_streq(map, field, "SliceId")) {
 				/*
 				 * We use sourceid because there's a


### PR DESCRIPTION
Fix two small bugs affecting the event parsing of AMD L3 counters. AMD's manual and JSON disagree about the naming scheme on recent processors.  I use the naming scheme present in the recent PPRs to be consistent, so in the json parser we rename allslices to  allsources just as we already do with sliceid and sourceid.  Also ensure that we parse the 0x prefix present in the newer json files.

Sponsored by: Netflix