### PR TITLE
fsck_msdosfs: fix 32-bit overflow in reconnect() that silently corrupts user data on FAT32 volumes larger than 4 GiB

### DIFF
--- a/sbin/fsck_msdosfs/dir.c
+++ b/sbin/fsck_msdosfs/dir.c
@@ -1129,8 +1129,8 @@ reconnect(struct fat_descriptor *fat, cl_t head, size_t length)
 			lfcl = (lostDir->head < boot->NumClusters) ? lostDir->head : 0;
 			return FSERROR;
 		}
-		lfoff = (lfcl - CLUST_FIRST) * boot->ClusterSize
-		    + boot->FirstCluster * boot->bpbBytesPerSec;
+		lfoff = (off_t)(lfcl - CLUST_FIRST) * boot->ClusterSize
+		    + (off_t)boot->FirstCluster * boot->bpbBytesPerSec;
 
 		if (lseek(dosfs, lfoff, SEEK_SET) != lfoff
 		    || (size_t)read(dosfs, lfbuf, boot->ClusterSize) != boot->ClusterSize) {


### PR DESCRIPTION
## Problem

`reconnect()` computes the byte offset of the LOST.DIR directory cluster with 32-bit arithmetic and only then assigns the result to an off_t:

```c
lfoff = (lfcl - CLUST_FIRST) * boot->ClusterSize
    + boot->FirstCluster * boot->bpbBytesPerSec;
```

`cl_t` is `u_int32_t` and `bootblock::ClusterSize` is `u_int`, so the multiplication is performed in 32-bit unsigned arithmetic and wraps modulo 2**32 before the widening conversion happens. When LOST.DIR's directory cluster is located beyond byte offset 2**32 in the volume, `lfoff` ends up pointing at `(true offset - 4 GiB)`, which on a large FAT32 volume is user file data.

`reconnect()` then uses that bogus offset both for reading and for writing:

1. it reads a cluster worth of user file data into `lfbuf`, believing it to be a directory cluster,
2. it scans `lfbuf` in 32-byte steps for a slot whose first byte is `SLOT_EMPTY` (0x00) or `SLOT_DELETED` (0xE5) - arbitrary file data usually contains such bytes at 32-byte boundaries,
3. it fills that slot with the new directory entry and writes the whole cluster back to the same wrong offset.

The result is silent corruption: exactly 32 bytes of an unrelated file are replaced by a synthetic directory entry (name equal to the decimal orphan cluster number, attribute 0, zero timestamps), while the surrounding bytes are rewritten unchanged so nothing looks obviously wrong. fsck reports "FILE SYSTEM WAS MODIFIED" and exits successfully.

The damage is also cumulative: because the entry never reaches the real LOST.DIR, the chain stays orphaned, so every subsequent fsck run reconnects it again and corrupts another 32-byte slot.

The other cluster-to-offset conversions in dir.c and fat.c are safe: they compute a 32-bit *sector* number first, assign it to an off_t and only then multiply by bpbBytesPerSec. `reconnect()` is the only place that multiplies a cluster number by the cluster size directly.

## Fix

```c
lfoff = (off_t)(lfcl - CLUST_FIRST) * boot->ClusterSize
    + (off_t)boot->FirstCluster * boot->bpbBytesPerSec;
```

## Reproduction

Scripts attached (no special hardware needed):

```sh
python3 make_poc_image.py /tmp/poc.img
fsck_msdos -y /tmp/poc.img
python3 check_poc_image.py /tmp/poc.img
```

`make_poc_image.py` builds a 6 GiB FAT32 image with 16 KiB clusters, two large payload files, a LOST.DIR whose directory cluster sits at offset 0x13103C000 (4.77 GiB) and one orphan cluster chain.

Before the fix:

```
victim range (PAYLOAD0.BIN data, volume offset 0x3103C000)
  bytes changed: 32
  first changed slot: cluster offset 0x1E0 (slot #15)
  before: 00494354494d2d444154412d534c4f54303031352d4b4545504d452d58592e2e
  after : 333132313531202020202000000000000000000004000000000057c300400000
  parsed as dirent: name='312151     ' attr=0x00 cluster=312151 size=0x4000
real LOST.DIR cluster 312144, third slot:
  EMPTY - orphan entry was never written (reconnect silently failed)

RESULT: BUG PRESENT
```

After the fix:

```
victim range (PAYLOAD0.BIN data, volume offset 0x3103C000)
  bytes changed: 0
real LOST.DIR cluster 312144, third slot:
  name='312151     ' cluster=312151 size=0x4000 - orphan entry written correctly

RESULT: OK - no user data touched
```

Note that the fix also makes `reconnect()` actually work: before it, orphan chains were never really reattached to LOST.DIR.

## Impact

This was found in the field on Android devices (`external/fsck_msdos` is a snapshot of this code). A 4.35 GiB firmware image was copied to a FAT32 USB stick; LOST.DIR was created after the copy, so its directory cluster landed past the 4 GiB mark. Every time the stick was mounted and fsck reconnected an orphan chain, 32 bytes inside the firmware image were replaced by a fake directory entry. The corrupted image was then flashed to devices, producing a broken shared library and a boot failure that took considerable effort to trace back to fsck.

Affected: FreeBSD main (`sbin/fsck_msdosfs/dir.c`) and AOSP `external/fsck_msdos` up to and including Android 16.

---

To my knowledge this is a previously unreported bug; a quick search of the freebsd-src history did not show any prior fix.