### PR TITLE
nullfs: allow mounting a single unix-domain socket

### DIFF
--- a/sbin/mount_nullfs/mount_nullfs.8
+++ b/sbin/mount_nullfs/mount_nullfs.8
@@ -62,12 +62,26 @@ but in other respects it is indistinguishable from the original.
 .Pp
 The
 .Nm
-utility supports mounting both directories and single files.
+utility supports mounting directories, single files, and single
+.Xr unix 4
+domain sockets.
 Both
 .Ar target
 and
 .Ar mount_point
 must be the same type.
+.Pp
+Note that a socket mount refers to one specific socket, not to a name:
+if the serving daemon unlinks and re-binds its socket, as it typically does
+when restarted, the mount continues to refer to the old socket and
+.Xr connect 2
+fails.
+Mounting the containing directory does not have this limitation.
+.Pp
+When mounting a single file or socket, the
+.Ar target
+must have exactly one hard link, and the resulting mount point cannot
+itself be covered by a further mount.
 Mounting directories to files or files to
 directories is not supported.
 .Pp
@@ -109,6 +123,7 @@ to the lower (mounted-from) filesystem layer.
 .Pp
 The effect is that lower and upper (bypassed) unix sockets
 are separate.
+It makes mounted unix sockets non-functional.
 .It Cm unixbypass
 Enable the bypass of unix socket file to lower filesystem layer.
 This is default.

--- a/sbin/mount_nullfs/mount_nullfs.c
+++ b/sbin/mount_nullfs/mount_nullfs.c
@@ -98,13 +98,14 @@ main(int argc, char *argv[])
 		err(EX_USAGE, "%s", target);
 	if (stat_realpath(argv[1], mountpoint, &mountpoint_stat) != 0)
 		err(EX_USAGE, "%s", mountpoint);
-	if (!S_ISDIR(target_stat.st_mode) && !S_ISREG(target_stat.st_mode))
-		errx(EX_USAGE, "%s: must be either a file or directory",
+	if (!S_ISDIR(target_stat.st_mode) && !S_ISREG(target_stat.st_mode) &&
+	    !S_ISSOCK(target_stat.st_mode))
+		errx(EX_USAGE, "%s: must be a file, directory or socket",
 		    target);
 	if ((target_stat.st_mode & S_IFMT) !=
 	    (mountpoint_stat.st_mode & S_IFMT))
 		errx(EX_USAGE,
-		    "%s: must be same type as %s (file or directory)",
+		    "%s: must be same type as %s (file, directory or socket)",
 		    mountpoint, target);
 
 	build_iovec(&iov, &iovlen, "fstype", nullfs, (size_t)-1);

--- a/sys/fs/nullfs/null_vfsops.c
+++ b/sys/fs/nullfs/null_vfsops.c
@@ -173,9 +173,10 @@ nullfs_mount(struct mount *mp)
 
 	/*
 	 * Lower vnode must be the same type as the covered vnode - we
-	 * don't allow mounting directories to files or vice versa.
+	 * don't allow mounting directories to files or sockets or vice versa.
 	 */
-	if ((lowerrootvp->v_type != VDIR && lowerrootvp->v_type != VREG) ||
+	if ((lowerrootvp->v_type != VDIR && lowerrootvp->v_type != VREG &&
+	    lowerrootvp->v_type != VSOCK) ||
 	    lowerrootvp->v_type != mp->mnt_vnodecovered->v_type) {
 		NULLFSDEBUG("nullfs_mount: target must be same type as fspath");
 		vput(lowerrootvp);

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -1171,12 +1171,15 @@ vfs_domount_first(
 	if (error == 0)
 		error = vinvalbuf(vp, V_SAVE, 0, 0);
 	if (vfsp->vfc_flags & VFCF_FILEMOUNT) {
-		if (error == 0 && vp->v_type != VDIR && vp->v_type != VREG)
+		if (error == 0 && vp->v_type != VDIR && vp->v_type != VREG &&
+		    vp->v_type != VSOCK)
 			error = EINVAL;
 		/*
-		 * For file mounts, ensure that there is only one hardlink to the file.
+		 * For file and socket mounts, ensure that there is only one
+		 * hardlink to the file or socket.
 		 */
-		if (error == 0 && vp->v_type == VREG && va.va_nlink != 1)
+		if (error == 0 && (vp->v_type == VREG ||
+		    vp->v_type == VSOCK) && va.va_nlink != 1)
 			error = EINVAL;
 	} else {
 		if (error == 0 && vp->v_type != VDIR)
@@ -1697,10 +1700,10 @@ vfs_domount(
 		return (error);
 	vp = nd.ni_vp;
 	/*
-	 * Don't allow stacking file mounts to work around problems with the way
-	 * that namei sets nd.ni_dvp to vp_crossmp for these.
+	 * Don't allow stacking file or socket mounts to work around problems
+	 * with the way that namei sets nd.ni_dvp to vp_crossmp for these.
 	 */
-	if (vp->v_type == VREG)
+	if (vp->v_type == VREG || vp->v_type == VSOCK)
 		fsflags |= MNT_NOCOVER;
 	if ((fsflags & MNT_UPDATE) == 0) {
 		if ((vp->v_vflag & VV_ROOT) != 0 &&


### PR DESCRIPTION
Extend nullfs file-mounts to VSOCK so a single socket can be exposed (e.g. into a jail) without sharing the directory that contains it. The motivating case is handing a jail exactly one daemon socket such as seatd's or a jailed bhyve's rfb unix socket instead of a directory in which anything else may later appear.

Note: If the socket is unbound and re-created, the mount needs to be torn down and set up again.

Sponsored by: Defenso