### PR TITLE
fsck_msdosfs: fix memory leaks in checkfilesys()

### DIFF
--- a/sbin/fsck_msdosfs/check.c
+++ b/sbin/fsck_msdosfs/check.c
@@ -181,7 +181,10 @@ checkfilesys(const char *fname)
     out:
 	if (finish_dosdirsection)
 		finishDosDirSection();
-	free(fat);
+	if (fat) {
+		releasefat(fat);
+		free(fat);
+	}
 	close(dosfs);
 
 	if (mod & (FSFATMOD|FSDIRMOD))

--- a/sbin/fsck_msdosfs/ext.h
+++ b/sbin/fsck_msdosfs/ext.h
@@ -109,6 +109,7 @@ bool fat_is_valid_cl(struct fat_descriptor *, cl_t);
  * descriptor of it.
  */
 int readfat(int, struct bootblock *, struct fat_descriptor **);
+void releasefat(struct fat_descriptor *);
 
 /*
  * Write back FAT entries

--- a/sbin/fsck_msdosfs/fat.c
+++ b/sbin/fsck_msdosfs/fat.c
@@ -783,7 +783,7 @@ err:
 	return 0;
 }
 
-static void
+void
 releasefat(struct fat_descriptor *fat)
 {
 	if (fat->is_mmapped) {


### PR DESCRIPTION
Invoke releasefat(fat) in checkfilesys() prior to free(fat) on exit paths so that fatbuf, headbitmap.map, and fat32_cache entries are properly freed.