### PR TITLE
ncal(1): handle Sweden's transitional calendar (1700-1712)

### DIFF
--- a/usr.bin/ncal/ncal.1
+++ b/usr.bin/ncal/ncal.1
@@ -221,5 +221,21 @@ command and manual were written by
 The assignment of Julian\(enGregorian switching dates to country
 codes is historically naive for many countries.
 .Pp
+Sweden
+.Pq Fl s Ar SE
+used a unique transitional calendar from 1700\(en1712.
+To begin a gradual shift to the Gregorian calendar, Sweden omitted the
+Julian leap day in 1700, so February 29, 1700 did not exist in Sweden.
+The transition was abandoned mid-way due to the Great Northern War, and
+in 1712 King Charles\~XII added an extra day,
+.Dq February\~30, 1712 ,
+to revert to the Julian calendar.
+Sweden finally adopted the Gregorian calendar in 1753.
+.Nm
+models this correctly: February 1700 is shown with 28 days, February
+1712 is shown with 30 days, and dates in the transitional period
+(1700\(en1712) reflect the one-day offset between the Swedish and Julian
+calendars.
+.Pp
 Not all options are compatible and using them in different orders
 will give varying results.

--- a/usr.bin/ncal/ncal.c
+++ b/usr.bin/ncal/ncal.c
@@ -164,7 +164,11 @@ static int nswitch;		/* user defined switch date */
 static int nswitchb;		/* switch date for backward compatibility */
 static int highlightdate;
 static bool flag_monday;	/* user wants week starts on Monday */
+static int flag_sweden;		/* Swedish transitional calendar (1700-1712) */
+static int sweden_start;	/* day number of first day of Swedish transitional period */
+static int sweden_end;		/* day number of first day after Swedish transitional period */
 
+static int	 date_in_sweden_transitional(const date *d);
 static char	*center(char *s, char *t, int w);
 static wchar_t *wcenter(wchar_t *s, wchar_t *t, int w);
 static int	firstday(int y, int m);
@@ -243,6 +247,7 @@ main(int argc, char *argv[])
 	} else {
 		nswitch = ndaysj(&p->dt);
 		dftswitch = p;
+		flag_sweden = (strcmp(p->cc, "SE") == 0);
 	}
 
 
@@ -342,6 +347,7 @@ main(int argc, char *argv[])
 				errx(EX_USAGE,
 				    "%s: invalid country code", optarg);
 			nswitch = ndaysj(&(p->dt));
+			flag_sweden = (strcmp(p->cc, "SE") == 0);
 			break;
 		case 'w':
 			if (flag_backward)
@@ -492,6 +498,19 @@ main(int argc, char *argv[])
 		dt.d = tm1->tm_mday;
 	}
 	highlightdate = sndaysb(&dt);
+
+	/*
+	 * Initialize Sweden-specific day number boundaries for the
+	 * transitional calendar period (1700-03-01 to 1712-03-01 Swedish).
+	 * sweden_start: solar day of Swedish Mar 1, 1700 (= Julian Feb 29, 1700)
+	 * sweden_end:   solar day of Swedish Mar 1, 1712 (= Julian Mar 1, 1712)
+	 */
+	if (flag_sweden) {
+		date sw_s = {1700, 2, 29};
+		date sw_e = {1712, 3,  1};
+		sweden_start = ndaysj(&sw_s);
+		sweden_end   = ndaysj(&sw_e);
+	}
 
 	/* And now we finally start to calculate and output calendars. */
 	if (flag_easter)
@@ -1010,10 +1029,33 @@ firstday(int y, int m)
 /*
  * Compute the number of days from date, obey the local switch from
  * Julian to Gregorian if specified by the user.
+ *
+ * For Sweden (-s SE), a special transitional calendar was in use from
+ * 1700-03-01 to 1712-03-01.  Sweden omitted the Julian leap day in 1700
+ * (so Feb 29, 1700 did not exist), and added an extra day "Feb 30" in 1712
+ * to revert to the Julian calendar before finally adopting the Gregorian
+ * calendar in 1753.  During the transitional period, Swedish dates ran one
+ * day ahead of the Julian calendar.
  */
 static int
 sndaysr(struct date *d)
 {
+
+	if (flag_sweden) {
+		/* Feb 30, 1712: Sweden's unique extra day */
+		if (d->y == 1712 && d->m == 2 && d->d == 30)
+			return (sweden_end - 1);
+
+		/*
+		 * During the Swedish transitional period [1700-03-01,
+		 * 1712-03-01), Swedish dates ran 1 day ahead of Julian.
+		 * Subtract 1 from the Julian day number to get the solar day.
+		 */
+		if (date_in_sweden_transitional(d))
+			return (ndaysj(d) - 1);
+
+		/* Outside transitional period: fall through to normal logic */
+	}
 
 	if (nswitch != 0)
 		if (nswitch < ndaysj(d))
@@ -1043,10 +1085,51 @@ static struct date *
 sdater(int nd, struct date *d)
 {
 
+	if (flag_sweden) {
+		/*
+		 * Swedish Feb 30, 1712: the extra day added to revert from
+		 * the Swedish transitional calendar back to Julian.
+		 */
+		if (nd == sweden_end - 1) {
+			d->y = 1712;
+			d->m = 2;
+			d->d = 30;
+			return (d);
+		}
+
+		/*
+		 * Within the Swedish transitional period, each solar day nd
+		 * corresponds to the Julian date of nd+1 (Swedish was 1 day
+		 * ahead of Julian).
+		 */
+		if (nd >= sweden_start && nd < sweden_end)
+			return (jdate(nd + 1, d));
+
+		/* Outside transitional period: fall through to normal logic */
+	}
+
 	if (nswitch < nd)
 		return (gdate(nd, d));
 	else
 		return (jdate(nd, d));
+}
+
+/*
+ * Returns 1 if the given Swedish date falls within the Swedish transitional
+ * calendar period [1700-03-01, 1712-03-01), during which Swedish dates ran
+ * one day ahead of the Julian calendar.
+ */
+static int
+date_in_sweden_transitional(const date *d)
+{
+
+	/* Before 1700 March: not in transitional period */
+	if (d->y < 1700 || (d->y == 1700 && d->m < 3))
+		return (0);
+	/* 1712 March or later: not in transitional period */
+	if (d->y > 1712 || (d->y == 1712 && d->m >= 3))
+		return (0);
+	return (1);
 }
 
 /* Inverse of sndaysb. */


### PR DESCRIPTION
## Summary

`ncal(1)` uses a single Julian→Gregorian switch date per country, but Sweden's
calendar history between 1700 and 1712 cannot be represented by a single switch
date. This was noted as a bug in https://blog.yossarian.net/2015/06/09/Dates-That-Dont-Exist
(addendum 2026-06-30, analysis by John Costello <https://joxn.org>).

**Background — the Swedish transitional calendar (1700–1712):**

Sweden planned a gradual switch to the Gregorian calendar by omitting one leap
day per four years from 1700 to 1740. In 1700 they dropped Feb 29; however, the
Great Northern War interrupted the plan and further omissions were skipped. In
1712, King Charles XII added a unique extra day — **February 30, 1712** — to
revert the calendar back to Julian. Sweden finally adopted the Gregorian calendar
in 1753 (the date already stored in the `switches[]` table, unchanged here).

**Bugs fixed:**

| Command | Before | After |
|---------|--------|-------|
| `ncal -s SE 2 1700` | Feb has 29 days (wrong — leap day was omitted) | Feb has **28 days** ✓ |
| `ncal -s SE 2 1712` | Feb has 29 days (wrong — extra day existed) | Feb has **30 days** ✓ |
| `ncal -s SE 3 1700` — `ncal -s SE 2 1712` | Weekdays anchored to Julian day numbers (off by 1) | Weekdays correctly anchored to solar days ✓ |

## Implementation

- Add `flag_sweden` (set when `-s SE` or locale selects Sweden).
- Add `sweden_start` / `sweden_end` day-number sentinels (initialised in `main()`
  before calendar output).
- Modify `sndaysr()`: during the transitional period, subtract 1 from the Julian
  day number to produce the correct solar day (since Swedish dates ran one day
  ahead of Julian).  Special-case `{1712, 2, 30}` to map to `sweden_end - 1`.
- Modify `sdater()`: map solar days in `[sweden_start, sweden_end)` to their
  Swedish date via `jdate(nd + 1)`.  Special-case `nd == sweden_end - 1` to
  return `{1712, 2, 30}`.
- Add `date_in_sweden_transitional()` helper.
- Update `ncal.1` BUGS section to document Sweden's history and the correction.

## Tests

Regression output files for the new Swedish calendar test cases need to be
generated by running the fixed binary on a FreeBSD build host (the existing
`tests/regress.sh` framework expects pre-computed `.out` files).  Test cases
to add once the implementation is validated:

```
ncal -h -s SE 2 1700   # should show Feb 1700 with 28 days
ncal -h -s SE 2 1712   # should show Feb 1712 with 30 days
ncal -h -s SE 3 1700   # first month of transitional period
```

This PR is marked **draft** pending:
1. Review of the calendar arithmetic
2. Build and functional testing on FreeBSD
3. Addition of regression test output files

## References

- Blog post and analysis: https://blog.yossarian.net/2015/06/09/Dates-That-Dont-Exist
- John Costello's gist: https://gist.github.com/woodruffw/bb056927958d7593793e9613bb810eb6
- Swedish calendar (Wikipedia): https://en.wikipedia.org/wiki/Swedish_calendar

🤖 Generated with [Claude Code](https://claude.com/claude-code)