### PR TITLE
bhyve: rtc_pl031: Fix PeriphID and CellID values

### DIFF
--- a/usr.sbin/bhyve/rtc_pl031.c
+++ b/usr.sbin/bhyve/rtc_pl031.c
@@ -236,13 +236,13 @@ rtc_pl031_read(struct rtc_pl031_softc *sc, int offset)
 	case RTCPeriphID1:
 	case RTCPeriphID2:
 	case RTCPeriphID3:
-		reg = RTCPeriphID_VAL(offset - RTCPeriphID0);
+		reg = RTCPeriphID_VAL((offset - RTCPeriphID0) >> 2);
 		break;
 	case RTCCellID0:
 	case RTCCellID1:
 	case RTCCellID2:
 	case RTCCellID3:
-		reg = RTCCellID_VAL(offset - RTCCellID0);
+		reg = RTCCellID_VAL((offset - RTCCellID0) >> 2);
 		break;
 	default:
 		/* Return 0 in reads from unasigned registers */


### PR DESCRIPTION
PeriphID and CellID values are determined by macros which take an
index. They currently receive a bus offset which has a stride of 4 bytes.
This causes the ID1-3 registers to report incorrect values.
Scale the offset before passing it to the macro to fix this.

Tested with kvm-unit-tests/arm/pl031.