### PR TITLE
kboot: Fix file2str() buffer under-read

### DIFF
--- a/stand/kboot/libkboot/util.c
+++ b/stand/kboot/libkboot/util.c
@@ -26,7 +26,7 @@ file2str(const char *fn, char *buffer, size_t buflen)
 	/*
 	 * Trim trailing white space
 	 */
-	while (isspace(buffer[len - 1]))
+	while (len > 0 && isspace(buffer[len - 1]))
 		buffer[--len] = '\0';
 	host_close(fd);
 	return true;


### PR DESCRIPTION
Calling file2str() on an empty or whitespace-only file causes a buffer under-read.