### PR TITLE
lib/libsbuf/tests: add sbuf_get_flags test and cleanup drain test

### DIFF
--- a/lib/libsbuf/tests/sbuf_core_test.c
+++ b/lib/libsbuf/tests/sbuf_core_test.c
@@ -242,6 +242,26 @@ ATF_TC_BODY(sbuf_setpos_test, tc)
 	sbuf_delete(sb);
 }
 
+ATF_TC_WITHOUT_HEAD(sbuf_get_flags_test);
+ATF_TC_BODY(sbuf_get_flags_test, tc)
+{
+	struct sbuf *sb;
+	int flags;
+
+	sb = sbuf_new(NULL, NULL, 0, 
+		SBUF_AUTOEXTEND | SBUF_INCLUDENUL);
+
+	ATF_REQUIRE_MSG(sb != NULL, 
+		"sbuf_new failed: %s", strerror(errno));
+
+	flags = sbuf_get_flags(sb);
+		
+	ATF_CHECK((flags & SBUF_AUTOEXTEND) != 0);
+	ATF_CHECK((flags & SBUF_INCLUDENUL) != 0);
+
+	sbuf_delete(sb);
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, sbuf_clear_test);
@@ -249,6 +269,7 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, sbuf_drain_ret0_test);
 	ATF_TP_ADD_TC(tp, sbuf_len_test);
 	ATF_TP_ADD_TC(tp, sbuf_new_fixedlen);
+	ATF_TP_ADD_TC(tp, sbuf_get_flags_test);
 #if 0
 	/* TODO */
 #ifdef HAVE_SBUF_CLEAR_FLAGS

--- a/lib/libsbuf/tests/sbuf_core_test.c
+++ b/lib/libsbuf/tests/sbuf_core_test.c
@@ -125,6 +125,8 @@ ATF_TC_BODY(sbuf_drain_ret0_test, tc)
 	    "required to return error when drain func returns 0");
 	ATF_CHECK_EQ_MSG(EDEADLK, errno,
 	    "errno required to be EDEADLK when drain func returns 0");
+	
+	sbuf_delete(sb);
 }
 
 ATF_TC_WITHOUT_HEAD(sbuf_len_test);


### PR DESCRIPTION
**Task from the FreeBSD JuniorJobs list.**

**Add** test coverage for `sbuf_get_flags()` in `sbuf_core_test.c`.

The new test verifies that flags configured during sbuf creation
can be retrieved through the public API.

Also add a missing `sbuf_delete()` call to `sbuf_drain_ret0_test()`
to ensure resources allocated by `sbuf_new_auto()` are properly
released.

## Testing

```sh
cd lib/libsbuf/tests
make clean
make
kyua test