### PR TITLE
bhyve: tpm: allow the last dword of the CRB command buffer

### DIFF
--- a/usr.sbin/bhyve/tpm_intf_crb.c
+++ b/usr.sbin/bhyve/tpm_intf_crb.c
@@ -321,7 +321,7 @@ tpm_crb_mem_handler(struct vcpu *vcpu __unused, const int dir,
 	crb = arg1;
 
 	off = addr - TPM_CRB_ADDRESS;
-	if (off > TPM_CRB_REGS_SIZE || off + size >= TPM_CRB_REGS_SIZE) {
+	if (off > TPM_CRB_REGS_SIZE || off + size > TPM_CRB_REGS_SIZE) {
 		return (EINVAL);
 	}
 


### PR DESCRIPTION
The bounds check rejected any access ending exactly at the end of the register block, so a four byte write at offset 0xffc was refused, returning EINVAL and killing the VM.

The following python code can be used in a Linux guest (or anything that does not validate TPM queries before submissions - i.e. not Windows) as a test case:

```python
import os, struct
N = 3968                                    # exactly fills the CRB buffer
cmd = struct.pack('>HII', 0x8001, N, 0x17B) # TPM_ST_NO_SESSIONS, size, TPM_CC_GetRandom
cmd += b'\xaa' * (N - 10)                   # padding; makes it malformed, which is fine
fd = os.open('/dev/tpm0', os.O_RDWR)
os.write(fd, cmd)
print(os.read(fd, 4096).hex())
```