### PR TITLE
ichsmb: Add Intel Lunar Lake-M SMBus Controller ID (0xa822)

### DIFF
--- a/sys/dev/ichsmb/ichsmb_pci.c
+++ b/sys/dev/ichsmb/ichsmb_pci.c
@@ -120,6 +120,7 @@
 #define	ID_METEORLAKE2			0x7f23
 #define	ID_METEORLAKE3			0xae22
 #define	ID_PANTHERLAKE			0xe422
+#define ID_LUNARLAKE_M 			0xa822
 
 static const struct pci_device_table ichsmb_devices[] = {
 	{ PCI_DEV(PCI_VENDOR_INTEL, ID_82801AA),
@@ -284,6 +285,9 @@ static const struct pci_device_table ichsmb_devices[] = {
 	{ PCI_DEV(PCI_VENDOR_INTEL, ID_PANTHERLAKE),
 	  .driver_data = (uintptr_t)ICHSMB_FEATURE_BLOCK_BUFFER,
 	  PCI_DESCR("Intel Panther Lake SMBus controller") },
+	{ PCI_DEV(PCI_VENDOR_INTEL, ID_LUNARLAKE_M),
+	  .driver_data = (uintptr_t)ICHSMB_FEATURE_BLOCK_BUFFER,
+	  PCI_DESCR("Intel Lunar Lake-M SMBus controller") },
 };
 
 /* Internal functions */


### PR DESCRIPTION
The Intel Lunar Lake-M SMBus controller with PCI ID 8086:a822 is currently unrecognized by FreeBSD, leaving the device unattached as noneX.

This patch adds the missing hardware ID definition and maps it using ICHSMB_FEATURE_BLOCK_BUFFER, which matches modern Intel controller requirements. Successfully tested compiling and attaching the driver on a Lunar Lake laptop platform.

