### PR TITLE
libpmc: Enable overriding PMU counter flags

### DIFF
--- a/lib/libpmc/libpmc.c
+++ b/lib/libpmc/libpmc.c
@@ -1247,17 +1247,13 @@ pmc_allocate(const char *ctrspec, enum pmc_mode mode,
 	 * this is unsupported on the platform, or the event is not found,
 	 * continue with searching the regular event tables.
 	 */
-	r = spec_copy = strdup(ctrspec);
-	ctrname = strsep(&r, ",");
 	if (pmc_pmu_enabled()) {
-		errno = pmc_pmu_pmcallocate(ctrname, &pmc_config);
+		errno = pmc_pmu_pmcallocate(ctrspec, &pmc_config);
 		if (errno == 0)
 			goto found;
 		if (errno == EOPNOTSUPP)
 			goto out;
 	}
-	free(spec_copy);
-	spec_copy = NULL;
 
 	/* replace an event alias with the canonical event specifier */
 	if (pmc_mdep_event_aliases)

--- a/lib/libpmc/libpmc_pmu_util.c
+++ b/lib/libpmc/libpmc_pmu_util.c
@@ -322,6 +322,14 @@ pmc_pmu_event_get_by_idx(const char *cpuid, int idx)
 	return (pme->table[idx].name);
 }
 
+static void
+pmu_init_event(struct pmu_event_desc *ped)
+{
+	bzero(ped, sizeof(*ped));
+	ped->ped_period = DEFAULT_SAMPLE_COUNT;
+	ped->ped_umask = -1;
+}
+
 static int
 pmu_parse_event(struct pmu_event_desc *ped, const char *eventin)
 {
@@ -332,9 +340,6 @@ pmu_parse_event(struct pmu_event_desc *ped, const char *eventin)
 	if ((event = strdup(eventin)) == NULL)
 		return (ENOMEM);
 	r = event;
-	bzero(ped, sizeof(*ped));
-	ped->ped_period = DEFAULT_SAMPLE_COUNT;
-	ped->ped_umask = -1;
 	while ((kvp = strsep(&event, ",")) != NULL) {
 		key = strsep(&kvp, "=");
 		if (key == NULL)
@@ -401,6 +406,7 @@ pmc_pmu_sample_rate_get(const char *event_name)
 		return (DEFAULT_SAMPLE_COUNT);
 	if (pe->event == NULL)
 		return (DEFAULT_SAMPLE_COUNT);
+	pmu_init_event(&ped);
 	if (pmu_parse_event(&ped, pe->event))
 		return (DEFAULT_SAMPLE_COUNT);
 	return (ped.ped_period);
@@ -435,8 +441,10 @@ pmc_pmu_print_counters(const char *event_name)
 		if (event_name != NULL && strcasestr(pe->name, event_name) == NULL)
 			continue;
 		printf("\t%s\n", pe->name);
-		if (do_debug)
+		if (do_debug) {
+			pmu_init_event(&ped);
 			pmu_parse_event(&ped, pe->event);
+		}
 	}
 }
 
@@ -654,33 +662,52 @@ pmc_pmu_intel_pmcallocate(const char *event_name, struct pmc_op_pmcallocate *pm,
 }
 
 static int
-pmc_pmu_pmcallocate_md(const char *event_name, struct pmc_op_pmcallocate *pm)
+pmc_pmu_pmcallocate_md(const char *ctrspec, struct pmc_op_pmcallocate *pm)
 {
 	const struct pmu_event *pe;
 	struct pmu_event_desc ped;
+	const char *ctrname;
+	char *tmp, *ctrmodifier;
 	pmu_mfr_t mfr;
 	int idx = -1;
+	int status;
 
 	if ((mfr = pmu_events_mfr()) == PMU_INVALID)
 		return (ENOENT);
 
+	tmp = ctrmodifier = strdup(ctrspec);
+	ctrname = strsep(&ctrmodifier, ",");
+
 	bzero(&pm->pm_md, sizeof(pm->pm_md));
 	pm->pm_caps |= (PMC_CAP_READ | PMC_CAP_WRITE);
-	event_name = pmu_alias_get(event_name);
-	if ((pe = pmu_event_get(NULL, event_name, &idx)) == NULL)
+	ctrname = pmu_alias_get(ctrname);
+	if ((pe = pmu_event_get(NULL, ctrname, &idx)) == NULL) {
+		free(tmp);
 		return (ENOENT);
+	}
 	assert(idx >= 0);
 	pm->pm_ev = idx;
 
-	if (pe->event == NULL)
+	if (pe->event == NULL) {
+		free(tmp);
 		return (ENOENT);
-	if (pmu_parse_event(&ped, pe->event))
+	}
+	pmu_init_event(&ped);
+	if (pmu_parse_event(&ped, pe->event)) {
+		free(tmp);
 		return (ENOENT);
+	}
+	if (ctrmodifier != NULL) {
+		pmu_parse_event(&ped, ctrmodifier);
+	}
 
 	if (mfr == PMU_INTEL)
-		return (pmc_pmu_intel_pmcallocate(event_name, pm, &ped));
+		status = pmc_pmu_intel_pmcallocate(ctrname, pm, &ped);
 	else
-		return (pmc_pmu_amd_pmcallocate(event_name, pm, &ped));
+		status = pmc_pmu_amd_pmcallocate(ctrname, pm, &ped);
+
+	free(tmp);
+	return (status);
 }
 
 #elif defined(__powerpc64__)
@@ -700,6 +727,7 @@ pmc_pmu_pmcallocate_md(const char *event_name, struct pmc_op_pmcallocate *pm)
 		return (ENOENT);
 	if (pe->event == NULL)
 		return (ENOENT);
+	pmu_init_event(&ped);
 	if (pmu_parse_event(&ped, pe->event))
 		return (ENOENT);
 
@@ -712,17 +740,18 @@ pmc_pmu_pmcallocate_md(const char *event_name, struct pmc_op_pmcallocate *pm)
 #elif defined(__aarch64__)
 
 static int
-pmc_pmu_pmcallocate_md(const char *event_name, struct pmc_op_pmcallocate *pm)
+pmc_pmu_pmcallocate_md(const char *ctrspec, struct pmc_op_pmcallocate *pm)
 {
 	const struct pmu_event *pe;
 	struct pmu_event_desc ped;
 	int idx = -1;
 
-	event_name = pmu_alias_get(event_name);
-	if ((pe = pmu_event_get(NULL, event_name, &idx)) == NULL)
+	ctrspec = pmu_alias_get(ctrspec);
+	if ((pe = pmu_event_get(NULL, ctrspec, &idx)) == NULL)
 		return (ENOENT);
 	if (pe->event == NULL)
 		return (ENOENT);
+	pmu_init_event(&ped);
 	if (pmu_parse_event(&ped, pe->event))
 		return (ENOENT);
 
@@ -745,11 +774,11 @@ pmc_pmu_pmcallocate_md(const char *e __unused, struct pmc_op_pmcallocate *p __un
 #endif
 
 int
-pmc_pmu_pmcallocate(const char *event_name, struct pmc_op_pmcallocate *pm)
+pmc_pmu_pmcallocate(const char *ctrspec, struct pmc_op_pmcallocate *pm)
 {
 	int error;
 
-	error = pmc_pmu_pmcallocate_md(event_name, pm);
+	error = pmc_pmu_pmcallocate_md(ctrspec, pm);
 	if (error != 0) {
 		/* Reset any changes. */
 		pm->pm_ev = 0;


### PR DESCRIPTION
Typically, PMU counters defined in the JSON have PMC arguments set by
the JSON definition. This change allows the PMC flags to be overridden
by a user. This is useful for some of the advanced flags that allow you
filter on types of events, cores, or threads. While we should expose the
core/thread filters through the CPU mask the problem is that in a number
of systems those ids do match APIC IDs.

For example:
pmcstat -s l3_xi_sampled_latency.all,allcores=0,coreid=0x1

This overrides the default behavior of monitoring the entire processor,
and filters for requests originating from the 2nd core.  Note that in
this case the coreid does not necessarily match the APIC ID.

Sponsored by: Netflix