### PR TITLE
lib/libsbuf/tests: add coverage for sbuf flag APIs

### DIFF
--- a/lib/libsbuf/tests/sbuf_core_test.c
+++ b/lib/libsbuf/tests/sbuf_core_test.c
@@ -264,6 +264,36 @@ ATF_TC_BODY(sbuf_get_flags_test, tc)
 	sbuf_delete(sb);
 }
 
+ATF_TC_WITHOUT_HEAD(sbuf_set_flags_test);
+ATF_TC_BODY(sbuf_set_flags_test, tc)
+{
+	struct sbuf *sb;
+
+	sb = sbuf_new_auto();
+
+	ATF_REQUIRE_MSG(sb != NULL, 
+		"sbuf_new_auto failed: %s", strerror(errno));
+
+	ATF_REQUIRE_EQ_MSG(0, 
+		sbuf_set_flags(sb, SBUF_INCLUDENUL),
+		"sbuf_set_flags failed");
+
+	ATF_REQUIRE_EQ_MSG(sbuf_cat(sb, test_string) == 0,
+		"sbuf_cat failed");
+
+	ATF_REQUIRE_EQ_MSG(0, 
+		sbuf_finish(sb),
+		"sbuf_finish failed: %s", strerror(errno));
+		
+	ATF_CHECK_EQ(
+		strlen(test_string) + 1,
+		sbuf_len(sb)
+	);
+
+	sbuf_delete(sb);
+}
+
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, sbuf_clear_test);
@@ -272,19 +302,14 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, sbuf_len_test);
 	ATF_TP_ADD_TC(tp, sbuf_new_fixedlen);
 	ATF_TP_ADD_TC(tp, sbuf_get_flags_test);
+	ATF_TP_ADD_TC(tp, sbuf_set_flags_test);
 #if 0
 	/* TODO */
 #ifdef HAVE_SBUF_CLEAR_FLAGS
 	ATF_TP_ADD_TC(tp, sbuf_clear_flags_test);
 #endif
-#ifdef HAVE_SBUF_GET_FLAGS
-	ATF_TP_ADD_TC(tp, sbuf_get_flags_test);
-#endif
 	ATF_TP_ADD_TC(tp, sbuf_new_positive_test);
 	ATF_TP_ADD_TC(tp, sbuf_new_negative_test);
-#ifdef HAVE_SBUF_SET_FLAGS
-	ATF_TP_ADD_TC(tp, sbuf_set_flags_test);
-#endif
 #endif
 	ATF_TP_ADD_TC(tp, sbuf_setpos_test);
 

--- a/lib/libsbuf/tests/sbuf_core_test.c
+++ b/lib/libsbuf/tests/sbuf_core_test.c
@@ -268,17 +268,18 @@ ATF_TC_WITHOUT_HEAD(sbuf_set_flags_test);
 ATF_TC_BODY(sbuf_set_flags_test, tc)
 {
 	struct sbuf *sb;
-	int flags;
+
 	sb = sbuf_new_auto();
 
 	ATF_REQUIRE_MSG(sb != NULL, 
 		"sbuf_new_auto failed: %s", strerror(errno));
- 
-	flags = sbuf_set_flags(sb, SBUF_INCLUDENUL);
-	sbuf_len(flags);
 
+	ATF_REQUIRE_EQ_MSG(0,
+		sbuf_set_flags(sb, SBUF_INCLUDENUL),
+		"sbuf_set_flags failed");
+ 
 	ATF_REQUIRE_MSG(sbuf_cat(sb, test_string) == 0,
-		"sbuf_cat failed");
+		"sbuf_cat failed");	
 
 	ATF_REQUIRE_EQ_MSG(0, 
 		sbuf_finish(sb),

--- a/lib/libsbuf/tests/sbuf_core_test.c
+++ b/lib/libsbuf/tests/sbuf_core_test.c
@@ -278,7 +278,7 @@ ATF_TC_BODY(sbuf_set_flags_test, tc)
 		sbuf_set_flags(sb, SBUF_INCLUDENUL),
 		"sbuf_set_flags failed");
 
-	ATF_REQUIRE_EQ_MSG(sbuf_cat(sb, test_string) == 0,
+	ATF_REQUIRE_MSG(sbuf_cat(sb, test_string) == 0,
 		"sbuf_cat failed");
 
 	ATF_REQUIRE_EQ_MSG(0, 
@@ -293,6 +293,32 @@ ATF_TC_BODY(sbuf_set_flags_test, tc)
 	sbuf_delete(sb);
 }
 
+ATF_TC_WITHOUT_HEAD(sbuf_clear_flags_test);
+ATF_TC_BODY(sbuf_clear_flags_test, tc)
+{
+	struct sbuf *sb;
+	int flags;
+
+	sb = sbuf_new(NULL, NULL, 0, 
+		SBUF_AUTOEXTEND | SBUF_INCLUDENUL);
+
+	ATF_REQUIRE_MSG(sb != NULL, 
+		"sbuf_new failed: %s", strerror(errno));
+
+	flags = sbuf_get_flags(sb);
+	ATF_REQUIRE(flags & SBUF_INCLUDENUL);
+
+	ATF_REQUIRE_EQ_MSG(0,
+		sbuf_clear_flags(sb, SBUF_INCLUDENUL),
+		"sbuf_clear_flags failed: %s", strerror(errno));
+
+	flag = sbuf_get_flags(sb);
+		
+	ATF_CHECK(!(flags & SBUF_INCLUDENUL) != 0);
+
+	sbuf_delete(sb);
+}
+
 
 ATF_TP_ADD_TCS(tp)
 {
@@ -303,13 +329,13 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, sbuf_new_fixedlen);
 	ATF_TP_ADD_TC(tp, sbuf_get_flags_test);
 	ATF_TP_ADD_TC(tp, sbuf_set_flags_test);
+	ATF_TP_ADD_TC(tp, sbuf_set_clear_test);
 #if 0
 	/* TODO */
-#ifdef HAVE_SBUF_CLEAR_FLAGS
-	ATF_TP_ADD_TC(tp, sbuf_clear_flags_test);
-#endif
+#ifdef 
 	ATF_TP_ADD_TC(tp, sbuf_new_positive_test);
 	ATF_TP_ADD_TC(tp, sbuf_new_negative_test);
+#endif
 #endif
 	ATF_TP_ADD_TC(tp, sbuf_setpos_test);
 

--- a/lib/libsbuf/tests/sbuf_core_test.c
+++ b/lib/libsbuf/tests/sbuf_core_test.c
@@ -242,6 +242,26 @@ ATF_TC_BODY(sbuf_setpos_test, tc)
 	sbuf_delete(sb);
 }
 
+ATF_TC_WITHOUT_HEAD(sbuf_get_flags_test);
+ATF_TC_BODY(sbuf_get_flags_test, tc)
+{
+	struct sbuf *sb;
+	int flags;
+
+	sb = sbuf_new(NULL, NULL, 0, 
+		SBUF_AUTOEXTEND | SBUF_INCLUDENUL);
+
+	ATF_REQUIRE_MSG(sb != NULL, 
+		"sbuf_new failed: %s", strerror(errno));
+
+	flags = sbuf_get_flags(sb);
+		
+	ATF_CHECK((flags & SBUF_AUTOEXTEND) != 0);
+	ATF_CHECK((flags & SBUF_INCLUDENUL) != 0);
+
+	sbuf_delete(sb);
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, sbuf_clear_test);
@@ -249,6 +269,7 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, sbuf_drain_ret0_test);
 	ATF_TP_ADD_TC(tp, sbuf_len_test);
 	ATF_TP_ADD_TC(tp, sbuf_new_fixedlen);
+	ATF_TP_ADD_TC(tp, sbuf_get_flags_test);
 #if 0
 	/* TODO */
 #ifdef HAVE_SBUF_CLEAR_FLAGS

--- a/lib/libsbuf/tests/sbuf_core_test.c
+++ b/lib/libsbuf/tests/sbuf_core_test.c
@@ -268,15 +268,14 @@ ATF_TC_WITHOUT_HEAD(sbuf_set_flags_test);
 ATF_TC_BODY(sbuf_set_flags_test, tc)
 {
 	struct sbuf *sb;
-
+	int flags;
 	sb = sbuf_new_auto();
 
 	ATF_REQUIRE_MSG(sb != NULL, 
 		"sbuf_new_auto failed: %s", strerror(errno));
-
-	ATF_REQUIRE_EQ_MSG(0, 
-		sbuf_set_flags(sb, SBUF_INCLUDENUL),
-		"sbuf_set_flags failed");
+ 
+	flags = sbuf_set_flags(sb, SBUF_INCLUDENUL);
+	sbuf_len(flags);
 
 	ATF_REQUIRE_MSG(sbuf_cat(sb, test_string) == 0,
 		"sbuf_cat failed");
@@ -286,7 +285,7 @@ ATF_TC_BODY(sbuf_set_flags_test, tc)
 		"sbuf_finish failed: %s", strerror(errno));
 		
 	ATF_CHECK_EQ(
-		strlen(test_string) + 1,
+		(ssize_t)(strlen(test_string) + 1),
 		sbuf_len(sb)
 	);
 
@@ -308,13 +307,11 @@ ATF_TC_BODY(sbuf_clear_flags_test, tc)
 	flags = sbuf_get_flags(sb);
 	ATF_REQUIRE(flags & SBUF_INCLUDENUL);
 
-	ATF_REQUIRE_EQ_MSG(0,
-		sbuf_clear_flags(sb, SBUF_INCLUDENUL),
-		"sbuf_clear_flags failed: %s", strerror(errno));
+	sbuf_clear_flags(sb, SBUF_INCLUDENUL);
 
-	flag = sbuf_get_flags(sb);
+	flags = sbuf_get_flags(sb);
 		
-	ATF_CHECK(!(flags & SBUF_INCLUDENUL) != 0);
+	ATF_CHECK((flags & SBUF_INCLUDENUL) == 0);
 
 	sbuf_delete(sb);
 }

--- a/lib/libsbuf/tests/sbuf_core_test.c
+++ b/lib/libsbuf/tests/sbuf_core_test.c
@@ -125,6 +125,8 @@ ATF_TC_BODY(sbuf_drain_ret0_test, tc)
 	    "required to return error when drain func returns 0");
 	ATF_CHECK_EQ_MSG(EDEADLK, errno,
 	    "errno required to be EDEADLK when drain func returns 0");
+	
+	sbuf_delete(sb);
 }
 
 ATF_TC_WITHOUT_HEAD(sbuf_len_test);

--- a/lib/libsbuf/tests/sbuf_core_test.c
+++ b/lib/libsbuf/tests/sbuf_core_test.c
@@ -274,9 +274,7 @@ ATF_TC_BODY(sbuf_set_flags_test, tc)
 	ATF_REQUIRE_MSG(sb != NULL, 
 		"sbuf_new_auto failed: %s", strerror(errno));
 
-	ATF_REQUIRE_EQ_MSG(0,
-		sbuf_set_flags(sb, SBUF_INCLUDENUL),
-		"sbuf_set_flags failed");
+	sbuf_set_flags(sb, SBUF_INCLUDENUL);
  
 	ATF_REQUIRE_MSG(sbuf_cat(sb, test_string) == 0,
 		"sbuf_cat failed");	
@@ -327,7 +325,7 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, sbuf_new_fixedlen);
 	ATF_TP_ADD_TC(tp, sbuf_get_flags_test);
 	ATF_TP_ADD_TC(tp, sbuf_set_flags_test);
-	ATF_TP_ADD_TC(tp, sbuf_set_clear_test);
+	ATF_TP_ADD_TC(tp, sbuf_clear_flags_test);
 #if 0
 	/* TODO */
 #ifdef 


### PR DESCRIPTION
This task was picked from the FreeBSD Junior Jobs list.

## Summary

Add test coverage for the sbuf flag-related APIs in lib/libsbuf/tests/sbuf_core_test.c

- Add tests for `sbuf_get_flags()`
- Add tests for `sbuf_set_flags()`
- Add tests for `sbuf_clear_flags()`
- Add missing  `sbuf_delete()` call in `sbuf_drain_ret0_test()`

## Testing
```sh
cd lib/libsbuf/tests
make clean
make
kyua test
```

## Results
```text
20/20 passed (0 broken, 0 failed, 0 skipped)