### PR TITLE
Syscall/linux: implement sched_getattr() - Related to Bugzilla - 297468

### DIFF
--- a/sys/compat/linux/linux_dummy.c
+++ b/sys/compat/linux/linux_dummy.c
@@ -97,7 +97,6 @@ DUMMY(process_vm_writev);
 /* Linux 3.8: */
 DUMMY(finit_module);
 DUMMY(sched_setattr);
-DUMMY(sched_getattr);
 /* Linux 3.18: */
 DUMMY(bpf);
 /* Linux 3.19: */

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -1384,19 +1384,19 @@ linux_sched_getattr(struct thread *td,
 
 	if (linux_map_sched_prio) {
 		switch (policy) {
-			case SCHED_OTHER:
-				sched_param.sched_priority = 0;
-				break;
-			case SCHED_FIFO:
-			case SCHED_RR:
-				sched_param.sched_priority =
-					(sched_param.sched_priority *
-					(LINUX_MAX_RT_PRIO - 1) +
-					(RTP_PRIO_MAX - RTP_PRIO_MIN - 1)) /
-					(RTP_PRIO_MAX - RTP_PRIO_MIN) + 1;
-				break;
-			}
-			attr.sched_priority = sched_param.sched_priority;
+		case SCHED_OTHER:
+			sched_param.sched_priority = 0;
+			break;
+		case SCHED_FIFO:
+		case SCHED_RR:
+			sched_param.sched_priority =
+				(sched_param.sched_priority *
+				(LINUX_MAX_RT_PRIO - 1) +
+				(RTP_PRIO_MAX - RTP_PRIO_MIN - 1)) /
+				(RTP_PRIO_MAX - RTP_PRIO_MIN) + 1;
+			break;
+		}
+		attr.sched_priority = sched_param.sched_priority;
 		} else {
 			attr.sched_priority =
 				sched_param.sched_priority;

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -116,6 +116,26 @@ struct l_pselect6arg {
 	l_size_t	ss_len;
 };
 
+#define LINUX_SCHED_ATTR_SIZE_VER0 48
+#define LINUX_SCHED_ATTR_SIZE_VER1 56
+/**
+ * Linux struct sched_attr
+ */
+struct linux_sched_attr {
+	l_uint 		size;
+	l_uint 		sched_policy;
+	uint64_t 	sched_flags;
+	int32_t  	sched_nice;
+	l_uint 		sched_priority;
+
+	uint64_t 	sched_runtime;
+	uint64_t 	sched_deadline;
+	uint64_t 	sched_period;
+
+	l_uint 		sched_util_min;
+	l_uint 		sched_util_max;
+};
+
 static int	linux_utimensat_lts_to_ts(struct l_timespec *,
 			struct timespec *);
 #if defined(__i386__) || (defined(__amd64__) && defined(COMPAT_LINUX32))
@@ -1326,6 +1346,65 @@ linux_sched_getscheduler(struct thread *td,
 		break;
 	}
 	return (error);
+}
+
+int
+linux_sched_getattr(struct thread *td,
+    struct linux_sched_getattr_args *args)
+{
+	struct linux_sched_attr attr;
+	struct sched_param sched_param;
+	struct thread *tdt;
+	int error, policy;
+
+	if (args->attr == NULL ||
+		args->pid < 0 ||
+		args->flags != 0 ||
+		args->size < LINUX_SCHED_ATTR_SIZE_VER0 ||
+		args->size > PAGE_SIZE)
+			return (EINVAL);
+
+	tdt = linux_tdfind(td, args->pid, -1);
+	if (tdt == NULL)
+		return (ESRCH);
+
+	error = kern_sched_getscheduler(td, tdt, &policy);
+	if (error) {
+		PROC_UNLOCK(tdt->td_proc);
+		return (error);
+	}
+
+	error = kern_sched_getparam(td, tdt, &sched_param);
+	PROC_UNLOCK(tdt->td_proc);
+	if (error)
+		return (error);
+
+	memset(&attr, 0, sizeof(attr));
+
+	attr.size = MIN(args->size, sizeof(attr));
+
+	if (linux_map_sched_prio){
+		switch (policy) {
+			case SCHED_OTHER:
+				sched_param.sched_priority = 0;
+				break;
+			case SCHED_FIFO:
+			case SCHED_RR:
+				sched_param.sched_priority =
+					(sched_param.sched_priority *
+					(LINUX_MAX_RT_PRIO - 1) +
+					(RTP_PRIO_MAX - RTP_PRIO_MIN - 1)) /
+					(RTP_PRIO_MAX - RTP_PRIO_MIN) + 1;
+				break;
+			}
+			attr.sched_priority = sched_param.sched_priority;
+		} else {
+			attr.sched_priority =
+				sched_param.sched_priority;
+		}
+
+	return (copyout(&attr, args->attr,
+	    MIN(args->size, sizeof(attr))));
 }
 
 int

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -1389,6 +1389,10 @@ linux_sched_getattr(struct thread *td,
 			break;
 		case SCHED_FIFO:
 		case SCHED_RR:
+			/*
+			 * Map [0, RTP_PRIO_MAX - RTP_PRIO_MIN] to
+			 * [1, LINUX_MAX_RT_PRIO - 1] (rounding up).
+			 */
 			sched_param.sched_priority =
 				(sched_param.sched_priority *
 				(LINUX_MAX_RT_PRIO - 1) +

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -117,7 +117,6 @@ struct l_pselect6arg {
 };
 
 #define LINUX_SCHED_ATTR_SIZE_VER0 48
-#define LINUX_SCHED_ATTR_SIZE_VER1 56
 /**
  * Linux struct sched_attr
  */

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -1403,8 +1403,7 @@ linux_sched_getattr(struct thread *td,
 				sched_param.sched_priority;
 		}
 
-	return (copyout(&attr, args->attr,
-	    MIN(args->size, sizeof(attr))));
+	return (copyout(&attr, args->attr, MIN(args->size, sizeof(attr))));
 }
 
 int

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -1382,7 +1382,7 @@ linux_sched_getattr(struct thread *td,
 
 	attr.size = MIN(args->size, sizeof(attr));
 
-	if (linux_map_sched_prio){
+	if (linux_map_sched_prio) {
 		switch (policy) {
 			case SCHED_OTHER:
 				sched_param.sched_priority = 0;


### PR DESCRIPTION
## Summary

Implement `sched_getattr()` in the Linux compatibility layer.

Replace the previous dummy implementation with support based on
FreeBSD scheduler APIs. The implementation retrieves scheduling
policy and priority information and returns them through a Linux
`sched_attr` structure.

Also remove the obsolete `DUMMY(sched_getattr)` entry from
`linux_dummy.c`.

Related to Bugzilla PR 297468:
"linuxulator: syscall sched_getattr not implemented".

## Testing

Built and installed a custom kernel.

Tested with a local Playwright script that launches Linux
Chromium, opens `https://example.com`, and retrieves the page
title:

```sh
python3.12 teste.py
```

Output:

```text
Example Domain
```

Verified that no

```text
linux: syscall sched_getattr not implemented
```
messages were emitted to the system log.

Additional validation was performed with a dedicated Linux test
program that invokes `sched_getattr()` directly via the syscall
interface.

Output:

```text
size=56
policy=0
priority=0
```

