### PR TITLE
pkgbase: make the ppp package conditional on MK_PPP

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -60,7 +60,6 @@ SUBDIR=	\
 	pam \
 	periodic \
 	powerd \
-	ppp \
 	rc \
 	rcmds \
 	resolvconf \
@@ -143,6 +142,7 @@ SUBDIR.${MK_OPENSSL}+=		openssl
 SUBDIR.${MK_PKGBOOTSTRAP}+=	pkg-bootstrap
 SUBDIR.${MK_PKGCONF}+=		pkgconf
 SUBDIR.${MK_PMC}+=		pmc
+SUBDIR.${MK_PPP}+=		ppp
 SUBDIR.${MK_QUOTAS}+=		quotacheck
 SUBDIR.${MK_RESCUE}+=		rescue
 SUBDIR.${MK_SENDMAIL}+=		sendmail libmilter


### PR DESCRIPTION
The `ppp` package is listed unconditionally in `packages/Makefile`, while the `MK_PPP` option exists and is honoured everywhere else.

Building a world with `WITHOUT_PPP=yes` and then running `make packages` fails in `create-world-packages`: nothing is staged with the `ppp` package tag, so `ppp.plist` / `ppp-dbg.plist` are never generated and make stops with

```
make[6]: don't know how to make ppp-dbg.plist. Stop
make[6]: stopped making "all" in .../packages/ppp
*** [create-world-packages] Error code 2
```

This patch moves `ppp` from the unconditional `SUBDIR` list to the option-driven list as `SUBDIR.${MK_PPP}`, keeping the entries in alphabetical order. With the change, `make packages` completes on a `WITHOUT_PPP` world; a default build is unaffected, since `MK_PPP` defaults to yes.

Found while building base packages for [BSDnas](https://github.com/bsdnas), a FreeBSD-based storage appliance whose `src.conf` has carried `WITHOUT_PPP` since its FreeNAS days; the same fix has been running there since.

Supersedes #2379, which was opened from a personal fork and without the `Signed-off-by` trailer.