### PR TITLE
rm(1): guard against accidental removal of /* and /dev

### DIFF
--- a/bin/rm/rm.c
+++ b/bin/rm/rm.c
@@ -55,6 +55,7 @@ static int	check(const char *, const char *, struct stat *);
 static int	check2(char **);
 static void	checkdot(char **);
 static void	checkslash(char **);
+static void	checkhazard(char **);
 static void	rm_file(char **);
 static void	rm_tree(char **);
 static void siginfo(int __unused);
@@ -141,6 +142,7 @@ main(int argc, char *argv[])
 
 	checkdot(argv);
 	checkslash(argv);
+	checkhazard(argv);
 	uid = geteuid();
 
 	(void)signal(SIGINFO, siginfo);
@@ -440,6 +442,31 @@ checkslash(char **argv)
 				u[0] = u[1];
 		} else {
 			++t;
+		}
+	}
+}
+
+/*
+ * Block removal of root-asterisk or /dev to
+ * prevent catastrophic system damage; added
+ * by Zhang Qiyue.
+ */
+/* Match literal "/dev", also matches root‑asterisk argument */
+#define ISDEV(a)	(strcmp((a), "/dev") == 0)
+/* Match literal "/dev/", also matches root‑asterisk‑slash argument */
+#define ISDEVSLASH(a)	(strcmp((a), "/dev/") == 0)
+static void
+checkhazard(char **argv)
+{
+	char **t;
+
+	for (t = argv; *t; ++t) {
+		if (ISDEV(*t)) {
+			errx(1, "/* or /dev may not be removed; "
+				"aborting entire removal");
+		} else if (ISDEVSLASH(*t)) {
+			errx(1, "/*/ or /dev/ may not be removed; "
+				"aborting entire removal");
 		}
 	}
 }


### PR DESCRIPTION
This change adds an early argument check in rm to reject attempts to remove `/*`, `/dev`, `/*/`, or `/dev/`.
This mitigation only targets accidental mass deletion from patterns such as `rm -rf /*`; deliberate destructive operations are not blocked.

This guard only blocks removal of the top-level `/dev` and `/dev/` directory, rather than extending the blocklist to `/bin`, `/usr` or other system hierarchies, for two primary reasons:
1. `/dev` is a required fundamental directory on a conforming POSIX system; a running system cannot function without it.
2. There are essentially no legitimate, routine use cases to delete the entire top-level `/dev` directory tree on an active, booted FreeBSD instance.

By contrast, `/bin` and `/usr` do have valid scenarios for full removal, such as chroot construction, embedded system customization, and root filesystem refactoring. Blocking them would interfere with legitimate system-administration workflows.

Additionally, an argument list containing `/dev` is a very strong signal of an accidental mass deletion originating from patterns like `rm -rf /*`. In such a failure mode, we abort the entire operation immediately instead of filtering out only the dangerous path and continuing to delete remaining items. Broken scripts or catastrophic typos should not be partially tolerated.

Tested:
- `rm -ri /*` → blocked, prints error and aborts
- `rm -ri /*/` → blocked, prints error and aborts
- `rm -ri /dev` → blocked, prints error and aborts
- `rm -ri /dev/` → blocked, prints error and aborts
- Ordinary file/directory removal continues to work as before
