### PR TITLE
usb: Fix misspelling of "frlengths" in comment

### DIFF
--- a/sys/dev/usb/usb_transfer.c
+++ b/sys/dev/usb/usb_transfer.c
@@ -1825,7 +1825,7 @@ usbd_transfer_submit(struct usb_xfer *xfer)
 	/* compute some variables */
 
 	for (x = 0; x != xfer->nframes; x++) {
-		/* make a copy of the frlenghts[] */
+		/* make a copy of the frlengths[] */
 		xfer->frlengths[x + xfer->max_frame_count] = xfer->frlengths[x];
 		/* compute total transfer length */
 		xfer->sumlen += xfer->frlengths[x];


### PR DESCRIPTION
Corrected a typo in the frame-length copy comment in usbd_transfer_setup_sub_malloc().