### PR TITLE
libusb: Fix NULL dereference when a hotplug callback deregisters itself

### DIFF
--- a/lib/libusb/libusb10_hotplug.c
+++ b/lib/libusb/libusb10_hotplug.c
@@ -408,8 +408,15 @@ int libusb_hotplug_register_callback(libusb_context *ctx,
 		TAILQ_INSERT_TAIL(&ctx->hotplug_cbh, handle, entry);
 	HOTPLUG_UNLOCK(ctx);
 
+	/*
+	 * The callback may have deregistered itself during the
+	 * LIBUSB_HOTPLUG_ENUMERATE pass above, in which case handle is
+	 * already freed.  Report the reserved id 0, which is never handed
+	 * out by the allocator above and which
+	 * libusb_hotplug_deregister_callback() treats as a no-op.
+	 */
 	if (phandle != NULL)
-		*phandle = handle->id;
+		*phandle = (handle != NULL) ? handle->id : 0;
 	return (LIBUSB_SUCCESS);
 }
 


### PR DESCRIPTION

## Summary

`libusb_hotplug_register_callback()` dereferences a freed pointer and crashes the caller. This is a regression introduced by 6bda9f26d2ed.

## Background

When `LIBUSB_HOTPLUG_ENUMERATE` is set, the function replays the newly registered callback over the already-enumerated device list. Per the libusb API a hotplug callback returning **non-zero** means *"deregister me"*, and the enumerate loop honours that by freeing the handle:

```c
if (flags & LIBUSB_HOTPLUG_ENUMERATE) {
        TAILQ_FOREACH(adev, &ctx->hotplug_devs, hotplug_entry) {
                if (libusb_hotplug_filter(ctx, handle, adev,
                    LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED) == 0)
                        continue;
                free(handle);
                handle = NULL;
                break;
        }
}