### PR TITLE
libusb: Validate arguments before dereferencing the hotplug context

### DIFF
--- a/lib/libusb/libusb10_hotplug.c
+++ b/lib/libusb/libusb10_hotplug.c
@@ -348,6 +348,12 @@ int libusb_hotplug_register_callback(libusb_context *ctx,
 
 	ctx = GET_CONTEXT(ctx);
 
+	if (ctx == NULL || cb_fn == NULL || events == 0 ||
+	    vendor_id < -1 || vendor_id > 0xffff ||
+	    product_id < -1 || product_id > 0xffff ||
+	    dev_class < -1 || dev_class > 0xff)
+		return (LIBUSB_ERROR_INVALID_PARAM);
+
 	if (ctx->no_discovery)
 		return (LIBUSB_SUCCESS);
 
@@ -357,12 +363,6 @@ int libusb_hotplug_register_callback(libusb_context *ctx,
 			ctx->usb_event_mode = usb_event_scan;
 		HOTPLUG_UNLOCK(ctx);
 	}
-
-	if (ctx == NULL || cb_fn == NULL || events == 0 ||
-	    vendor_id < -1 || vendor_id > 0xffff ||
-	    product_id < -1 || product_id > 0xffff ||
-	    dev_class < -1 || dev_class > 0xff)
-		return (LIBUSB_ERROR_INVALID_PARAM);
 
 	handle = malloc(sizeof(*handle));
 	if (handle == NULL)


### PR DESCRIPTION
## Summary

`libusb_hotplug_register_callback()` dereferences its context twice before checking whether that context is `NULL`, so the existing guard never gets the chance to fire.

## The bug

The function resolves its context and then immediately reads two fields from it, but only validates `ctx` afterwards:

```c
ctx = GET_CONTEXT(ctx);

if (ctx->no_discovery)              /* dereference #1 */
        return (LIBUSB_SUCCESS);

if (ctx->usb_event_mode == usb_event_none) {   /* dereference #2 */
        ...
}

if (ctx == NULL || cb_fn == NULL || events == 0 ||   /* too late */
    ...)
        return (LIBUSB_ERROR_INVALID_PARAM);
```

`GET_CONTEXT()` falls back to `usbi_default_context`:

```c
#define GET_CONTEXT(ctx) (((ctx) == NULL) ? usbi_default_context : (ctx))
```

That global is `NULL` before `libusb_init()` and is reset to `NULL` by `libusb_exit()` (`lib/libusb/libusb10.c:379`), so it is genuinely reachable as `NULL`.

## Impact

An application calling `libusb_hotplug_register_callback(NULL, ...)` without an initialised default context crashes on the `ctx->no_discovery` read, instead of receiving the `LIBUSB_ERROR_INVALID_PARAM` the guard was clearly written to return. The `ctx == NULL` check is live code — it is simply placed two dereferences too late to do its job.

## The fix

Move the argument validation ahead of the first dereference. No lines are added or removed; the block is only reordered. None of the validated arguments depend on the context, so no other ordering constraint is affected.

## Note for reviewers

This also means invalid arguments are now reported as `LIBUSB_ERROR_INVALID_PARAM` on a `no_discovery` context, which previously returned `LIBUSB_SUCCESS` without inspecting them.

Rejecting bad arguments regardless of the context's discovery mode seems the more defensible behaviour, but it *is* a visible behaviour change and worth an opinion.

## Relationship to #2383

Independent of the NULL-dereference fix in #2383. Both touch this function but in well-separated hunks, and they merge cleanly in either order.

## Testing

Reviewed by inspection; the change is a pure reordering of an existing block.