### PR TITLE
LinuxKPI: Run irq_work callbacks under RCU protection

### DIFF
--- a/sys/compat/linuxkpi/common/src/linux_work.c
+++ b/sys/compat/linuxkpi/common/src/linux_work.c
@@ -757,7 +757,9 @@ linux_irq_work_fn(void *context, int pending)
 {
 	struct irq_work *irqw = context;
 
+	rcu_read_lock();
 	irqw->func(irqw);
+	rcu_read_unlock();
 }
 
 static void


### PR DESCRIPTION
## Problem

Linux `irq_work` callbacks execute in interrupt context, which provides
implicit RCU read-side protection on non-PREEMPT_RT kernels. LinuxKPI
dispatches these callbacks through a taskqueue without equivalent RCU
protection. A grace period can therefore complete while a callback is still
using an RCU-protected object. This produced the i915/GuC use-after-free
reported in freebsd/drm-kmod#489.

## Change

Wrap `irqw->func(irqw)` in `rcu_read_lock()` and `rcu_read_unlock()`. The
current taskqueue selection is unchanged.

The LinuxKPI-level approach was proposed by @wulf7 in
https://github.com/freebsd/drm-kmod/issues/489#issuecomment-5379463564. He
subsequently confirmed that the RCU correction is independent of the
taskqueue-selection change discussed there:
https://github.com/freebsd/drm-kmod/issues/489#issuecomment-5385200656.

## Testing

* A purpose-built `irq_work`/RCU test failed deterministically on the
  unpatched kernel: `synchronize_rcu()` returned while the callback remained
  active.
* The same test passed 27 consecutive times with this change.
* A complete `GENERIC` kernel and module build from current `main` completed
  successfully with `-Werror`.
* drm-kmod 6.12 was built without the driver-local workaround from
  freebsd/drm-kmod#491. Thirty controlled i915 recovery cycles were requested
  while a Mesa workload was active. No panic, use-after-free, or relevant
  INVARIANTS/WITNESS diagnostic occurred, and normal rendering succeeded
  afterward.

Related: freebsd/drm-kmod#489
Base-system alternative to: freebsd/drm-kmod#491
