### PR TITLE
ports.7: Document test target

### DIFF
--- a/share/man/man7/ports.7
+++ b/share/man/man7/ports.7
@@ -25,7 +25,7 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd February 24, 2026
+.Dd August 25, 2026
 .Dt PORTS 7
 .Os
 .Sh NAME
@@ -294,6 +294,12 @@ Remove an installed port from the system, similar to
 Remove all installed ports with the same
 .Va PKGORIGIN
 from the system.
+.It Cm test
+Run the port's tests, if it has defined a
+.Va TEST_TARGET
+value or a
+.Cm do-test
+target.
 .It Cm package
 Make a binary package for the port.
 The port will be installed if it has not already been.
@@ -567,12 +573,15 @@ More information on these and other related variables may be found in
 and the
 .Fx
 Porter's Handbook.
-.Bl -tag -width "WITH_CCACHE_BUILD"
+.Bl -tag -width "WITHOUT_TESTING_PORTS"
 .It Va WITH_DEBUG
 .Pq Vt bool
 If set, debugging symbols are installed for ports binaries.
 .It Va WITH_DEBUG_PORTS
 A list of origins for which to set
+.Va WITH_DEBUG .
+.It Va WITHOUT_DEBUG_PORTS
+A list of origins for which to unset
 .Va WITH_DEBUG .
 .It Va DEBUG_FLAGS
 .Pq Default: Ql -g
@@ -581,6 +590,18 @@ Additional
 to set when
 .Va WITH_DEBUG
 is set.
+.It Va WITH_TESTING
+.Pq Vt bool
+If set, runs the
+.Cm test
+target before
+.Cm package .
+.It Va WITH_TESTING_PORTS
+A list of origins for which to set
+.Va WITH_TESTING .
+.It Va WITHOUT_TESTING_PORTS
+A list of origins for which to unset
+.Va WITH_TESTING .
 .It Va DEFAULT_VERSIONS
 Override the default variant used for ports
 with multiple concurrent versions in the tree,


### PR DESCRIPTION
While here, document WITHOUT_DEBUG_PORTS.