### PR TITLE
arm64/vmm: vgic_v3: Fix value of ICH_VTR_EL2.PREbits

### DIFF
--- a/sys/arm64/vmm/io/vgic_v3_reg.h
+++ b/sys/arm64/vmm/io/vgic_v3_reg.h
@@ -114,7 +114,7 @@
 #define ICH_VTR_EL2_PREBITS_SHIFT	26
 #define ICH_VTR_EL2_PREBITS_MASK	(0x7 << ICH_VTR_EL2_PREBITS_SHIFT)
 #define	ICH_VTR_EL2_PREBITS(x)		\
-    (((x) & ICH_VTR_EL2_PREBITS_MASK) >> ICH_VTR_EL2_PREBITS_SHIFT)
+    ((((x) & ICH_VTR_EL2_PREBITS_MASK) >> ICH_VTR_EL2_PREBITS_SHIFT) + 1)
 #define ICH_VTR_EL2_SEIS		(1 << 22)	/* System Error Interrupt (SEI) Support */
 #define ICH_VTR_EL2_A3V			(1 << 21)	/* Affinity 3 Valid */
 #define ICH_VTR_EL2_NV4			(1 << 20)	/* Direct injection of virtual interrupts. RES1 for GICv3 */


### PR DESCRIPTION
ICH_VTR_EL2.PREbits contains the number of virtual preemption bits implemented minus one, analogous to ICH_VTR_EL2.PRIbits. Unlike PRIbits, the macro for PREbits does not account for "minus one". Make the two match.