### PR TITLE
hwpmc/amd: add UMC PMC counter support

### DIFF
--- a/sys/dev/hwpmc/hwpmc_amd.c
+++ b/sys/dev/hwpmc/hwpmc_amd.c
@@ -64,7 +64,7 @@ struct amd_descr {
 };
 
 static int amd_npmcs;
-static int amd_core_npmcs, amd_l3_npmcs, amd_df_npmcs;
+static int amd_core_npmcs, amd_l3_npmcs, amd_df_npmcs, amd_umc_npmcs;
 static struct amd_descr amd_pmcdesc[AMD_NPMCS_MAX];
 struct amd_event_code_map {
 	enum pmc_event	pe_ev;	 /* enum value */
@@ -190,6 +190,8 @@ static uint64_t amd_df_allowed_mask;
 static uint64_t amd_core_extra_mask;
 static uint64_t amd_l3_extra_mask;
 static uint64_t amd_df_extra_mask;
+static uint64_t amd_umc_allowed_mask;
+static uint64_t amd_umc_extra_mask;
 
 SYSCTL_DECL(_kern_hwpmc);
 
@@ -205,6 +207,10 @@ SYSCTL_U64(_kern_hwpmc, OID_AUTO, amd_df_extra_mask, CTLFLAG_RDTUN,
     &amd_df_extra_mask, 0,
     "Extra allowed bits in AMD DF PMU control (override; default 0)");
 
+SYSCTL_U64(_kern_hwpmc, OID_AUTO, amd_umc_extra_mask, CTLFLAG_RDTUN,
+    &amd_umc_extra_mask, 0,
+    "Extra allowed bits in AMD UMC PMU control (override; default 0)");
+
 static void
 amd_init_policy(void)
 {
@@ -219,6 +225,8 @@ amd_init_policy(void)
 
 	amd_df_allowed_mask = (family <= 0x19) ?
 	    AMD_PMC_DF_FAMILY17_MASK : AMD_PMC_DF_FAMILY1A_MASK;
+
+	amd_umc_allowed_mask = AMD_PMC_UMC_MASK;
 }
 
 static uint64_t
@@ -234,6 +242,8 @@ amd_config_mask(enum sub_class subclass, uint64_t caps)
 		return (amd_l3_allowed_mask | amd_l3_extra_mask);
 	case PMC_AMD_SUB_CLASS_DATA_FABRIC:
 		return (amd_df_allowed_mask | amd_df_extra_mask);
+	case PMC_AMD_SUB_CLASS_UMC:
+		return (amd_umc_allowed_mask | amd_umc_extra_mask);
 	default:
 		return (0);
 	}
@@ -529,13 +539,20 @@ amd_start_pmc(int cpu __diagused, int ri, struct pmc *pm)
 	 * Triggered by DF counters because all DF MSRs are shared.  We need to
 	 * change the code to honor the per-package flag in the JSON event
 	 * definitions.
+	 *
+	 * UMC counters use a different stopped check (enable bit at bit 31).
 	 */
-	KASSERT(AMD_PMC_IS_STOPPED(pd->pm_evsel),
-	    ("[amd,%d] pmc%d,cpu%d: Starting active PMC \"%s\"", __LINE__,
-	    ri, cpu, pd->pm_descr.pd_name));
-
-	/* turn on the PMC ENABLE bit */
-	config = pm->pm_md.pm_amd.pm_amd_evsel | AMD_PMC_ENABLE;
+	if (pd->pm_subclass == PMC_AMD_SUB_CLASS_UMC) {
+		KASSERT(AMD_PMC_UMC_IS_STOPPED(pd->pm_evsel),
+		    ("[amd,%d] pmc%d,cpu%d: Starting active UMC PMC \"%s\"",
+		    __LINE__, ri, cpu, pd->pm_descr.pd_name));
+		config = pm->pm_md.pm_amd.pm_amd_evsel | AMD_PMC_UMC_ENABLE;
+	} else {
+		KASSERT(AMD_PMC_IS_STOPPED(pd->pm_evsel),
+		    ("[amd,%d] pmc%d,cpu%d: Starting active PMC \"%s\"",
+		    __LINE__, ri, cpu, pd->pm_descr.pd_name));
+		config = pm->pm_md.pm_amd.pm_amd_evsel | AMD_PMC_ENABLE;
+	}
 
 	PMCDBG1(MDP, STA, 2, "amd-start config=0x%x", config);
 
@@ -560,11 +577,21 @@ amd_stop_pmc(int cpu __diagused, int ri, struct pmc *pm)
 
 	pd = &amd_pmcdesc[ri];
 
+	PMCDBG1(MDP, STO, 1, "amd-stop ri=%d", ri);
+
+	if (pd->pm_subclass == PMC_AMD_SUB_CLASS_UMC) {
+		KASSERT(!AMD_PMC_UMC_IS_STOPPED(pd->pm_evsel),
+		    ("[amd,%d] UMC PMC%d, CPU%d \"%s\" already stopped",
+		    __LINE__, ri, cpu, pd->pm_descr.pd_name));
+		/* UMC counters have no overflow NMI; stop is immediate. */
+		config = pm->pm_md.pm_amd.pm_amd_evsel & ~AMD_PMC_UMC_ENABLE;
+		wrmsr(pd->pm_evsel, config);
+		return (0);
+	}
+
 	KASSERT(!AMD_PMC_IS_STOPPED(pd->pm_evsel),
 	    ("[amd,%d] PMC%d, CPU%d \"%s\" already stopped",
 		__LINE__, ri, cpu, pd->pm_descr.pd_name));
-
-	PMCDBG1(MDP, STO, 1, "amd-stop ri=%d", ri);
 
 	/* turn off the PMC ENABLE bit */
 	config = pm->pm_md.pm_amd.pm_amd_evsel & ~AMD_PMC_ENABLE;
@@ -758,7 +785,7 @@ amd_get_msr(int ri, uint32_t *msr)
 	} else if (ri < amd_core_npmcs + amd_l3_npmcs) {
 		/* ECX 10-15: L3 Cache counters */
 		*msr = 10 + (ri - amd_core_npmcs);
-	} else {
+	} else if (ri < amd_core_npmcs + amd_l3_npmcs + amd_df_npmcs) {
 		/* ECX 6-9: DF counters 0-3
 		 * ECX 16-27: DF counters 4-15 */
 		df_idx = ri - amd_core_npmcs - amd_l3_npmcs;
@@ -768,6 +795,9 @@ amd_get_msr(int ri, uint32_t *msr)
 			*msr = 16 + (df_idx - 4);
 		else
 			return (EINVAL);
+	} else {
+		/* UMC counters are not accessible via RDPMC. */
+		return (EINVAL);
 	}
 	return (0);
 }
@@ -952,6 +982,7 @@ pmc_amd_initialize(void)
 	enum pmc_cputype cputype;
 	int ncpus, nclasses, i;
 	int family, model, stepping;
+	int amd_umc_nodes, amd_umc_per_node;
 	int error;
 
 	/*
@@ -1002,6 +1033,7 @@ pmc_amd_initialize(void)
 		if (regs[1] != 0) {
 			amd_core_npmcs = EXTPERFMON_CORE_PMCS(regs[1]);
 			amd_df_npmcs = EXTPERFMON_DF_PMCS(regs[1]);
+			amd_umc_npmcs = EXTPERFMON_UMC_PMCS(regs[1]);
 		}
 	}
 
@@ -1062,6 +1094,31 @@ pmc_amd_initialize(void)
 			d->pm_subclass = PMC_AMD_SUB_CLASS_DATA_FABRIC;
 		}
 		amd_npmcs += amd_df_npmcs;
+	}
+
+	if (amd_umc_npmcs > 0) {
+		/*
+		 * UMC counters are per Data Fabric node. regs[2] (ECX of
+		 * CPUID 0x80000022) is a bitmask of nodes present; popcntq()
+		 * gives the node count.  Divide total PMCs evenly per node.
+		 */
+		amd_umc_nodes = (regs[2] != 0) ? popcntq(regs[2]) : 1;
+		amd_umc_per_node = amd_umc_npmcs / amd_umc_nodes;
+		if (amd_umc_per_node == 0)
+			amd_umc_per_node = amd_umc_npmcs;
+		for (i = 0; i < amd_umc_npmcs; i++) {
+			d = &amd_pmcdesc[amd_npmcs + i];
+			snprintf(d->pm_descr.pd_name, PMC_NAME_MAX,
+			    "K8-UMC%d-%d", i / amd_umc_per_node,
+			    i % amd_umc_per_node);
+			d->pm_descr.pd_class = PMC_CLASS_K8;
+			d->pm_descr.pd_caps = AMD_PMC_UMC_CAPS;
+			d->pm_descr.pd_width = 48;
+			d->pm_evsel = AMD_PMC_UMC_BASE + 2 * i;
+			d->pm_perfctr = AMD_PMC_UMC_BASE + 2 * i + 1;
+			d->pm_subclass = PMC_AMD_SUB_CLASS_UMC;
+		}
+		amd_npmcs += amd_umc_npmcs;
 	}
 
 	/*

--- a/sys/dev/hwpmc/hwpmc_amd.h
+++ b/sys/dev/hwpmc/hwpmc_amd.h
@@ -35,6 +35,7 @@
 #define	CPUID_EXTPERFMON	0x80000022
 #define	EXTPERFMON_CORE_PMCS(x)	((x) & 0x0F)
 #define	EXTPERFMON_DF_PMCS(x)	(((x) >> 10) & 0x3F)
+#define	EXTPERFMON_UMC_PMCS(x)	(((x) >> 16) & 0xFF)
 
 /* AMD K8 PMCs */
 #define	AMD_PMC_EVSEL_0		0xC0010000
@@ -170,9 +171,33 @@
 	 AMD_PMC_DF2_TO_EVENTMASK(0x7fff) |				\
 	 AMD_PMC_DF2_TO_UNITMASK(0xfff))
 
+/*
+ * UMC (Unified Memory Controller) PMCs.
+ * Enable bit is at bit 31, unlike core/L3/DF counters.
+ *
+ * Refer to PPR for AMD Family 1Ah Model 02h (57238 Rev 3.10, March 2026).
+ * MSR layout: evsel at UMC_BASE + 2*i, perfctr at UMC_BASE + 2*i + 1.
+ */
+#define	AMD_PMC_UMC_BASE	0xC0010800
+#define	AMD_PMC_UMC_MAX		256
+
+#define	AMD_PMC_UMC_CAPS	(PMC_CAP_READ | PMC_CAP_WRITE | \
+	PMC_CAP_QUALIFIER | PMC_CAP_DOMWIDE)
+
+#define	AMD_PMC_UMC_ENABLE	0x80000000ULL	/* bit 31 (moved) */
+#define	AMD_PMC_UMC_RDWRMASK	0x00000300ULL	/* bits [9:8] rd/wr filter */
+#define	AMD_PMC_UMC_EVENTMASK	0x000000FFULL	/* bits [7:0] event */
+#define	AMD_PMC_UMC_MASK	(AMD_PMC_UMC_ENABLE | AMD_PMC_UMC_RDWRMASK | \
+				 AMD_PMC_UMC_EVENTMASK)
+
+#define	AMD_PMC_UMC_IS_STOPPED(evsel) \
+	((rdmsr((evsel)) & AMD_PMC_UMC_ENABLE) == 0)
+#define	AMD_PMC_UMC_TO_EVENTMASK(x)	((x) & AMD_PMC_UMC_EVENTMASK)
+#define	AMD_PMC_UMC_TO_RDWRMASK(x)	(((x) & 0x3) << 8)
+
 #define	AMD_NPMCS_K8		4
 #define AMD_NPMCS_MAX		(AMD_PMC_CORE_MAX + AMD_PMC_L3_MAX + \
-				 AMD_PMC_DF_MAX)
+				 AMD_PMC_DF_MAX + AMD_PMC_UMC_MAX)
 
 #define AMD_PMC_IS_STOPPED(evsel) ((rdmsr((evsel)) & AMD_PMC_ENABLE) == 0)
 #define AMD_PMC_HAS_OVERFLOWED(pmc) ((rdpmc(pmc) & (1ULL << 47)) == 0)
@@ -183,7 +208,8 @@
 enum sub_class {
 	PMC_AMD_SUB_CLASS_CORE,
 	PMC_AMD_SUB_CLASS_L3_CACHE,
-	PMC_AMD_SUB_CLASS_DATA_FABRIC
+	PMC_AMD_SUB_CLASS_DATA_FABRIC,
+	PMC_AMD_SUB_CLASS_UMC
 };
 
 struct pmc_md_amd_op_pmcallocate {


### PR DESCRIPTION
## Summary

AMD's Unified Memory Controller (UMC) exposes per-node performance
counters accessible via MSRs starting at 0xC0010800 (evsel at BASE +
2*i, perfctr at BASE + 2*i + 1). The counter count and node topology
are reported by CPUID leaf 0x80000022: EBX[23:16] gives the total PMC
count, ECX is a bitmask of Data Fabric nodes present.

UMC counters differ from core/L3/DF counters in two important ways:

- The enable bit is at bit 31 (0x80000000) rather than the standard
  position used by other AMD counter types.
- UMC counters do not trigger overflow NMIs, so the stop path needs no
  overflow-wait loop.

Counters are registered as `K8-UMC<node>-<i>`, where the node index is
derived from `popcntq(ECX)` to identify which Data Fabric node (and
thus which memory controller) a counter belongs to. On single-node
systems the naming is `K8-UMC0-0` .. `K8-UMC0-N`.

UMC MSRs are not addressable via RDPMC, so `amd_get_msr()` returns
EINVAL for the UMC subclass rather than falling through to the DF
branch.

This is the kernel-side change. A companion libpmc change (userland
event mapping and allocator) will follow as a separate PR.

## Test plan

Tested on EPYC 9654 (Zen 4, `AuthenticAMD-25-11-1`):

- [x] CPUID 0x80000022 reports 4 UMC PMCs across 1 node
- [x] Counters register as `K8-UMC0-{0..3}` (visible in dmesg as `K8/32`: 6 core + 6 L3 + 16 DF + 4 UMC)
- [x] 4 simultaneous system-wide counting PMCs allocate successfully
- [x] A 5th allocation correctly returns EINVAL
- [x] `buildkernel GENERIC` completes cleanly with `-Werror`

Sponsored by:	AMD