### PR TITLE
if_bridge: Fix NULL softc dereference in bridge_input()

### DIFF
--- a/sys/net/if_bridge.c
+++ b/sys/net/if_bridge.c
@@ -2857,11 +2857,8 @@ bridge_input(struct ifnet *ifp, struct mbuf *m)
 	/* We need the Ethernet header later, so make sure we have it now. */
 	if (m->m_len < ETHER_HDR_LEN) {
 		m = m_pullup(m, ETHER_HDR_LEN);
-		if (m == NULL) {
-			if_inc_counter(sc->sc_ifp, IFCOUNTER_IERRORS, 1);
-			m_freem(m);
+		if (m == NULL)
 			return (NULL);
-		}
 	}
 
 	eh = mtod(m, struct ether_header *);


### PR DESCRIPTION
In CURRENT bridge_input, sc is initialized to NULL and doesn't get resolved until after the Ethernet header pullup. So the pullup's failure path ends up dereferencing the NULL sc when bumping up IFCOUNTER_IERRORS.

The m_freem call right under it is redundant as the failure path in m_pullup already freed the chain.

Drop both lines, matching what we have in bridge_output.

ether_input_internal() discards frames shorter than ETHER_HDR_LEN before the bridge hook, so it is unlikely that it will fire.

We still keep the guard as lagg(4) and ng_ether(4) may replace the mbuf before the bridge hook.