### PR TITLE
sbin/dump: Add test for live UFS2 dumps with SUJ

### DIFF
--- a/sbin/dump/Makefile
+++ b/sbin/dump/Makefile
@@ -10,6 +10,8 @@
 #	DEBUG			use local directory to find ddate and dumpdates
 #	TDEBUG			trace out the process forking
 
+.include <src.opts.mk>
+
 PACKAGE=ufs
 PROG=	dump
 CONFS=	/dev/null
@@ -23,5 +25,8 @@ MAN=	dump.8
 LIBADD=	ufs
 MLINKS=	dump.8 rdump.8
 WARNS?=	2
+
+HAS_TESTS=
+SUBDIR.${MK_TESTS}+=	tests
 
 .include <bsd.prog.mk>

--- a/sbin/dump/tests/Makefile
+++ b/sbin/dump/tests/Makefile
@@ -1,0 +1,3 @@
+PACKAGE=	tests
+ATF_TESTS_SH+=	dump_test
+.include <bsd.test.mk>

--- a/sbin/dump/tests/dump_test.sh
+++ b/sbin/dump/tests/dump_test.sh
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2026 Mitsutaka Fujita
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+atf_test_case ufs2_suj_live cleanup
+
+ufs2_suj_live_head()
+{
+        atf_set descr "Verify dump -L works on a live UFS2 filesystem with SUJ"
+        atf_set require.user root
+}
+
+ufs2_suj_live_body()
+{
+        atf_check -o save:md mdconfig -a -t swap -s 1g
+        md=/dev/$(cat md)
+
+        atf_check -o ignore -e ignore \
+                newfs -t -O 2 -U -j "${md}"
+
+        atf_check mkdir mnt
+        atf_check mkdir restore
+        atf_check mount "${md}" mnt
+
+        echo "Hello FreeBSD dump test" > mnt/testfile
+
+        atf_check -s exit:0 -o ignore -e ignore \
+                dump -0Laf dumpfile "${md}"
+
+        cd restore
+
+        atf_check -s exit:0 -o ignore -e ignore \
+                restore -rf ../dumpfile
+
+        atf_check cmp testfile ../mnt/testfile
+}
+
+ufs2_suj_live_cleanup()
+{
+        if [ -d ./mnt ]; then
+                umount ./mnt
+        fi
+
+        if [ -d restore ]; then
+                # restore(8) recreates .sujournal with flags that prevent its removal.
+                chflags -R noschg,nosunlink restore 2>/dev/null || true
+        fi
+
+        if [ -s md ]; then
+                mdconfig -d -u "$(cat md)"
+        fi
+}
+
+atf_init_test_cases()
+{
+        atf_add_test_case ufs2_suj_live
+}


### PR DESCRIPTION
`dump -L` uses UFS snapshots when dumping a mounted filesystem.

UFS2 filesystems with soft updates journaling are supported by the snapshot mechanism, but `dump(8)` currently has no regression test covering this combination.

This change adds an ATF test that creates a UFS2 filesystem with SUJ enabled, performs a live level-0 dump, restores it, and verifies that the restored file contents match the original.

Tested with:

`kyua test sbin/dump/dump_test:ufs2_suj_live`

The test was run repeatedly and verified to leave no md(4) devices or mounts behind.
