### PR TITLE
localtime compatibility with upstream

### DIFF
--- a/contrib/tzcode/localtime.c
+++ b/contrib/tzcode/localtime.c
@@ -1987,23 +1987,6 @@ tzset(void)
 }
 #endif
 
-#ifdef __FreeBSD__
-void
-freebsd13_tzsetwall(void)
-{
-  monotime_t now = get_monotonic_time();
-  int err = lock();
-  if (0 < err) {
-    errno = err;
-    return;
-  }
-  tzset_unlocked(!err, true, now);
-  unlock(!err);
-}
-__sym_compat(tzsetwall, freebsd13_tzsetwall, FBSD_1.0);
-__warn_references(tzsetwall,
-    "warning: tzsetwall() is deprecated, use tzset() instead.");
-#endif /* __FreeBSD__ */
 static void
 gmtcheck1(void)
 {

--- a/contrib/tzcode/localtime.c
+++ b/contrib/tzcode/localtime.c
@@ -929,9 +929,6 @@ tzloadbody(char const *name, struct state *sp, char tzloadflags,
 		name = TZDEFAULT;
 		if (! name)
 		  return EINVAL;
-#ifdef __FreeBSD__
-		tzloadflags &= ~TZLOAD_FROMENV;
-#endif /* __FreeBSD__ */
 	}
 
 	if (name[0] == ':')

--- a/lib/libc/stdtime/Makefile.inc
+++ b/lib/libc/stdtime/Makefile.inc
@@ -2,7 +2,7 @@
 
 .PATH:	${LIBC_SRCTOP}/stdtime ${SRCTOP}/contrib/tzcode
 
-TZCODE_SRCS=	asctime.c difftime.c localtime.c
+TZCODE_SRCS=	asctime.c difftime.c localtime-compat.c
 STDTIME_SRCS=	strftime.c strptime.c timelocal.c
 SRCS+=		${TZCODE_SRCS} ${STDTIME_SRCS} time32.c
 
@@ -15,9 +15,9 @@ CFLAGS.${src}+=	-I${SRCTOP}/contrib/tzcode -include tzconfig.h
 CFLAGS.${src}+=	-I${LIBC_SRCTOP}/stdtime
 .endfor
 
-CFLAGS.localtime.c+= -DALL_STATE -DTHREAD_SAFE
+CFLAGS.localtime-compat.c+= -DALL_STATE -DTHREAD_SAFE
 .if ${MK_DETECT_TZ_CHANGES} != "no"
-CFLAGS.localtime.c+= -DDETECT_TZ_CHANGES
+CFLAGS.localtime-compat.c+= -DDETECT_TZ_CHANGES
 CFLAGS.Version.map+= -DDETECT_TZ_CHANGES
 .endif
 

--- a/lib/libc/stdtime/localtime-compat.c
+++ b/lib/libc/stdtime/localtime-compat.c
@@ -1,0 +1,21 @@
+/* Like upstream localtime.c, but also define tzsetwall compat symbol.
+   This file is in the public domain, so clarified as of 1996-06-05 by
+   Arthur David Olson.  */
+
+#include "localtime.c"
+
+void
+freebsd13_tzsetwall(void)
+{
+  monotime_t now = get_monotonic_time();
+  int err = lock();
+  if (0 < err) {
+    errno = err;
+    return;
+  }
+  tzset_unlocked(!err, true, now);
+  unlock(!err);
+}
+__sym_compat(tzsetwall, freebsd13_tzsetwall, FBSD_1.0);
+__warn_references(tzsetwall,
+    "warning: tzsetwall() is deprecated, use tzset() instead.");


### PR DESCRIPTION
The two patches in this pull request adjust contrib/tzcode/localtime.c so that it is identical to upstream (as of the current TZDB release, 2026c). This should improve coordination of FreeBSD's localtime implementation with upstream. TZDB 2026d (not yet released) is planned to have some patches will make localtime work better in the presence of adversarial TZif files, and when that happens the goal is for the 2026d localtime.c to drop in unchanged.