### PR TITLE
libusb: Fixes .pc files to link to pthread

### DIFF
--- a/lib/libusb/libusb-0.1.pc.in
+++ b/lib/libusb/libusb-0.1.pc.in
@@ -7,5 +7,5 @@ includedir=@includedir@
 Name: libusb-0.1
 Description: Library that abstracts ways to access USB devices (v0.1)
 Version: 0.1.0
-Libs: -L${libdir} -lusb
+Libs: -L${libdir} -lusb -lpthread
 Cflags: -I${includedir}

--- a/lib/libusb/libusb-1.0.pc.in
+++ b/lib/libusb/libusb-1.0.pc.in
@@ -7,5 +7,5 @@ includedir=@includedir@
 Name: libusb-1.0
 Description: Library that abstracts ways to access USB devices (v1.0)
 Version: 1.0.27
-Libs: -L${libdir} -lusb
+Libs: -L${libdir} -lusb -lpthread
 Cflags: -I${includedir}

--- a/lib/libusb/libusb-2.0.pc.in
+++ b/lib/libusb/libusb-2.0.pc.in
@@ -7,5 +7,5 @@ includedir=@includedir@
 Name: libusb-2.0
 Description: Library that abstracts ways to access USB devices (v2.0)
 Version: 2.0.0
-Libs: -L${libdir} -lusb
+Libs: -L${libdir} -lusb -lpthread
 Cflags: -I${includedir}


### PR DESCRIPTION
As seen in the libusb Makefile, libusb is linked with the pthread library.
As a side note, the issue that I was having with this .pc not giving the pthread dependency was due to a broken symlink: `/usr/lib/libusb.so -> /usr/lib/libusb.so.3` while there was just `/usr/lib/libusb.so.4` .
Maybe we should verify that it won't break stuff while statically linking to `/usr/lib/libusb.a`