### PR TITLE
ichsmb: Enable block buffer mode for Elkhart Lake

### DIFF
--- a/sys/dev/ichsmb/ichsmb_pci.c
+++ b/sys/dev/ichsmb/ichsmb_pci.c
@@ -251,6 +251,7 @@ static const struct pci_device_table ichsmb_devices[] = {
 	  .driver_data = (uintptr_t)ICHSMB_FEATURE_BLOCK_BUFFER,
 	  PCI_DESCR("Intel Tiger Lake SMBus controller") },
 	{ PCI_DEV(PCI_VENDOR_INTEL, ID_ELKHARTLAKE),
+	  .driver_data = (uintptr_t)ICHSMB_FEATURE_BLOCK_BUFFER,
 	  PCI_DESCR("Intel Elkhart Lake SMBus controller") },
 	{ PCI_DEV(PCI_VENDOR_INTEL, ID_GEMINILAKE),
 	  .driver_data = (uintptr_t)ICHSMB_FEATURE_BLOCK_BUFFER,


### PR DESCRIPTION
Elkhart Lake SMBus controllers support the 32-byte block buffer used by SMBus block process calls. Set ICHSMB_FEATURE_BLOCK_BUFFER for the Elkhartlake PCI ID so ichsmb_bpcall() is not rejected with SMB_ENOTSUPP.