### PR TITLE
sys/conf/options: Add WITNESS_LOCK_CHILDCOUNT

### DIFF
--- a/share/man/man4/witness.4
+++ b/share/man/man4/witness.4
@@ -21,7 +21,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 26, 2026
+.Dd September 1, 2026
 .Dt WITNESS 4
 .Os
 .Sh NAME
@@ -30,6 +30,7 @@
 .Sh SYNOPSIS
 .Cd options WITNESS
 .Cd options WITNESS_COUNT
+.Cd options WITNESS_LOCK_CHILDCOUNT=number
 .Cd options WITNESS_KDB
 .Cd options WITNESS_NO_VNODE
 .Cd options WITNESS_SKIPSPIN
@@ -69,6 +70,17 @@ It can also be set from the
 via the
 .Va debug.witness.witness_count
 environment variable.
+.Pp
+The
+.Dv WITNESS_LOCK_CHILDCOUNT
+kernel option specifies the number of entries in the statically allocated
+pool used by
+.Nm
+to record lock-order relationships.
+The value must be greater than zero.
+The default is 2048.
+Increasing this value permits more relationships to be tracked at the cost
+of additional kernel memory.
 .Pp
 The
 .Dv WITNESS_NO_VNODE

--- a/sys/conf/options
+++ b/sys/conf/options
@@ -702,6 +702,7 @@ WITNESS_KDB		opt_witness.h
 WITNESS_NO_VNODE	opt_witness.h
 WITNESS_SKIPSPIN	opt_witness.h
 WITNESS_COUNT		opt_witness.h
+WITNESS_LOCK_CHILDCOUNT		opt_witness.h
 OPENSOLARIS_WITNESS	opt_global.h
 
 EPOCH_TRACE		opt_global.h

--- a/sys/kern/subr_witness.c
+++ b/sys/kern/subr_witness.c
@@ -148,7 +148,13 @@
  * probably be safe for the most part, but it's still a SWAG.
  */
 #define	LOCK_NCHILDREN	5
-#define	LOCK_CHILDCOUNT	2048
+#ifndef WITNESS_LOCK_CHILDCOUNT
+#define	WITNESS_LOCK_CHILDCOUNT	2048
+#endif
+
+#if WITNESS_LOCK_CHILDCOUNT < 1
+  #error "WITNESS_LOCK_CHILDCOUNT must be greater than zero"
+#endif
 
 #define	MAX_W_NAME	64
 
@@ -484,7 +490,7 @@ SYSCTL_INT(_debug_witness, OID_AUTO, sleep_cnt, CTLFLAG_RD, &w_sleep_cnt, 0,
 
 static struct witness *w_data;
 static uint8_t **w_rmatrix;
-static struct lock_list_entry w_locklistdata[LOCK_CHILDCOUNT];
+static struct lock_list_entry w_locklistdata[WITNESS_LOCK_CHILDCOUNT];
 static struct witness_hash w_hash;	/* The witness hash table. */
 static u_long w_sz;	/* Witness startup memory allocation size */
 
@@ -928,7 +934,7 @@ witness_startup(void *mem)
 		    (witness_count + 1));
 	}
 
-	for (i = 0; i < LOCK_CHILDCOUNT; i++)
+	for (i = 0; i < WITNESS_LOCK_CHILDCOUNT; i++)
 		witness_lock_list_free(&w_locklistdata[i]);
 	witness_init_hash_tables();
 
@@ -1611,7 +1617,7 @@ witness_checkorder(struct lock_object *lock, int flags, const char *file,
 			int trace;
 			bool pstackv;
 
-			MPASS(j < LOCK_CHILDCOUNT * LOCK_NCHILDREN);
+			MPASS(j < WITNESS_LOCK_CHILDCOUNT * LOCK_NCHILDREN);
 			lock1 = &lle->ll_children[i];
 
 			/*


### PR DESCRIPTION
Make the witness LOCK_CHILDCOUNT a configurable kernel option. On machines with a very high core count the default value is too low, leading to witness exhaustion after boot.