### PR TITLE
arm64: Fix definition of CLIDR_EL1_op0

### DIFF
--- a/sys/arm64/include/armreg.h
+++ b/sys/arm64/include/armreg.h
@@ -205,7 +205,7 @@
 
 /* CLIDR_EL1 - Cache level ID register */
 #define	CLIDR_EL1_REG		MRS_REG_ALT_NAME(CLIDR_EL1)
-#define	CLIDR_EL1_op0		2
+#define	CLIDR_EL1_op0		3
 #define	CLIDR_EL1_op1		1
 #define	CLIDR_EL1_CRn		0
 #define	CLIDR_EL1_CRm		0


### PR DESCRIPTION
Fix incorrect opcode on CLIDR_EL1.