### PR TITLE
cam: Change ccb spare field for use with the I/O scheduler

### DIFF
--- a/sys/cam/cam_ccb.h
+++ b/sys/cam/cam_ccb.h
@@ -341,7 +341,7 @@ typedef union {
 } ccb_spriv_area;
 
 typedef struct {
-	struct timeval	*etime;
+	uintptr_t	sched_data;
 	uintptr_t	sim_data;
 	uintptr_t	periph_data;
 } ccb_qos_area;


### PR DESCRIPTION
etime is a spare ccb field that is not in use, this changes the field into a uintptr_t and renames it for use by the I/O scheduler.  There should be no change to the ccb structure size.

Sponsored by: Netflix