### PR TITLE
bhyve: fix build with WITHOUT_CAPSICUM

### DIFF
--- a/usr.sbin/bhyve/net_backend_netgraph.c
+++ b/usr.sbin/bhyve/net_backend_netgraph.c
@@ -28,12 +28,14 @@
 #ifndef WITHOUT_CAPSICUM
 #include <sys/capsicum.h>
 #endif
+#include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
 
 #ifndef WITHOUT_CAPSICUM
 #include <capsicum_helpers.h>
 #endif
+#include <fcntl.h>
 #include <err.h>
 #include <netgraph.h>
 #include <string.h>


### PR DESCRIPTION
This PR fixes a build failure when `bhyve` is compiled with `WITHOUT_CAPSICUM`.

`net_backend_netgraph.c` uses and several definitions from `fcntl.h` and `sys/param.h`, but the required headers are only indirectly available when Capsicum is enabled.

The patch includes <fcntl.h> and <sys/param.h> when WITHOUT_CAPSICUM is defined.