### PR TITLE
ig4: Add Lunar Lake-M I2C controllers 4 and 5

### DIFF
--- a/sys/dev/ichiic/ig4_pci.c
+++ b/sys/dev/ichiic/ig4_pci.c
@@ -196,6 +196,8 @@ static int ig4iic_pci_detach(device_t dev);
 #define PCI_CHIP_LUNARLAKE_M_I2C_1      0xa8798086
 #define PCI_CHIP_LUNARLAKE_M_I2C_2      0xa87a8086
 #define PCI_CHIP_LUNARLAKE_M_I2C_3      0xa87b8086
+#define PCI_CHIP_LUNARLAKE_M_I2C_4      0xa8508086
+#define PCI_CHIP_LUNARLAKE_M_I2C_5      0xa8518086
 #define PCI_CHIP_PANTHERLAKE_H_I2C_0    0xe4788086
 #define PCI_CHIP_PANTHERLAKE_H_I2C_1    0xe4798086
 #define PCI_CHIP_PANTHERLAKE_H_I2C_2    0xe4508086
@@ -342,6 +344,8 @@ static struct ig4iic_pci_device ig4iic_pci_devices[] = {
 	{ PCI_CHIP_LUNARLAKE_M_I2C_1, "Intel Lunar Lake-M I2C Controller-1", IG4_TIGERLAKE},
 	{ PCI_CHIP_LUNARLAKE_M_I2C_2, "Intel Lunar Lake-M I2C Controller-2", IG4_TIGERLAKE},
 	{ PCI_CHIP_LUNARLAKE_M_I2C_3, "Intel Lunar Lake-M I2C Controller-3", IG4_TIGERLAKE},
+	{ PCI_CHIP_LUNARLAKE_M_I2C_4, "Intel Lunar Lake-M I2C Controller-4", IG4_TIGERLAKE},
+	{ PCI_CHIP_LUNARLAKE_M_I2C_5, "Intel Lunar Lake-M I2C Controller-5", IG4_TIGERLAKE},
 	{ PCI_CHIP_PANTHERLAKE_H_I2C_0, "Intel Panther Lake-H I2C Controller-0", IG4_TIGERLAKE},
 	{ PCI_CHIP_PANTHERLAKE_H_I2C_1, "Intel Panther Lake-H I2C Controller-1", IG4_TIGERLAKE},
 	{ PCI_CHIP_PANTHERLAKE_H_I2C_2, "Intel Panther Lake-H I2C Controller-2", IG4_TIGERLAKE},


### PR DESCRIPTION
Commit 851dffef532a (#1995) added the Lunar Lake-M I2C controllers 0-3 (`0xa878`-`0xa87b`), which live on PCI device `0x15`. The platform has two more controllers, `0xa850` and `0xa851` on PCI device `0x19`, reported by Intel as I2C #&NoBreak;4 and #&NoBreak;5. Arrow Lake-U already lists both of its ranges (`0x777x` and `0x775x`), and so does Panther Lake-H.

This is not just completeness. On an HP OmniBook X Flip 16-as0xxx (Core Ultra 9 288V) the firmware enables only four of the six controllers, and **both HID devices sit on the two that are missing** — with `main` as it stands the machine has no touchscreen and no touchpad:

- `00:19.0` (`0xa850`, I2C #&NoBreak;4) → ELAN2514 touchscreen
- `00:19.1` (`0xa851`, I2C #&NoBreak;5) → SYNA3503 touchpad

`0xa879` and `0xa87b` are not present at all, and `0xa87a` only carries the CS35L41 audio amplifiers, so none of the four currently supported IDs is of any use on this machine.

### Testing

Two `ig4.ko` variants were built on 15.1-RELEASE with the current `main` ID table backported: one with controllers 0-3 only (equivalent to `main` today) and one with this patch on top.

**Before** — controllers 0-3 only:

```
ig4iic0: <Intel Lunar Lake-M I2C Controller-0> at device 21.0 on pci0
iicbus0: <Philips I2C bus (ACPI-hinted)> on ig4iic0
ig4iic1: <Intel Lunar Lake-M I2C Controller-2> at device 21.2 on pci0
iicbus1: <Philips I2C bus (ACPI-hinted)> on ig4iic1
iicbus1: <unknown card> at addr 0x40
```

```
ig4iic0@pci0:0:21:0: class=0x0c8000 vendor=0x8086 device=0xa878 subvendor=0x103c subdevice=0x8da1
ig4iic1@pci0:0:21:2: class=0x0c8000 vendor=0x8086 device=0xa87a subvendor=0x103c subdevice=0x8da1
none8@pci0:0:25:0:   class=0x0c8000 vendor=0x8086 device=0xa850 subvendor=0x103c subdevice=0x8da1
none9@pci0:0:25:1:   class=0x0c8000 vendor=0x8086 device=0xa851 subvendor=0x103c subdevice=0x8da1
```

`0xa850` and `0xa851` get no driver, and no `iichid` child is created anywhere.

**After** — with this patch:

```
ig4iic2: <Intel Lunar Lake-M I2C Controller-4> at device 25.0 on pci0
ig4iic2: Using MSI
iicbus2: <Philips I2C bus (ACPI-hinted)> on ig4iic2
iichid0: <ELAN2514:04 04F3:43EF I2C HID device> at addr 0x10 irq 108 on iicbus2
hidbus1: <HID bus> on iichid0
ig4iic3: <Intel Lunar Lake-M I2C Controller-5> at device 25.1 on pci0
ig4iic3: Using MSI
iicbus3: <Philips I2C bus (ACPI-hinted)> on ig4iic3
iichid1: <SYNA3503:00 06CB:CFC6 I2C HID device> at addr 0x2c irq 84 on iicbus3
hidbus2: <HID bus> on iichid1
hmt0: <ELAN2514:04 04F3:43EF TouchScreen> on hidbus1
hmt0: Multitouch touchscreen with 0 external buttons
hmt0: 10 contacts with [CWH] properties. Report range [0:0] - [3984:2256]
hmt1: <SYNA3503:00 06CB:CFC6 TouchPad> on hidbus2
hmt1: Multitouch touchpad with 0 external buttons, click-pad
hmt1: 5 contacts with [C] properties. Report range [0:0] - [1572:984]
```

Both the touchscreen and the touchpad work.

### Notes

These controllers use the Tiger Lake revision of the I2C IP like the other four; Linux routes `0xa850`/`0xa851` through the same `ehl_i2c_info` as `0xa878`-`0xa87b` in `drivers/mfd/intel-lpss-pci.c`.

cc @Defenso-EBO, who added the first four.
