### PR TITLE
vfs: fix vn_io_fault1() resume point past 2 GiB

### DIFF
--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -1520,8 +1520,21 @@ vn_io_fault1(struct vnode *vp, struct uio *uio, struct vn_io_fault_args *args,
 		goto out;
 
 	atomic_add_long(&vn_io_faults_cnt, 1);
+	/*
+	 * Advance the clone to the redo point.  uiomove(9) takes an int
+	 * byte count, so the advance has to be split when the first attempt
+	 * transferred INT_MAX bytes or more before faulting; passing the
+	 * size_t difference directly truncates it, the clone is then not
+	 * (or not fully) advanced, and the retry loop below re-does I/O
+	 * that was already accounted in uio, which ends with a negative
+	 * uio_resid and a read(2)/write(2) return value larger than the
+	 * request.
+	 */
 	uio_clone->uio_segflg = UIO_NOCOPY;
-	uiomove(NULL, resid - uio->uio_resid, uio_clone);
+	for (adv = resid - uio->uio_resid; adv > 0; adv -= cnt) {
+		cnt = adv > INT_MAX ? INT_MAX : (int)adv;
+		uiomove(NULL, cnt, uio_clone);
+	}
 	uio_clone->uio_segflg = uio->uio_segflg;
 
 	saveheld = curthread_pflags_set(TDP_UIOHELD);


### PR DESCRIPTION
`vn_io_fault1()` advances its clone to the EFAULT resume point with `uiomove(NULL, resid - uio->uio_resid, uio_clone)`. The count is a `size_t`; `uiomove(9)` takes an `int`. When the first (faults-disabled) attempt transferred 2 GiB or more before hitting a non-resident user page, the truncated count is negative, the clone is not advanced, and the retry loop re-does the whole request while still subtracting from `uio->uio_resid`. `read(2)`/`write(2)` then return more bytes than requested; the data is correct. Present since the original `vn_io_fault()` commit (41014d996a5a, 2012), shipped in 9.2 through 15.1.

**Real-world impact.** borgbackup 1.x reads its repository index with a single `read()` of the whole file. Users on FreeBSD/ZFS hosting (Hetzner StorageBox, rsync.net) with indexes above 2 GiB have been getting `raw readinto() returned invalid length N (should have been between 0 and M)` from CPython since 2022 (https://github.com/borgbackup/borg/issues/6140, https://github.com/python/cpython/issues/93287). Every reported N/M pair is `N = M + P - 18` with `P` a 128 KiB ZFS record boundary in (2^31, 2^32), i.e. exactly this truncation.

**Reproduction** (15.1-RELEASE amd64, stock GENERIC kernel; sources: https://gist.github.com/ThomasWaldmann/8b5c0e6f0c376b7a3da2de9fd29e3639): `gen` writes a 3 GiB file of counters, `faultread2` maps a fresh anonymous buffer, touches its first N bytes and issues one `read()` of the rest of the file from offset 18.

| touched prefix | fs | read() returned | expected |
|---|---|---|---|
| 1 GiB | zfs | 3221225454 | 3221225454 |
| 2 GiB − 128 KiB | zfs | 3221225454 | 3221225454 |
| 2 GiB + 128 KiB | zfs | 5368840156 | 3221225454 |
| 2.25 GiB | zfs | 5637144540 | 3221225454 |
| 2.25 GiB | ufs | 5637144540 | 3221225454 |

The excess is always `prefix − 18` and record aligned; the file offset advances by the same excess; the buffer content is correct. `write()` of 3221225472 bytes with a 2.25 GiB touched prefix returns 5637144576. With `debug.vn_io_fault_enable=0` the counts are exact.

**Validation of the fix.** Kernel built from the stock GENERIC config on 15.1-RELEASE, installed and booted: every cell above returns the exact count, `write()` returns 3221225472, and `debug.vn_io_faults` still increments, so the retry path is exercised rather than bypassed.

**Checklist.** `tools/build/checkstyle9.pl` on the commit: 0 errors, 0 warnings; no trailing whitespace. No new Kyua test is included because a test needs a ≥ 3 GiB file and ≥ 2.25 GiB of RAM for the user buffer; I can add one under `tests/sys/kern` with `require.memory`/`require.diskspace` metadata if that is wanted. Bugzilla: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=298159 (reproducers attached there; the patch is submitted only via this pull request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
