### PR TITLE
arm64/pmap: Fix invalidate_icache condition in stage2 fault

### DIFF
--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -9761,7 +9761,7 @@ fault_exec:
 			 * of Coherency.
 			 */
 			if ((pte & ATTR_S2_XN_MASK) !=
-			    ATTR_S2_XN(ATTR_S2_XN_NONE)) {
+			    ATTR_S2_XN(ATTR_S2_XN_ALL)) {
 				invalidate_icache();
 			}
 			pmap_set_bits(ptep, ATTR_AF | ATTR_DESCR_VALID);


### PR DESCRIPTION
pmap_stage2_fault is supposed to invalidate the icache if it is accessing an executable page. Instead, the condition currently checks whether execution is disallowed at any EL. Make it check whether execution is allowed at any EL to match the intended behaviour.