### PR TITLE
elftoolchain/native-elf-format: add LoongArch support

### DIFF
--- a/contrib/elftoolchain/common/native-elf-format
+++ b/contrib/elftoolchain/common/native-elf-format
@@ -41,6 +41,8 @@ $1 ~ "Machine:" {
             elfarch = "EM_PPC64";
         } else if (match($0, "AArch64")) {
             elfarch = "EM_AARCH64";
+        } else if (match($0, "LoongArch")) {
+            elfarch = "EM_LOONGARCH";
         } else {
             elfarch = "unknown";
         }


### PR DESCRIPTION
Add detection for LoongArch architecture in the native-elf-format script. This allows the build system to correctly identify LoongArch ELF files and set the appropriate EM_LOONGARCH macro.