### PR TITLE
imgact_aout: fix i386 header size overflow check

### DIFF
--- a/sys/kern/imgact_aout.c
+++ b/sys/kern/imgact_aout.c
@@ -239,13 +239,25 @@ exec_aout_imgact(struct image_params *imgp)
 	    a_out->a_entry >= virtual_offset + a_out->a_text ||
 
 	    /* text and data size must each be page rounded */
-	    a_out->a_text & PAGE_MASK || a_out->a_data & PAGE_MASK
+	    a_out->a_text & PAGE_MASK || a_out->a_data & PAGE_MASK ||
 
-#ifdef __amd64__
-	    ||
-	    /* overflows */
-	    virtual_offset + a_out->a_text + a_out->a_data + bss_size > UINT_MAX
-#endif
+	    /*
+	     * overflows: a_text/a_data/a_bss are attacker-controlled
+	     * uint32_t fields straight from the file header. This sum
+	     * must be computed in a type wider than 32 bits before
+	     * comparing against UINT_MAX: on ILP32 platforms (e.g. i386,
+	     * where this is the native, non-compat a.out personality)
+	     * "unsigned long" is itself only 32 bits, so the addition
+	     * would silently wrap *before* any "> UINT_MAX" comparison
+	     * ever ran, making such a check a no-op there. A crafted
+	     * small file (even a 0-byte one) could claim huge a_text/
+	     * a_data values that wrap back to something small enough to
+	     * also sail past the "text + data can't exceed file size"
+	     * check a few lines down. Casting to uint64_t first avoids
+	     * this on every platform, not just LP64 ones.
+	     */
+	    (uint64_t)virtual_offset + a_out->a_text + a_out->a_data + bss_size >
+	        UINT_MAX
 	    )
 		return (-1);
 


### PR DESCRIPTION
exec_aout_imgact() checks that "virtual_offset + a_text + a_data + bss_size" does not exceed UINT_MAX before trusting those (fully attacker-controlled, straight from the file's uint32_t header fields) sizes to build the process's VM mappings. This check was guarded by #ifdef __amd64__, so it did not exist at all on i386 -- the architecture where the native (non-freebsd32-compat) a.out personality actually runs.

Worse, simply removing the #ifdef would not have been enough: on an ILP32 platform "unsigned long" is itself only 32 bits, so the addition would silently wrap *before* the ">  UINT_MAX" comparison ever ran, making the check a no-op there regardless.

Concretely, a 0-byte file with a_text = a_data = 0x80000000 (each individually page-aligned, so it also passes the earlier alignment check) sums to exactly 0 in 32-bit arithmetic, which then also sails past the "a_data + a_text > imgp->attr->va_size" file-size sanity check a few lines down, since 0 is never greater than any real file's size.

Fix by widening the sum to uint64_t before comparing, which closes the gap on ILP32 platforms and is a no-op behavioural change on LP64 ones (where "unsigned long" was already 64 bits).