### PR TITLE
stdio: type a positional %F argument in __find_arguments()

### DIFF
--- a/lib/libc/stdio/printf-pos.c
+++ b/lib/libc/stdio/printf-pos.c
@@ -362,6 +362,7 @@ reswitch:	switch (ch) {
 		case 'e':
 		case 'E':
 		case 'f':
+		case 'F':
 		case 'g':
 		case 'G':
 			error = addtype(&types,
@@ -551,6 +552,7 @@ reswitch:	switch (ch) {
 		case 'e':
 		case 'E':
 		case 'f':
+		case 'F':
 		case 'g':
 		case 'G':
 			error = addtype(&types,


### PR DESCRIPTION
__find_arguments() and __find_warguments() in lib/libc/stdio/printf-pos.c
list a A e E f g G as the floating point conversions and leave out F, so
an argument that only appears as %F in a positional format is never
typed.  The conversion then reads an unset slot of the argument table:

    #include <stdio.h>
    #include <math.h>
    int main(void) {
        printf("[%1$F]\n", -INFINITY);
        printf("[%1$F]\n", 1.5);
        printf("[%F]\n", 1.5);
        return 0;
    }

prints [0.000000], [0.000000], [1.500000] on 15.1.  With a width from a
second argument ("%1$*2$F") the return value of vsnprintf(3) came out as
2103024 for a ten character result; abseil's str_format test allocates
that many bytes and was killed for it, which is how I found this.

The change adds F next to f in both scanners.  I rebuilt lib/libc from
the 15.1 source with it and ran the program above against the new
libc.so.7 through LD_LIBRARY_PATH: it prints [-INF], [1.500000],
[1.500000], and "%1$*2$F" returns 10.  Not built on main, though the
diff applies to it unchanged.

NetBSD and DragonFly have the same omission and I am reporting it
there too; OpenBSD's vfprintf.c already has the F.
