### PR TITLE
msun: keep a long nan(3) payload out of the sign bit

### DIFF
--- a/lib/msun/ld128/s_nanl.c
+++ b/lib/msun/ld128/s_nanl.c
@@ -40,6 +40,7 @@ nanl(const char *s)
 	} u;
 
 	_scan_nan(u.bits, 4, s);
+	u.ieee.bits.sign = 0;	/* a long payload must not reach the sign */
 	u.ieee.bits.exp = 0x7fff;
 	u.ieee.bits.manh |= 1ULL << 47;	/* make it a quiet NaN */
 	return (u.ieee.e);

--- a/lib/msun/ld80/s_nanl.c
+++ b/lib/msun/ld80/s_nanl.c
@@ -40,6 +40,7 @@ nanl(const char *s)
 	} u;
 
 	_scan_nan(u.bits, 3, s);
+	u.ieee.bits.sign = 0;	/* a long payload must not reach the sign */
 	u.ieee.bits.exp = 0x7fff;
 	u.ieee.bits.manh |= 0xc0000000;	/* make it a quiet NaN */
 	return (u.ieee.e);

--- a/lib/msun/src/s_nan.c
+++ b/lib/msun/src/s_nan.c
@@ -85,10 +85,11 @@ nan(const char *s)
 	} u;
 
 	_scan_nan(u.bits, 2, s);
+	/* Keep the mantissa only; a long payload must not reach the sign. */
 #if _BYTE_ORDER == _LITTLE_ENDIAN
-	u.bits[1] |= 0x7ff80000;
+	u.bits[1] = (u.bits[1] & 0x000fffff) | 0x7ff80000;
 #else
-	u.bits[0] |= 0x7ff80000;
+	u.bits[0] = (u.bits[0] & 0x000fffff) | 0x7ff80000;
 #endif
 	return (u.d);
 }
@@ -102,7 +103,7 @@ nanf(const char *s)
 	} u;
 
 	_scan_nan(u.bits, 1, s);
-	u.bits[0] |= 0x7fc00000;
+	u.bits[0] = (u.bits[0] & 0x007fffff) | 0x7fc00000;
 	return (u.f);
 }
 


### PR DESCRIPTION
_scan_nan() in lib/msun/src/s_nan.c fills every bit of the words it is
given, so a payload longer than the mantissa reaches the exponent and
the sign.  nan() and nanf() OR in the exponent afterwards, which hides
that part, but the sign survives, and both nanl() variants assign the
exponent and leave the sign alone in the same way:

    nan("9999999999999999")        fff9999999999999
    strtod("nan(9999999999999999)") 7ff9999999999999
    nanf("ffffffff")               ffffffff
    strtof("nan(ffffffff)")        7fffffff
    nanl("ffffffffffffffffffff")   ffff ffffffffffffffff (sign set)

C11 7.12.11.2 defines nan(s) as strtod("NAN(s)"), so the two columns
should agree; the comment in _scan_nan() also says the high order bits
are discarded.  abseil's charconv test compares from_chars, which
follows nan(3), against strtod and caught it.

The change keeps only the mantissa in nan() and nanf() and clears the
sign in nanl().  I rebuilt lib/msun from the 15.1 source with it and
ran the probe against the new libm.so.5 through LD_LIBRARY_PATH:
nan("9999999999999999") is 7ff9999999999999, nanf("ffffffff") is
7fffffff, nanl("ffffffffffffffffffff") has 7fff in the sign and
exponent, and short payloads such as nan("1") are unchanged.  Not built
on main, though the diff applies to it unchanged.

OpenBSD carries the same s_nan.c and I am sending the same change to
tech@ there.

