### PR TITLE
Add LoongArch ELF machine type definition

### DIFF
--- a/contrib/elftoolchain/common/elfdefinitions.h
+++ b/contrib/elftoolchain/common/elfdefinitions.h
@@ -869,7 +869,8 @@ _ELF_DEFINE_EM(EM_KMX32,            211, "KM211 KMX32 32-bit processor") \
 _ELF_DEFINE_EM(EM_KMX16,            212, "KM211 KMX16 16-bit processor") \
 _ELF_DEFINE_EM(EM_KMX8,             213, "KM211 KMX8 8-bit processor")  \
 _ELF_DEFINE_EM(EM_KVARC,            214, "KM211 KMX32 KVARC processor") \
-_ELF_DEFINE_EM(EM_RISCV,            243, "RISC-V")
+_ELF_DEFINE_EM(EM_RISCV,            243, "RISC-V") \
+_ELF_DEFINE_EM(EM_LOONGARCH,        258, "LoongArch")
 
 #undef	_ELF_DEFINE_EM
 #define	_ELF_DEFINE_EM(N, V, DESCR)	N = V ,

--- a/contrib/elftoolchain/readelf/readelf.c
+++ b/contrib/elftoolchain/readelf/readelf.c
@@ -595,6 +595,7 @@ elf_machine(unsigned int mach)
 	case EM_UNICORE: return "Microprocessor series from PKU-Unity Ltd";
 	case EM_AARCH64: return "AArch64";
 	case EM_RISCV: return "RISC-V";
+	case EM_LOONGARCH: return "LOONGARCH";
 	default:
 		snprintf(s_mach, sizeof(s_mach), "<unknown: %#x>", mach);
 		return (s_mach);

--- a/usr.bin/elfdump/elfdump.c
+++ b/usr.bin/elfdump/elfdump.c
@@ -274,6 +274,7 @@ e_machines(u_int mach)
 	case EM_X86_64:	return "EM_X86_64";
 	case EM_AARCH64:return "EM_AARCH64";
 	case EM_RISCV:	return "EM_RISCV";
+	case EM_LOONGARCH:return "EM_LOONGARCH";
 	}
 	snprintf(machdesc, sizeof(machdesc),
 	    "(unknown machine) -- type 0x%x", mach);


### PR DESCRIPTION
EM_LOONGARCH has been officially registered as e_machine 258. 
Add the corresponding definition to elftoolchain's ELF header and teach readelf/elfdump to recognize and print it.

Upstream registration in GNU binutils:
https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=4cf2ad720078a9f490dd5b5bc8893a926479196e